### PR TITLE
Autolock rail issue. S1P S2P

### DIFF
--- a/LhymicroWriter.py
+++ b/LhymicroWriter.py
@@ -539,9 +539,10 @@ class LhymicroWriter:
                 self.move_x(dx)
             if dy != 0:
                 self.move_y(dy)
-            self.controller += b'S1P\n'
-            if not self.autolock:
-                self.controller += b'IS2P\n'
+            if self.autolock:
+                self.controller += b'S1P\n'
+            else:
+                self.controller += b'S2P\n'
         elif self.state == STATE_COMPACT:
             if dx != 0 and dy != 0 and abs(dx) != abs(dy):
                 for x, y, on in self.group_plots(self.current_x, self.current_y,
@@ -651,9 +652,10 @@ class LhymicroWriter:
         if self.state == STATE_DEFAULT:
             self.controller += b'I'
             self.controller += COMMAND_ON
-            self.controller += b'S1P\n'
-            if not self.autolock:
-                self.controller += b'IS2P\n'
+            if self.autolock:
+                self.controller += b'S1P\n'
+            else:
+                self.controller += b'S2P\n'
         elif self.state == STATE_COMPACT:
             self.controller += COMMAND_ON
         elif self.state == STATE_CONCAT:
@@ -668,9 +670,10 @@ class LhymicroWriter:
         if self.state == STATE_DEFAULT:
             self.controller += b'I'
             self.controller += COMMAND_OFF
-            self.controller += b'S1P\n'
-            if not self.autolock:
-                self.controller += b'IS2P\n'
+            if self.autolock:
+                self.controller += b'S1P\n'
+            else:
+                self.controller += b'S2P\n'
         elif self.state == STATE_COMPACT:
             self.controller += COMMAND_OFF
         elif self.state == STATE_CONCAT:
@@ -681,9 +684,10 @@ class LhymicroWriter:
 
     def to_default_mode(self):
         if self.state == STATE_CONCAT:
-            self.controller += b'S1P\n'
-            if not self.autolock:
-                self.controller += b'IS2P\n'
+            if self.autolock:
+                self.controller += b'S1P\n'
+            else:
+                self.controller += b'S2P\n'
         elif self.state == STATE_COMPACT:
             self.controller += b'FNSE-\n'
             self.reset_modes()

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -538,7 +538,7 @@ class CutConfiguration(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
         self.SetSize((503, -1))
         self.element_tree = wx.TreeCtrl(self, wx.ID_ANY, style=wx.FULL_REPAINT_ON_RESIZE)
-        self.bitmap_button_1 = wx.BitmapButton(self, ID_CUT_BURN_BUTTON, icons8_gas_industry_50.GetBitmap())
+        self.bitmap_button_1 = wx.BitmapButton(self, ID_CUT_BURN_BUTTON, icons8_laser_beam_52.GetBitmap())
 
         self.__set_properties()
         self.__do_layout()


### PR DESCRIPTION
Autolock uses IS2P to lock rail but did so after commands that called S1P. That should be pointless as ending with S2P should do that automatically.