### PR TITLE
Exception raised when rotating empty design

### DIFF
--- a/LaserProject.py
+++ b/LaserProject.py
@@ -328,8 +328,10 @@ class LaserProject:
         self.validate()
         if position is not None:
             self.set_selected_by_position(position)
-        else:
+        elif self.selected is not None:
             position = self.selected.center
+        else:
+            return
         if self.selected is not None:
             self.validate()
             for e in self.selected:


### PR DESCRIPTION
When "Design->Transform->Rotate tau/4" is clicked with empty project, following exception is being raised:
```
Traceback (most recent call last):
  File "meerk40t/MeerK40t.py", line 516, in transform_rotate_right
    self.project.menu_rotate(0.25 * tau)
  File "meerk40t/LaserProject.py", line 332, in menu_rotate
    position = self.selected.center
AttributeError: 'NoneType' object has no attribute 'center'
```
in
https://github.com/meerk40t/meerk40t/blob/57c4c3c957bece764ea27cdab91ed1f0a511a759/LaserProject.py#L327-L339

Is it OK to fix it like that?
