### PR TITLE
#164 hotfix

### DIFF
--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -104,7 +104,10 @@ if args.input is not None:
 
 if args.path is not None:
     from svgelements import Path
-    kernel.elements.append(Path(args.path))
+    try:
+        kernel.elements.append(Path(args.path))
+    except Exception:
+        pass
 
 if args.verbose:
     kernel.device.execute('Debug Device')


### PR DESCRIPTION
Prevent crashing from -p flags with a malformed path statement. eg: `MeerK40t -p S`