### PR TITLE
Auto-create operations for any encountered colors & enable context-menu conversion

### DIFF
--- a/Kernel.py
+++ b/Kernel.py
@@ -1260,9 +1260,11 @@ class Elemental(Module):
         if elements is None:
             return
         for element in elements:
+            found_color = False
             for op in self.ops():
                 if op.color == element.stroke:
                     op.append(element)
+                    found_color = True
                 elif op.color == 'black':
                     if op.operation == 'Raster' and not isinstance(element, SVGImage):
                         op.append(element)
@@ -1270,6 +1272,10 @@ class Elemental(Module):
                         op.append(element)
                     elif op.operation not in ('Raster', 'Image'):
                         op.append(element)
+            if not found_color:
+                op = LaserOperation(operation="Engrave", color=element.stroke, speed=35.0)
+                op.append(element)
+                self.add_op(op)
 
     def load(self, pathname, **kwargs):
         for loader_name, loader in self.device.registered['load'].items():

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -1732,7 +1732,6 @@ class RootNode(list):
             for name in ("Raster", "Engrave", "Cut"):
                 menu_op = operation_convert_submenu.Append(wx.ID_ANY, _("Convert %s") % name, "", wx.ITEM_NORMAL)
                 gui.Bind(wx.EVT_MENU, self.menu_convert_operation(node, name), menu_op)
-                menu_op.Enable(False)
             menu.AppendSubMenu(operation_convert_submenu, _("Convert Operation"))
             duplicate_menu = wx.Menu()
             gui.Bind(wx.EVT_MENU, self.menu_passes(node, 1),
@@ -2193,7 +2192,8 @@ class RootNode(list):
 
     def menu_convert_operation(self, node, name):
         def specific(event):
-            raise NotImplementedError
+            node.object.operation = name
+            self.device.signal('element_property_update', node.object)
 
         return specific
 


### PR DESCRIPTION
Currently there's no way to "Add" an operation, and if you have paths that don't match up color-wise with operations, they are just binned as raster. This makes it so you can define different paths as different colors, and each color gets its own operation.

I also implemented the "Convert Operation" context menu, for ease of conversion.

Test plan:
open an SVG with an orange line, a blue line, and a red line.
the blue and red lines should get binned into the preexisting operations, and a new orange operation should be created.

right-click the orange auto-created "engrave" operation, use "Convert Operation" to change it to a `Cut`. Double-click on it to see that in the edit window it also appears as a "Cut".

![image](https://user-images.githubusercontent.com/112170/86410744-962f4880-bc78-11ea-94a2-cfa9081e751e.png)
