### PR TITLE
Initial -H home command.

### DIFF
--- a/Console.py
+++ b/Console.py
@@ -1473,6 +1473,11 @@ class Console(Module, Pipe):
                                 new_data[x, y] = (v, v, v, 255)
                     elements.add_elem(image_element)
             elif args[0] == 'resample':
+                try:
+                    from OperationPreprocessor import OperationPreprocessor
+                except ImportError:
+                    yield "No Render Engine Installed."
+                    return
                 for element in elements.elems(emphasized=True):
                     if isinstance(element, SVGImage):
                         OperationPreprocessor.make_actual(element)

--- a/Console.py
+++ b/Console.py
@@ -1397,6 +1397,17 @@ class Console(Module, Pipe):
             if not elements.has_emphasis():
                 yield "No selected images."
                 return
+            elif args[0] == 'path':
+                for element in list(elements.elems(emphasized=True)):
+                    bounds = element.bbox()
+                    p = Path()
+                    p.move((bounds[0], bounds[1]),
+                            (bounds[0], bounds[3]),
+                            (bounds[2], bounds[3]),
+                           (bounds[2], bounds[1]))
+                    p.closed()
+                    self.add_element(p)
+                return
             elif args[0] == 'wizard':
                 if len(args) == 1:
                     try:

--- a/Console.py
+++ b/Console.py
@@ -1580,10 +1580,10 @@ class Console(Module, Pipe):
                     if isinstance(element, SVGImage):
                         img = element.image
                         try:
-                            left = int(args[1])
-                            upper = int(args[2])
-                            right = int(args[3])
-                            lower = int(args[4])
+                            left = int(Length(args[1]).value(ppi=1000.0, relative_length=self.device.bed_width * 39.3701))
+                            upper = int(Length(args[2]).value(ppi=1000.0, relative_length=self.device.bed_height * 39.3701))
+                            right = int(Length(args[3]).value(ppi=1000.0, relative_length=self.device.bed_width * 39.3701))
+                            lower = int(Length(args[4]).value(ppi=1000.0, relative_length=self.device.bed_height * 39.3701))
                             element.image = img.crop((left, upper, right, lower))
                             element.image_width = right - left
                             element.image_height = lower - upper

--- a/Console.py
+++ b/Console.py
@@ -1464,24 +1464,20 @@ class Console(Module, Pipe):
                     if OperationPreprocessor.needs_actualization(image_element):
                         OperationPreprocessor.make_actual(image_element)
                     img = image_element.image
-                    new_data = img.load()
-                    width, height = img.size
-                    for y in range(height):
-                        for x in range(width):
-                            pixel = new_data[x, y]
-                            if pixel[3] == 0:
-                                new_data[x, y] = (255, 255, 255, 255)
-                                continue
-                            gray = (pixel[0] + pixel[1] + pixel[2]) / 3.0
-                            if threshold_min >= gray:
-                                new_data[x, y] = (0, 0, 0, 255)
-                            elif threshold_max < gray:
-                                new_data[x, y] = (255, 255, 255, 255)
-                            else:  # threshold_min <= grey < threshold_max
-                                v = gray - threshold_min
-                                v *= divide
-                                v = int(round(v))
-                                new_data[x, y] = (v, v, v, 255)
+                    img = img.convert('L')
+
+                    def thresh(g):
+                        if threshold_min >= g:
+                            return 0
+                        elif threshold_max < g:
+                            return 255
+                        else:  # threshold_min <= grey < threshold_max
+                            value = g - threshold_min
+                            value *= divide
+                            return int(round(value))
+                    lut = [thresh(g) for g in range(256)]
+                    img = img.point(lut)
+                    image_element.image = img
                     elements.add_elem(image_element)
             elif args[0] == 'resample':
                 try:

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -216,7 +216,7 @@ class ImageLoader:
     def load(kernel, pathname, **kwargs):
         basename = os.path.basename(pathname)
 
-        image = SVGImage({'href': pathname, 'width': "100%", 'height': "100%"})
+        image = SVGImage({'href': pathname, 'width': "100%", 'height': "100%", 'id': basename})
         image.load()
         try:
             kernel.setting(bool, 'image_dpi', True)

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -123,12 +123,18 @@ class SVGLoader:
         kernel.setting(int, "bed_width", 320)
         kernel.setting(int, "bed_height", 220)
         elements = []
+        if 'ppi' in kwargs:
+            ppi = float(kwargs['ppi'])
+        else:
+            ppi = 96.0
+        if ppi == 0:
+            ppi = 96.0
         basename = os.path.basename(pathname)
-        scale_factor = 1000.0 / 96.0
+        scale_factor = 1000.0 / ppi
         svg = SVG.parse(source=pathname,
                         width='%fmm' % (kernel.bed_width),
                         height='%fmm' % (kernel.bed_height),
-                        ppi=96.0,
+                        ppi=ppi,
                         transform='scale(%f)' % scale_factor)
         ops = None
         note = None

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -132,6 +132,7 @@ class SVGLoader:
         basename = os.path.basename(pathname)
         scale_factor = 1000.0 / ppi
         svg = SVG.parse(source=pathname,
+                        reify=False,
                         width='%fmm' % (kernel.bed_width),
                         height='%fmm' % (kernel.bed_height),
                         ppi=ppi,

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -135,6 +135,7 @@ class SVGLoader:
                         width='%fmm' % (kernel.bed_width),
                         height='%fmm' % (kernel.bed_height),
                         ppi=ppi,
+                        color='none',
                         transform='scale(%f)' % scale_factor)
         ops = None
         note = None

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -123,8 +123,8 @@ class SVGLoader:
         kernel.setting(int, "bed_width", 320)
         kernel.setting(int, "bed_height", 220)
         elements = []
-        if 'ppi' in kwargs:
-            ppi = float(kwargs['ppi'])
+        if 'svg_ppi' in kwargs:
+            ppi = float(kwargs['svg_ppi'])
         else:
             ppi = 96.0
         if ppi == 0:

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -132,7 +132,6 @@ class SVGLoader:
         basename = os.path.basename(pathname)
         scale_factor = 1000.0 / ppi
         svg = SVG.parse(source=pathname,
-                        reify=False,
                         width='%fmm' % (kernel.bed_width),
                         height='%fmm' % (kernel.bed_height),
                         ppi=ppi,

--- a/Kernel.py
+++ b/Kernel.py
@@ -1274,19 +1274,28 @@ class Elemental(Module):
             return
         for element in elements:
             found_color = False
+            added_to_op = False
             for op in self.ops():
-                if op.operation in ("Engrave", "Cut", "Raster") and op.color == element.stroke:
+                if op.operation == "Raster" and op.color == element.stroke:
+                    if not added_to_op:
+                        op.append(element)
+                    found_color = True
+                    added_to_op = True
+                elif op.operation in ("Engrave", "Cut") and op.color == element.stroke:
                     op.append(element)
                     found_color = True
+                    added_to_op = True
                 elif op.operation == 'Image' and isinstance(element, SVGImage):
                     op.append(element)
                     found_color = True
+                    added_to_op = True
                 elif op.operation == 'Raster' and \
                         not isinstance(element, SVGImage) and \
                         element.fill is not None and \
                         element.fill.value is not None:
                     op.append(element)
                     found_color = True
+                    added_to_op = True
             if not found_color:
                 if element.stroke is not None and element.stroke.value is not None:
                     op = LaserOperation(operation="Engrave", color=element.stroke, speed=35.0)

--- a/Kernel.py
+++ b/Kernel.py
@@ -2388,7 +2388,7 @@ class Kernel(Device):
         Device.__init__(self, self, 0)
         # Current Project.
         self.device_name = "MeerK40t"
-        self.device_version = "0.6.5"
+        self.device_version = "0.6.6"
         self.device_root = self
 
         # Persistent storage if it exists.

--- a/Kernel.py
+++ b/Kernel.py
@@ -1276,7 +1276,13 @@ class Elemental(Module):
             found_color = False
             added_to_op = False
             for op in self.ops():
-                if op.operation == "Raster" and op.color == element.stroke:
+                if op.operation == "Raster" and (
+                        op.color == element.stroke or
+                        (
+                                not isinstance(element, SVGImage) and
+                                element.fill is not None and
+                                element.fill.value is not None
+                        )):
                     if not added_to_op:
                         op.append(element)
                     found_color = True
@@ -1286,13 +1292,6 @@ class Elemental(Module):
                     found_color = True
                     added_to_op = True
                 elif op.operation == 'Image' and isinstance(element, SVGImage):
-                    op.append(element)
-                    found_color = True
-                    added_to_op = True
-                elif op.operation == 'Raster' and \
-                        not isinstance(element, SVGImage) and \
-                        element.fill is not None and \
-                        element.fill.value is not None:
                     op.append(element)
                     found_color = True
                     added_to_op = True

--- a/Kernel.py
+++ b/Kernel.py
@@ -1274,27 +1274,23 @@ class Elemental(Module):
             return
         for element in elements:
             found_color = False
-            added_to_op = False
+            image_added = False
             for op in self.ops():
-                if op.operation == "Raster" and (
-                        op.color == element.stroke or
-                        (
-                                not isinstance(element, SVGImage) and
-                                element.fill is not None and
-                                element.fill.value is not None
-                        )):
-                    if not added_to_op:
+                if op.operation == "Raster":
+                    if op.color == element.stroke:
+                        op.append(element)
+                    elif not image_added and isinstance(element, SVGImage):
+                        op.append(element)
+                    elif element.fill is not None and element.fill.value is not None:
                         op.append(element)
                     found_color = True
-                    added_to_op = True
                 elif op.operation in ("Engrave", "Cut") and op.color == element.stroke:
                     op.append(element)
                     found_color = True
-                    added_to_op = True
                 elif op.operation == 'Image' and isinstance(element, SVGImage):
                     op.append(element)
                     found_color = True
-                    added_to_op = True
+                    image_added = True
             if not found_color:
                 if element.stroke is not None and element.stroke.value is not None:
                     op = LaserOperation(operation="Engrave", color=element.stroke, speed=35.0)

--- a/LhystudiosDevice.py
+++ b/LhystudiosDevice.py
@@ -289,10 +289,11 @@ class LhymicroInterpreter(Interpreter):
         if isinstance(path, SVGImage):
             bounds = path.bbox()
             p = Path()
-            p.move([(bounds[0], bounds[1]),
-                            (bounds[0], bounds[3]),
-                            (bounds[2], bounds[1]),
-                            (bounds[2], bounds[3])])
+            p.move((bounds[0], bounds[1]),
+                   (bounds[0], bounds[3]),
+                   (bounds[2], bounds[3]),
+                   (bounds[2], bounds[1]))
+            p.closed()
             self.plot = self.convert_to_wrapped_plot(ZinglPlotter.plot_path(p), True, self.device.current_x, self.device.current_y)
             return
         if len(path) == 0:

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -52,8 +52,7 @@ parser.add_argument('-gb', '--adjust_y', type=int, help='adjust grbl home_y posi
 parser.add_argument('-rs', '--ruida', action='store_true', help='run ruida-emulator')
 
 
-argm = [0, '-zHmcs', 'home_adjust_x', '20', 'home_adjust_y', '20']
-args = parser.parse_args(argm[1:])
+args = parser.parse_args(sys.argv[1:])
 
 kernel.register('static', 'RasterScripts', RasterScripts)
 kernel.register('module', 'Console', Console)

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -30,6 +30,14 @@ kernel = Kernel()
 kernel.open('module', 'Signaler')
 kernel.open('module', 'Elemental')
 
+
+def pair(value):
+    rv = value.split('=')
+    if len(rv) != 2:
+        raise argparse.ArgumentParser()
+    return rv
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument('input', nargs='?', type=argparse.FileType('r'), help='input file')
 parser.add_argument('-z', '--no_gui', action='store_true', help='run without gui')
@@ -40,7 +48,7 @@ parser.add_argument('-t', '--transform', type=str, help="adds SVG Transform comm
 parser.add_argument('-o', '--output', type=argparse.FileType('w'), help='output file name')
 parser.add_argument('-v', '--verbose', action='store_true', help='display verbose debugging')
 parser.add_argument('-m', '--mock', action='store_true', help='uses mock usb device')
-parser.add_argument('-s', '--set', action='append', nargs='+', help='set a device variable')
+parser.add_argument('-s', '--set', action='append', nargs='?', type=pair, metavar='key=value', help='set a device variable')
 parser.add_argument('-H', '--home', action='store_true', help="prehome the device")
 parser.add_argument('-b', '--batch', type=argparse.FileType('r'), help='console batch file')
 parser.add_argument('-S', '--speed', type=float, help='set the speed of all operations')
@@ -53,7 +61,6 @@ parser.add_argument('-rs', '--ruida', action='store_true', help='run ruida-emula
 
 
 args = parser.parse_args(sys.argv[1:])
-
 kernel.register('static', 'RasterScripts', RasterScripts)
 kernel.register('module', 'Console', Console)
 kernel.register('module', 'LaserServer', LaserServer)
@@ -141,9 +148,9 @@ if args.transform:
 if args.set is not None:
     # Set the variables requested here.
     for var in args.set:
-        for i in range(0, len(var), 2):
-            attr = var[i]
-            value = var[i+1]
+        for v in var:
+            attr = v[0]
+            value = v[1]
             if hasattr(device, attr):
                 v = getattr(device, attr)
                 if isinstance(v, bool):
@@ -177,6 +184,8 @@ if device is not kernel:  # We can process this stuff only with a real device.
 
     if args.home:
         console = device.using('module', 'Console').write('home\n')
+        device.setting(bool, 'quit', True)
+        device.quit = True
 
     if args.auto:
         # Automatically classify and start the job.

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -52,7 +52,8 @@ parser.add_argument('-gb', '--adjust_y', type=int, help='adjust grbl home_y posi
 parser.add_argument('-rs', '--ruida', action='store_true', help='run ruida-emulator')
 
 
-args = parser.parse_args(sys.argv[1:])
+argm = [0, '-zHmcs', 'home_adjust_x', '20', 'home_adjust_y', '20']
+args = parser.parse_args(argm[1:])
 
 kernel.register('static', 'RasterScripts', RasterScripts)
 kernel.register('module', 'Console', Console)
@@ -141,20 +142,19 @@ if args.transform:
 if args.set is not None:
     # Set the variables requested here.
     for var in args.set:
-        if len(var) <= 1:
-            continue  # Need at least two for a set.
-        attr = var[0]
-        value = var[1]
-        if hasattr(device, attr):
-            v = getattr(device, attr)
-            if isinstance(v, bool):
-                setattr(device, attr, bool(value))
-            elif isinstance(v, int):
-                setattr(device, attr, int(value))
-            elif isinstance(v, float):
-                setattr(device, attr, float(value))
-            elif isinstance(v, str):
-                setattr(device, attr, str(value))
+        for i in range(0, len(var), 2):
+            attr = var[i]
+            value = var[i+1]
+            if hasattr(device, attr):
+                v = getattr(device, attr)
+                if isinstance(v, bool):
+                    setattr(device, attr, bool(value))
+                elif isinstance(v, int):
+                    setattr(device, attr, int(value))
+                elif isinstance(v, float):
+                    setattr(device, attr, float(value))
+                elif isinstance(v, str):
+                    setattr(device, attr, str(value))
 
 if device is not kernel:  # We can process this stuff only with a real device.
     if args.grbl is not None:

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -41,6 +41,7 @@ parser.add_argument('-o', '--output', type=argparse.FileType('w'), help='output 
 parser.add_argument('-v', '--verbose', action='store_true', help='display verbose debugging')
 parser.add_argument('-m', '--mock', action='store_true', help='uses mock usb device')
 parser.add_argument('-s', '--set', action='append', nargs='+', help='set a device variable')
+parser.add_argument('-H', '--home', action='store_true', help="prehome the device")
 parser.add_argument('-b', '--batch', type=argparse.FileType('r'), help='console batch file')
 parser.add_argument('-S', '--speed', type=float, help='set the speed of all operations')
 parser.add_argument('-gs', '--grbl', type=int, help='run grbl-emulator on given port.')
@@ -52,7 +53,6 @@ parser.add_argument('-rs', '--ruida', action='store_true', help='run ruida-emula
 
 
 args = parser.parse_args(sys.argv[1:])
-# args = parser.parse_args(["-zc"])
 
 kernel.register('static', 'RasterScripts', RasterScripts)
 kernel.register('module', 'Console', Console)
@@ -138,6 +138,24 @@ if args.transform:
         except AttributeError:
             pass
 
+if args.set is not None:
+    # Set the variables requested here.
+    for var in args.set:
+        if len(var) <= 1:
+            continue  # Need at least two for a set.
+        attr = var[0]
+        value = var[1]
+        if hasattr(device, attr):
+            v = getattr(device, attr)
+            if isinstance(v, bool):
+                setattr(device, attr, bool(value))
+            elif isinstance(v, int):
+                setattr(device, attr, int(value))
+            elif isinstance(v, float):
+                setattr(device, attr, float(value))
+            elif isinstance(v, str):
+                setattr(device, attr, str(value))
+
 if device is not kernel:  # We can process this stuff only with a real device.
     if args.grbl is not None:
         # Start the GRBL server on the device.
@@ -158,6 +176,9 @@ if device is not kernel:  # We can process this stuff only with a real device.
     if args.ruida:
         console = device.using('module', 'Console').write('ruidaserver\n')
 
+    if args.home:
+        console = device.using('module', 'Console').write('home\n')
+
     if args.auto:
         # Automatically classify and start the job.
         elements = kernel.elements
@@ -170,23 +191,6 @@ if device is not kernel:  # We can process this stuff only with a real device.
         device.setting(bool, 'quit', True)
         device.quit = True
 
-if args.set is not None:
-    # Set the variables requested here.
-    for var in args.set:
-        if len(var) <= 1:
-            continue  # Need at least two for a set.
-        attr = var[0]
-        value = var[1]
-        if hasattr(device, attr):
-            v = getattr(device, attr)
-            if isinstance(v, bool):
-                setattr(device, attr, bool(value))
-            elif isinstance(v, int):
-                setattr(device, attr, int(value))
-            elif isinstance(v, float):
-                setattr(device, attr, float(value))
-            elif isinstance(v, str):
-                setattr(device, attr, str(value))
 if args.mock:
     # Set the device to mock.
     device.setting(bool, 'mock', True)

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -147,20 +147,19 @@ if args.transform:
 
 if args.set is not None:
     # Set the variables requested here.
-    for var in args.set:
-        for v in var:
-            attr = v[0]
-            value = v[1]
-            if hasattr(device, attr):
-                v = getattr(device, attr)
-                if isinstance(v, bool):
-                    setattr(device, attr, bool(value))
-                elif isinstance(v, int):
-                    setattr(device, attr, int(value))
-                elif isinstance(v, float):
-                    setattr(device, attr, float(value))
-                elif isinstance(v, str):
-                    setattr(device, attr, str(value))
+    for v in args.set:
+        attr = v[0]
+        value = v[1]
+        if hasattr(device, attr):
+            v = getattr(device, attr)
+            if isinstance(v, bool):
+                setattr(device, attr, bool(value))
+            elif isinstance(v, int):
+                setattr(device, attr, int(value))
+            elif isinstance(v, float):
+                setattr(device, attr, float(value))
+            elif isinstance(v, str):
+                setattr(device, attr, str(value))
 
 if device is not kernel:  # We can process this stuff only with a real device.
     if args.grbl is not None:

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -132,9 +132,10 @@ if args.path is not None:
     try:
         path = Path(args.path)
         path.stroke = Color('blue')
-        kernel.elements.add(path)
+        kernel.elements.add_elem(path)
     except Exception:
         print("SVG Path Exception to: %s" % ' '.join(sys.argv))
+
 if args.transform:
     # Transform any data loaded data
     from svgelements import Matrix

--- a/MeerK40t.py
+++ b/MeerK40t.py
@@ -50,6 +50,7 @@ parser.add_argument('-v', '--verbose', action='store_true', help='display verbos
 parser.add_argument('-m', '--mock', action='store_true', help='uses mock usb device')
 parser.add_argument('-s', '--set', action='append', nargs='?', type=pair, metavar='key=value', help='set a device variable')
 parser.add_argument('-H', '--home', action='store_true', help="prehome the device")
+parser.add_argument('-O', '--origin', action='store_true', help="return back to 0,0 on finish")
 parser.add_argument('-b', '--batch', type=argparse.FileType('r'), help='console batch file')
 parser.add_argument('-S', '--speed', type=float, help='set the speed of all operations')
 parser.add_argument('-gs', '--grbl', type=int, help='run grbl-emulator on given port.')
@@ -197,6 +198,14 @@ if device is not kernel:  # We can process this stuff only with a real device.
         device.spooler.jobs(ops)
         device.setting(bool, 'quit', True)
         device.quit = True
+
+    if args.origin:
+        def origin():
+            yield COMMAND_WAIT_FINISH
+            yield COMMAND_MODE_RAPID
+            yield COMMAND_SET_ABSOLUTE
+            yield COMMAND_MOVE, 0, 0
+        device.spooler.job(origin)
 
 if args.mock:
     # Set the device to mock.

--- a/OperationPreprocessor.py
+++ b/OperationPreprocessor.py
@@ -194,7 +194,6 @@ class OperationPreprocessor:
         image_element.cache = None
         matrix = image_element.transform
         bbox = OperationPreprocessor.bounding_box([image_element])
-        print(bbox)
         element_width = int(ceil(bbox[2] - bbox[0]))
         element_height = int(ceil(bbox[3] - bbox[1]))
         if step_level is None:
@@ -221,7 +220,6 @@ class OperationPreprocessor:
         matrix.reset()
 
         box = pil_image.getbbox()
-        print(box)
         width = box[2] - box[0]
         height = box[3] - box[1]
         if width != element_width and height != element_height:

--- a/PathProperty.py
+++ b/PathProperty.py
@@ -52,7 +52,11 @@ class PathProperty(wx.Frame, Module):
 
         self.__set_properties()
         self.__do_layout()
-
+        try:
+            if element.id is not None:
+                self.text_name.SetValue(str(element.id))
+        except AttributeError:
+            pass
         self.Bind(wx.EVT_TEXT, self.on_text_name_change, self.text_name)
         self.Bind(wx.EVT_TEXT_ENTER, self.on_text_name_change, self.text_name)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_none)
@@ -183,7 +187,8 @@ class PathProperty(wx.Frame, Module):
 
     def on_text_name_change(self, event):  # wxGlade: ElementProperty.<event_handler>
         try:
-            self.path_element.name = self.text_name.GetValue()
+            self.path_element.id = self.text_name.GetValue()
+            self.path_element.values[SVG_ATTR_ID] = self.path_element.id
             self.device.signal('element_property_update', self.path_element)
         except AttributeError:
             pass

--- a/RasterScripts.py
+++ b/RasterScripts.py
@@ -409,7 +409,7 @@ class RasterScripts:
                                 pass
                             m = [r, g, b, 1.0]
                             if image.mode != "L":
-                                if image.mode == "P":
+                                if image.mode == "P" or image.mode == '1':
                                     image = image.convert('RGBA')
                                 if op['invert']:
                                     color = 0, 0, 0

--- a/RasterScripts.py
+++ b/RasterScripts.py
@@ -322,7 +322,6 @@ class RasterScripts:
         height = box[3] - box[1]
         if width != element_width and height != element_height:
             image = image.crop(box)
-            box = image.getbbox()
             matrix.post_translate(box[0], box[1])
         # step level requires the new actualized matrix be scaled up.
         matrix.post_scale(step_level, step_level)

--- a/Settings.py
+++ b/Settings.py
@@ -16,27 +16,28 @@ _ = wx.GetTranslation
 
 class Settings(wx.Frame, Module):
     def __init__(self, parent, *args, **kwds):
-        # begin wxGlade: Preferences.__init__
+        # begin wxGlade: Settings.__init__
         wx.Frame.__init__(self, parent, -1, "",
                           style=wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT | wx.TAB_TRAVERSAL)
         Module.__init__(self)
-        self.SetSize((412, 183))
-
-        self.checklist_options = wx.CheckListBox(self, wx.ID_ANY,
-                                                 choices=[
-                                                     _("Invert Mouse Wheel Zoom"),
-                                                     _("Print Shutdown"),
-                                                     _("SVG Uniform Save"),
-                                                     _("Image DPI Scaling"),
-                                                     _("Show Negative Guide"),
-                                                     _("Launch Spooler JobStart"),
-                                                 ])
-
-        self.radio_units = wx.RadioBox(self, wx.ID_ANY, _("Units"),
-                                       choices=[_("mm"), _("cm"), _("inch"), _("mils")],
-                                       majorDimension=1,
+        self.SetSize((455, 183))
+        self.radio_units = wx.RadioBox(self, wx.ID_ANY, _("Units"), choices=["mm", "cm", "inch", "mils"], majorDimension=1,
                                        style=wx.RA_SPECIFY_ROWS)
-
+        self.combo_language = wx.ComboBox(self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN)
+        self.combo_svg_ppi = wx.ComboBox(self, wx.ID_ANY,
+                                         choices=[_("96 px/in Inkscape"),
+                                                  _("72 px/in Illustrator"),
+                                                  _("90 px/in Old Inkscape"),
+                                                  _("Custom")], style=wx.CB_DROPDOWN)
+        # self.text_svg_ppi = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_svg_ppi = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.checklist_options = wx.CheckListBox(self, wx.ID_ANY, choices=[_("Invert Mouse Wheel Zoom"),
+                                                                           _("Print Shutdown"),
+                                                                           _("SVG Uniform Save"),
+                                                                           _("Image DPI Scaling"),
+                                                                           _("Show Negative Guide"),
+                                                                           _("Launch Spooler JobStart")
+                                                                           ])
         from wxMeerK40t import supported_languages
         choices = [language_name for language_code, language_name, language_index in supported_languages]
         self.combo_language = wx.ComboBox(self, wx.ID_ANY, choices=choices, style=wx.CB_DROPDOWN)
@@ -46,7 +47,11 @@ class Settings(wx.Frame, Module):
 
         self.Bind(wx.EVT_RADIOBOX, self.on_radio_units, self.radio_units)
         self.Bind(wx.EVT_COMBOBOX, self.on_combo_language, self.combo_language)
+        self.Bind(wx.EVT_COMBOBOX, self.on_combo_svg_ppi, self.combo_svg_ppi)
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_svg_ppi, self.text_svg_ppi)
+        self.Bind(wx.EVT_TEXT, self.on_text_svg_ppi, self.text_svg_ppi)
         self.Bind(wx.EVT_CHECKLISTBOX, self.on_checklist_settings, self.checklist_options)
+
         # end wxGlade
         self.Bind(wx.EVT_CLOSE, self.on_close, self)
 
@@ -61,6 +66,9 @@ class Settings(wx.Frame, Module):
     def initialize(self, channel=None):
         self.device.close('window', self.name)
         self.Show()
+
+        self.device.device_root.setting(float, 'svg_ppi', 96.0)
+        self.text_svg_ppi.SetValue(str(self.device.device_root.svg_ppi))
 
         self.device.setting(bool, "mouse_zoom_invert", False)
         self.device.setting(bool, "print_shutdown", False)
@@ -94,7 +102,7 @@ class Settings(wx.Frame, Module):
         except RuntimeError:
             pass
 
-    def shutdown(self,  channel=None):
+    def shutdown(self, channel=None):
         try:
             self.Close()
         except RuntimeError:
@@ -110,23 +118,64 @@ class Settings(wx.Frame, Module):
         self.radio_units.SetToolTip(_("Set default units for guides"))
         self.radio_units.SetSelection(0)
         self.combo_language.SetToolTip(_("Select the desired language to use."))
+        self.combo_svg_ppi.SetToolTip(_("Select the Pixels Per Inch to use when loading an SVG file"))
+        self.text_svg_ppi.SetMinSize((60, 23))
+        self.text_svg_ppi.SetToolTip(_("Custom Pixels Per Inch to use when loading an SVG file"))
         # end wxGlade
 
     def __do_layout(self):
         # begin wxGlade: Settings.__do_layout
-        sizer_1 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer_6 = wx.BoxSizer(wx.VERTICAL)
-        sizer_5 = wx.BoxSizer(wx.VERTICAL)
+        sizer_settings = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_gui_options = wx.BoxSizer(wx.VERTICAL)
+        sizer_3 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("SVG Pixel Per Inch")), wx.HORIZONTAL)
         sizer_2 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Language")), wx.HORIZONTAL)
-        sizer_5.Add(self.radio_units, 0, wx.EXPAND, 0)
+        sizer_gui_options.Add(self.radio_units, 0, wx.EXPAND, 0)
         sizer_2.Add(self.combo_language, 0, 0, 0)
-        sizer_5.Add(sizer_2, 0, wx.EXPAND, 0)
-        sizer_1.Add(sizer_5, 1, wx.EXPAND, 0)
-        sizer_6.Add(self.checklist_options, 1, wx.EXPAND, 0)
-        sizer_1.Add(sizer_6, 1, wx.EXPAND, 0)
-        self.SetSizer(sizer_1)
+        sizer_gui_options.Add(sizer_2, 0, wx.EXPAND, 0)
+        sizer_3.Add(self.combo_svg_ppi, 0, 0, 0)
+        sizer_3.Add((20, 20), 0, 0, 0)
+        sizer_3.Add(self.text_svg_ppi, 1, 0, 0)
+        sizer_gui_options.Add(sizer_3, 0, wx.EXPAND, 0)
+        sizer_settings.Add(sizer_gui_options, 0, wx.EXPAND, 0)
+        sizer_settings.Add(self.checklist_options, 1, wx.EXPAND, 0)
+        self.SetSizer(sizer_settings)
         self.Layout()
         # end wxGlade
+
+    def on_combo_svg_ppi(self, event):  # wxGlade: Settings.<event_handler>
+        ppi = self.combo_svg_ppi.GetSelection()
+        if ppi == 0:
+            self.device.device_root.setting(float, 'svg_ppi', 96.0)
+            self.device.device_root.svg_ppi = 96.0
+        elif ppi == 1:
+            self.device.device_root.setting(float, 'svg_ppi', 72.0)
+            self.device.device_root.svg_ppi = 72.0
+        elif ppi == 2:
+            self.device.device_root.setting(float, 'svg_ppi', 90.0)
+            self.device.device_root.svg_ppi = 90.0
+        else:
+            self.device.device_root.setting(float, 'svg_ppi', 96.0)
+            self.device.device_root.svg_ppi = 96.0
+        self.text_svg_ppi.SetValue(str(self.device.device_root.svg_ppi))
+
+    def on_text_svg_ppi(self, event):  # wxGlade: Settings.<event_handler>
+        try:
+            svg_ppi = float(self.text_svg_ppi.GetValue())
+        except ValueError:
+            return
+        if svg_ppi == 96:
+            if self.combo_svg_ppi.GetSelection() != 0:
+                self.combo_svg_ppi.SetSelection(0)
+        elif svg_ppi == 72:
+            if self.combo_svg_ppi.GetSelection() != 1:
+                self.combo_svg_ppi.SetSelection(1)
+        elif svg_ppi == 90:
+            if self.combo_svg_ppi.GetSelection() != 2:
+                self.combo_svg_ppi.SetSelection(2)
+        else:
+            if self.combo_svg_ppi.GetSelection() != 3:
+                self.combo_svg_ppi.SetSelection(3)
+        self.device.device_root.svg_ppi = svg_ppi
 
     def on_checklist_settings(self, event):  # wxGlade: Settings.<event_handler>
         self.device.mouse_zoom_invert = self.checklist_options.IsChecked(0)

--- a/svgelements.py
+++ b/svgelements.py
@@ -2715,6 +2715,11 @@ class Transformable(SVGElement):
         The default method will be called by submethods but will only scale properties like stroke_width which should
         scale with the transform.
         """
+        if SVG_ATTR_STROKE_WIDTH in self.values:
+            width = Length(self.values[SVG_ATTR_STROKE_WIDTH]).value()
+            t = self.transform
+            det = t.a * t.d - t.c * t.b
+            self.values[SVG_ATTR_STROKE_WIDTH] = width * sqrt(abs(det))
         return self
 
     def render(self, **kwargs):
@@ -6969,5 +6974,6 @@ class SVG(Group):
                             styles[selector.strip()] = value
                 context, values = stack.pop()
             elif event == 'start-ns':
-                values[elem[0]] = elem[1]
+                if elem[0] != SVG_ATTR_DATA:
+                    values[elem[0]] = elem[1]
         return root

--- a/svgelements.py
+++ b/svgelements.py
@@ -5408,6 +5408,8 @@ class _RoundShape(Shape):
         path = Path()
         steps = 4
         step_size = tau / steps
+        if transformed and self.transform.value_scale_x() * self.transform.value_scale_y() < 0:
+            step_size = -step_size
         t_start = 0
         t_end = step_size
         path.move((self.point_at_t(0)))
@@ -5430,8 +5432,8 @@ class _RoundShape(Shape):
         Skewed and Rotated roundshapes cannot be reified.
         """
         Transformable.reify(self)
-        scale_x = self.transform.value_scale_x()
-        scale_y = self.transform.value_scale_y()
+        scale_x = abs(self.transform.value_scale_x())
+        scale_y = abs(self.transform.value_scale_y())
         translate_x = self.transform.value_trans_x()
         translate_y = self.transform.value_trans_y()
         if self.transform.value_skew_x() == 0 and self.transform.value_skew_y() == 0 \

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -2991,7 +2991,7 @@ def handleGUIException(exc_type, exc_value, exc_traceback):
         print(_("Saving Log: %s") % filename)
         with open(filename, "w") as file:
             # Crash logs are not translated.
-            file.write("MeerK40t crash log. Version: %s\n" % '0.6.5')
+            file.write("MeerK40t crash log. Version: %s\n" % '0.6.6')
             file.write("Please report to: %s\n\n" % MEERK40T_ISSUES)
             file.write(err_msg)
             print(file)

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -1592,7 +1592,13 @@ class Node(list):
         self.root = root
         self.object = data_object
         if name is None:
-            self.name = str(data_object)
+            self.name = None
+            try:
+                self.name = data_object.id
+            except AttributeError:
+                pass
+            if self.name is None:
+                self.name = str(data_object)
         else:
             self.name = name
         self.type = node_type

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -918,16 +918,23 @@ class MeerK40t(wx.Frame, Module):
     def load(self, pathname):
         self.device.setting(bool, 'auto_note', True)
         self.device.device_root.setting(bool, 'uniform_svg', False)
+        self.device.device_root.setting(float, 'svg_ppi', 96.0)
         with wx.BusyInfo(_("Loading File...")):
             n = self.device.device_root.elements.note
-            results = self.device.load(pathname, channel=self.device.channel_open('load'))
+            is_svg = pathname.lower().endswith('svg')
+            if is_svg:
+                results = self.device.load(pathname,
+                                           channel=self.device.channel_open('load'),
+                                           svg_ppi=self.device.device_root.svg_ppi)
+            else:
+                results = self.device.load(pathname, channel=self.device.channel_open('load'))
             if results is not None:
                 elements, pathname, basename = results
                 self.save_recent(pathname)
                 self.device.classify(elements)
                 if n != self.device.device_root.elements.note and self.device.auto_note:
                     self.device.open('window', "Notes", self)
-                if (self.device.device_root.uniform_svg and pathname.lower().endswith('svg')) or \
+                if (self.device.device_root.uniform_svg and is_svg) or \
                         (len(elements) > 0 and 'meerK40t' in elements[0].values):
                     self.working_file = pathname
                 return True

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -1591,17 +1591,15 @@ class Node(list):
         self.parent = parent
         self.root = root
         self.object = data_object
-        if name is None:
-            self.name = None
-            try:
-                self.name = data_object.id
-            except AttributeError:
-                pass
-            if self.name is None:
-                self.name = str(data_object)
-        else:
-            self.name = name
         self.type = node_type
+        self.name = name
+        if self.name is None:
+            try:
+                self.name = self.object.id
+                if self.name is None:
+                    self.name = str(self.object)
+            except AttributeError:
+                self.name = str(self.object)
         parent.append(self)
         self.filepath = None
         try:
@@ -1640,9 +1638,13 @@ class Node(list):
         return "Node(%d, %s, %s, %s)" % (self.type, str(self.object), str(self.parent), str(self.root))
 
     def update_name(self):
-        self.name = str(self.object)
-        if len(self.name) >= 27:
-            self.name = self.name[:28] + '...'
+        self.name = None
+        try:
+            self.name = self.object.id
+        except AttributeError:
+            pass
+        if self.name is None:
+            self.name = str(self.object)
         self.root.tree.SetItemText(self.item, self.name)
         try:
             stroke = self.object.values[SVG_ATTR_STROKE]


### PR DESCRIPTION
- [x] CLI -H command added for home.
- [x] CLI -s changed key=value
- [x] CLI -O command origin return after.
- [x] CLI -p is fixed. -p takes in an SVG path. so -p M1000,1000v1000h1000v-1000h-1000 should work to draw a 1in 1in rectangle at 1in 1in. The paths are native so 1000 = 1in.
- [x] Correct Actualization Crash. 0.6.5 introduced.
- [x] Add svg_ppi to kernel for loading svgs.
- [x] Correct other actualization routines with the 0.6.5 bounds correction.
- [x] Correct meerk40t/svgelements#50 circle decomposition if h or v mirrored.
- [x] Paths renamed to be Path_1 Path_2, etc. The path names are mostly pointless, even I can't read them. 
- [x] Corrected a right click actualization crash.
- [x] Stroke Width scale correction. Reifies as the abs(sqrt(det)) of the matrix.
- [x] Sped up image threshold.
- [x] Allow crop to accept length values.
- [x] Changed some raster classification stuff.
- [x] Added `image path` command.