### PR TITLE
0.6.7 Minor Development

### DIFF
--- a/Kernel.py
+++ b/Kernel.py
@@ -2392,7 +2392,7 @@ class Kernel(Device):
         Device.__init__(self, self, 0)
         # Current Project.
         self.device_name = "MeerK40t"
-        self.device_version = "0.6.6"
+        self.device_version = "0.6.7"
         self.device_root = self
 
         # Persistent storage if it exists.

--- a/Kernel.py
+++ b/Kernel.py
@@ -1273,25 +1273,27 @@ class Elemental(Module):
         if elements is None:
             return
         for element in elements:
-            found_color = False
+            was_classified = False
             image_added = False
             for op in self.ops():
                 if op.operation == "Raster":
+                    if image_added:
+                        continue  # already added to an image operation, is not added her.
                     if op.color == element.stroke:
                         op.append(element)
-                    elif not image_added and isinstance(element, SVGImage):
+                    elif isinstance(element, SVGImage):
                         op.append(element)
                     elif element.fill is not None and element.fill.value is not None:
                         op.append(element)
-                    found_color = True
+                    was_classified = True
                 elif op.operation in ("Engrave", "Cut") and op.color == element.stroke:
                     op.append(element)
-                    found_color = True
+                    was_classified = True
                 elif op.operation == 'Image' and isinstance(element, SVGImage):
                     op.append(element)
-                    found_color = True
+                    was_classified = True
                     image_added = True
-            if not found_color:
+            if not was_classified:
                 if element.stroke is not None and element.stroke.value is not None:
                     op = LaserOperation(operation="Engrave", color=element.stroke, speed=35.0)
                     op.append(element)

--- a/LhystudiosDevice.py
+++ b/LhystudiosDevice.py
@@ -1139,14 +1139,18 @@ class LhystudioController(Module, Pipe):
         self.device.signal('pipe;thread', self.state)
 
     def stop(self):
-        self.quit()
-        self._thread.join()  # Wait until stop completes before continuing.
+        if self._thread is not None and self._thread.is_alive():
+            self.quit()
+            self._thread.join()  # Wait until stop completes before continuing.
 
     def quit(self):
         """
         Writes the quit control to the buffer.
+
+        If the thread is alive.
         """
-        self.write(b'\x18\n')
+        if self._thread is not None and self._thread.is_alive():
+            self.write(b'\x18\n')
 
     def update_usb_state(self, code):
         """

--- a/Settings.py
+++ b/Settings.py
@@ -23,7 +23,6 @@ class Settings(wx.Frame, Module):
         self.SetSize((455, 183))
         self.radio_units = wx.RadioBox(self, wx.ID_ANY, _("Units"), choices=["mm", "cm", "inch", "mils"], majorDimension=1,
                                        style=wx.RA_SPECIFY_ROWS)
-        self.combo_language = wx.ComboBox(self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN)
         self.combo_svg_ppi = wx.ComboBox(self, wx.ID_ANY,
                                          choices=[_("96 px/in Inkscape"),
                                                   _("72 px/in Illustrator"),

--- a/svgelements.py
+++ b/svgelements.py
@@ -6810,13 +6810,14 @@ class SVG(Group):
         metadata elements are not processed.
         foreignObject elements are not processed.
 
-        use elements are not processed.
+        Color refers to the value of the current color from the default context. This could be set with some external
+        values that the parsing of the SVG would be unaware. This is the color for the 'currentColor' value.
         """
         root = context
         styles = {}
         stack = []
-        values = {SVG_ATTR_COLOR: color, SVG_ATTR_FILL: color,
-                  SVG_ATTR_STROKE: color}
+        values = {SVG_ATTR_COLOR: color, SVG_ATTR_FILL: "black",
+                  SVG_ATTR_STROKE: "none"}
         if transform is not None:
             values[SVG_ATTR_TRANSFORM] = transform
         for event, elem in SVG.svg_structure_parse(source):

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -2977,8 +2977,7 @@ class wxMeerK40t(wx.App, Module):
         try:
             language_code, language_name, language_index = supported_languages[lang]
         except (IndexError, ValueError):
-            language_code, language_name, language_index = supported_languages[0]
-            lang = 0  # Language is corrupted. Do not fail launch.
+            return
         device.language = lang
 
         if self.locale:

--- a/wxMeerK40t.py
+++ b/wxMeerK40t.py
@@ -2974,7 +2974,11 @@ class wxMeerK40t(wx.App, Module):
         Update language to the requested language.
         """
         device = self.device
-        language_code, language_name, language_index = supported_languages[lang]
+        try:
+            language_code, language_name, language_index = supported_languages[lang]
+        except (IndexError, ValueError):
+            language_code, language_name, language_index = supported_languages[0]
+            lang = 0  # Language is corrupted. Do not fail launch.
         device.language = lang
 
         if self.locale:
@@ -3006,7 +3010,7 @@ def handleGUIException(exc_type, exc_value, exc_traceback):
         print(_("Saving Log: %s") % filename)
         with open(filename, "w") as file:
             # Crash logs are not translated.
-            file.write("MeerK40t crash log. Version: %s\n" % '0.6.6')
+            file.write("MeerK40t crash log. Version: %s\n" % '0.6.7')
             file.write("Please report to: %s\n\n" % MEERK40T_ISSUES)
             file.write(err_msg)
             print(file)


### PR DESCRIPTION
- [x] Corrects a launch error for MeerK40t if the language settings are corrupted.
- [x] Correct Initial SVG Color Values
- [x] Correct Classification (again). The SVG values were wrong to try to fix classification, this is corrected differently.
- [x] Avoid starting the controller thread just to shut it down. If it's not started, don't start it just to kill it.


With regard to #233 the correct initial values are stroke `none`, fill `black`, and color=`black` which only defines the `currentColor` value which would have to be expressed within the file. This is corrected within svgelements.