### PR TITLE
Make xml link to meerk40t svg namespace immutable.

### DIFF
--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -25,7 +25,7 @@ class SVGWriter:
         root.set(SVG_ATTR_XMLNS, SVG_VALUE_XMLNS)
         root.set(SVG_ATTR_XMLNS_LINK, SVG_VALUE_XLINK)
         root.set(SVG_ATTR_XMLNS_EV, SVG_VALUE_XMLNS_EV)
-        root.set("xmlns:meerK40t", "https://github.com/meerk40t/meerk40t/wiki/Namespace")
+        root.set("xmlns:meerK40t", "https://raw.githubusercontent.com/meerk40t/meerk40t/master/svg-namespace")
         # Native unit is mils, these must convert to mm and to px
         mils_per_mm = 39.3701
         mils_per_px = 1000.0 / 96.0

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -25,7 +25,7 @@ class SVGWriter:
         root.set(SVG_ATTR_XMLNS, SVG_VALUE_XMLNS)
         root.set(SVG_ATTR_XMLNS_LINK, SVG_VALUE_XLINK)
         root.set(SVG_ATTR_XMLNS_EV, SVG_VALUE_XMLNS_EV)
-        root.set("xmlns:meerK40t", "https://raw.githubusercontent.com/meerk40t/meerk40t/master/svg-namespace.html")
+        root.set("xmlns:meerK40t", "https://htmlpreview.github.io/?https://github.com/meerk40t/meerk40t/blob/patch-2/svg-namespace.html")
         # Native unit is mils, these must convert to mm and to px
         mils_per_mm = 39.3701
         mils_per_px = 1000.0 / 96.0

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -25,7 +25,7 @@ class SVGWriter:
         root.set(SVG_ATTR_XMLNS, SVG_VALUE_XMLNS)
         root.set(SVG_ATTR_XMLNS_LINK, SVG_VALUE_XLINK)
         root.set(SVG_ATTR_XMLNS_EV, SVG_VALUE_XMLNS_EV)
-        root.set("xmlns:meerK40t", "https://raw.githubusercontent.com/meerk40t/meerk40t/master/svg-namespace")
+        root.set("xmlns:meerK40t", "https://raw.githubusercontent.com/meerk40t/meerk40t/master/svg-namespace.html")
         # Native unit is mils, these must convert to mm and to px
         mils_per_mm = 39.3701
         mils_per_px = 1000.0 / 96.0

--- a/DefaultModules.py
+++ b/DefaultModules.py
@@ -25,7 +25,7 @@ class SVGWriter:
         root.set(SVG_ATTR_XMLNS, SVG_VALUE_XMLNS)
         root.set(SVG_ATTR_XMLNS_LINK, SVG_VALUE_XLINK)
         root.set(SVG_ATTR_XMLNS_EV, SVG_VALUE_XMLNS_EV)
-        root.set("xmlns:meerK40t", "https://htmlpreview.github.io/?https://github.com/meerk40t/meerk40t/blob/patch-2/svg-namespace.html")
+        root.set("xmlns:meerK40t", "https://htmlpreview.github.io/?https://github.com/meerk40t/meerk40t/blob/master/svg-namespace.html")
         # Native unit is mils, these must convert to mm and to px
         mils_per_mm = 39.3701
         mils_per_px = 1000.0 / 96.0

--- a/svg-namespace.html
+++ b/svg-namespace.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<meta http-equiv="refresh" content="1;url=https://github.com/meerk40t/meerk40t/wiki/Tech:-SVG-Namespace" />
+<title>Redirecting to Wiki</title>
+</head>
+<body>
+The MeerK40t SVG Namespace description can be found <a href="https://github.com/meerk40t/meerk40t/wiki/Tech:-SVG-Namespace">here</a>.
+</body>
+</html>


### PR DESCRIPTION
Wiki pages URLs are subject to change by anyone (like me 😄 this evening) and should not be linked to in this way.

We need an immutable URL which contains sufficient HTML to give a brief description and a link to the actual Wiki page.
