### PR TITLE
#459 Fix incorrect error types loading drivers

### DIFF
--- a/meerk40t/device/ch341/libusb.py
+++ b/meerk40t/device/ch341/libusb.py
@@ -114,7 +114,7 @@ class Handler(CH341Handler):
                     )
                 )
                 connection.close()
-                raise ConnectionRefusedError("Chip Version Wrong.")
+                raise ImportError("Chip Version Wrong.")
         if bus != -1:
             match_bus = connection.bus
             if bus != match_bus:
@@ -123,7 +123,7 @@ class Handler(CH341Handler):
                     _("K40 devices were found but they were rejected due to usb bus.")
                 )
                 connection.close()
-                raise ConnectionRefusedError("USB Bus Wrong.")
+                raise ImportError("USB Bus Wrong.")
         if address != -1:
             match_address = connection.address
             if address != match_address:
@@ -134,5 +134,5 @@ class Handler(CH341Handler):
                     )
                 )
                 connection.close()
-                raise ConnectionRefusedError("USB Address Wrong.")
+                raise ImportError("USB Address Wrong.")
         return connection

--- a/meerk40t/device/ch341/windll.py
+++ b/meerk40t/device/ch341/windll.py
@@ -1,4 +1,5 @@
 from ctypes import c_byte, windll
+from math import e
 
 from .ch341 import Connection as CH341Connection
 from .ch341 import Handler as CH341Handler
@@ -151,7 +152,7 @@ class Handler(CH341Handler):
             self.driver = windll.LoadLibrary("CH341DLL.dll")
         except (NameError, OSError, FileNotFoundError) as e:
             self.channel(str(e))
-            raise ConnectionRefusedError
+            raise ImportError
 
     def connect(self, driver_index=0, chipv=-1, bus=-1, address=-1):
         """Tries to open device at index, with given criteria"""


### PR DESCRIPTION
ch341.py expects drivers to raise ImportError when a failure occurs during initialization, and ConnectionRefusedError when the failure occurs during connection.

libusb.py and windll.py both are throwing ConnectionRefusedError during the initialization phase. A failure to load the driver during this phase will not be caught by the calling code and will result in a failure to fall back to any alternate driver present.