### PR TITLE
Prefer forward paths to backward paths in greedy

### DIFF
--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -1165,7 +1165,7 @@ def short_travel_cutcode(context: CutCode):
             s = cut.start()
             s = complex(s[0], s[1])
             d = abs(s - curr)
-            if d < distance:
+            if d <= distance:
                 distance = d
                 backwards = False
                 closest = cut


### PR DESCRIPTION
Amazingly, one character should do it (for perfect matches).

So for closed paths (which are the primary issue I see with this) where path segments are exactly the same points, this should make these always forwards.