### PR TITLE
Spooler time

### DIFF
--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -138,6 +138,7 @@ class Driver:
         # We have a spooled item to process.
         if self.command(self.spooled_item):
             self.spooled_item = None
+            self.spooler.pop()
             return
 
         # We are dealing with an iterator/generator
@@ -148,6 +149,7 @@ class Driver:
         except StopIteration:
             # The spooled item is finished.
             self.spooled_item = None
+            self.spooler.pop()
 
     def plotplanner_process(self):
         """
@@ -170,7 +172,7 @@ class Driver:
         if element is None:
             return  # Spooler is empty.
 
-        self.spooler.pop()
+        # self.spooler.pop()
         if isinstance(element, int):
             self.spooled_item = (element,)
         elif isinstance(element, tuple):

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -43,6 +43,9 @@ class Spooler:
         self._queue = None
         self.next = None
 
+    def __len__(self):
+        return len(self._queue)
+
     def as_device(self):
         links = []
         obj = self
@@ -65,6 +68,7 @@ class Spooler:
 
     def pop(self):
         if len(self._queue) == 0:
+            self.context.signal("spooler;queue", len(self._queue), self.name)
             return None
         self.queue_lock.acquire(True)
         queue_head = self._queue[0]

--- a/meerk40t/device/moshi/moshidevice.py
+++ b/meerk40t/device/moshi/moshidevice.py
@@ -462,6 +462,11 @@ class MoshiDriver(Driver, Modifier):
         root_context.setting(int, "opt_jog_mode", 0)
         root_context.setting(int, "opt_jog_minimum", 256)
 
+        context.setting(int, "usb_index", -1)
+        context.setting(int, "usb_bus", -1)
+        context.setting(int, "usb_address", -1)
+        context.setting(int, "usb_version", -1)
+
     def __repr__(self):
         return "MoshiDriver(%s)" % self.name
 
@@ -1157,7 +1162,7 @@ class MoshiController(Module):
                     if self.refuse_counts >= self.max_attempts:
                         # We were refused too many times, kill the thread.
                         self.update_state(STATE_TERMINATE)
-                        self.context.signal("pipe;error", self.refuse_counts)
+                        self.context.signal("pipe;failing", self.refuse_counts)
                         break
                     continue
                 except ConnectionError:

--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -16,6 +16,7 @@ STATE_ACTIVE = 2
 STATE_BUSY = 3
 STATE_PAUSE = 4
 STATE_END = 5
+STATE_SUSPEND = 6  # Controller is suspended.
 STATE_WAIT = 7  # Controller is waiting for something. This could be aborted.
 STATE_TERMINATE = 10
 


### PR DESCRIPTION
Keeps the current spooler item in the spooler until it is finished.
Adds in `channel: spooler` to log time between spooled objects.