### PR TITLE
Operation Commands

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1671,7 +1671,6 @@ class Elemental(Modifier):
             return "ops", subops
 
 
-
         @context.console_command(
             "list",
             help=_("Show information about the chained data"),
@@ -2067,6 +2066,26 @@ class Elemental(Modifier):
                     channel("%d: %s" % (i, name))
             channel("----------")
             return "elements", data
+
+
+        @context.console_argument("start", type=int, help=_("elements start"))
+        @context.console_argument("end", type=int, help=_("elements end"))
+        @context.console_argument("step", type=int, help=_("elements step"))
+        @context.console_command(
+            "range",
+            help=_("Toggle selection by begin, end and step"),
+            input_type="elements",
+            output_type="elements",
+        )
+        def element_select_range(data=None, start=None, end=None, step=1, **kwgs):
+            subelem = list()
+            for e in range(start, end, step):
+                try:
+                    subelem.append(data[e])
+                except IndexError:
+                    pass
+            self.set_emphasis(subelem)
+            return "elements", subelem
 
         @context.console_command(
             "merge",

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1798,6 +1798,42 @@ class Elemental(Modifier):
                 self.context.signal("refresh_scene")
             return
 
+        @context.console_argument("speed", type=float, help=_("operation speed in mm/s"))
+        @context.console_command(
+            "speed", help=_("speed <speed>"), input_type="ops", output_type="ops"
+        )
+        def op_speed(command, channel, _, speed=None, data=None, **kwrgs):
+            if speed is None:
+                for op in data:
+                    old_speed = op.settings.speed
+                    channel(_("Speed for '%s' is currently: %f") % (str(op), old_speed))
+                return
+            for op in data:
+                old_speed = op.settings.speed
+                op.settings.speed = speed
+                channel(_("Speed for '%s' updated %f -> %f") % (str(op), old_speed, speed))
+                op.modified()
+                self.context.signal("element_property_reload", op)
+            return "ops", data
+
+        @context.console_argument("ppi", type=float, help=_("ppi in pulses per inch mm/s"))
+        @context.console_command(
+            "ppi", help=_("ppi <ppi>"), input_type="ops", output_type="ops"
+        )
+        def op_ppi(command, channel, _, ppi=None, data=None, **kwrgs):
+            if ppi is None:
+                for op in data:
+                    old_ppi = op.settings.ppi
+                    channel(_("PPI for '%s' is currently: %d") % (str(op), old_ppi))
+                return
+            for op in data:
+                old_ppi = op.settings.ppi
+                op.settings.ppi = ppi
+                channel(_("PPI for '%s' updated %s -> %s") % (str(op), old_ppi, ppi))
+                op.modified()
+                self.context.signal("element_property_reload", op)
+            return "ops", data
+
         # ==========
         # ELEMENT/OPERATION SUBCOMMANDS
         # ==========

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1844,6 +1844,45 @@ class Elemental(Modifier):
                 op.notify_update()
             return "ops", data
 
+        @context.console_argument("passes", type=int, help=_("Set operation passes"))
+        @context.console_command(
+            "passes", help=_("passes <passes>"), input_type="ops", output_type="ops"
+        )
+        def op_ppi(command, channel, _, passes=None, data=None, **kwrgs):
+            if passes is None:
+                for op in data:
+                    old_passes = op.settings.passes
+                    channel(_("Passes for '%s' is currently: %d") % (str(op), old_passes))
+                return
+            for op in data:
+                old_passes = op.settings.passes
+                op.settings.passes = passes
+                if passes >= 1:
+                    op.settings.passes_custom = True
+                channel(_("Passes for '%s' updated %d -> %d") % (str(op), old_passes, passes))
+                op.notify_update()
+            return "ops", data
+
+        @context.console_command(
+            "disable", help=_("disable the given operations"), input_type="ops", output_type="ops"
+        )
+        def op_disable(command, channel, _, data=None, **kwrgs):
+            for op in data:
+                op.settings.output = False
+                channel(_("Operation '%s' disabled.") % str(op))
+                op.notify_update()
+            return "ops", data
+
+        @context.console_command(
+            "enable", help=_("enable the given operations"), input_type="ops", output_type="ops"
+        )
+        def op_enable(command, channel, _, data=None, **kwrgs):
+            for op in data:
+                op.settings.output = True
+                channel(_("Operation '%s' enabled.") % str(op))
+                op.notify_update()
+            return "ops", data
+
         # ==========
         # ELEMENT/OPERATION SUBCOMMANDS
         # ==========

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1814,20 +1814,20 @@ class Elemental(Modifier):
                 op.notify_update()
             return "ops", data
 
-        @context.console_argument("ppi", type=int, help=_("ppi in pulses per inch mm/s"))
+        @context.console_argument("power", type=int, help=_("power in pulses per inch (ppi, 1000=max)"))
         @context.console_command(
-            "ppi", help=_("ppi <ppi>"), input_type="ops", output_type="ops"
+            "power", help=_("power <ppi>"), input_type="ops", output_type="ops"
         )
-        def op_ppi(command, channel, _, ppi=None, data=None, **kwrgs):
+        def op_power(command, channel, _, ppi=None, data=None, **kwrgs):
             if ppi is None:
                 for op in data:
-                    old_ppi = op.settings.ppi
-                    channel(_("PPI for '%s' is currently: %d") % (str(op), old_ppi))
+                    old_ppi = op.settings.power
+                    channel(_("Power for '%s' is currently: %d") % (str(op), old_ppi))
                 return
             for op in data:
-                old_ppi = op.settings.ppi
-                op.settings.ppi = ppi
-                channel(_("PPI for '%s' updated %d -> %d") % (str(op), old_ppi, ppi))
+                old_ppi = op.settings.power
+                op.settings.power = ppi
+                channel(_("Power for '%s' updated %d -> %d") % (str(op), old_ppi, ppi))
                 op.notify_update()
             return "ops", data
 

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1818,16 +1818,16 @@ class Elemental(Modifier):
         @context.console_command(
             "power", help=_("power <ppi>"), input_type="ops", output_type="ops"
         )
-        def op_power(command, channel, _, ppi=None, data=None, **kwrgs):
-            if ppi is None:
+        def op_power(command, channel, _, power=None, data=None, **kwrgs):
+            if power is None:
                 for op in data:
                     old_ppi = op.settings.power
                     channel(_("Power for '%s' is currently: %d") % (str(op), old_ppi))
                 return
             for op in data:
                 old_ppi = op.settings.power
-                op.settings.power = ppi
-                channel(_("Power for '%s' updated %d -> %d") % (str(op), old_ppi, ppi))
+                op.settings.power = power
+                channel(_("Power for '%s' updated %d -> %d") % (str(op), old_ppi, power))
                 op.notify_update()
             return "ops", data
 

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1651,6 +1651,27 @@ class Elemental(Modifier):
             self.set_emphasis(ops)
             return "ops", ops
 
+        @context.console_argument("start", type=int, help=_("operation start"))
+        @context.console_argument("end", type=int, help=_("operation end"))
+        @context.console_argument("step", type=int, help=_("operation step"))
+        @context.console_command(
+            "range",
+            help=_("Toggle selection by begin, end and step"),
+            input_type="ops",
+            output_type="ops",
+        )
+        def operation_select_range(data=None, start=None, end=None, step=1, **kwgs):
+            subops = list()
+            for e in range(start, end, step):
+                try:
+                    subops.append(data[e])
+                except IndexError:
+                    pass
+            self.set_emphasis(subops)
+            return "ops", subops
+
+
+
         @context.console_command(
             "list",
             help=_("Show information about the chained data"),


### PR DESCRIPTION
Adds several operation commands for mass renaming. Also allows a range command.

```
operation* range 0 50 10 power 100
operation* range 1 50 10 power 200
operation* range 2 50 10 power 300
operation* range 3 50 10 power 400
...
operation* range 0 10 1 speed 8
operation* range 10 20 1 speed 10
operation* range 20 30 1 speed 15
...
```

Was used to quickly assign the operations groups for sven's project rather than doing all 50 one at a time.  Specifically it's work for #494