### PR TITLE
Create elements.py

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -441,12 +441,17 @@ class Node:
             if node._parent is not None:
                 raise ValueError("Cannot reparent node on add.")
         else:
-            try:
-                node_class = self._root.bootstrap[type]
-            except KeyError:
-                node_class = Node
-            except AttributeError:
-                raise AttributeError(self.__class__.__name__ + ' needs to be added to tree before adding "' + type + '" for ' + data_object.__class__.__name__)
+            node_class = Node
+            if type is not None:
+                try:
+                    node_class = self._root.bootstrap[type]
+                except (KeyError, AttributeError):
+                    # AttributeError indicates that we are adding a node with a type to an object which is NOT part of the tree.
+                    # This should be treated as an exception, however when we run Execute Job (and possibly other tasks)
+                    # it adds nodes even though the object isn't part of the tree.
+                    pass
+                # except AttributeError:
+                #    raise AttributeError('%s needs to be added to tree before adding "%s" for %s' % (self.__class__.__name__, type, data_object.__class__.__name__))
             node = node_class(data_object)
             node.set_label(label)
             if self._root is not None:


### PR DESCRIPTION
Execute Job was not working - but no error messages

I traced this to the use of bootstrapped node types when the copied laser operation was not in the tree, and therefore did not have self._root set.

It didn't help that Execute Job (which works as usual by executing console tasks) had some sort of global exception handler which threw away the error messages!!!!! So one step in the Execute Job was getting an Exception, but we never knew. This is **INCREDIBLY** poor style. We should probably:

1. Have a Console Error exception class, and any explicit exceptions should raise this and be reported to the console, whilst any other exceptions should create an error report as usual.
2. Handle errors for user issued console commands differently from internally issued console commands - dont submit user generated errors centrally, just report them locally, whilst reporting centrally all errors during internal use of console commands.