### PR TITLE
Raster Ops not matched to exact colors as default

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4912,6 +4912,11 @@ class Elemental(Modifier):
         default_cut_ops = []
         default_engrave_ops = []
         default_raster_ops = []
+        new_ops = []
+
+        raster_ops = []
+        deferred_raster_elements = []
+
         for op in operations:
             if op.default:
                 if op.operation == "Cut":
@@ -4920,8 +4925,8 @@ class Elemental(Modifier):
                     default_engrave_ops.append(op)
                 if op.operation == "Raster":
                     default_raster_ops.append(op)
-
-        new_ops = []
+            if op.operation == "Raster":
+                raster_ops.append(op)
 
         for element in elements:
             if hasattr(element, "operation"):
@@ -4939,7 +4944,7 @@ class Elemental(Modifier):
 
 
             add_vector = False    # For everything except shapes
-            add_non_vector = True # Text - Dots and Images will also abuse this
+            add_non_vector = True # Text, Images and Dots
             if isinstance(element,Shape) and not is_dot:
                 if element_color.rgb == Color("black").rgb: # Treated as a raster for user convenience
                     add_vector = False
@@ -5013,36 +5018,44 @@ class Elemental(Modifier):
                         op.add(element, type="opnode")
                     add_non_vector = False
 
+            # If element is a raster - defer creating a default raster op until we are sure that there are no empty existing raster ops to use first.
+            if add_non_vector and isinstance(element, (Shape, SVGText)) and not is_dot:
+                deferred_raster_elements.append(element)
+                add_non_vector = False
+
             # If we have matched element to an original operation or matched to all relavent new operations, we can move to the next element
-            if not (add_vector or add_non_vector):
+            if not add_vector and not add_non_vector:
                 continue
 
             # Need to add an operation to classify into
-            ops = []
             if is_dot:
-                ops.append(LaserOperation(operation="Dots", color="White", default=True))
+                op = LaserOperation(operation="Dots", color="Transparent", default=True)
             elif isinstance(element, SVGImage):
-                ops.append(LaserOperation(operation="Image", color="Transparent", default=True))
-            elif isinstance(element, Shape) or isinstance(element, SVGText):
-                if add_vector:
-                    if is_cut: # This will be initialised because criteria are same as above
-                        ops.append(LaserOperation(operation="Cut", color=abs(element_color)))
-                    else:
-                        op = LaserOperation(operation="Engrave", color=abs(element_color))
-                        if element_color == Color("white"):
-                            op.settings.laser_enabled = False
-                        ops.append(op)
-                if add_non_vector:
-                    op = LaserOperation(operation="Raster", color="Black", default=True)
-                    default_raster_ops.append(op)
-                    ops.append(op)
-            for op in ops:
-                operations.append(op)
-                new_ops.append(op)
-                add_op_function(op)
-                # element cannot be added to op before op is added to operations - otherwise opnode is not created.
-                op.add(element, type="opnode")
+                op = LaserOperation(operation="Image", color="Transparent", default=True)
+            elif isinstance(element, Shape):
+                if is_cut: # This will be initialised because criteria are same as above
+                    op = LaserOperation(operation="Cut", color=abs(element_color))
+                else:
+                    op = LaserOperation(operation="Engrave", color=abs(element_color))
+                    if element_color == Color("white"):
+                        op.settings.laser_enabled = False
+            operations.append(op)
+            new_ops.append(op)
+            add_op_function(op)
+            # element cannot be added to op before op is added to operations - otherwise opnode is not created.
+            op.add(element, type="opnode")
 
+        # Now deal with leftover raster elements
+        if deferred_raster_elements:
+            raster_ops = [op for op in raster_ops if len(op.children) == 0]
+            if not raster_ops:
+                op = LaserOperation(operation="Raster", color="Transparent", default=True)
+                operations.append(op)
+                raster_ops.append(op)
+                add_op_function(op)
+            for element in deferred_raster_elements:
+                for op in raster_ops:
+                    op.add(element, type="opnode")
 
     def load(self, pathname, **kwargs):
         kernel = self.context.kernel
@@ -5052,13 +5065,16 @@ class Elemental(Modifier):
                 if str(pathname).lower().endswith(extensions):
                     try:
                         results = loader.load(self.context, self, pathname, **kwargs)
+                        if results and isinstance(results, Node):
+                            results.focus()
+                            self.classify([elem.object for elem in results.flat(types=("elem"))])
                     except FileNotFoundError:
                         return False
                     except OSError:
                         return False
-                    if not results:
-                        continue
-                    return True
+                    if results:
+                        return True
+        return False
 
     def load_types(self, all=True):
         kernel = self.context.kernel

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -287,10 +287,11 @@ class SVGLoader:
         basename = os.path.basename(pathname)
         file_node = context_node.add(type="file", label=basename)
         file_node.filepath = pathname
-        file_node.focus()
-        return SVGLoader.parse(
+        if SVGLoader.parse(
             svg, elements_modifier, file_node, pathname, scale_factor, reverse
-        )
+        ):
+            return file_node
+        return None
 
     @staticmethod
     def parse(svg, elements_modifier, context_node, pathname, scale_factor, reverse):
@@ -309,13 +310,11 @@ class SVGLoader:
                 if element.text is None:
                     continue
                 context_node.add(element, type="elem")
-                elements_modifier.classify([element])
             elif isinstance(element, Path):
                 if len(element) == 0:
                     continue
                 element.approximate_arcs_with_cubics()
                 context_node.add(element, type="elem")
-                elements_modifier.classify([element])
             elif isinstance(element, Shape):
                 if not element.transform.is_identity():
                     # Shape Reification failed.
@@ -329,13 +328,11 @@ class SVGLoader:
                     if len(e) == 0:
                         continue  # Degenerate.
                 context_node.add(element, type="elem")
-                elements_modifier.classify([element])
             elif isinstance(element, SVGImage):
                 try:
                     element.load(os.path.dirname(pathname))
                     if element.image is not None:
                         context_node.add(element, type="elem")
-                        elements_modifier.classify([element])
                 except OSError:
                     pass
             elif isinstance(element, SVG):

--- a/meerk40t/device/lhystudios/lhystudiosemulator.py
+++ b/meerk40t/device/lhystudios/lhystudiosemulator.py
@@ -327,4 +327,5 @@ class EgvLoader:
                 "module/LhystudiossEmulator", basename
             )
             lhymicroemulator.write_header(f.read())
-            return [lhymicroemulator.cutcode], None, None, pathname, basename
+            kernel.root.close(basename)
+        return True

--- a/meerk40t/device/ruida/ruidadevice.py
+++ b/meerk40t/device/ruida/ruidadevice.py
@@ -1944,4 +1944,4 @@ class RDLoader:
             ruidaemulator.elements = elements_modifier
             ruidaemulator.write(BytesIO(ruidaemulator.unswizzle(f.read())))
             kernel.root.close(basename)
-            return True
+        return True

--- a/meerk40t/dxf/dxf_io.py
+++ b/meerk40t/dxf/dxf_io.py
@@ -108,9 +108,7 @@ class DxfLoader:
         file_node = element_branch.add(type="file", label=basename)
         file_node.filepath = pathname
         file_node.add_all(elements, type="elem")
-        file_node.focus()
-        elements_modifier.classify(elements)
-        return True
+        return file_node
 
     @staticmethod
     def entity_to_svg(elements, dxf, entity, scale, translate_y):

--- a/meerk40t/image/imagetools.py
+++ b/meerk40t/image/imagetools.py
@@ -1795,7 +1795,4 @@ class ImageLoader:
         file_node = element_branch.add(type="file", label=basename)
         file_node.filepath = pathname
         file_node.add(image, type="elem")
-        file_node.focus()
-
-        elements_modifier.classify([image])
-        return True
+        return file_node


### PR DESCRIPTION
Backwards compatibility so that Raster Ops not matched exactly to any elements are treated as default.

Note: svg_io classified elements individually (which is suboptimal anyway) but does not work with this approach - consequently changes were needed with how various file loaders dealt with things - they now return either False or None (failed), True (succeeded but no file / elements in tree, or the file_node.