### PR TITLE
Second attempt to improve classification of Raster elements.

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4444,7 +4444,7 @@ class Elemental(Modifier):
         settings.clear_persistent()
 
         for i, op in enumerate(self.ops()):
-            op_set = settings.derive(str(i))
+            op_set = settings.derive("%06i" % i)
             if not hasattr(op, "settings"):
                 continue  # Might be a function.
             sets = op.settings

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1898,7 +1898,7 @@ class Elemental(Modifier):
             output_type="ops",
         )
         def operation_list(channel, _, data=None, **kwgs):
-            channel(_("----------"))
+            channel("----------")
             channel(_("Operations:"))
             index_ops = list(self.ops())
             for op_obj in data:
@@ -1906,9 +1906,9 @@ class Elemental(Modifier):
                 selected = op_obj.emphasized
                 select_piece = " *" if selected else "  "
                 color = (
-                    "None"
-                    if not hasattr(op_obj, "color") or op_obj.color is None
-                    else Color(op_obj.color).hex
+                    Color(op_obj.color).hex
+                    if hasattr(op_obj, "color") and op_obj.color is not None
+                    else "None"
                 )
                 name = "%d: %s %s - %s" % (i, str(op_obj), select_piece, color)
                 channel(name)
@@ -1934,7 +1934,7 @@ class Elemental(Modifier):
                             fill_piece,
                         )
                         channel(name)
-            channel(_("----------"))
+            channel("----------")
 
         @context.console_option("color", "c", type=Color)
         @context.console_option("default", "d", type=bool)
@@ -2276,7 +2276,7 @@ class Elemental(Modifier):
             output_type="elements",
         )
         def element_list(command, channel, _, data=None, **kwgs):
-            channel(_("----------"))
+            channel("----------")
             channel(_("Graphical Elements:"))
             index_list = list(self.elems())
             for e in data:
@@ -2851,7 +2851,7 @@ class Elemental(Modifier):
             if data is None:
                 data = list(self.elems(emphasized=True))
             if stroke_width is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Stroke-Width Values:"))
                 i = 0
                 for e in self.elems():
@@ -2863,7 +2863,7 @@ class Elemental(Modifier):
                     else:
                         channel(_("%d: stroke = %s - %s") % (i, e.stroke_width, name))
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
 
             if len(data) == 0:
@@ -2910,7 +2910,7 @@ class Elemental(Modifier):
                     except IndexError:
                         channel(_("index %d out of range") % value)
             if color is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Stroke Values:"))
                 i = 0
                 for e in self.elems():
@@ -2922,7 +2922,7 @@ class Elemental(Modifier):
                     else:
                         channel(_("%d: stroke = %s - %s") % (i, e.stroke.hex, name))
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
             elif color == "none":
                 for e in apply:
@@ -2966,7 +2966,7 @@ class Elemental(Modifier):
                     except IndexError:
                         channel(_("index %d out of range") % value)
             if color is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Fill Values:"))
                 i = 0
                 for e in self.elems():
@@ -2978,7 +2978,7 @@ class Elemental(Modifier):
                     else:
                         channel(_("%d: fill = %s - %s") % (i, e.fill.hex, name))
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return "elements", data
             elif color == "none":
                 for e in apply:
@@ -3084,7 +3084,7 @@ class Elemental(Modifier):
             **kwgs
         ):
             if angle is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Rotate Values:"))
                 i = 0
                 for element in self.elems():
@@ -3096,7 +3096,7 @@ class Elemental(Modifier):
                         % (i, element.rotation.as_turns, name)
                     )
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
             if data is None:
                 data = list(self.elems(emphasized=True))
@@ -3177,7 +3177,7 @@ class Elemental(Modifier):
             **kwgs
         ):
             if scale_x is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Scale Values:"))
                 i = 0
                 for e in self.elems():
@@ -3194,7 +3194,7 @@ class Elemental(Modifier):
                         )
                     )
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
             if data is None:
                 data = list(self.elems(emphasized=True))
@@ -3274,7 +3274,7 @@ class Elemental(Modifier):
             command, channel, _, tx, ty, absolute=False, data=None, **kwgs
         ):
             if tx is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Translate Values:"))
                 i = 0
                 for e in self.elems():
@@ -3291,7 +3291,7 @@ class Elemental(Modifier):
                         )
                     )
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
             if data is None:
                 data = list(self.elems(emphasized=True))
@@ -3412,7 +3412,7 @@ class Elemental(Modifier):
             command, channel, _, sx, kx, sy, ky, tx, ty, data=None, **kwgs
         ):
             if tx is None:
-                channel(_("----------"))
+                channel("----------")
                 channel(_("Matrix Values:"))
                 i = 0
                 for e in self.elems():
@@ -3421,7 +3421,7 @@ class Elemental(Modifier):
                         name = name[:50] + "..."
                     channel("%d: %s - %s" % (i, str(e.transform), name))
                     i += 1
-                channel(_("----------"))
+                channel("----------")
                 return
             if data is None:
                 data = list(self.elems(emphasized=True))
@@ -3555,12 +3555,12 @@ class Elemental(Modifier):
         def tree_list(command, channel, _, data=None, **kwgs):
             if data is None:
                 data = self._tree
-            channel(_("----------"))
+            channel("----------")
             channel(_("Tree:"))
             path = ""
             for i, node in enumerate(data.children):
                 channel("%s:%d %s" % (path, i, str(node.label)))
-            channel(_("----------"))
+            channel("----------")
             return "tree", data
 
         # ==========
@@ -4913,6 +4913,10 @@ class Elemental(Modifier):
         default_cut_ops = []
         default_engrave_ops = []
         default_raster_ops = []
+
+        raster_ops = []
+        deferred_raster_elements = []
+
         for op in operations:
             if op.default:
                 if op.operation == "Cut":
@@ -4921,8 +4925,8 @@ class Elemental(Modifier):
                     default_engrave_ops.append(op)
                 if op.operation == "Raster":
                     default_raster_ops.append(op)
-
-        new_ops = []
+            if op.operation == "Raster":
+                raster_ops.append(op)
 
         for element in elements:
             if hasattr(element, "operation"):
@@ -4940,7 +4944,7 @@ class Elemental(Modifier):
 
 
             add_vector = False    # For everything except shapes
-            add_non_vector = True # Text - Dots and Images will also abuse this
+            add_non_vector = True # Text, Images and Dots
             if isinstance(element,Shape) and not is_dot:
                 if element_color.rgb == Color("black").rgb: # Treated as a raster for user convenience
                     add_vector = False
@@ -4973,14 +4977,10 @@ class Elemental(Modifier):
                     and op not in default_engrave_ops
                     and op not in default_raster_ops
                 ):
+                    op.add(element, type="opnode")
                     if op.operation == "Raster":
-                        # Only do raster add to existing raster ops because new reaster ops is default / a different color
-                        if op not in new_ops: # if an existing Operation, then we will not add opposite type later.
-                            op.add(element, type="opnode")
-                            add_non_vector = False
+                        add_non_vector = False
                     else:
-                        # Always do vector add because newly created vector ops match colour
-                        op.add(element, type="opnode")
                         add_vector = False
                 elif (
                     isinstance(element, SVGText)
@@ -4999,7 +4999,7 @@ class Elemental(Modifier):
                     break  # May only classify in one Image operation.
 
             # Check for default operations
-            if (isinstance(element,Shape) or isinstance(element,SVGText)) and not is_dot:
+            if isinstance(element, (Shape, SVGText)) and not is_dot:
                 is_cut = Color.distance_sq("red", element_color) <= 18825
                 if add_vector and is_cut and default_cut_ops:
                     for op in default_cut_ops:
@@ -5009,40 +5009,49 @@ class Elemental(Modifier):
                     for op in default_engrave_ops:
                         op.add(element, type="opnode")
                     add_vector = False
-                if add_non_vector and default_raster_ops:
-                    for op in default_raster_ops:
-                        op.add(element, type="opnode")
-                    add_non_vector = False
+
+            # If element is a raster - defer creating a default raster op until we are sure that there are no empty existing raster ops to use first.
+            if add_non_vector and isinstance(element, (Shape, SVGText)) and not is_dot:
+                deferred_raster_elements.append(element)
+                add_non_vector = False
 
             # If we have matched element to an original operation or matched to all relavent new operations, we can move to the next element
-            if not (add_vector or add_non_vector):
+            if not add_vector and not add_non_vector:
                 continue
 
             # Need to add an operation to classify into
-            ops = []
             if is_dot:
-                ops.append(LaserOperation(operation="Dots", color="White", default=True))
+                op = LaserOperation(operation="Dots", color="Transparent", default=True)
             elif isinstance(element, SVGImage):
-                ops.append(LaserOperation(operation="Image", color="Transparent", default=True))
-            elif isinstance(element, Shape) or isinstance(element, SVGText):
-                if add_vector:
-                    if is_cut: # This will be initialised because criteria are same as above
-                        ops.append(LaserOperation(operation="Cut", color=abs(element_color)))
-                    else:
-                        op = LaserOperation(operation="Engrave", color=abs(element_color))
-                        if element_color == Color("white"):
-                            op.settings.laser_enabled = False
-                        ops.append(op)
-                if add_non_vector:
-                    op = LaserOperation(operation="Raster", color="Black", default=True)
-                    default_raster_ops.append(op)
-                    ops.append(op)
-            for op in ops:
+                op = LaserOperation(operation="Image", color="Transparent", default=True)
+            elif isinstance(element, Shape):
+                if is_cut: # This will be initialised because criteria are same as above
+                    op = LaserOperation(operation="Cut", color=abs(element_color))
+                else:
+                    op = LaserOperation(operation="Engrave", color=abs(element_color))
+                    if element_color == Color("white"):
+                        op.settings.laser_enabled = False
+            operations.append(op)
+            add_op_function(op)
+            # element cannot be added to op before op is added to operations - otherwise opnode is not created.
+            op.add(element, type="opnode")
+
+        # Now deal with leftover raster elements
+        if deferred_raster_elements:
+            if default_raster_ops:
+                raster_ops = default_raster_ops
+            else:
+                # Because this is a check for an empty operation, this functionality relies on all elements in a file being classified at the same time.
+                # If you add elements individually, after the first raster operation the empty ops will no longer be empty and a default Raster op will be created instead.
+                raster_ops = [op for op in raster_ops if len(op.children) == 0 and op.color.alpha != 0 and not op.default]
+            if not raster_ops:
+                op = LaserOperation(operation="Raster", color="Transparent", default=True)
                 operations.append(op)
-                new_ops.append(op)
+                raster_ops.append(op)
                 add_op_function(op)
-                # element cannot be added to op before op is added to operations - otherwise opnode is not created.
-                op.add(element, type="opnode")
+            for element in deferred_raster_elements:
+                for op in raster_ops:
+                    op.add(element, type="opnode")
 
     def load(self, pathname, **kwargs):
         kernel = self.context.kernel
@@ -5056,9 +5065,9 @@ class Elemental(Modifier):
                         return False
                     except OSError:
                         return False
-                    if not results:
-                        continue
-                    return True
+                    if results:
+                        return True
+        return False
 
     def load_types(self, all=True):
         kernel = self.context.kernel

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -693,7 +693,7 @@ class Node:
         self._parent._children.remove(self)
         self.notify_detached(self)
         self.notify_destroyed(self)
-        for ref in self._references:
+        for ref in list(self._references):
             ref.remove_node()
         self.item = None
         self._parent = None


### PR DESCRIPTION
Raster elements will now be classified as follows:

1. By exact colour to a Raster op of the exact same color
2. After all raster elements have been classified by color, then any raster elements not previously classified are classified as follows:
    1. If there are one or more existing default Raster ops, they are classified into these.
    2. If there are one or more empty non-default Raster ops, they are classified into these.
    3. Otherwise a new Default Raster op is created and they are classified into this.

This should be fully backward compatible.

Note: Because of the way this works, it only works for the first file when elements are classified in a single group. Later classifications for e.g. changes of color or a 2nd file, will work the same way, but the empty Raster groups when you loaded the first file may no longer be empty and a default Raster  op may be created instead.

This PR also fixed a bug with persistent ops > 10 not being loaded back in the same order.

This PR also fixes the bug where elements are left in operations when the file is removed.