### PR TITLE
Fix typo in get_elem_node.

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4844,7 +4844,7 @@ class Elemental(Modifier):
         raise IndexError
 
     def get_elem_node(self, index, **kwargs):
-        for i, elem in enumerate(self.elems(**kwargs)):
+        for i, elem in enumerate(self.elems_nodes(**kwargs)):
             if i == index:
                 return elem
         raise IndexError


### PR DESCRIPTION
`get_elem_node` is not currently used anywhere but this is a typo as it is currently same code as `get_elem`.