### PR TITLE
Fix add_classify_op if existing special op

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5127,10 +5127,14 @@ class Elemental(Modifier):
             return self.add_op(op)
 
         for pos, old_op in reversed_enumerate(operations):
-            if OP_PRIORITIES.index(old_op.operation) < priority:
-                   return self.add_op(op, pos=pos + 1)
+            try:
+                if OP_PRIORITIES.index(old_op.operation) < priority:
+                    return self.add_op(op, pos=pos + 1)
+            except ValueError:
+                pass
         return self.add_op(op, pos=0)
 
+    
     def classify(self, elements, operations=None, add_op_function=None):
         """
         Classify does the placement of elements within operations.


### PR DESCRIPTION
```
MeerK40t crash log. Version: 0.7.0 RC-10s on win32
Traceback (most recent call last):
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\gui\wxmeerk40t.py", line 2578, in on_drop_file
    if self.load(pathname):
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\gui\wxmeerk40t.py", line 2539, in load
    results = self.context.load(
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\core\elements.py", line 5369, in load
    results = loader.load(self.context, self, pathname, **kwargs)
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\dxf\dxf_io.py", line 112, in load
    elements_modifier.classify(elements)
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\core\elements.py", line 5342, in classify
    add_op_function(op)
  File "c:\users\lexan\appdata\local\programs\python\python38-32\lib\site-packages\meerk40t\core\elements.py", line 5109, in add_classify_op
    if OP_PRIORITIES.index(old_op.operation) < priority:
ValueError: 'Command' is not in list
```