### PR TITLE
Fixed remove_n_ops functionality

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4316,7 +4316,7 @@ class Elemental(Modifier):
             help=""
         )
         def remove_n_ops(node, **kwgs):
-            self.context("element delete\n")
+            self.context("operation delete\n")
 
         @self.tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 1)
         @self.tree_calc("ecount", lambda i: len(list(self.elems(emphasized=True))))


### PR DESCRIPTION
previous code did context("element delete") when it really should have been context("operation delete") for remove_n_ops.