### PR TITLE
Winsleep Plugin / Correct Shutdown while running.

### DIFF
--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -1914,7 +1914,6 @@ class LhystudiosController:
                 ):
                     self.update_state(STATE_ACTIVE)
                 self.count = 0
-                continue
             else:
                 # No packet could be sent.
                 if self.state not in (

--- a/meerk40t/device/moshi/moshidevice.py
+++ b/meerk40t/device/moshi/moshidevice.py
@@ -981,12 +981,12 @@ class MoshiController:
                 if self.is_shutdown:
                     break
                 # Stage 0: New Program send.
-                self.context.signal("pipe;running", True)
                 if len(self._buffer) == 0:
                     if len(self._programs) == 0:
                         self.pipe_channel("Nothing to process")
                         # time.sleep(0.4)
                         break  # There is nothing to run.
+                    self.context.signal("pipe;running", True)
                     self.pipe_channel("New Program")
                     self.open()
                     self.wait_until_accepting_packets()
@@ -1008,6 +1008,7 @@ class MoshiController:
                 self.pipe_channel("Waiting for finish processing.")
                 if len(self._buffer) == 0:
                     self.wait_finished()
+                self.context.signal("pipe;running", False)
 
             except ConnectionRefusedError:
                 if self.is_shutdown:
@@ -1029,7 +1030,7 @@ class MoshiController:
                 time.sleep(0.5)
                 self.close()
                 continue
-        self.context.signal("pipe;running", True)
+        self.context.signal("pipe;running", False)
         self._thread = None
         self.is_shutdown = False
         self.update_state(STATE_END)

--- a/meerk40t/extra/README.md
+++ b/meerk40t/extra/README.md
@@ -24,3 +24,7 @@ Path Optimize are the older path-based optimizations routines from 0.6.x that wo
 
 Vectrace performs simple black/white image decomposition. Converting an image into a vector elements. This should allow for some tracing of image objects.
 This can be invoked with `vectrace` in console.
+
+## Winsleep
+
+Winsleep is a windows only plugin that prevents Microsoft Windows OSes from entering sleepmode while projects are actively sending a laser project.

--- a/meerk40t/extra/winsleep.py
+++ b/meerk40t/extra/winsleep.py
@@ -1,12 +1,20 @@
 import sys
 
-SLEEP_DISABLED = [False, None]
+SLEEP_DISABLED = [dict(), None, False]
 
 
 def on_usb_running(origin, value):
-    if value != SLEEP_DISABLED[0]:
-        SLEEP_DISABLED[0] = value
-        if value:
+    running = SLEEP_DISABLED[0]
+    running[origin] = value
+    any = False
+    for v in running:
+        q = running[v]
+        if q:
+            any = True
+            break
+    if any != SLEEP_DISABLED[2]:
+        SLEEP_DISABLED[2] = any
+        if any:
             SLEEP_DISABLED[1](".sleepmode_disable\n")
         else:
             SLEEP_DISABLED[1](".sleepmode_enable\n")

--- a/meerk40t/extra/winsleep.py
+++ b/meerk40t/extra/winsleep.py
@@ -1,0 +1,48 @@
+import sys
+
+SLEEP_DISABLED = [False, None]
+
+
+def on_usb_running(origin, value):
+    if value != SLEEP_DISABLED[0]:
+        SLEEP_DISABLED[0] = value
+        if value:
+            SLEEP_DISABLED[1](".sleepmode_disable\n")
+        else:
+            SLEEP_DISABLED[1](".sleepmode_enable\n")
+
+
+def plugin(kernel, lifecycle):
+    if sys.platform != 'win32':
+        # Plugin only matters for MSW platform
+        return
+    if lifecycle == "boot":
+        context = kernel.root
+
+        context.listen("pipe;running", on_usb_running)
+    elif lifecycle == "register":
+        context = kernel.root
+
+        SLEEP_DISABLED[1] = context
+        _ = kernel.translation
+
+        @context.console_command("sleepmode_disable", help=_("disables sleepmode"), hidden=True)
+        def sleepmode_disable(**kwargs):
+            try:
+                import ctypes
+                # ES_CONTINUOUS, 0x80000000, # ES_SYSTEM_REQUIRED = 0x00000001
+                ctypes.windll.kernel32.SetThreadExecutionState(0x80000001)
+            except AttributeError:
+                pass
+
+        @context.console_command("sleepmode_enable", help=_("enables sleepmode"), hidden=True)
+        def sleepmode_enable(**kwargs):
+            try:
+                import ctypes
+                # ES_CONTINUOUS, 0x80000000
+                ctypes.windll.kernel32.SetThreadExecutionState(0x80000000)
+            except AttributeError:
+                pass
+    elif lifecycle == "shutdown":
+        context = kernel.root
+        context.unlisten("pipe;running", on_usb_running)

--- a/meerk40t/extra/winsleep.py
+++ b/meerk40t/extra/winsleep.py
@@ -1,9 +1,28 @@
 import sys
 
+"""
+Winsleep is a internal standalone Windows-only plugin that works for sys.platform 'win32'.
+The plugin does not register if the platform is not MSW.
+
+If any signal origin gives a pipe;running signal of True, it will execute sleepmode_disable.
+When all signals then give pipe;running signals of False, it will execute sleepmode_enable.
+
+We also register sleepmode_disable and sleepmode_enable as hidden commands which flag
+the ctypes windll kernel32 threadstate to be ES_SYSTEM_REQUIRED which disables sleeping
+in windows.
+"""
+
+
 SLEEP_DISABLED = [None, dict(), False]
 
 
 def on_usb_running(origin, value):
+    """
+    Registered during the boot and unregistered during shutdown lifecycle.
+
+    On_usb_running listens for pipe;running signals and if any origin value is true
+    This calls sleepmode_disable.
+    """
     running = SLEEP_DISABLED[1]
     running[origin] = value
     any = False
@@ -21,7 +40,7 @@ def on_usb_running(origin, value):
 
 
 def plugin(kernel, lifecycle):
-    if sys.platform != 'win32':
+    if sys.platform != "win32":
         # Plugin only matters for MSW platform
         return
     if lifecycle == "boot":
@@ -34,23 +53,30 @@ def plugin(kernel, lifecycle):
         SLEEP_DISABLED[0] = context
         _ = kernel.translation
 
-        @context.console_command("sleepmode_disable", help=_("disables sleepmode"), hidden=True)
+        @context.console_command(
+            "sleepmode_disable", help=_("disables sleepmode"), hidden=True
+        )
         def sleepmode_disable(**kwargs):
             try:
                 import ctypes
+
                 # ES_CONTINUOUS, 0x80000000, # ES_SYSTEM_REQUIRED = 0x00000001
                 ctypes.windll.kernel32.SetThreadExecutionState(0x80000001)
             except AttributeError:
                 pass
 
-        @context.console_command("sleepmode_enable", help=_("enables sleepmode"), hidden=True)
+        @context.console_command(
+            "sleepmode_enable", help=_("enables sleepmode"), hidden=True
+        )
         def sleepmode_enable(**kwargs):
             try:
                 import ctypes
+
                 # ES_CONTINUOUS, 0x80000000
                 ctypes.windll.kernel32.SetThreadExecutionState(0x80000000)
             except AttributeError:
                 pass
+
     elif lifecycle == "shutdown":
         context = kernel.root
         context.unlisten("pipe;running", on_usb_running)

--- a/meerk40t/extra/winsleep.py
+++ b/meerk40t/extra/winsleep.py
@@ -1,10 +1,10 @@
 import sys
 
-SLEEP_DISABLED = [dict(), None, False]
+SLEEP_DISABLED = [None, dict(), False]
 
 
 def on_usb_running(origin, value):
-    running = SLEEP_DISABLED[0]
+    running = SLEEP_DISABLED[1]
     running[origin] = value
     any = False
     for v in running:
@@ -15,9 +15,9 @@ def on_usb_running(origin, value):
     if any != SLEEP_DISABLED[2]:
         SLEEP_DISABLED[2] = any
         if any:
-            SLEEP_DISABLED[1](".sleepmode_disable\n")
+            SLEEP_DISABLED[0](".sleepmode_disable\n")
         else:
-            SLEEP_DISABLED[1](".sleepmode_enable\n")
+            SLEEP_DISABLED[0](".sleepmode_enable\n")
 
 
 def plugin(kernel, lifecycle):
@@ -31,7 +31,7 @@ def plugin(kernel, lifecycle):
     elif lifecycle == "register":
         context = kernel.root
 
-        SLEEP_DISABLED[1] = context
+        SLEEP_DISABLED[0] = context
         _ = kernel.translation
 
         @context.console_command("sleepmode_disable", help=_("disables sleepmode"), hidden=True)

--- a/meerk40t/gui/mwindow.py
+++ b/meerk40t/gui/mwindow.py
@@ -66,6 +66,9 @@ class MWindow(wx.Frame, Module):
         if self.state == 5:
             event.Veto()
         else:
+            if hasattr(self, "window_close_veto") and self.window_close_veto():
+                event.Veto()
+                return
             self.window_context.width, self.window_context.height = self.Size
             self.window_context.x, self.window_context.y = self.GetPosition()
             self.state = 5

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -943,6 +943,7 @@ class MeerK40t(MWindow):
 
         context.listen("device;noactive", self.on_device_noactive)
         context.listen("pipe;failing", self.on_usb_error)
+        context.listen("pipe;running", self.on_usb_running)
         context.listen("pipe;usb_status", self.on_usb_state_text)
         context.listen("pipe;thread", self.on_pipe_state)
         context.listen("spooler;thread", self.on_spooler_state)
@@ -2211,6 +2212,14 @@ class MeerK40t(MWindow):
     def on_active_change(self, origin, active):
         self.__set_titlebar()
 
+    def window_close_veto(self):
+        if self.usb_running:
+            message = _("The device is actively sending data. Really quit?")
+            answer = wx.MessageBox(
+                message, _("Currently Sending Data..."), wx.YES_NO | wx.CANCEL, None
+            )
+            return answer != wx.YES
+
     def window_close(self):
         context = self.context
 
@@ -2236,6 +2245,7 @@ class MeerK40t(MWindow):
 
         context.unlisten("device;noactive", self.on_device_noactive)
         context.unlisten("pipe;failing", self.on_usb_error)
+        context.unlisten("pipe;running", self.on_usb_running)
         context.unlisten("pipe;usb_status", self.on_usb_state_text)
         context.unlisten("pipe;thread", self.on_pipe_state)
         context.unlisten("spooler;thread", self.on_spooler_state)
@@ -2341,7 +2351,7 @@ class MeerK40t(MWindow):
             dlg.ShowModal()
             dlg.Destroy()
 
-    def on_usb_running(self, value):
+    def on_usb_running(self, origin, value):
         self.usb_running = value
 
     def on_usb_state_text(self, origin, value):

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -268,6 +268,15 @@ def run():
     except ImportError:
         pass
 
+    if sys.platform == 'win32':
+        # Windows only plugin.
+        try:
+            from .extra import winsleep
+
+            kernel.add_plugin(winsleep.plugin)
+        except ImportError:
+            pass
+
     try:
         from camera import camera
 


### PR DESCRIPTION
* Implements Windows sleep mode disable and enable.
* Adds windows only plugin `winsleep` which adds hidden commands `winsleep_disable` and `winsleep_enable`
* Corrects `pipe;running` value for lhystudios driver
* Adds window_close_veto to mwindow.
* Adds feature to prevent shutdown of MeerK40t if device is running.
* Corrected Moshiboard `pipe;running` value for those drivers to only enable when sending data rather than all the time.
* While this might be another issue with the shutdown blocking while sending there is no issue with winsleep and multiple drivers running. The routine only turns when anything is marked as running.