### PR TITLE
Remove camhead option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,5 @@ setup(
         'gui': ['wxPython>=4.0.0', "Pillow>=7.0.0"],
         'cam': ["meerk40t_camera", "opencv-python-headless>=3.4.0.0"],
         'dxf': ["ezdxf>=0.14.0"],
-        'camhead': ["meerk40t_camera", "opencv-python>=3.4.0.0"],
     }
 )


### PR DESCRIPTION
Headless is sufficient for MK.
Most users these days use a virtual environment so will not need headed for other projects.
If user needs headed they probably have skills to install it.
Giving user a headed option as standard is a choice they don't need IMO.