### PR TITLE
Build script trigger on Create Release, PYTHONHASHSEED, wxPython 4.0.…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,14 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow builds PyInstaller single-file executables
+# of Meerk40t for Windows, (and hopefully) Linux, Mac
 
 name: Meerk40t
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.*'
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-ubuntu:
-
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
@@ -28,31 +25,24 @@ jobs:
         pip3 install pyinstaller wheel
         pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
         if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+
     - name: Build meerk40t
       run: |
         mv meerk40t.py mk40t.py
         pyinstaller --windowed --onefile --name meerk40t mk40t.py
         mv mk40t.py meerk40t.py
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        mv dist/meerk40t dist/MeerK40t-Ubuntu-Latest
+
+# Switched to using softprops/action-gh-release@v1
+# because it supports uploading to existing release based on current tag.
+    - name: Upload Release Assets
+      id: release
+      uses: softprops/action-gh-release@v1
       with:
-          tag_name: release-${{ github.sha }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/meerk40t
-          asset_name: MeerK40t
-          asset_content_type: application/exe
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          dist/MeerK40t-Ubuntu-Latest
+
 
   build-windows:
     runs-on: windows-latest
@@ -60,27 +50,16 @@ jobs:
     - name: Checkout meerk40t
       uses: actions/checkout@v2
 
-    - name: Set outputs
-      id: prevars
-      run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=tag::$(git tag --points-at)"
-    - name: Fix outputs
-      id: vars
-      if: ${{ steps.prevars.outputs.tag == '' }}
-      run: |
-          echo "::set-output name=sha_short::${{ steps.prevars.outputs.sha_short }}"
-          echo "::set-output name=tag::${{ steps.prevars.outputs.sha_short }}"
-    - name: Check outputs
-      run: |
-          echo ${{ steps.vars.outputs.sha_short }}
-          echo ${{ steps.vars.outputs.tag }}
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
         architecture: 'x86'
 # Yikes. ch341dll.dll is not compatible with 64-bit python/pyinstaller/ctypes
+#
+# Python 3.7, wxPython 4.0.7-post2 is specifically chosen to workaround
+# issue meerk40t/meerk40t#242, once the SetLocale issue is resolved, we can test
+# newer versions again. Python 3.8 is latest possible for Windows 7 support.
 
     - name: Install dependencies
       run: |
@@ -88,8 +67,11 @@ jobs:
         pip install wxPython==4.0.7-post2
         pip install meerk40t-camera ezdxf opencv-python-headless
 
-#       Compile bootloaders in order to reduce virus totals
+# Compile bootloaders in order to reduce virus totals
+# PYTHONHASHSEED is an attempt to get deterministic builds for VirusTotal
     - name: Build pyinstaller, generate bootloaders
+      env:
+        PYTHONHASHSEED: 12506
       run: |
         git clone --depth=1 https://github.com/pyinstaller/pyinstaller
         cd pyinstaller/bootloader
@@ -98,34 +80,30 @@ jobs:
         python3 setup.py install
         cd ..
 
-#    - name: Directory structure
-#      run: |
-#        tree D:/ /a /f
-
-    - name: Build MeerK40t
+    - name: Build MeerK40t (wxPython 4.0.7-post2)
+      if: ${{ false }}
       run: |
         move meerk40t.py mk40t.py
         pyinstaller --windowed --onefile --name meerk40t .github/workflows/win/meerk40t.spec
         move mk40t.py meerk40t.py
+        move dist/meerk40t.exe dist/wx-meerk40t.exe
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-          tag_name: release-${{ steps.vars.outputs.tag }}
-          release_name: ${{ steps.vars.outputs.tag }}
-          draft: false
-          prerelease: false
+    - name: Build MeerK40t (wxPython 4.1.1)
+      run: |
+        pip install wxPython==4.1.1
+        move meerk40t.py mk40t.py
+        pyinstaller --windowed --onefile --name meerk40t .github/workflows/win/meerk40t.spec
+        move mk40t.py meerk40t.py
+        move dist/meerk40t.exe dist/MeerK40t.exe
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# Switched to using softprops/action-gh-release@v1
+# because it supports uploading to existing release based on current tag.
+    - name: Upload Release Assets
+      id: release
+      uses: softprops/action-gh-release@v1
       with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/meerk40t.exe
-          asset_name: MeerK40t.exe
-          asset_content_type: application/exe
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          dist/MeerK40t.exe
+          dist/wx-meerk40t.exe
+

--- a/.github/workflows/platform-check.yml
+++ b/.github/workflows/platform-check.yml
@@ -1,0 +1,15 @@
+name: BuildBoxTest
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-mac:
+    runs-on: [macos-10.15, macos-11]
+    steps:
+    - name: system_profiler basic
+      run: |
+        system_profiler -detailLevel basic
+    - name: system_profiler full
+      run: |
+        system_profiler


### PR DESCRIPTION
…7-post2,4.1.1, reenable ubuntu build

Builds now triggered by creating new release.
PYTHONHASHSEED is attempt to make builds deterministic with respect to VirusTotal
Renabled ubuntu-latest build.
Windows builds now name exe, and build for both wxpython 4.0.7-post2 and 4.1.1
