### PR TITLE
Fix removing elements removes more opnodes than it should

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5428,9 +5428,11 @@ class Elemental(Modifier):
         self.note = None
 
     def remove_elements(self, elements_list):
-        for e in list(self.elems()):
-            if e in elements_list:
-                e.node.remove_node()
+        for elem in elements_list:
+            for e in list(self.elems()):
+                if elem is e:
+                    e.node.remove_node()
+                    break  # inner for loop
         self.validate_selected_area()
 
     def remove_operations(self, operations_list):


### PR DESCRIPTION
This PR fixes #610.

It also contains several code optimisations.

I have no idea why I had to revert the code in the last commit - however before reverting this code, when removing a single image from the file example in #610 approx 1/3 of the other images were also deleted in some form of recursive call i.e. deleting one element resulted in a remove_element call with another image in the same operation which then resulted in a further remove_element call etc.