### PR TITLE
Fix opencv version on windows builds (camera wasn't working)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
       run: |
         pip install wheel
         pip install wxPython==4.0.7-post2
-        pip install meerk40t-camera ezdxf opencv-python-headless
+        pip install meerk40t-camera ezdxf opencv-python-headless==4.5.3.56
+# 10/25/2021 0.7.3-beta4 ok, but 0.7.3 release lacked camera. Fixing opencv @4.5.3.56 until it's fixed
 
 # Compile bootloaders in order to reduce virus totals
 # PYTHONHASHSEED is an attempt to get deterministic builds for VirusTotal


### PR DESCRIPTION
Fixes an issue we had with 0.7.3 release not including camera build.
0.7.3-beta4 was OK on pyinstaller dev branch, but 0.7.3 was not.

I left a comment in the build script to that effect.