### PR TITLE
Adds `move_at_speed` command. Prevents Keydown overtrigger. Fix alias -keyword registration.

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -89,6 +89,8 @@ class BindAlias(Modifier):
                     value = context.alias[key]
                     channel("%d: %s %s" % (i, key.ljust(15), value))
                 channel(_("----------"))
+            elif len(args) == 1:
+                raise SyntaxError
             else:
                 key = args[0].lower()
                 if key == "default":

--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -76,33 +76,35 @@ class BindAlias(Modifier):
                         pass
             return
 
+        @self.context.console_argument("alias", type=str, help=_("alias command"))
         @self.context.console_command(
             "alias", help=_("alias <alias> <console commands[;console command]*>")
         )
-        def alias(command, channel, _, args=tuple(), **kwgs):
+        def alias(command, channel, _, alias=None, remainder=None, **kwgs):
             context = self.context
             _ = self.context._
-            if len(args) == 0:
+            if alias is None:
                 channel(_("----------"))
                 channel(_("Aliases:"))
                 for i, key in enumerate(context.alias):
                     value = context.alias[key]
                     channel("%d: %s %s" % (i, key.ljust(15), value))
                 channel(_("----------"))
-            elif len(args) == 1:
-                raise SyntaxError
-            else:
-                key = args[0].lower()
-                if key == "default":
-                    context.alias = dict()
-                    context.default_alias()
-                    channel(_("Set default aliases."))
-                    return
-                value = " ".join(args[1:])
-                if value == "":
-                    del context.alias[args[0]]
+                return
+            alias = alias.lower()
+            if alias == "default":
+                context.alias = dict()
+                context.default_alias()
+                channel(_("Set default aliases."))
+                return
+            if remainder is None:
+                if alias in context.alias:
+                    channel(_("Alias %s unset.") % alias)
+                    del context.alias[alias]
                 else:
-                    context.alias[args[0]] = value
+                    channel(_("No alias for %s was set.") % alias)
+            else:
+                context.alias[alias] = remainder
 
         @self.context.console_command(".*", regex=True, hidden=True)
         def alias_execute(command, **kwgs):

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -578,3 +578,41 @@ class Group(PlotManipulation):
         self.group_y = None
         self.group_dx = 0
         self.group_dy = 0
+
+
+def grouped(plot):
+    """
+    Converts a generated series of single stepped plots into grouped orthogonal/diagonal plots.
+
+    :param plot: single stepped plots to be grouped into orth/diag sequences.
+    :return:
+    """
+    group_x = None
+    group_y = None
+    group_dx = 0
+    group_dy = 0
+
+    for x, y in plot:
+        if group_x is None:
+            group_x = x
+        if group_y is None:
+            group_y = y
+        if x == group_x + group_dx and y == group_y + group_dy:
+            # This is an orthogonal/diagonal step along the same path.
+            group_x = x
+            group_y = y
+            continue
+        # This is non orth-diag point. Must drop a point.
+        yield group_x, group_y
+        # If we do not have a defined direction, set our current direction.
+        group_dx = x - group_x
+        group_dy = y - group_y
+        if abs(group_dx) > 1 or abs(group_dy) > 1:
+            # The last step was not valid.
+            raise ValueError(
+                "dx(%d) or dy(%d) exceeds 1" % (group_dx, group_dy)
+            )
+        group_x = x
+        group_y = y
+    # There are no more plots.
+    yield group_x, group_y

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -67,6 +67,7 @@ class MeerK40tScenePanel(wx.Panel):
         sizer_2.Fit(self)
         self.Layout()
 
+        self.triggered_keys = dict()
         self.scene.Bind(wx.EVT_KEY_UP, self.on_key_up)
         self.scene.Bind(wx.EVT_KEY_DOWN, self.on_key_down)
         self.scene.scene_panel.Bind(wx.EVT_KEY_UP, self.on_key_up)
@@ -286,8 +287,10 @@ class MeerK40tScenePanel(wx.Panel):
         keyvalue = get_key_name(event)
         keymap = self.context.keymap
         if keyvalue in keymap:
-            action = keymap[keyvalue]
-            self.context(action + "\n")
+            if keyvalue not in self.triggered_keys:
+                self.triggered_keys[keyvalue] = 1
+                action = keymap[keyvalue]
+                self.context(action + "\n")
         else:
             event.Skip()
 
@@ -295,6 +298,8 @@ class MeerK40tScenePanel(wx.Panel):
         keyvalue = get_key_name(event)
         keymap = self.context.keymap
         if keyvalue in keymap:
+            if keyvalue in self.triggered_keys:
+                del self.triggered_keys[keyvalue]
             action = keymap[keyvalue]
             if action.startswith("+"):
                 # Keyup commands only trigger if the down command started with +


### PR DESCRIPTION
* Tests jog at speed.
* Adds `move_at_speed`
* Fixes keydown overtriggering.
* Fixes alias bug where -left couldn't be aliased because `-left` counts as OPT tokens. Permits quoting correctly

```
alias +down egv IV2232511NBRS1Ez#$z#$z#$
alias +left egv IV2232511NRTS1Ez#$z#$z#$
alias +right egv IV2232511NRBS1Ez#$z#$z#$
alias +up egv IV2232511NBLS1Ez#$z#$z#$
alias "-down" egv I$I$I$
alias "-left" egv I$I$I$
alias "-right" egv I$I$I$
alias "-up" egv I$I$I$
```