### PR TITLE
Fix #667 - include stroke width when making image of raster elements

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3064,12 +3064,15 @@ class Elemental(Modifier):
             context = self.context
             if data is None:
                 data = list(self.elems(emphasized=True))
+            reverse = context.classify_reverse
+            if reverse:
+                data = list(reversed(data))
             elements = context.elements
             make_raster = self.context.registered.get("render-op/make_raster")
             if not make_raster:
                 channel(_("No renderer is registered to perform render."))
                 return
-            bounds = Group.union_bbox(data)
+            bounds = Group.union_bbox(data, with_stroke=True)
             if bounds is None:
                 return
             if step <= 0:
@@ -5085,8 +5088,11 @@ class Elemental(Modifier):
             context = self.context
             elements = context.elements
             subitems = list(node.flat(types=("elem", "opnode")))
+            reverse = self.context.classify_reverse
+            if reverse:
+                subitems = list(reversed(subitems))
             make_raster = self.context.registered.get("render-op/make_raster")
-            bounds = Group.union_bbox([s.object for s in subitems])
+            bounds = Group.union_bbox([s.object for s in subitems], with_stroke=True)
             if bounds is None:
                 return
             step = float(node.settings.raster_step)

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -505,7 +505,7 @@ class CutPlan:
             subitems = list(reversed(subitems))
         make_raster = self.context.registered.get("render-op/make_raster")
         objs = [s.object for s in subitems]
-        bounds = Group.union_bbox(objs)
+        bounds = Group.union_bbox(objs, with_stroke=True)
         if bounds is None:
             return None
         xmin, ymin, xmax, ymax = bounds


### PR DESCRIPTION
This also fixes an issue when classify_reverse is True whereby images are rastered in the wrong sequence.

Note: This does not include raster area optimisation when there is a lot of white space. I still need details of accelerations from Joe to calculate the minimum whitespace so as to know when to group raster elements into the same raster image and when to create separate raster images. 