### PR TITLE
About and Preferences needed RESIZE_BORDER flag to be consistent with…

### DIFF
--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -137,7 +137,8 @@ class About(MWindow):
             style=wx.CAPTION
             | wx.CLOSE_BOX
             | wx.FRAME_FLOAT_ON_PARENT
-            | wx.TAB_TRAVERSAL,
+            | wx.TAB_TRAVERSAL
+            | wx.RESIZE_BORDER,
             **kwds
         )
         self.panel = AboutPanel(self, wx.ID_ANY, context=self.context)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -460,7 +460,8 @@ class Preferences(MWindow):
             style=wx.CAPTION
             | wx.CLOSE_BOX
             | wx.FRAME_FLOAT_ON_PARENT
-            | wx.TAB_TRAVERSAL,
+            | wx.TAB_TRAVERSAL
+            | wx.RESIZE_BORDER,
             **kwds
         )
 


### PR DESCRIPTION
… other windows.

Tested on Linux, About and Preferences were not previously resizable, and adding these flags allows them to be resized to be consistent with all the other windows in meerk40t