### PR TITLE
Change string substitution from % to format

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -27,7 +27,10 @@ class BindAlias(Modifier):
         self.context.default_keymap = self.default_keymap
         self.context.default_alias = self.default_alias
 
-        @self.context.console_command("bind", help="bind "+_("<key> <console command>"))
+        @self.context.console_command(
+            "bind",
+            help=_("Lists key bindings or adds/removes a binding of a command to a key.")
+            )
         def bind(command, channel, _, args=tuple(), **kwgs):
             """
             Binds a key to a given keyboard keystroke.
@@ -75,9 +78,10 @@ class BindAlias(Modifier):
                         pass
             return
 
-        @self.context.console_argument("alias", type=str, help=_("alias command"))
+        @self.context.console_argument("alias", type=str, help=_("<alias> <console commands[;console command]*>"))
         @self.context.console_command(
-            "alias", help="alias "+_("<alias> <console commands[;console command]*>")
+            "alias",
+            help=_("Lists command aliases or adds/removes an alias equivalent to one or more commands.")
         )
         def alias(command, channel, _, alias=None, remainder=None, **kwgs):
             context = self.context
@@ -116,7 +120,7 @@ class BindAlias(Modifier):
             if command in self.alias:
                 aliased_command = self.alias[command]
                 for alias in aliased_command.split(";"):
-                    context("{alias:s}\n".format(alias=alias)
+                    context("{alias:s}\n".format(alias=alias))
             else:
                 raise CommandMatchRejected(_("{command:s} is not an alias.").format(command=command))
 

--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -27,7 +27,7 @@ class BindAlias(Modifier):
         self.context.default_keymap = self.default_keymap
         self.context.default_alias = self.default_alias
 
-        @self.context.console_command("bind", help=_("bind <key> <console command>"))
+        @self.context.console_command("bind", help="bind "+_("<key> <console command>"))
         def bind(command, channel, _, args=tuple(), **kwgs):
             """
             Binds a key to a given keyboard keystroke.
@@ -35,12 +35,11 @@ class BindAlias(Modifier):
             context = self.context
             _ = self.context._
             if len(args) == 0:
-                channel(_("----------"))
                 channel(_("Binds:"))
                 for i, key in enumerate(context.keymap):
                     value = context.keymap[key]
-                    channel(_("%d: key %s %s") % (i, key.ljust(15), value))
-                channel(_("----------"))
+                    channel(_("{i:3d}: key {key:s} {value:s}").format(i=i, key=key.ljust(25), value=value))
+                channel("----------")
             else:
                 key = args[0].lower()
                 if key == "default":
@@ -52,7 +51,7 @@ class BindAlias(Modifier):
                 f = command_line.find("bind")
                 if f == -1:  # If bind value has a bind, do not evaluate.
                     spooler, input_driver, output = context.registered[
-                        "device/%s" % context.root.active
+                        "device/{device:s}".format(device=context.root.active)
                     ]
                     if "$x" in command_line:
                         try:
@@ -71,40 +70,40 @@ class BindAlias(Modifier):
                 else:
                     try:
                         del context.keymap[key]
-                        channel(_("Unbound %s") % key)
+                        channel(_("Unbound {key:s}").format(key=key))
                     except KeyError:
                         pass
             return
 
         @self.context.console_argument("alias", type=str, help=_("alias command"))
         @self.context.console_command(
-            "alias", help=_("alias <alias> <console commands[;console command]*>")
+            "alias", help="alias "+_("<alias> <console commands[;console command]*>")
         )
         def alias(command, channel, _, alias=None, remainder=None, **kwgs):
             context = self.context
             _ = self.context._
             if alias is None:
-                channel(_("----------"))
                 channel(_("Aliases:"))
                 for i, key in enumerate(context.alias):
                     value = context.alias[key]
-                    channel("%d: %s %s" % (i, key.ljust(15), value))
-                channel(_("----------"))
+                    channel("{i:3d}: {key:s} {value:s}".format(i=i, key=key.ljust(25), value=value))
+                channel("----------")
                 return
             alias = alias.lower()
             if alias == "default":
                 context.alias = dict()
                 context.default_alias()
-                channel(_("Set default aliases."))
+                channel(_("Default aliases set."))
                 return
             if remainder is None:
                 if alias in context.alias:
-                    channel(_("Alias %s unset.") % alias)
+                    channel(_("Alias {alias:s} unset.").format(alias=alias))
                     del context.alias[alias]
                 else:
-                    channel(_("No alias for %s was set.") % alias)
+                    channel(_("No alias for {alias:s} was set.").format(alias))
             else:
                 context.alias[alias] = remainder
+                channel(_("Alias {alias:s} set to {remainder:s}.").format(alias=alias, remainder=remainder))
 
         @self.context.console_command(".*", regex=True, hidden=True)
         def alias_execute(command, **kwgs):
@@ -116,10 +115,10 @@ class BindAlias(Modifier):
             context = self.context
             if command in self.alias:
                 aliased_command = self.alias[command]
-                for cmd in aliased_command.split(";"):
-                    context("%s\n" % cmd)
+                for alias in aliased_command.split(";"):
+                    context("{alias:s}\n".format(alias=alias)
             else:
-                raise CommandMatchRejected(_("This is not an alias."))
+                raise CommandMatchRejected(_("{command:s} is not an alias.").format(command=command))
 
     def boot(self, *args, **kwargs):
         self.boot_keymap()

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -249,9 +249,9 @@ class CutGroup(list, CutObject, ABC):
         return CutGroup(self.parent, self)
 
     def __repr__(self):
-        return "CutGroup(children=%s, parent=%s)" % (
-            list.__repr__(self),
-            str(self.parent),
+        return "CutGroup(children={children:s}, parent={parent:s})".format(
+            children=list.__repr__(self),
+            parent=str(self.parent),
         )
 
     def reversible(self):
@@ -308,9 +308,7 @@ class CutCode(CutGroup):
         self.mode = None
 
     def __str__(self):
-        parts = list()
-        parts.append("%d items" % len(self))
-        return "CutCode(%s)" % " ".join(parts)
+        return "CutCode({len:d} items})".format(len=len(self))
 
     def __copy__(self):
         return CutCode(self)

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -569,7 +569,7 @@ class Drivers(Modifier):
         @context.console_option("new", "n", type=str, help=_("new driver type"))
         @self.context.console_command(
             "driver",
-            help=_("driver<?> <command>"),
+            help=_("Lists devices or selects a device to be active"),
             regex=True,
             input_type=(None, "spooler"),
             output_type="driver",
@@ -589,7 +589,7 @@ class Drivers(Modifier):
 
             driver = self.get_or_make_driver(device_name, new)
             if driver is None:
-                raise SyntaxError("No Driver.")
+                raise SyntaxError("No driver.")
 
             if spooler is not None:
                 try:
@@ -599,45 +599,42 @@ class Drivers(Modifier):
                 except AttributeError:
                     pass
             elif remainder is None:
-                channel(_("----------"))
-                channel(_("Driver:"))
+                channel(_("Device slots:"))
                 for i, drv in enumerate(self.context.root.match("device", suffix=True)):
-                    channel("%d: %s" % (i, drv))
-                channel(_("----------"))
-                channel(_("Driver %s:" % device_name))
+                    channel("{i:2d}: {driver:s}".format(i=i, driver=drv))
+                channel("----------")
+                channel(_("Active device {device:s}:".format(device=device_name)))
                 channel(str(driver))
-                channel(_("----------"))
+                channel("----------")
             return "driver", (driver, device_name)
 
         @self.context.console_command(
             "list",
-            help=_("driver<?> list"),
+            help=_("Lists devices"),
             input_type="driver",
             output_type="driver",
         )
         def driver_list(command, channel, _, data_type=None, data=None, **kwgs):
-            driver_obj, name = data
-            channel(_("----------"))
-            channel(_("Driver:"))
+            driver, device_name = data
+            channel(_("Device slots:"))
             for i, drv in enumerate(self.context.root.match("device", suffix=True)):
-                channel("%d: %s" % (i, drv))
-            channel(_("----------"))
-            channel(_("Driver %s:" % name))
-            channel(str(driver_obj))
-            channel(_("----------"))
+                channel("{i:2d}: {driver:s}".format(i=i, driver=drv))
+            channel("----------")
+            channel(_("Active device {device:s}:".format(device=device_name)))
+            channel(str(driver))
+            channel("----------")
             return data_type, data
 
         @context.console_command(
             "type",
-            help=_("list driver types"),
+            help=_("List available drivers"),
             input_type="driver",
         )
         def list_type(channel, _, **kwgs):
-            channel(_("----------"))
-            channel(_("Drivers permitted:"))
+            channel(_("Drivers available:"))
             for i, name in enumerate(context.match("driver/", suffix=True)):
                 channel("%d: %s" % (i + 1, name))
-            channel(_("----------"))
+            channel("----------")
 
         @self.context.console_command(
             "reset",

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -508,7 +508,7 @@ class Driver:
         parts.append("x={x:f}".format(x=self.current_x))
         parts.append("y={y:f}".format(y=self.current_y))
         parts.append("speed={speed:f}".format(speed=self.settings.speed))
-        parts.append("power={power:d}".format(power=self.settings.power)
+        parts.append("power={power:d}".format(power=self.settings.power))
         status = ";".join(parts)
         self.context.signal("driver;status", status)
 

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -98,7 +98,7 @@ class Driver:
             self._thread = self.context.threaded(
                 self._driver_threaded,
                 result=clear_thread,
-                thread_name="Driver(%s)" % self.context.path,
+                thread_name="Driver({path:s})".format(self.context.path),
             )
             self._thread.stop = clear_thread
 
@@ -174,7 +174,7 @@ class Driver:
 
         if self.last_fetch is not None:
             self.context.channel("spooler")(
-                "Time between fetches: %f" % (time.time() - self.last_fetch)
+                "Time between fetches: {delta:f}".format(delta=time.time()-self.last_fetch)
             )
             self.last_fetch = None
 
@@ -505,10 +505,10 @@ class Driver:
 
     def status(self):
         parts = list()
-        parts.append("x=%f" % self.current_x)
-        parts.append("y=%f" % self.current_y)
-        parts.append("speed=%f" % self.settings.speed)
-        parts.append("power=%d" % self.settings.power)
+        parts.append("x={x:f}".format(x=self.current_x))
+        parts.append("y={y:f}".format(y=self.current_y))
+        parts.append("speed={speed:f}".format(speed=self.settings.speed))
+        parts.append("power={power:d}".format(power=self.settings.power)
         status = ";".join(parts)
         self.context.signal("driver;status", status)
 
@@ -533,14 +533,14 @@ class Drivers(Modifier):
         Modifier.__init__(self, context, name, channel)
 
     def get_driver(self, driver_name, **kwargs):
-        dev = "device/%s" % driver_name
+        dev = "device/{device:s}".format(device=driver_name)
         try:
             return self.context.registered[dev][1]
         except (KeyError, IndexError):
             return None
 
     def get_or_make_driver(self, device_name, driver_type=None, **kwargs):
-        dev = "device/%s" % device_name
+        dev = "device/{device:s}".format(device=device_name)
         try:
             device = self.context.registered[dev]
         except KeyError:
@@ -549,7 +549,7 @@ class Drivers(Modifier):
         if device[1] is not None and driver_type is None:
             return device[1]
         try:
-            for itype in self.context.match("driver/%s" % driver_type):
+            for itype in self.context.match("driver/{driver:s}".format(driver_type)):
                 driver_class = self.context.registered[itype]
                 driver = driver_class(self.context, device_name, **kwargs)
                 device[1] = driver
@@ -633,12 +633,12 @@ class Drivers(Modifier):
         def list_type(channel, _, **kwgs):
             channel(_("Drivers available:"))
             for i, name in enumerate(context.match("driver/", suffix=True)):
-                channel("%d: %s" % (i + 1, name))
+                channel("{i:2d}: {name:s}".format(i=i+1, name=name))
             channel("----------")
 
         @self.context.console_command(
             "reset",
-            help=_("driver<?> reset"),
+            help=_("Reset a driver"),
             input_type="driver",
             output_type="driver",
         )


### PR DESCRIPTION
In order for translations to work consistently substitution needs to be done using named parameters rather than position.

For example `_("%s is in %s")` might be translated in a different language to something meaning `"%s contains %s"` and a substitution like `_("%s is in %s") % (inside, outside)` which in english would give "inside is in outside" might result instead in "inside contains outside" rather than "outside contains inside" as it should. 

Instead we plan to do `_("{inside:s} is in {outside:s}").format(inside="inside", outside="outside")` which uses named parameters so that a translation "{outside:s} contains {inside:s}" will still result in the correct substition order.

The minimum required is to convert translation strings containing 2 or more variable substitutions. Ideally for consistency all translations should use `str.format()`, and ideally all `%` substitutions would be changed also.

**PLUS...**
This is also an opportunity to ensure that console command help strings do **not** have the command names translated (which is an error in current code). e.g. `@self.context.console_command("bind", help=_("bind <key> <console command>"))` should be `@self.context.console_command("bind", help="bind "+_("<key> <console command>"))`.