### PR TITLE
Merge fixes and optimisation improvements

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -265,11 +265,13 @@ class CutGroup(list, CutObject, ABC):
     def start(self):
         if len(self) == 0:
             return None
+        # handle group normal/reverse - start and end already handle segment reverse
         return self[0].start() if self.normal else self[-1].end()
 
     def end(self):
         if len(self) == 0:
             return None
+        # handle group normal/reverse - start and end already handle segment reverse
         return self[-1].end() if self.normal else self[0].start()
 
     def flat(self):

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1127,7 +1127,7 @@ class LaserOperation(Node):
                 yield COMMAND_WAIT, (self.settings.speed / 1000.0)
                 yield COMMAND_LASER_OFF
 
-    def as_cutobjects(self, closed_distance=15):
+    def as_cutobjects(self, closed_distance=15, passes=1):
         """
         Generator of cutobjects for a particular operation.
         """
@@ -1162,7 +1162,7 @@ class LaserOperation(Node):
                         isinstance(sp[-1], Close)
                         or abs(sp.z_point - sp.current_point) <= closed_distance
                     )
-                    group = CutGroup(None, closed=closed)
+                    group = CutGroup(None, closed=closed, settings=settings)
                     group.path = Path(subpath)
                     group.original_op = self._operation
                     for seg in subpath:
@@ -1171,12 +1171,12 @@ class LaserOperation(Node):
                         elif isinstance(seg, Close):
                             if seg.start != seg.end:
                                 group.append(
-                                    LineCut(seg.start, seg.end, settings=settings)
+                                    LineCut(seg.start, seg.end, settings=settings, passes=passes)
                                 )
                         elif isinstance(seg, Line):
                             if seg.start != seg.end:
                                 group.append(
-                                    LineCut(seg.start, seg.end, settings=settings)
+                                    LineCut(seg.start, seg.end, settings=settings, passes=passes)
                                 )
                         elif isinstance(seg, QuadraticBezier):
                             group.append(
@@ -1185,6 +1185,7 @@ class LaserOperation(Node):
                                     seg.control,
                                     seg.end,
                                     settings=settings,
+                                    passes=passes,
                                 )
                             )
                         elif isinstance(seg, CubicBezier):
@@ -1195,6 +1196,7 @@ class LaserOperation(Node):
                                     seg.control2,
                                     seg.end,
                                     settings=settings,
+                                    passes=passes,
                                 )
                             )
                     for i, cut_obj in enumerate(group):
@@ -1234,7 +1236,8 @@ class LaserOperation(Node):
                     pil_image,
                     matrix.value_trans_x(),
                     matrix.value_trans_y(),
-                    settings,
+                    settings=settings,
+                    passes=passes,
                 )
                 cut.path = path
                 cut.original_op = self._operation
@@ -1244,8 +1247,9 @@ class LaserOperation(Node):
                         pil_image,
                         matrix.value_trans_x(),
                         matrix.value_trans_y(),
-                        settings,
                         crosshatch=True,
+                        settings=settings,
+                        passes=passes,
                     )
                     cut.path = path
                     cut.original_op = self._operation
@@ -1301,8 +1305,9 @@ class LaserOperation(Node):
                         pil_image,
                         matrix.value_trans_x(),
                         matrix.value_trans_y(),
-                        settings,
                         crosshatch=True,
+                        settings=settings,
+                        passes=passes,
                     )
                     cut.path = path
                     cut.original_op = self._operation

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1294,7 +1294,9 @@ class LaserOperation(Node):
                     )
                 )
                 cut = RasterCut(
-                    pil_image, matrix.value_trans_x(), matrix.value_trans_y(), settings
+                    pil_image, matrix.value_trans_x(), matrix.value_trans_y(),
+                    settings= settings,
+                    passes=passes,
                 )
                 cut.path = path
                 cut.original_op = self._operation

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -361,6 +361,7 @@ class CutPlan:
                 group = []
             group.append(c)
         grouped_plan.append(group)
+        print(repr(grouped_plan))
 
         # If Merge operations and not merge passes we need to iterate passes first and operations second
         passes_first = context.opt_merge_ops and not context.opt_merge_passes
@@ -1639,17 +1640,17 @@ def short_travel_cutcode(context: CutCode, channel=None):
             if (
                 closest.next
                 and closest.next.permitted
-                and closent.next.burns_remaining >= closest.burns_remaining
+                and closest.next.burns_remaining >= closest.burns_remaining
                 and closest.next.start == closest.end
             ):
                 closest = closest.next
                 backwards = False
         else:
             if (
-                closest.prev
-                and closest.prev.permitted
-                and closent.prev.burns_remaining > closest.burns_remaining
-                and closest.prev.end == closest.start
+                closest.previous
+                and closest.previous.permitted
+                and closest.previous.burns_remaining > closest.burns_remaining
+                and closest.previous.end == closest.start
             ):
                 closest = closest.next
                 backwards = False

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -1579,6 +1579,11 @@ def short_travel_cutcode(context: CutCode, channel=None):
                     closest = cut
                     distance = abs(complex(closest.end()) - curr)
                     backwards = True
+            # Gap or continuing on path not permitted, try reversing
+            if distance > 50 and last_segment.permitted and last_segment.burns_remaining >= 1:
+                closest = last_segment
+                distance = 0  # By definition
+                backwards = closest.normal
 
         # Stay on path in same direction if gap <= 1/20" i.e. path not quite closed
         # Travel only if path is complete or gap > 1/20"

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -1622,21 +1622,33 @@ def short_travel_cutcode(context: CutCode, channel=None):
                             closest = cut
                             backwards = True
                             if d <= 0.1:  # Distance in px is zero, we cannot improve.
-                                # Need to swap to next segment forward if it is coincident and permitted
-                                if (
-                                    cut.next
-                                    and cut.next.permitted
-                                    and cut.next.burns_remaining >= 1
-                                    and cut.next.start == cut.end
-                                ):
-                                    closest = cut.next
-                                    backwards = False
                                 break
                             distance = d
                             closest_length = l
 
         if closest is None:
             break
+
+        # Change direction if other direction is coincident and has more burns remaining
+        if backwards:
+            if (
+                closest.next
+                and closest.next.permitted
+                and closent.next.burns_remaining >= closest.burns_remaining
+                and closest.next.start == closest.end
+            ):
+                closest = closest.next
+                backwards = False
+        else:
+            if (
+                closest.prev
+                and closest.prev.permitted
+                and closent.prev.burns_remaining > closest.burns_remaining
+                and closest.prev.end == closest.start
+            ):
+                closest = closest.next
+                backwards = False
+
         closest.burns_remaining -= 1
         if closest.burns_remaining == 0:
             closest.permitted = False


### PR DESCRIPTION
1. Fixes various merge issues, specifically:
    a. Merge operations not working when passes >=2 and merge passes not set (because CutCode sequence was inappropriate)
    b. Operations being merged when Merge passes set and Merge ops not set because operations of same type were being incorrectly merged. Fixes #656 and reported in #528 and #465.
    c. Merge passes reversing direction unncessarily.

2. Improves Greedy optimisation with Merged Passes by reducing the size of the CutCode object being optimised by holding only a single copy of each CutGroup and continuing to burn this object rather than having to find the next copy of the same CutGroup. Implements #655.