### PR TITLE
Limit Resource Usage

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,6 +27,7 @@ jobs:
 
     name: ${{ matrix.os }}+py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We should be more sparing with resources.

Might be out of minutes for the month.
OSX unit tests do not complete.
Unittests do not have Timeout.