### PR TITLE
Fix for mac and linux open in system

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5140,11 +5140,11 @@ class Elemental(Modifier):
             from sys import platform
 
             if platform == "darwin":
-                open_in_shell('"open {file}"'.format(file=normalized))
+                open_in_shell("open '{file}'".format(file=normalized))
             elif "win" in platform:
-                open_in_shell('"{file}"'.format(file=normalized))
+                open_in_shell("'{file}'".format(file=normalized))
             else:
-                open_in_shell('"xdg-open {file}"'.format(file=normalized))
+                open_in_shell("xdg-open '{file}'".format(file=normalized))
 
         @self.tree_submenu(_("Duplicate element(s)"))
         @self.tree_operation(_("Make 1 copy"), node_type="elem", help="")


### PR DESCRIPTION
The issue was using the double-set of quotes. Rather than running
$ xdg-open file.svg

it was trying to run
$ "xdg-open file.svg"

which doesn't work. Instead, do this:
$ xdg-open 'file.svg'

Tested working on 2 different linux distros and mac.
Didn't test on pi, but xdg-open exists there, I see no reason why it wouldn't work.