### PR TITLE
NSE scanline switching / twitchless mode

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -98,9 +98,22 @@ class LaserSettings:
         for q in dir(obj):
             if q.startswith("_") or q.startswith("implicit"):
                 continue
+            obj_type = type(obj)
+            if hasattr(obj_type, q) and isinstance(getattr(obj_type, q), property):
+                # Do not set property values
+                continue
+
             value = getattr(obj, q)
             if isinstance(value, (int, float, bool, str)):
                 setattr(self, q, value)
+
+    @property
+    def horizontal_raster(self):
+        return self.raster_step and (self.raster_direction == 0 or self.raster_direction == 1)
+
+    @property
+    def vertical_raster(self):
+        return self.raster_step and (self.raster_direction == 2 or self.raster_direction == 3)
 
     @property
     def implicit_accel(self):

--- a/meerk40t/device/lhystudios/laserspeed.py
+++ b/meerk40t/device/lhystudios/laserspeed.py
@@ -14,7 +14,7 @@ class LaserSpeed:
     All values relate to a value in the counter to count off the number of oscillations within the
     (typically 22.1184) Mhz crystal. The max value here is 65535, with the addition of a diagonal delay.
 
-    For the M2 board, the original Chinese Software gave a slope of 12120. However experiments with the actual
+    For the M2 board, the original Chinese Software gave a slope of 12120. However, experiments with the actual
     physical speed put this value at 11142, which properly reflects that all speeds tend to be at 91.98% of the
     requested speed.
 

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -1342,8 +1342,8 @@ class LhystudiosDriver(Driver):
         delta = math.trunc(self.step_total)
         self.step_total -= delta
 
-        step_amount = (set_step if self.is_prop(STATE_Y_FORWARD_TOP) else -set_step)
-        delta = delta + step_amount
+        step_amount = (-set_step if self.is_prop(STATE_Y_FORWARD_TOP) else set_step)
+        delta = delta - step_amount
 
         self.data_output(b"N")
         if delta != 0:
@@ -1352,9 +1352,10 @@ class LhystudiosDriver(Driver):
             else:
                 self.data_output(self.CODE_BOTTOM)
             self.data_output(lhymicro_distance(abs(delta)))
+            self.current_y += delta
         self.data_output(b"SE")
+        self.current_y += step_amount
         self.toggle_prop(STATE_X_FORWARD_LEFT)
-        self.current_y += delta
         self.laser = False
         self.step_index += 1
 
@@ -1375,8 +1376,8 @@ class LhystudiosDriver(Driver):
         delta = math.trunc(self.step_total)
         self.step_total -= delta
 
-        step_amount = (set_step if self.is_prop(STATE_X_FORWARD_LEFT) else -set_step)
-        delta = delta + step_amount
+        step_amount = (-set_step if self.is_prop(STATE_X_FORWARD_LEFT) else set_step)
+        delta = delta - step_amount
 
         self.data_output(b"N")
         if delta != 0:
@@ -1385,9 +1386,10 @@ class LhystudiosDriver(Driver):
             else:
                 self.data_output(self.CODE_RIGHT)
             self.data_output(lhymicro_distance(abs(delta)))
+            self.current_x += delta
         self.data_output(b"SE")
+        self.current_x += step_amount
         self.toggle_prop(STATE_Y_FORWARD_TOP)
-        self.current_x += delta
         self.laser = False
         self.step_index += 1
 

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -725,6 +725,7 @@ class LhystudiosDriver(Driver):
         context.setting(str, "board", "M2")
         context.setting(bool, "twitchless", False)
         context.setting(bool, "nse_raster", False)
+        context.setting(bool, "nse_stepraster", False)
         context.setting(bool, "fix_speeds", False)
 
         self.CODE_RIGHT = b"B"
@@ -1188,7 +1189,7 @@ class LhystudiosDriver(Driver):
         self.step_index = 0
         self.step = self.settings.raster_step
         self.step_value_set = 0
-        if self.context.nse_raster:
+        if self.context.nse_raster and not self.context.nse_stepraster:
             return 0
         self.step_value_set = self.step
         return self.step_value_set

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -566,6 +566,8 @@ distance_lookup = [
 
 
 def lhymicro_distance(v):
+    if v < 0:
+        raise ValueError("Cannot permit negative values.")
     dist = b""
     if v >= 255:
         zs = int(v / 255)
@@ -1349,7 +1351,7 @@ class LhystudiosDriver(Driver):
                 self.data_output(self.CODE_TOP)
             else:
                 self.data_output(self.CODE_BOTTOM)
-            self.data_output(lhymicro_distance(delta))
+            self.data_output(lhymicro_distance(abs(delta)))
         self.data_output(b"SE")
         self.toggle_prop(STATE_X_FORWARD_LEFT)
         self.current_y += delta
@@ -1382,7 +1384,7 @@ class LhystudiosDriver(Driver):
                 self.data_output(self.CODE_LEFT)
             else:
                 self.data_output(self.CODE_RIGHT)
-            self.data_output(lhymicro_distance(delta))
+            self.data_output(lhymicro_distance(abs(delta)))
         self.data_output(b"SE")
         self.toggle_prop(STATE_Y_FORWARD_TOP)
         self.current_x += delta

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -726,6 +726,8 @@ class LhystudiosDriver(Driver):
         context.setting(bool, "autolock", True)
 
         context.setting(str, "board", "M2")
+        context.setting(bool, "twitchless", False)
+        context.setting(bool, "nse_raster", False)
         context.setting(bool, "fix_speeds", False)
 
         self.CODE_RIGHT = b"B"
@@ -854,38 +856,44 @@ class LhystudiosDriver(Driver):
                 self.ensure_raster_mode()
                 if self.is_prop(STATE_X_STEPPER_ENABLE):
                     if dy != 0:
-                        if self.is_prop(STATE_Y_FORWARD_TOP):
-                            if abs(dy) > step:
-                                self.ensure_finished_mode()
-                                self.move_relative(0, dy + step)
-                                self.set_prop(STATE_X_STEPPER_ENABLE)
-                                self.unset_prop(STATE_Y_STEPPER_ENABLE)
-                                self.ensure_raster_mode()
+                        if self.context.nse_raster:
+                            self.h_switch(step)
                         else:
-                            if abs(dy) > step:
-                                self.ensure_finished_mode()
-                                self.move_relative(0, dy - step)
-                                self.set_prop(STATE_X_STEPPER_ENABLE)
-                                self.unset_prop(STATE_Y_STEPPER_ENABLE)
-                                self.ensure_raster_mode()
-                        self.h_switch()
+                            if self.is_prop(STATE_Y_FORWARD_TOP):
+                                if abs(dy) > step:
+                                    self.ensure_finished_mode()
+                                    self.move_relative(0, dy + step)
+                                    self.set_prop(STATE_X_STEPPER_ENABLE)
+                                    self.unset_prop(STATE_Y_STEPPER_ENABLE)
+                                    self.ensure_raster_mode()
+                            else:
+                                if abs(dy) > step:
+                                    self.ensure_finished_mode()
+                                    self.move_relative(0, dy - step)
+                                    self.set_prop(STATE_X_STEPPER_ENABLE)
+                                    self.unset_prop(STATE_Y_STEPPER_ENABLE)
+                                    self.ensure_raster_mode()
+                            self.h_switch_g()
                 elif self.is_prop(STATE_Y_STEPPER_ENABLE):
                     if dx != 0:
-                        if self.is_prop(STATE_X_FORWARD_LEFT):
-                            if abs(dx) > step:
-                                self.ensure_finished_mode()
-                                self.move_relative(dx + step, 0)
-                                self.set_prop(STATE_Y_STEPPER_ENABLE)
-                                self.unset_prop(STATE_X_STEPPER_ENABLE)
-                                self.ensure_raster_mode()
+                        if self.context.nse_raster:
+                            self.v_switch()
                         else:
-                            if abs(dx) > step:
-                                self.ensure_finished_mode()
-                                self.move_relative(dx - step, 0)
-                                self.set_prop(STATE_Y_STEPPER_ENABLE)
-                                self.unset_prop(STATE_X_STEPPER_ENABLE)
-                                self.ensure_raster_mode()
-                        self.v_switch()
+                            if self.is_prop(STATE_X_FORWARD_LEFT):
+                                if abs(dx) > step:
+                                    self.ensure_finished_mode()
+                                    self.move_relative(dx + step, 0)
+                                    self.set_prop(STATE_Y_STEPPER_ENABLE)
+                                    self.unset_prop(STATE_X_STEPPER_ENABLE)
+                                    self.ensure_raster_mode()
+                            else:
+                                if abs(dx) > step:
+                                    self.ensure_finished_mode()
+                                    self.move_relative(dx - step, 0)
+                                    self.set_prop(STATE_Y_STEPPER_ENABLE)
+                                    self.unset_prop(STATE_X_STEPPER_ENABLE)
+                                    self.ensure_raster_mode()
+                            self.v_switch_g()
             self.goto_octent_abs(x, y, on & 1)
             if self.hold():
                 return True
@@ -1226,7 +1234,7 @@ class LhystudiosDriver(Driver):
                 acceleration=self.settings.implicit_accel,
                 fix_limit=True,
                 fix_lows=True,
-                suffix_c=True,
+                suffix_c=self.context.twitchless,
                 fix_speeds=self.context.fix_speeds,
                 raster_horizontal=True,
             ).speedcode
@@ -1302,7 +1310,7 @@ class LhystudiosDriver(Driver):
             acceleration=self.settings.implicit_accel,
             fix_limit=True,
             fix_lows=True,
-            suffix_c=True,
+            suffix_c=self.context.twitchless,
             fix_speeds=self.context.fix_speeds,
             raster_horizontal=True,
         ).speedcode

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -1205,17 +1205,31 @@ class LhystudiosDriver(Driver):
         dy = int(round(dy))
         self.data_output(b"@NSE")
         self.state = DRIVER_STATE_RAPID
-        speed_code = LaserSpeed(
-            self.context.board,
-            self.settings.speed,
-            self.settings.raster_step,
-            d_ratio=self.settings.implicit_d_ratio,
-            acceleration=self.settings.implicit_accel,
-            fix_limit=True,
-            fix_lows=True,
-            fix_speeds=self.context.fix_speeds,
-            raster_horizontal=True,
-        ).speedcode
+        if self.settings.raster_step:
+            speed_code = LaserSpeed(
+                self.context.board,
+                self.settings.speed,
+                self.settings.raster_step,
+                d_ratio=self.settings.implicit_d_ratio,
+                acceleration=self.settings.implicit_accel,
+                fix_limit=True,
+                fix_lows=True,
+                fix_speeds=self.context.fix_speeds,
+                raster_horizontal=True,
+            ).speedcode
+        else:
+            speed_code = LaserSpeed(
+                self.context.board,
+                self.settings.speed,
+                self.settings.raster_step,
+                d_ratio=self.settings.implicit_d_ratio,
+                acceleration=self.settings.implicit_accel,
+                fix_limit=True,
+                fix_lows=True,
+                suffix_c=True,
+                fix_speeds=self.context.fix_speeds,
+                raster_horizontal=True,
+            ).speedcode
         try:
             speed_code = bytes(speed_code)
         except TypeError:
@@ -1288,6 +1302,7 @@ class LhystudiosDriver(Driver):
             acceleration=self.settings.implicit_accel,
             fix_limit=True,
             fix_lows=True,
+            suffix_c=True,
             fix_speeds=self.context.fix_speeds,
             raster_horizontal=True,
         ).speedcode

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -1,3 +1,4 @@
+import math
 import threading
 import time
 
@@ -104,12 +105,8 @@ def plugin(kernel, lifecycle=None):
         )
         def move_speed(channel, _, speed, dx, dy, data=None, **kwgs):
             spooler, driver, output = data
-            dx = Length(dx).value(
-                ppi=1000.0
-            )
-            dy = Length(dy).value(
-                ppi=1000.0
-            )
+            dx = Length(dx).value(ppi=1000.0)
+            dy = Length(dy).value(ppi=1000.0)
 
             def move_at_speed():
                 yield COMMAND_SET_SPEED, speed
@@ -758,6 +755,18 @@ class LhystudiosDriver(Driver):
         self.min_x = self.current_x
         self.min_y = self.current_y
 
+        # Step amount expected of the current operation
+        self.step = 0
+
+        # Step amount is the current correctly set step amount in the controller.
+        self.step_value_set = 0
+
+        # Step index of the current step taken for unidirectional
+        self.step_index = 0
+
+        # Step total the count for fractional step amounts
+        self.step_total = 0.0
+
     def __repr__(self):
         return "LhystudiosDriver(%s)" % self.name
 
@@ -857,43 +866,15 @@ class LhystudiosDriver(Driver):
                 if self.is_prop(STATE_X_STEPPER_ENABLE):
                     if dy != 0:
                         if self.context.nse_raster:
-                            self.h_switch(step)
+                            self.h_switch(dy)
                         else:
-                            if self.is_prop(STATE_Y_FORWARD_TOP):
-                                if abs(dy) > step:
-                                    self.ensure_finished_mode()
-                                    self.move_relative(0, dy + step)
-                                    self.set_prop(STATE_X_STEPPER_ENABLE)
-                                    self.unset_prop(STATE_Y_STEPPER_ENABLE)
-                                    self.ensure_raster_mode()
-                            else:
-                                if abs(dy) > step:
-                                    self.ensure_finished_mode()
-                                    self.move_relative(0, dy - step)
-                                    self.set_prop(STATE_X_STEPPER_ENABLE)
-                                    self.unset_prop(STATE_Y_STEPPER_ENABLE)
-                                    self.ensure_raster_mode()
-                            self.h_switch_g()
+                            self.h_switch_g(dy)
                 elif self.is_prop(STATE_Y_STEPPER_ENABLE):
                     if dx != 0:
                         if self.context.nse_raster:
-                            self.v_switch()
+                            self.v_switch(dx)
                         else:
-                            if self.is_prop(STATE_X_FORWARD_LEFT):
-                                if abs(dx) > step:
-                                    self.ensure_finished_mode()
-                                    self.move_relative(dx + step, 0)
-                                    self.set_prop(STATE_Y_STEPPER_ENABLE)
-                                    self.unset_prop(STATE_X_STEPPER_ENABLE)
-                                    self.ensure_raster_mode()
-                            else:
-                                if abs(dx) > step:
-                                    self.ensure_finished_mode()
-                                    self.move_relative(dx - step, 0)
-                                    self.set_prop(STATE_Y_STEPPER_ENABLE)
-                                    self.unset_prop(STATE_X_STEPPER_ENABLE)
-                                    self.ensure_raster_mode()
-                            self.v_switch_g()
+                            self.v_switch_g(dx)
             self.goto_octent_abs(x, y, on & 1)
             if self.hold():
                 return True
@@ -1198,6 +1179,20 @@ class LhystudiosDriver(Driver):
         self.state = DRIVER_STATE_RAPID
         self.context.signal("driver;mode", self.state)
 
+    def instance_step(self):
+        """
+        Sets and returns the step values, setting step to the raster_step
+
+        @return:
+        """
+        self.step_index = 0
+        self.step = self.settings.raster_step
+        self.step_value_set = 0
+        if self.context.nse_raster:
+            return 0
+        self.step_value_set = self.step
+        return self.step_value_set
+
     def mode_shift_on_the_fly(self, dx=0, dy=0):
         """
         Mode shift on the fly changes the current modes while in programmed or raster mode
@@ -1213,35 +1208,19 @@ class LhystudiosDriver(Driver):
         dy = int(round(dy))
         self.data_output(b"@NSE")
         self.state = DRIVER_STATE_RAPID
-        if self.settings.raster_step:
-            speed_code = LaserSpeed(
-                self.context.board,
-                self.settings.speed,
-                self.settings.raster_step,
-                d_ratio=self.settings.implicit_d_ratio,
-                acceleration=self.settings.implicit_accel,
-                fix_limit=True,
-                fix_lows=True,
-                fix_speeds=self.context.fix_speeds,
-                raster_horizontal=True,
-            ).speedcode
-        else:
-            speed_code = LaserSpeed(
-                self.context.board,
-                self.settings.speed,
-                self.settings.raster_step,
-                d_ratio=self.settings.implicit_d_ratio,
-                acceleration=self.settings.implicit_accel,
-                fix_limit=True,
-                fix_lows=True,
-                suffix_c=self.context.twitchless,
-                fix_speeds=self.context.fix_speeds,
-                raster_horizontal=True,
-            ).speedcode
-        try:
-            speed_code = bytes(speed_code)
-        except TypeError:
-            speed_code = bytes(speed_code, "utf8")
+        speed_code = LaserSpeed(
+            self.context.board,
+            self.settings.speed,
+            self.instance_step(),
+            d_ratio=self.settings.implicit_d_ratio,
+            acceleration=self.settings.implicit_accel,
+            fix_limit=True,
+            fix_lows=True,
+            suffix_c=True if self.context.twitchless and not self.step else None,
+            fix_speeds=self.context.fix_speeds,
+            raster_horizontal=True,
+        ).speedcode
+        speed_code = bytes(speed_code, "utf8")
         self.data_output(speed_code)
         if dx != 0:
             self.goto_x(dx)
@@ -1251,10 +1230,10 @@ class LhystudiosDriver(Driver):
         self.set_requested_directions()
         self.data_output(self.code_declare_directions())
         self.data_output(b"S1E")
-        if self.settings.raster_step == 0:
-            self.state = DRIVER_STATE_PROGRAM
-        else:
+        if self.step:
             self.state = DRIVER_STATE_RASTER
+        else:
+            self.state = DRIVER_STATE_PROGRAM
 
     def ensure_finished_mode(self, *values):
         if self.state == DRIVER_STATE_FINISH:
@@ -1272,6 +1251,13 @@ class LhystudiosDriver(Driver):
         self.context.signal("driver;mode", self.state)
 
     def ensure_raster_mode(self, *values):
+        """
+        Raster mode runs in either G0xx stepping mode or NSE stepping but is only intended to move horizontal or
+        vertical rastering, usually at a high speed. Accel twitches are required for this mode.
+
+        @param values:
+        @return:
+        """
         if self.state == DRIVER_STATE_RASTER:
             return
         self.ensure_finished_mode()
@@ -1279,6 +1265,7 @@ class LhystudiosDriver(Driver):
         speed_code = LaserSpeed(
             self.context.board,
             self.settings.speed,
+            self.instance_step(),
             d_ratio=self.settings.implicit_d_ratio,
             acceleration=self.settings.implicit_accel,
             fix_limit=True,
@@ -1299,6 +1286,12 @@ class LhystudiosDriver(Driver):
         self.context.signal("driver;mode", self.state)
 
     def ensure_program_mode(self, *values):
+        """
+        Vector Mode implies but doesn't discount rastering. Twitches are used if twitchless is set to False.
+
+        @param values:
+        @return:
+        """
         if self.state == DRIVER_STATE_PROGRAM:
             return
         self.ensure_finished_mode()
@@ -1306,11 +1299,12 @@ class LhystudiosDriver(Driver):
         speed_code = LaserSpeed(
             self.context.board,
             self.settings.speed,
+            self.instance_step(),
             d_ratio=self.settings.implicit_d_ratio,
             acceleration=self.settings.implicit_accel,
             fix_limit=True,
             fix_lows=True,
-            suffix_c=self.context.twitchless,
+            suffix_c=True if self.context.twitchless else None,
             fix_speeds=self.context.fix_speeds,
             raster_horizontal=True,
         ).speedcode
@@ -1326,66 +1320,145 @@ class LhystudiosDriver(Driver):
         self.state = DRIVER_STATE_PROGRAM
         self.context.signal("driver;mode", self.state)
 
-    def h_switch(self, step=None):
-        if step is None:
-            step = self.settings.raster_step
-        self.data_output(b"N")
-        if self.is_prop(STATE_Y_FORWARD_TOP):
-            self.current_y -= step
-            self.data_output(self.CODE_TOP)
-        else:
-            self.current_y += step
-            self.data_output(self.CODE_BOTTOM)
+    def h_switch(self, dy: float):
+        """
+        NSE h_switches replace the mere reversal of direction with N<v><distance>SE
 
-        self.data_output(lhymicro_distance(step))
+        If a G-value is set we should subtract that from the step for our movement.
+
+        @param dy: The amount along the directional axis we should move.
+
+        @return:
+        """
+        set_step = self.step_value_set
+        if isinstance(set_step, tuple):
+            set_step = set_step[self.step_index % len(set_step)]
+
+        # correct for fractional stepping
+        self.step_total += dy
+        delta = math.trunc(self.step_total)
+        self.step_total -= delta
+
+        step_amount = (set_step if self.is_prop(STATE_Y_FORWARD_TOP) else -set_step)
+        delta = delta + step_amount
+
+        self.data_output(b"N")
+        if delta != 0:
+            if self.is_prop(STATE_Y_FORWARD_TOP):
+                self.data_output(self.CODE_TOP)
+            else:
+                self.data_output(self.CODE_BOTTOM)
+            self.data_output(lhymicro_distance(delta))
         self.data_output(b"SE")
-        if self.is_prop(STATE_X_FORWARD_LEFT):
-            self.unset_prop(STATE_X_FORWARD_LEFT)
-        else:
-            self.set_prop(STATE_X_FORWARD_LEFT)
-
+        self.toggle_prop(STATE_X_FORWARD_LEFT)
+        self.current_y += delta
         self.laser = False
+        self.step_index += 1
 
-    def h_switch_g(self):
-        if self.is_prop(STATE_X_FORWARD_LEFT):
-            self.data_output(self.CODE_RIGHT)
-            self.unset_prop(STATE_X_FORWARD_LEFT)
-        else:
-            self.data_output(self.CODE_LEFT)
-            self.set_prop(STATE_X_FORWARD_LEFT)
-        if self.is_prop(STATE_Y_FORWARD_TOP):
-            self.current_y -= self.settings.raster_step
-        else:
-            self.current_y += self.settings.raster_step
-        self.laser = False
+    def v_switch(self, dx: float):
+        """
+        NSE v_switches replace the mere reversal of direction with N<h><distance>SE
 
-    def v_switch(self, step=None):
-        if step is None:
-            step = self.settings.raster_step
+        @param dx: The amount along the directional axis we should move.
+
+        @return:
+        """
+        set_step = self.step_value_set
+        if isinstance(set_step, tuple):
+            set_step = set_step[self.step_index % len(set_step)]
+
+        # correct for fractional stepping
+        self.step_total += dx
+        delta = math.trunc(self.step_total)
+        self.step_total -= delta
+
+        step_amount = (set_step if self.is_prop(STATE_X_FORWARD_LEFT) else -set_step)
+        delta = delta + step_amount
+
         self.data_output(b"N")
-        if self.is_prop(STATE_X_FORWARD_LEFT):
-            self.current_x -= step
-            self.data_output(self.CODE_LEFT)
-        else:
-            self.current_x += step
-            self.data_output(self.CODE_RIGHT)
-        self.data_output(lhymicro_distance(step))
+        if delta != 0:
+            if self.is_prop(STATE_X_FORWARD_LEFT):
+                self.data_output(self.CODE_LEFT)
+            else:
+                self.data_output(self.CODE_RIGHT)
+            self.data_output(lhymicro_distance(delta))
         self.data_output(b"SE")
         self.toggle_prop(STATE_Y_FORWARD_TOP)
+        self.current_x += delta
         self.laser = False
+        self.step_index += 1
 
-    def v_switch_g(self):
+    def h_switch_g(self, dy: float):
+        """
+        Horizontal switch with a Gvalue set. The board will automatically step according to the step_value_set.
+
+        @return:
+        """
+        set_step = self.step_value_set
+        if isinstance(set_step, tuple):
+            set_step = set_step[self.step_index % len(set_step)]
+
+        # correct for fractional stepping
+        self.step_total += dy
+        delta = math.trunc(self.step_total)
+        self.step_total -= delta
+
+        step_amount = (set_step if self.is_prop(STATE_Y_FORWARD_TOP) else -set_step)
+        delta = delta + step_amount
+        if delta != 0:
+            # Movement exceeds the standard raster step amount. Rapid relocate.
+            self.ensure_finished_mode()
+            self.move_relative(0, delta)
+            self.set_prop(STATE_X_STEPPER_ENABLE)
+            self.unset_prop(STATE_Y_STEPPER_ENABLE)
+            self.ensure_raster_mode()
+
+        # We reverse direction and step.
+        if self.is_prop(STATE_X_FORWARD_LEFT):
+            self.data_output(self.CODE_RIGHT)
+            self.unset_prop(STATE_X_FORWARD_LEFT)
+        else:
+            self.data_output(self.CODE_LEFT)
+            self.set_prop(STATE_X_FORWARD_LEFT)
+        self.current_y += step_amount
+        self.laser = False
+        self.step_index += 1
+
+    def v_switch_g(self, dx: float):
+        """
+        Vertical switch with a Gvalue set. The board will automatically step according to the step_value_set.
+
+        @return:
+        """
+        set_step = self.step_value_set
+        if isinstance(set_step, tuple):
+            set_step = set_step[self.step_index % len(set_step)]
+
+        # correct for fractional stepping
+        self.step_total += dx
+        delta = math.trunc(self.step_total)
+        self.step_total -= delta
+
+        step_amount = (set_step if self.is_prop(STATE_X_FORWARD_LEFT) else -set_step)
+        delta = delta + step_amount
+        if delta != 0:
+            # Movement exceeds the standard raster step amount. Rapid relocate.
+            self.ensure_finished_mode()
+            self.move_relative(delta, 0)
+            self.set_prop(STATE_Y_STEPPER_ENABLE)
+            self.unset_prop(STATE_X_STEPPER_ENABLE)
+            self.ensure_raster_mode()
+
+        # We reverse direction and step.
         if self.is_prop(STATE_Y_FORWARD_TOP):
             self.data_output(self.CODE_BOTTOM)
             self.unset_prop(STATE_Y_FORWARD_TOP)
         else:
             self.data_output(self.CODE_TOP)
             self.set_prop(STATE_Y_FORWARD_TOP)
-        if self.is_prop(STATE_X_FORWARD_LEFT):
-            self.current_x -= self.settings.raster_step
-        else:
-            self.current_x += self.settings.raster_step
+        self.current_x += step_amount
         self.laser = False
+        self.step_index += 1
 
     def calc_home_position(self):
         x = 0

--- a/meerk40t/gui/lhystudios/lhystudiosdrivergui.py
+++ b/meerk40t/gui/lhystudios/lhystudiosdrivergui.py
@@ -28,6 +28,12 @@ class LhystudiosConfigurationPanel(wx.Panel):
         self.checkbox_fix_speeds = wx.CheckBox(
             self, wx.ID_ANY, _("Fix rated to actual speed")
         )
+        self.checkbox_twitchless = wx.CheckBox(
+            self, wx.ID_ANY, _("Twitchless Vector")
+        )
+        self.checkbox_alternative_raster = wx.CheckBox(
+            self, wx.ID_ANY, _("Alt Raster Style")
+        )
         self.checkbox_flip_x = wx.CheckBox(self, wx.ID_ANY, _("Flip X"))
         self.checkbox_home_right = wx.CheckBox(self, wx.ID_ANY, _("Home Right"))
         self.checkbox_flip_y = wx.CheckBox(self, wx.ID_ANY, _("Flip Y"))
@@ -65,6 +71,8 @@ class LhystudiosConfigurationPanel(wx.Panel):
         self.Bind(wx.EVT_CHECKBOX, self.on_check_home_bottom, self.checkbox_home_bottom)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_swapxy, self.checkbox_swap_xy)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_strict, self.checkbox_strict)
+        self.Bind(wx.EVT_CHECKBOX, self.on_check_twitchless, self.checkbox_twitchless)
+        self.Bind(wx.EVT_CHECKBOX, self.on_check_alt_raster, self.checkbox_alternative_raster)
         self.Bind(wx.EVT_SPINCTRLDOUBLE, self.spin_on_home_x, self.spin_home_x)
         self.Bind(wx.EVT_TEXT_ENTER, self.spin_on_home_x, self.spin_home_x)
         self.Bind(wx.EVT_SPINCTRLDOUBLE, self.spin_on_home_y, self.spin_home_y)
@@ -132,6 +140,10 @@ class LhystudiosConfigurationPanel(wx.Panel):
                 "Forces the device to enter and exit programmed speed mode from the same direction.\nThis may prevent devices like the M2-V4 and earlier from having issues. Not typically needed."
             )
         )
+        self.checkbox_alternative_raster.SetToolTip(
+            _("Forces the device to use an alternative method of rastering using NSE transfers rather than the default G0xx raster mode and directional changes.")
+        )
+        self.checkbox_twitchless.SetToolTip(_("Forces the device to utilize twitchless mode for vector engraving"))
         self.spin_home_x.SetMinSize((80, 23))
         self.spin_home_x.SetToolTip(_("Translate Home X"))
         self.spin_home_y.SetMinSize((80, 23))
@@ -208,13 +220,22 @@ class LhystudiosConfigurationPanel(wx.Panel):
         sizer_3 = wx.BoxSizer(wx.VERTICAL)
         sizer_16 = wx.BoxSizer(wx.VERTICAL)
         sizer_17 = wx.BoxSizer(wx.VERTICAL)
+
         sizer_board = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, _("Board Setup:")), wx.HORIZONTAL
         )
-        sizer_board.Add(self.combobox_board, 1, 0, 0)
-        label_1 = wx.StaticText(self, wx.ID_ANY, "")
-        sizer_board.Add(label_1, 1, 0, 0)
-        sizer_board.Add(self.checkbox_fix_speeds, 0, 0, 0)
+        sizer_board_1 = wx.BoxSizer(wx.VERTICAL)
+        sizer_board_2 = wx.BoxSizer(wx.VERTICAL)
+
+        sizer_board_1.Add(self.combobox_board, 1, 0, 0)
+        sizer_board_1.Add(self.checkbox_fix_speeds, 0, 0, 0)
+
+        sizer_board_2.Add(self.checkbox_alternative_raster, 0, 0, 0)
+        sizer_board_2.Add(self.checkbox_twitchless, 0, 0, 0)
+
+        sizer_board.Add(sizer_board_1, 1, 0, 0)
+        sizer_board.Add(sizer_board_2, 1, 0, 0)
+
         sizer_main.Add(sizer_board, 1, wx.EXPAND, 0)
         sizer_17.Add(self.checkbox_flip_x, 0, 0, 0)
         sizer_17.Add(self.checkbox_home_right, 0, 0, 0)
@@ -277,6 +298,8 @@ class LhystudiosConfigurationPanel(wx.Panel):
         context.setting(bool, "home_right", False)
         context.setting(bool, "home_bottom", False)
         context.setting(bool, "strict", False)
+        context.setting(bool, "nse_raster", False)
+        context.setting(bool, "twitchless", False)
 
         context.setting(int, "home_adjust_x", 0)
         context.setting(int, "home_adjust_y", 0)
@@ -296,6 +319,8 @@ class LhystudiosConfigurationPanel(wx.Panel):
         self.checkbox_home_right.SetValue(context.home_right)
         self.checkbox_home_bottom.SetValue(context.home_bottom)
         self.checkbox_strict.SetValue(context.strict)
+        self.checkbox_twitchless.SetValue(context.twitchless)
+        self.checkbox_alternative_raster.SetValue(context.nse_raster)
 
         self.spin_home_x.SetValue(context.home_adjust_x)
         self.spin_home_y.SetValue(context.home_adjust_y)
@@ -328,6 +353,12 @@ class LhystudiosConfigurationPanel(wx.Panel):
 
     def on_check_strict(self, event=None):
         self.context.strict = self.checkbox_strict.GetValue()
+
+    def on_check_twitchless(self, event=None):
+        self.context.twitchless = self.checkbox_twitchless.GetValue()
+
+    def on_check_alt_raster(self, event=None):
+        self.context.nse_raster = self.checkbox_alternative_raster.GetValue()
 
     def on_check_flip_x(self, event=None):
         self.context.flip_x = self.checkbox_flip_x.GetValue()


### PR DESCRIPTION
This is mostly for testing unless there's a better reason to add it than it exists.

The core of this is understanding that G001 mode turns the switch of right moving raster or left moving raster into what is apparently the same as `N<step>SE` so if we're going right (B) we can switch, turn off the laser, and reverse with the command `T` which means turn right. The G001 flagged the scanline step at 1.

With NSE scanline switching we can simply replace the `T` in that case with `NLcSE` assuming we're stepping towards the top (L) and our step size for that step is 3 (c). We are going to be wasting 4 characters each scanline, however this type of scanline can be set dynamically. So we could do interlace rastering. Or raster with a variable step such as a 3,3,4 pattern which would give you a DPI of about 300 rather than 250 or 333. This would require pixels also have a 3,3,4 width-wise. We can also do more fine grain control of rastering. I at one time thought G001G002 would do variable stepping on each side, but it doesn't work. G000 might as well just be a flag that means perform unidirectional rastering. With NSE stepping we can more effectively perform a scanline step effectively.

Also, since this is a vector mode option, it should also work for things like lightburn ruida emulation which suffered serious problems. Since the options there included DPI of values like 225 or whatever, which aren't able to be achieved with a set step the current implementation is a hard-raster. It's vector mode raster implementation which often clicks at the edges and needs to run much more slowly. Here, if we could interpret the commands correctly and perform the relative movements correctly we could implement raster mode in a much more vector-mode friendly way. And we could even avoid ever calling vector mode anyway.

This means that the only real need to call `@NSE` or kick all the way back to real rapid mode is that we will sometimes need to set the major and minor axis. This is to say `NSE` and `other-direction-of-a-raster` perform a step along one specific and explicitly given axis. And there appears to be no way to set this axis elsehow. Which means we can change the speed and accel value and other values on the fly. This means the N<stepping-axis><initial-direction>S1E command that seems to be done in real raster mode is the only reason we'd be forced back to full raster mode.

Whichever value we set there is highly important since if we do an NSE command switch we end up performing a raster-endstop step. This means we do the raster-twitch in the last direction set. And the twitching works differently based on the step axis setting. If we could *also* change this more easily, we could likely get around some of the last remaining hurdles to getting rid of twitching.