### PR TITLE
Fix #702 and switch to os.path

### DIFF
--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -2773,23 +2773,30 @@ class ConsoleFunction(Job):
         return self.data.replace("\n", "")
 
 
-def get_safe_path(name, create=False):
-    from pathlib import Path
+def get_safe_path(name: str, create: Optional[bool]=False, system: Optional[str]=None) -> str:
     import platform
 
-    if platform.system() == "Darwin":
-        directory = (
-            Path.home()
-            .joinpath("Library")
-            .joinpath("Application Support")
-            .joinpath(name)
-        )
-    elif "win" in platform:
-        from os.path import expandvars
+    if not system:
+        system = platform.system()
 
-        directory = Path(expandvars("%LOCALAPPDATA%")).joinpath(name)
+    if system == "Darwin":
+        directory = os.path.join(
+            os.path.expanduser("~"),
+            "Library",
+            "Application Support",
+            name,
+        )
+    elif system == "Windows":
+        directory = os.path.join(
+            os.path.expandvars("%LOCALAPPDATA%"),
+            name
+        )
     else:
-        directory = Path.home().joinpath(".config").joinpath(name)
+        directory = os.path.join(
+            os.path.expanduser("~"),
+            ".config",
+            name
+        )
     if directory is not None and create:
-        directory.mkdir(parents=True, exist_ok=True)
+        os.makedirs(directory, exist_ok=True)
     return directory

--- a/test/test_kernel.py
+++ b/test/test_kernel.py
@@ -1,15 +1,10 @@
-
 import unittest
-
 from test import bootstrap
-
 
 class TestKernel(unittest.TestCase):
     def test_kernel_commands(self):
         """
         Tests all commands with no arguments to test for crashes...
-
-        :return:
         """
         kernel = bootstrap.bootstrap()
         try:
@@ -26,3 +21,34 @@ class TestKernel(unittest.TestCase):
                     kernel.console(command.split("/")[-1] + "\n")
         finally:
             kernel.shutdown()
+
+class TestGetSafePath(unittest.TestCase):
+    def test_get_safe_path(self):
+        from meerk40t.kernel import get_safe_path
+        import os
+        """
+        Tests the get_safe_path method for all o/ses
+        """
+        sep = os.sep
+        self.assertEquals(
+            str(get_safe_path("test", system="Darwin")),
+            (
+                os.path.expanduser("~")
+                + sep + "Library" + sep + "Application Support" + sep + "test"
+            )
+        )
+        self.assertEquals(
+            str(get_safe_path("test", system="Windows")),
+            (
+                os.path.expandvars("%LOCALAPPDATA%")
+                + sep + "test"
+            )
+        )
+        self.assertEquals(
+            str(get_safe_path("test", system="Linux")),
+            (
+                os.path.expanduser("~")
+                + sep + ".config" + sep + "test"
+            )
+        )
+


### PR DESCRIPTION
1. Fix bug from #702
2. Remove single reference to pathlib for consistency and replace with equivalent os.path functions.
3. Add support for unit testing all O/S'