### PR TITLE
Fix open-in-system when run on windows from exe

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5136,15 +5136,17 @@ class Elemental(Modifier):
             filepath = node.filepath
             normalized = os.path.realpath(filepath)
 
-            from os import system as open_in_shell
             import platform
 
             system = platform.system()
             if system == "Darwin":
+                from os import system as open_in_shell
                 open_in_shell("open '{file}'".format(file=normalized))
             elif system == "Windows":
+                from os import startfile as open_in_shell
                 open_in_shell('"{file}"'.format(file=normalized))
             else:
+                from os import system as open_in_shell
                 open_in_shell("xdg-open '{file}'".format(file=normalized))
 
         @self.tree_submenu(_("Duplicate element(s)"))


### PR DESCRIPTION
Open-in-system runs synchronously on Windows i.e. MK hangs until the process completes (I can't speak for other o/s). I am unclear whether this is by design or not.

When run from a pyinstaller exe additionally a CMD window is opened (probably due to this: https://github.com/pyinstaller/pyinstaller/wiki/Recipe-subprocess ).

This PR changes the `os.system` call with `os.startfile` when running on Windows which runs it asynchronously - unclear whether we will still get a CMD window under pyinstaller on Windows or not.