### PR TITLE
Fix crash dialog width.

### DIFF
--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -728,7 +728,7 @@ Send the following data to the MeerK40t team?
         caption = _("Crash Detected! Send Log?")
         style = wx.YES_NO | wx.CANCEL | wx.ICON_WARNING
     ext_msg += error_log
-    dlg = wx.GenericMessageDialog(
+    dlg = wx.MessageDialog(
         None,
         message,
         caption=caption,


### PR DESCRIPTION
Crash due to e.g. infinite loop creates a wide dialog box and lacks a vertical scroll bar.

Switch back to `MessageDialog` from `GenericMessageDialog` resolves this.  