### PR TITLE
Fix issue #724

### DIFF
--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -404,15 +404,18 @@ class SVGLoader:
                                             key,
                                             type_v(element.values[key]),
                                         )
-                                    except (ValueError, KeyError):
+                                    except (ValueError, KeyError, AttributeError):
                                         pass
                                 elif type_v == bool:
-                                    setattr(
-                                        op.settings,
-                                        key,
-                                        str(element.values[key]).lower()
-                                        in ("true", "1"),
-                                    )
+                                    try:
+                                        setattr(
+                                            op.settings,
+                                            key,
+                                            str(element.values[key]).lower()
+                                            in ("true", "1"),
+                                        )
+                                    except (ValueError, KeyError, AttributeError):
+                                        pass
                         elements_modifier.add_op(op)
                 except KeyError:
                     pass


### PR DESCRIPTION
Vertical_raster is saved in the test file but setting vertical_raster is not possible because it's a @property. To rectify we go ahead and except the attribute error for the setattr. there.

Fixes #724