### PR TITLE
Configure Github repo settings for ...

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence,
+* @tatarize
+# will be requested for review when someone opens a pull request.
+# If you want to add more owners just add them above

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# MeerK40t Code of Conduct
+
+This page is provided to set expectations about how all contributors, big or small,
+to the MeerK40t project are expected to behave towards one another and to the project as a whole.
+
+It is based on, and is a simplified version of,
+the [Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Overview
+
+We want the MeerK40t project to be an open and welcoming environment.
+We expect contributors to make participation a harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity,
+sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behaviour that contributes to creating a positive environment
+include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting the majority view or @Tatarize's overarching veto even if you disagree with it
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Using welcoming and inclusive language
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour by participants include:
+
+* The use of sexualized language or imagery and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Attempting to add malicious or inappropriate code to the codebase
+* Use of unacceptable language in code, online comments, wiki pages etc.
+* Any other conduct which could reasonably be considered inappropriate
+
+## Our Responsibilities
+
+@Tatarize and deputised contributors (MeerKittens) may take appropriate and fair corrective action
+in response to any instances of unacceptable behaviour, including removing, editing, or rejecting comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
+or in the case of extreme or persistent to ban temporarily or permanently any contributor
+for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+In the event of an appeal by the contributor, the ultimate arbiter will be @Tatarize whose decision will be final.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an
+official project e-mail address, posting via an official social media account
+or acting as an appointed representative at an online or offline event.
+Representation of a project may be further defined and clarified by @Tatarize.
+
+## Flagging concerns
+
+Instances of abusive, harassing or otherwise unacceptable behaviour may be
+reported by contacting @Tatarize via Github, Discord or irc.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org/], version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code-of-conduct.html>

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,3 +38,7 @@ complaints about which will always be treated seriously.
 
 Instances of abusive, harassing or otherwise unacceptable behaviour may be
 reported in confidence by contacting @Tatarize via Github, Discord or irc.
+
+## Exceptions
+
+Joseph Lane ( @joerlane ) is exempt from the aforementioned. This is not to say he has free reign to troll, harass, or be toxic, but will be banned if/when he becomes more trouble than he's worth.

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,68 +1,40 @@
 # MeerK40t Code of Conduct
 
-This page is provided to set expectations about how all contributors, big or small,
-to the MeerK40t project are expected to behave towards one another and to the project as a whole.
-
-It is based on, and is a simplified version of,
-the [Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+This page is provided to set expectations about how all contributors to the MeerK40t project,
+big or small, are expected to behave towards one another and to the project as a whole.
 
 ## Overview
 
 We want the MeerK40t project to be an open and welcoming environment.
-We expect contributors to make participation a harassment-free experience for everyone,
-regardless of age, body size, visible or invisible disability, ethnicity,
-sex characteristics, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance,
-race, caste, color, religion, or sexual identity and orientation.
+We expect contributors to make participation a harassment-free experience
+but without limiting people's willingness or ability to engage in lively debate.
 
-## Our Standards
+People are welcome to participate of all ages, body sizes, with or without visible or invisible disability,
+of any ethnicity, sex characteristics, gender/sexual identity/orientation/expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race/caste/color, or religion.
 
-Examples of behaviour that contributes to creating a positive environment
-include:
+These are not important factors. What is important is what you can contribute to the project -
+though, we should stress that the level of your contribution is not a valid excuse for poor behaviour.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting the majority view or @Tatarize's overarching veto even if you disagree with it
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Using welcoming and inclusive language
-* Focusing on what is best not just for us as individuals, but for the overall community
+In simple terms, you are free to hold contrary opinions and to disagree,
+but equally you need respect other people's right to a viewpoint that is different from yours,
+and to debate the opinion and **not** the person or their character or personality.
+Equally, if you are unable to rationally defend your viewpoint if it is challenged,
+please do not incorrectly claim any of the above without genuine merit purely as an alternative.
 
-Examples of unacceptable behaviour by participants include:
+## What happens if someone does make a complaint?
 
-* The use of sexualized language or imagery and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Attempting to add malicious or inappropriate code to the codebase
-* Use of unacceptable language in code, online comments, wiki pages etc.
-* Any other conduct which could reasonably be considered inappropriate
+We hope that people will be tolerant of other people's differing views and opinions,
+and that people will view others for what they do deliver to the project and not be
+over-sensitive if the ideals we would like to aspire to are not met 100% -
+after all we are all human and all make mistakes at times.
 
-## Our Responsibilities
-
-@Tatarize and deputised contributors (MeerKittens) may take appropriate and fair corrective action
-in response to any instances of unacceptable behaviour, including removing, editing, or rejecting comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
-or in the case of extreme or persistent to ban temporarily or permanently any contributor
-for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
-
-In the event of an appeal by the contributor, the ultimate arbiter will be @Tatarize whose decision will be final.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public
-spaces when an individual is representing the project or its community.
-Examples of representing a project or community include using an
-official project e-mail address, posting via an official social media account
-or acting as an appointed representative at an online or offline event.
-Representation of a project may be further defined and clarified by @Tatarize.
+If people make complaints over small matters, this can easily create a worse environment
+than the behaviours being complained about - so please try to heal wounds rather than open them wider.
+That said, we do not want to trivialise serious or persistent/frequent inappropriate behaviours,
+complaints about which will always be treated seriously.
 
 ## Flagging concerns
 
 Instances of abusive, harassing or otherwise unacceptable behaviour may be
-reported by contacting @Tatarize via Github, Discord or irc.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org/], version 2.1,
-available at <https://www.contributor-covenant.org/version/2/1/code-of-conduct.html>
+reported in confidence by contacting @Tatarize via Github, Discord or irc.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+@Tatarize welcomes contributions to this repository from users of MeerK40t.
+These can be code improvements or language translations made as [Pull Requests](/meerk40t/meerk40t/pulls),
+wiki edits made directly,
+constructive suggestions or bug reports made using [Issues](/meerk40t/meerk40t/issues),
+or comments against other people's Pull Requests or Issues.
+
+If your thoughts are not firmed up enough to make a formal submission,
+please come and find us for an informal discussion on:
+* [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
+* [Discord](https://discord.gg/qvASRhFZGB)
+
+Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+## Pull Requests
+
+Code improvements and language improvements need to be submitted as Push Requests.
+Usually you will need to fork the
+[MeerK40t/MeerK40t repo](/meerk40t/meerk40t),
+then use Git to clone your fork to your computer,
+create a new Git branch for your changes,
+code and test your changes,
+use Git to push them up to Github,
+and then create a Github Push Request.
+If you are not a Git expert (and how many of us are?),
+you may want to install Github Desktop to make this easy for you.
+
+When you are submitting a Pull Request:
+
+1. Please feel free to submit incomplete changes if you want early feedback.
+Please mark such submissions as **Draft** until they are ready for formal review.
+2. Where appropriate add new Unit Tests.
+Please ensure that both existing and new Unit Tests run cleanly when you have finished coding.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,14 +15,17 @@ Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md), please follow it in
 
 ## Pull Requests
 
-Code improvements and language improvements need to be submitted as Push Requests.
-Usually you will need to fork the
+Code improvements and language improvements need to be submitted as Pull Requests.
+Usually you will need to:
+
+1. On Github, fork the
 [MeerK40t/MeerK40t repo](/meerk40t/meerk40t),
-then use Git to clone your fork to your computer,
-create a new Git branch for your changes,
-code and test your changes,
-use Git to push them up to Github,
-and then create a Github Push Request.
+2. Use Git to clone your fork to your computer
+3. Create a new Git branch for your changes
+4. Code and test your changes
+5. Use Git to push them up to Github; and
+6. Create a Github Push Request.
+
 If you are not a Git expert (and how many of us are?),
 you may want to install Github Desktop to make this easy for you.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,8 @@ or comments against other people's Pull Requests or Issues.
 
 If your thoughts are not firmed up enough to make a formal submission,
 please come and find us for an informal discussion on:
-* [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
-* [Discord](https://discord.gg/qvASRhFZGB)
+*   [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
+*   [Discord](https://discord.gg/qvASRhFZGB)
 
 Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
@@ -18,20 +18,20 @@ Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md), please follow it in
 Code improvements and language improvements need to be submitted as Pull Requests.
 Usually you will need to:
 
-1. On Github, fork the
+1.  On Github, fork the
 [MeerK40t/MeerK40t repo](/meerk40t/meerk40t),
-2. Use Git to clone your fork to your computer
-3. Create a new Git branch for your changes
-4. Code and test your changes
-5. Use Git to push them up to Github; and
-6. Create a Github Push Request.
+2.  Use Git to clone your fork to your computer
+3.  Create a new Git branch for your changes
+4.  Code and test your changes
+5.  Use Git to push them up to Github; and
+6.  Create a Github Push Request.
 
 If you are not a Git expert (and how many of us are?),
 you may want to install Github Desktop to make this easy for you.
 
 When you are submitting a Pull Request:
 
-1. Please feel free to submit incomplete changes if you want early feedback.
+1.  Please feel free to submit incomplete changes if you want early feedback.
 Please mark such submissions as **Draft** until they are ready for formal review.
-2. Where appropriate add new Unit Tests.
+2.  Where appropriate add new Unit Tests.
 Please ensure that both existing and new Unit Tests run cleanly when you have finished coding.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!-----------------------------------------------
+
+Thank you for taking the time to report a MeerK40t bug or make an enhancement suggestion! 😄
+
+To help us avoid duplicates, please search open and closed issues before submitting a new one.
+If you find an existing issue that is close to the one you want to report, 
+and to help avoid us having duplicate issues, 
+please consider adding your points as a new comment rather than opening a new issue.
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before completing this form.
+
+Please remove any sections that you believe are not needed to describe your issue.
+
+📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛-->
+
+This is a:
+
+* [] Bug
+* [] Suggestion for an enhancement
+
+## SUMMARY
+
+<!-- A clear and concise short description of what the issue is about. -->
+
+## DETAILS
+
+<!-- A clear and concise detailed description of what the issue is about. -->
+
+## ERROR MESSAGE
+```
+<!-- Please copy and paste any error messages from e.g. a crash report file. -->
+```
+
+## YOUR ENVIRONMENT
+
+* MeerK40t version: 
+* OS: <!-- e.g. Windows 10 1904 or Ubuntu 5.4.0-26-generic x86_64 etc. ... -->
+* Running from: <|-- e.g. Executable, package (PIP3/Pypi), downloaded source, git managed source 
+
+### SCREENSHOTS
+<!-- If applicable, add screenshots or videos to help explain your problem. -->
+
+### Zipped SVG File(s)
+<!-- Please add zipped copies of any e.g. SVG files that cause the issue you are reporting.-->

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["Type: Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug!
+
+        This form should only be used to report genuine bugs inside MeerK40t,
+        and not as a means of requesting help on how to use MeerK40t.
+
+        Please check that this is not going to be a duplicate before submitting it.
+        If there is a similar bug already logged, please add your additions
+        as a comment on the existing issue rather than creating a new one.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: e.g. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary Description
+      description: Please explain in general terms in a single paragraph what the bug is.
+      placeholder: Summary paragraph
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional Details
+      description: |
+        Please provide any further fine details that might help us to locate this bug.
+
+        For example, details of what you expected to happen and what actually happened.
+        Please also zip any relevant SVG etc. files and drop them onto this field.
+      placeholder: Additional details
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Crash logs
+      description: Please copy and paste any relevant log output. This will not be formatted into paragraphs.
+      render: shell
+  - type: input
+    id: meerk40t_version
+    attributes:
+      label: MeerK40t Version
+      description: What version of MeerK40t are you running?
+    validations:
+      required: true
+  - type: dropdown
+    id: meerk40t_type
+    attributes:
+      label: MeerK40t Type
+      description: How are you running Meerk40t?
+      options:
+        - Executable
+        - PIP3/Pypi Package
+        - Source (zip/tar file from Github)
+        - Git
+    validations:
+      required: true
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Your Operating System
+      description: What operating system are you running under?
+      options:
+        - Windows
+        - Linux
+        - Mac (before M1/Bigsur)
+        - Mac (M1/Bigsur)
+        - Raspberry Pi
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](/meerk40t/meerk40t/.github/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yml
@@ -1,0 +1,97 @@
+name: Suggestion
+description: Suggest an enhancement
+title: "[Suggestion]: "
+labels: ["Type: Enhancement"]
+assignees: tatarize
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to make a suggestion for an enhancement to MeerK40t!
+
+        This form should only be used when your idea is fully formed.
+        Please discuss your ideas in one of our chat rooms before submitting it if you are
+        unsure.
+
+        Please check that this is not going to be a duplicate before submitting it.
+        If there is a similar suggestion already logged, please make any further
+        suggestions as a comment on the existing issue rather than creating a new one.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: e.g. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary Description
+      description: Please explain in general terms what your suggestion is.
+      placeholder: Summary paragraph
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current functionality
+      description: |
+        Please explain what functionality is available in the latest version of MeerK40t
+        and / or  why the current version cannot achieve what you want to do.
+
+        Please drag and drop any pictures or videos that might help us understand the difficulties.
+        You can also zip any e.g. SVG files that would help and drop these here too.
+      placeholder: Current functionality
+    validations:
+      required: false
+  - type: textarea
+    id: future
+    attributes:
+      label: Future functionality
+      description: |
+        Please explain what functionality you would like to see in a future version of MeerK40t.
+      placeholder: Future functionality
+    validations:
+      required: false
+  - type: input
+    id: meerk40t_version
+    attributes:
+      label: MeerK40t Version
+      description: What version of MeerK40t are you running?
+    validations:
+      required: true
+  - type: dropdown
+    id: meerk40t_type
+    attributes:
+      label: MeerK40t Type
+      description: How are you running Meerk40t?
+      options:
+        - Executable
+        - PIP3/Pypi Package
+        - Source (zip/tar file from Github)
+        - Git
+    validations:
+      required: true
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Your Operating System
+      description: What operating system are you running under?
+      options:
+        - Windows
+        - Linux
+        - Mac (before M1/Bigsur)
+        - Mac (M1/Bigsur)
+        - Raspberry Pi
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](/meerk40t/meerk40t/.github/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+The MeerK40t development team try hard to be responsive to difficulties experienced by users,
+whether they are bugs or simply difficulties in using MeerK40t.
+
+However we do ask that you only use [Github Issues](/meerk40t/meerk40t/issues) to make formal bug reports
+or make fully formed suggestions for improvements.
+
+If you are not ready to make a formal report, then do please come and discuss it with the MeerK40t team
+using one of the following links:
+* [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
+* [Discord](https://discord.gg/qvASRhFZGB)
+
+Please see also the [Contribution Guidelines](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -8,7 +8,7 @@ or make fully formed suggestions for improvements.
 
 If you are not ready to make a formal report, then do please come and discuss it with the MeerK40t team
 using one of the following links:
-* [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
-* [Discord](https://discord.gg/qvASRhFZGB)
+*   [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
+*   [Discord](https://discord.gg/qvASRhFZGB)
 
 Please see also the [Contribution Guidelines](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
...

1. Default PR reviewers
2. Code of Conduct
3. Simple PR Guidelines (for new contributors)
4. Simple Issue template
5. How to request support
6. New style bug/suggestion issue templates. (Currently as an alternative to 4. with a view of removing 4. once these are shown to be working.)

Inspired by coming across https://github.com/Josee9988/project-template/tree/master/.github

Whilst the templates can be viewed in [Files changed](meerk40t/meerk40t/pull/743/files), they cannot be tested until they are merged.