### PR TITLE
Additional optimisation options

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1200,10 +1200,14 @@ class LaserOperation(Node):
                                     passes=passes,
                                 )
                             )
+                    if len(group) > 0:
+                        group[0].first = True
                     for i, cut_obj in enumerate(group):
+                        cut_obj.closed = closed
                         try:
                             cut_obj.next = group[i + 1]
                         except IndexError:
+                            cut_obj.last = True
                             cut_obj.next = group[0]
                         cut_obj.previous = group[i - 1]
                     yield group

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -277,7 +277,9 @@ def plugin(kernel, lifecycle=None):
                     "Try to complete a set of inner burns and the associated outer cut before moving onto other elements."
                     + "If your design has multiple separate pieces on it, "
                     + "this should mostly cause each piece to be burned in entirety "
-                    + "before moving on to burn another piece."
+                    + "before moving on to burn another piece. "
+                    + "This can reduce the risk of e.g. a shift ruining an entire piece of material "
+                    + "by trying to ensure that one piece is finished before starting on another."
                 )
                 + "\n\n"
                 + _(

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -154,7 +154,7 @@ def plugin(kernel, lifecycle=None):
             {
                 "attr": "opt_reduce_travel",
                 "object": context,
-                "default": False,
+                "default": True,
                 "type": bool,
                 "label": _("Reduce Travel Time"),
                 "tip": _(
@@ -180,7 +180,7 @@ def plugin(kernel, lifecycle=None):
                 "object": context,
                 # Default is false for backwards compatibility.
                 # Initial tests suggest that in most cases this actually results in shorter burn times.
-                "default": False,
+                "default": True,
                 "type": bool,
                 "label": _("Burn Complete Subpaths"),
                 "tip": _(
@@ -251,7 +251,7 @@ def plugin(kernel, lifecycle=None):
             {
                 "attr": "opt_inner_first",
                 "object": context,
-                "default": False,
+                "default": True,
                 "type": bool,
                 "label": _("Burn Inner First"),
                 "tip": _(

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -283,6 +283,10 @@ def plugin(kernel, lifecycle=None):
                 )
                 + "\n\n"
                 + _(
+                    "This optimization works best with Merge Operations also checked though this is not a requirement. "
+                )
+                + "\n\n"
+                + _(
                     "Because this optimisation is done once rasters have been turned into images, "
                     + "inner elements may span multiple design pieces, "
                     + "in which case they may be optimised together."

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -275,6 +275,7 @@ def plugin(kernel, lifecycle=None):
                 "label": _("Group Inner Burns"),
                 "tip": _(
                     "Try to complete a set of inner burns and the associated outer cut before moving onto other elements."
+                    + "This option only does something if Burn Inner First is also selected. "
                     + "If your design has multiple separate pieces on it, "
                     + "this should mostly cause each piece to be burned in entirety "
                     + "before moving on to burn another piece. "

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -57,7 +57,7 @@ class PlannerPanel(wx.Panel):
         self.list_command = wx.ListBox(self, wx.ID_ANY, choices=[])
 
         self.panel_operation = wx.Panel(self, wx.ID_ANY)
-        choices = self.context.registered["choices/optimize"][:5]
+        choices = self.context.registered["choices/optimize"][:7]
         self.panel_optimize = PropertiesPanel(
             self, wx.ID_ANY, context=self.context, choices=choices
         )
@@ -349,7 +349,9 @@ class PlannerPanel(wx.Panel):
         self.context.setting(bool, "opt_merge_passes", False)
         self.context.setting(bool, "opt_merge_ops", False)
         self.context.setting(bool, "opt_reduce_travel", True)
+        self.context.setting(bool, "opt_complete_subpaths", False)
         self.context.setting(bool, "opt_inner_first", True)
+        self.context.setting(bool, "opt_inners_grouped", False)
         self.context.setting(bool, "opt_reduce_directions", False)
         self.context.setting(bool, "opt_remove_overlap", False)
         self.context.setting(bool, "opt_rapid_between", True)


### PR DESCRIPTION
1. Burn Complete Subpaths - with this option, closed subpaths can be entered anywhere, but non-closed subpaths will always be burned from one of the ends.
2. Group Inner Burns - when the first inner element has been burned, the rest of the matching inner burns will be burned next, followed by the outer path before moving on to other elements. For a design with multiple parts, this will normally burn each part in turn rather than e.g. doing inner burns for one part then outer burns for another then returning for outer burns for the first. This reduces the risk of a shift ruining all parts by completing one part before moving onto another.

Additionally, minor fixes for:
a. Repeat step and multiple passes without Travel optimisation; 
b. Default values changed for Travel Optimisation and Cut Inner First (see #753)
 