### PR TITLE
Attempt to fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
-exclude = svgelements\.py
+exclude = "svgelements\.py"
 
 
 [tool.isort]
-profile = black
+profile = "black"
 line_length = 88
 src_paths =  ["meerk40t"]
 


### PR DESCRIPTION
@tatarize reported the following on [Discord](https://discord.com/channels/910979180970278922/932716887404601364/933944551188602940):
>  Trying to apply black I get a config error for main. 
`Error: Could not open file 'C:\\Users\\Tat\\PycharmProjects\\meerk40t\\pyproject.toml': Error reading configuration file: Invalid value (at line 13, column 11)`
`exclude = svgelements\.py`
> Must require being a proper string there.
> also, line 17 requires black to be quoted.