### PR TITLE
Force append \n for normal context calls

### DIFF
--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -149,6 +149,8 @@ class Context:
         return "Context('%s')" % self._path
 
     def __call__(self, data: str, **kwargs):
+        if len(data) and data[-1] != "\n":
+            data += "\n"
         return self._kernel.console(data)
 
     def boot(self, channel: "Channel" = None):


### PR DESCRIPTION
Forces \n if one doesn't exist within console `__call__` methods.