### PR TITLE
Add "ConsoleOperation" to allow interrupts to have notes and custom labels

### DIFF
--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -300,6 +300,10 @@ class Driver:
                     t = values[0]
                     if callable(t):
                         t()
+            elif command == COMMAND_CONSOLE:
+                if len(values) == 1:
+                    fn = self.context.console_function(values[0])
+                    fn()
             elif command == COMMAND_SIGNAL:
                 if isinstance(values, str):
                     self.context.signal(values, None)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1360,15 +1360,16 @@ class ConsoleOperation(Node):
     Node type "consoleop"
     """
 
-    def __init__(self, name, command, **kwargs):
+    def __init__(self, command, name="", **kwargs):
         super().__init__(type="consoleop")
-        self.label = self.name = name
+        self.name = name
         self.command = command
+        self.label = name or command
         self.output = True
         self.operation = "Console"
 
     def __repr__(self):
-        return "ConsoleOperation('%s', '%s')" % (self.label, self.command)
+        return "ConsoleOperation('%s', '%s')" % (self.command, self.name)
 
     def __str__(self):
         parts = list()
@@ -5062,13 +5063,8 @@ class Elemental(Modifier):
         @self.tree_submenu(_("Append special operation(s)"))
         @self.tree_operation(_("Append Interrupt (console)"), node_type="branch ops", help="")
         def append_operation_interrupt_console(node, pos=None, **kwargs):
-            cmd = "interrupt \"Spooling was interrupted\""
-            fn = self.context.console_function(cmd)
             self.context.elements.op_branch.add(
-                ConsoleOperation(
-                    "Interrupt (console)",
-                    cmd,
-                ),
+                ConsoleOperation("interrupt \"Spooling was interrupted\""),
                 type="consoleop",
                 pos=pos,
             )
@@ -5753,7 +5749,7 @@ class Elemental(Modifier):
             elif op_type == "consoleop":
                 name = op_setting_context.get_persistent_value(str, "label")
                 command = op_setting_context.get_persistent_value(int, "command")
-                op = ConsoleOperation(name, command)
+                op = ConsoleOperation(command, name)
                 op_setting_context.load_persistent_object(op)
             else:
                 continue

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1364,9 +1364,20 @@ class ConsoleOperation(Node):
         super().__init__(type="consoleop")
         self.name = name
         self.command = command
-        self.label = name or command
+        self._update_label()
         self.output = True
         self.operation = "Console"
+
+    def set_name(self, name):
+        self.name = name
+        self._update_label()
+
+    def set_command(self, command):
+        self.command = command
+        self._update_label()
+
+    def _update_label(self):
+        self.label = self.name or self.command
 
     def __repr__(self):
         return "ConsoleOperation('%s', '%s')" % (self.command, self.name)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5721,7 +5721,7 @@ class Elemental(Modifier):
                         if isinstance(value, Color):
                             value = value.argb
                         op_set.write_persistent(key, value)
-            elif isinstance(op, CommandOperation):
+            elif isinstance(op, CommandOperation) or isinstance(op, ConsoleOperation):
                 for key in dir(op):
                     value = getattr(op, key)
                     if key.startswith("_"):

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4635,7 +4635,7 @@ class Elemental(Modifier):
         @self.tree_separator_after()
         @self.tree_operation(_("Edit"), node_type="consoleop", help="")
         def edit_console_command(node, **kwargs):
-            pass
+            self.context.open("window/ConsoleProperty", self.context.gui, node=node)
 
         @self.tree_separator_after()
         @self.tree_conditional(lambda node: isinstance(node.object, Shape))

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -983,7 +983,7 @@ class Planner(Modifier):
         def plan_copy(command, channel, _, data_type=None, data=None, **kwgs):
             operations = elements.get(type="branch ops")
             for c in operations.flat(
-                types=("op", "cutcode", "cmdop", "lasercode", "blob"), depth=1
+                types=("op", "cutcode", "cmdop", "consoleop", "lasercode", "blob"), depth=1
             ):
                 try:
                     if not c.output:

--- a/meerk40t/device/lasercommandconstants.py
+++ b/meerk40t/device/lasercommandconstants.py
@@ -53,6 +53,7 @@ COMMAND_LOCK = 301  # Locks the rail
 COMMAND_UNLOCK = 302  # Unlocks the rail.
 COMMAND_BEEP = 320  # Beep.
 COMMAND_FUNCTION = 350  # Execute the function given by this command. Blocking.
+COMMAND_CONSOLE = 355 # Execute the specified console command.
 COMMAND_SIGNAL = 360  # Sends the signal, given: "signal_name", operands.
 
 REALTIME_RESET = 1000  # Resets the state, purges buffers
@@ -149,6 +150,8 @@ def lasercode_string(code):
         return (
             "COMMAND_FUNCTION"  # Execute the function given by this command. Blocking.
         )
+    if code == COMMAND_CONSOLE:
+        return "COMMAND_CONSOLE"  # Execute the specified console command.
     if code == COMMAND_SIGNAL:  # Sends the signal, given: "signal_name:
         return "COMMAND_SIGNAL"  # Sends the signal, given: "signal_name", operands.
     if code == REALTIME_RESET:

--- a/meerk40t/gui/consoleproperty.py
+++ b/meerk40t/gui/consoleproperty.py
@@ -19,13 +19,6 @@ class ConsoleProperty(MWindow):
         self.SetTitle(_("Console Properties"))
         self.Children[0].SetFocus()
 
-    # def window_open(self):
-    #     self.context.close(self.name)
-    #     self.panel.initialize()
-
-    # def window_close(self):
-    #     self.panel.finalize()
-
 
 class ConsolePropertiesPanel(wx.Panel):
     def __init__(self, *args, context=None, node=None, **kwds):

--- a/meerk40t/gui/consoleproperty.py
+++ b/meerk40t/gui/consoleproperty.py
@@ -42,7 +42,6 @@ class ConsolePropertiesPanel(wx.Panel):
             style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP
         )
 
-        self.__set_properties()
         self.__do_layout()
 
         if node:
@@ -55,9 +54,6 @@ class ConsolePropertiesPanel(wx.Panel):
         self.Bind(wx.EVT_TEXT_ENTER, self.on_change_command, self.command_text)
         # end wxGlade
 
-    def __set_properties(self):
-        pass
-
     def __do_layout(self):
         # begin wxGlade: NotePanel.__do_layout
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
@@ -69,13 +65,15 @@ class ConsolePropertiesPanel(wx.Panel):
         # end wxGlade
 
     def on_change_name(self, event=None):
-        self.console_operation.name = self.command_name.GetValue()
-        self.console_operation.label = (
-            self.console_operation.name or self.console_operation.command)
+        self.console_operation.set_name(self.command_name.GetValue())
         self.context.signal("element_property_update", self.console_operation)
 
     def on_change_command(self, event=None):
-        self.console_operation.command = self.command_text.GetValue()
-        self.console_operation.label = (
-            self.console_operation.name or self.console_operation.command)
+        raw = self.command_text.GetValue()
+        # Mac converts " to smart quotes, can't figure out
+        # how to disable autocorrect in this textctrl 🙃
+        command = raw.replace("“", '"').replace("”", '"')
+        # TODO: It would be really nice to do some validation on here,
+        # to catch mistakes.
+        self.console_operation.set_command(command)
         self.context.signal("element_property_update", self.console_operation)

--- a/meerk40t/gui/consoleproperty.py
+++ b/meerk40t/gui/consoleproperty.py
@@ -1,0 +1,81 @@
+import wx
+
+from .icons import icons8_comments_50
+from .mwindow import MWindow
+from .panes.notespanel import NotePanel
+
+_ = wx.GetTranslation
+
+
+class ConsoleProperty(MWindow):
+    def __init__(self, *args, node=None, **kwds):
+        super().__init__(730, 621, *args, **kwds)
+
+        self.panel = ConsolePropertiesPanel(
+            self, wx.ID_ANY, context=self.context, node=node)
+        _icon = wx.NullIcon
+        _icon.CopyFromBitmap(icons8_comments_50.GetBitmap())
+        self.SetIcon(_icon)
+        self.SetTitle(_("Console Properties"))
+        self.Children[0].SetFocus()
+
+    # def window_open(self):
+    #     self.context.close(self.name)
+    #     self.panel.initialize()
+
+    # def window_close(self):
+    #     self.panel.finalize()
+
+
+class ConsolePropertiesPanel(wx.Panel):
+    def __init__(self, *args, context=None, node=None, **kwds):
+        kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
+        wx.Panel.__init__(self, *args, **kwds)
+        self.context = context
+
+        self.console_operation = node
+        self.command_name = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.command_text = wx.TextCtrl(
+            self,
+            wx.ID_ANY,
+            "Command text",
+            style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP
+        )
+
+        self.__set_properties()
+        self.__do_layout()
+
+        if node:
+            self.command_name.SetValue(node.name)
+            self.command_text.SetValue(node.command)
+
+        self.Bind(wx.EVT_TEXT, self.on_change_name, self.command_name)
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_change_name, self.command_name)
+        self.Bind(wx.EVT_TEXT, self.on_change_command, self.command_text)
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_change_command, self.command_text)
+        # end wxGlade
+
+    def __set_properties(self):
+        pass
+
+    def __do_layout(self):
+        # begin wxGlade: NotePanel.__do_layout
+        sizer_1 = wx.BoxSizer(wx.VERTICAL)
+        sizer_1.Add(self.command_name, 0, wx.EXPAND, 0)
+        sizer_1.Add(self.command_text, 1, wx.EXPAND, 0)
+        self.SetSizer(sizer_1)
+        sizer_1.Fit(self)
+        self.Layout()
+        # end wxGlade
+
+    def on_change_name(self, event=None):
+        self.console_operation.name = self.command_name.GetValue()
+        self.console_operation.label = (
+            self.console_operation.name or self.console_operation.command)
+        self.context.signal("element_property_update", self.console_operation)
+
+    def on_change_command(self, event=None):
+        self.console_operation.command = self.command_text.GetValue()
+        self.console_operation.label = (
+            self.console_operation.name or self.console_operation.command)
+        self.context.signal("element_property_update", self.console_operation)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -32,6 +32,7 @@ from .lhystudios.lhystudiosdrivergui import LhystudiosDriverGui
 from .moshi.moshicontrollergui import MoshiControllerGui
 from .moshi.moshidrivergui import MoshiDriverGui
 from .notes import Notes
+from .consoleproperty import ConsoleProperty
 from .operationproperty import OperationProperty
 from .panes.camerapanel import CameraInterface
 from .panes.consolepanel import Console
@@ -237,7 +238,7 @@ class wxMeerK40t(wx.App, Module):
     @staticmethod
     def sub_register(kernel):
         kernel.register("window/MeerK40t", MeerK40t)
-        # kernel.register("window/ConsoleProperty", ConsoleProperty)
+        kernel.register("window/ConsoleProperty", ConsoleProperty)
         kernel.register("window/PathProperty", PathProperty)
         kernel.register("window/TextProperty", TextProperty)
         kernel.register("window/ImageProperty", ImageProperty)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -237,6 +237,7 @@ class wxMeerK40t(wx.App, Module):
     @staticmethod
     def sub_register(kernel):
         kernel.register("window/MeerK40t", MeerK40t)
+        # kernel.register("window/ConsoleProperty", ConsoleProperty)
         kernel.register("window/PathProperty", PathProperty)
         kernel.register("window/TextProperty", TextProperty)
         kernel.register("window/ImageProperty", ImageProperty)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -315,20 +315,6 @@ class MeerK40t(MWindow):
                     context._stepping_force = None
             dlg.Destroy()
 
-        @context.console_command("dialog_load", hidden=True)
-        def load_dialog(**kwargs):
-            # This code should load just specific project files rather than all importable formats.
-            files = context.load_types()
-            with wx.FileDialog(
-                gui, _("Open"), wildcard=files, style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
-            ) as fileDialog:
-                if fileDialog.ShowModal() == wx.ID_CANCEL:
-                    return  # the user changed their mind
-                pathname = fileDialog.GetPath()
-<<<<<<< HEAD
-=======
-                gui.clear_and_open(pathname)
-
         @context.console_argument("message", help=_("Message to display, optional"), default="")
         @context.console_command("interrupt", hidden=True)
         def interrupt(message="", **kwargs):
@@ -344,16 +330,17 @@ class MeerK40t(MWindow):
             dlg.ShowModal()
             dlg.Destroy()
 
-        @context.console_command("dialog_import", hidden=True)
-        def import_dialog(**kwargs):
+        @context.console_command("dialog_load", hidden=True)
+        def load_dialog(**kwargs):
+            # This code should load just specific project files rather than all importable formats.
             files = context.load_types()
             with wx.FileDialog(
-                gui, _("Import"), wildcard=files, style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
+                gui, _("Open"), wildcard=files, style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
             ) as fileDialog:
                 if fileDialog.ShowModal() == wx.ID_CANCEL:
                     return  # the user changed their mind
                 pathname = fileDialog.GetPath()
->>>>>>> 3017137d (adding consoleop to places)
+                gui.clear_and_open(pathname)
                 gui.load(pathname)
 
         @context.console_command("dialog_save", hidden=True)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -331,12 +331,13 @@ class MeerK40t(MWindow):
 
         @context.console_argument("message", help=_("Message to display, optional"), default="")
         @context.console_command("interrupt", hidden=True)
-        def interrupt(_, __, ___, message="", **kwargs):
-            if len(message):
-                message = "\n\n" + message
+        def interrupt(message="", **kwargs):
+            if not message:
+                message = _("Spooling Interrupted.")
+
             dlg = wx.MessageDialog(
                 None,
-                _("Spooling Interrupted. Press OK to Continue." + message),
+                message + "\n\n" + _("Press OK to Continue."),
                 _("Interrupt"),
                 wx.OK,
             )

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -325,6 +325,34 @@ class MeerK40t(MWindow):
                 if fileDialog.ShowModal() == wx.ID_CANCEL:
                     return  # the user changed their mind
                 pathname = fileDialog.GetPath()
+<<<<<<< HEAD
+=======
+                gui.clear_and_open(pathname)
+
+        @context.console_argument("message", help=_("Message to display, optional"), default="")
+        @context.console_command("interrupt", hidden=True)
+        def interrupt(_, __, ___, message="", **kwargs):
+            if len(message):
+                message = "\n\n" + message
+            dlg = wx.MessageDialog(
+                None,
+                _("Spooling Interrupted. Press OK to Continue." + message),
+                _("Interrupt"),
+                wx.OK,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+
+        @context.console_command("dialog_import", hidden=True)
+        def import_dialog(**kwargs):
+            files = context.load_types()
+            with wx.FileDialog(
+                gui, _("Import"), wildcard=files, style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
+            ) as fileDialog:
+                if fileDialog.ShowModal() == wx.ID_CANCEL:
+                    return  # the user changed their mind
+                pathname = fileDialog.GetPath()
+>>>>>>> 3017137d (adding consoleop to places)
                 gui.load(pathname)
 
         @context.console_command("dialog_save", hidden=True)


### PR DESCRIPTION
Fixes #764 

Here's my first stab at it! I left in the original interrupt menu item so I could compare behavior, I'm happy to take them out once this is in good shape.

https://user-images.githubusercontent.com/112170/150663972-47504b97-5f61-4295-9001-da3a20b6c793.mp4


