### PR TITLE
Fix Group Inner Burns

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -329,12 +329,6 @@ class CutGroup(list, CutObject, ABC):
             for s in c.flat():
                 yield s
 
-    def is_burned(self):
-        for c in self:
-            if c.burns_done != c.passes:
-                return False
-        return True
-
     def candidate(self, complete_path: Optional[bool]=False, grouped_inner: Optional[bool]=False):
         """
         Candidates are CutObjects:

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -159,7 +159,7 @@ class CutObject:
         self.next = None
         self.previous = None
         self.passes = passes
-        self.burns_done = 0
+        self._burns_done = 0
 
         self.mode = None
         self.inside = None
@@ -167,9 +167,26 @@ class CutObject:
         self.first = False
         self.last = False
         self.closed = False
-        self.path = None
         self.original_op = None
         self.pass_index = -1
+
+    @property
+    def burns_done(self):
+        return self._burns_done
+
+    @burns_done.setter
+    def burns_done(self, burns):
+        """
+        Maintain parent burns_done
+        """
+        self._burns_done = burns
+        if self.parent is not None:
+            # If we are resetting then we are going to be resetting all
+            # so don't bother looping
+            if burns != 0:
+                for o in self.parent:
+                    burns = burns if o._burns_done == 0 else min(burns, o._burns_done)
+            self.parent._burns_done = burns
 
     def reversible(self):
         return True
@@ -236,18 +253,16 @@ class CutObject:
         if self.contains is None:
             return False
         for c in self.contains:
-            for pp in c.flat():
-                if pp.burns_done > 0:
-                    return True
+            if c.burns_done > 0:
+                return True
         return False
 
     def contains_unburned_groups(self):
         if self.contains is None:
             return False
         for c in self.contains:
-            for pp in c.flat():
-                if pp.burns_done < pp.passes:
-                    return True
+            if c.burns_done < c.passes:
+                return True
         return False
 
     def flat(self):
@@ -269,10 +284,10 @@ class CutGroup(list, CutObject, ABC):
 
     def __init__(
         self, parent, children=(),
-        settings=None, constrained=False, closed=False
+        settings=None, passes=1, constrained=False, closed=False,
     ):
         list.__init__(self, children)
-        CutObject.__init__(self, parent=parent, settings=settings)
+        CutObject.__init__(self, parent=parent, settings=settings, passes=passes)
         self.closed = closed
         self.constrained = constrained
 
@@ -576,8 +591,8 @@ class CutCode(CutGroup):
 
 
 class LineCut(CutObject):
-    def __init__(self, start_point, end_point, settings=None, passes=1):
-        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes)
+    def __init__(self, start_point, end_point, settings=None, passes=1, parent=None):
+        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes, parent=parent)
         settings.raster_step = 0
 
     def generator(self):
@@ -587,8 +602,8 @@ class LineCut(CutObject):
 
 
 class QuadCut(CutObject):
-    def __init__(self, start_point, control_point, end_point, settings=None, passes=1):
-        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes)
+    def __init__(self, start_point, control_point, end_point, settings=None, passes=1, parent=None):
+        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes, parent=parent)
         settings.raster_step = 0
         self._control = control_point
 
@@ -615,8 +630,8 @@ class QuadCut(CutObject):
 
 
 class CubicCut(CutObject):
-    def __init__(self, start_point, control1, control2, end_point, settings=None, passes=1):
-        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes)
+    def __init__(self, start_point, control1, control2, end_point, settings=None, passes=1, parent=None):
+        CutObject.__init__(self, start_point, end_point, settings=settings, passes=passes, parent=parent)
         settings.raster_step = 0
         self._control1 = control1
         self._control2 = control2
@@ -657,8 +672,8 @@ class RasterCut(CutObject):
     this is a crosshatched cut or not.
     """
 
-    def __init__(self, image, tx, ty, settings=None, crosshatch=False, passes=1):
-        CutObject.__init__(self, settings=settings, passes=passes)
+    def __init__(self, image, tx, ty, settings=None, crosshatch=False, passes=1, parent=None):
+        CutObject.__init__(self, settings=settings, passes=passes, parent=parent)
         assert image.mode in ("L", "1")
         self.first = True  # Raster cuts are always first within themselves.
         self.image = image
@@ -766,8 +781,8 @@ class RawCut(CutObject):
     Raw cuts are non-shape based cut objects with location and laser amount.
     """
 
-    def __init__(self, settings=None):
-        CutObject.__init__(self, settings=settings)
+    def __init__(self, settings=None, passes=1, parent=None):
+        CutObject.__init__(self, settings=settings, passes=passes, parent=parent)
         self.plot = []
 
     def __len__(self):

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -183,9 +183,12 @@ class CutObject:
         if self.parent is not None:
             # If we are resetting then we are going to be resetting all
             # so don't bother looping
-            if burns != 0:
-                for o in self.parent:
-                    burns = burns if o._burns_done == 0 else min(burns, o._burns_done)
+            if burns == 0:
+                self.parent._burns_done = 0
+                return
+            for o in self.parent:
+                burns = min(burns, o._burns_done)
+            self.parent.burn_started = True
             self.parent._burns_done = burns
 
     def reversible(self):
@@ -253,8 +256,11 @@ class CutObject:
         if self.contains is None:
             return False
         for c in self.contains:
-            if c.burns_done > 0:
-                return True
+            if isinstance(c, CutGroup):
+                if c.burn_started:
+                    return True
+            elif c.burns_done == c.passes:
+                    return True
         return False
 
     def contains_unburned_groups(self):
@@ -290,6 +296,7 @@ class CutGroup(list, CutObject, ABC):
         CutObject.__init__(self, parent=parent, settings=settings, passes=passes)
         self.closed = closed
         self.constrained = constrained
+        self.burn_started = False
 
     def __copy__(self):
         return CutGroup(self.parent, self)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1164,7 +1164,12 @@ class LaserOperation(Node):
                         isinstance(sp[-1], Close)
                         or abs(sp.z_point - sp.current_point) <= closed_distance
                     )
-                    group = CutGroup(None, closed=closed, settings=settings)
+                    group = CutGroup(
+                        None,
+                        closed=closed,
+                        settings=settings,
+                        passes=passes,
+                    )
                     group.path = Path(subpath)
                     group.original_op = self._operation
                     for seg in subpath:
@@ -1173,12 +1178,24 @@ class LaserOperation(Node):
                         elif isinstance(seg, Close):
                             if seg.start != seg.end:
                                 group.append(
-                                    LineCut(seg.start, seg.end, settings=settings, passes=passes)
+                                    LineCut(
+                                        seg.start,
+                                        seg.end,
+                                        settings=settings,
+                                        passes=passes,
+                                        parent=group,
+                                    )
                                 )
                         elif isinstance(seg, Line):
                             if seg.start != seg.end:
                                 group.append(
-                                    LineCut(seg.start, seg.end, settings=settings, passes=passes)
+                                    LineCut(
+                                        seg.start,
+                                        seg.end,
+                                        settings=settings,
+                                        passes=passes,
+                                        parent=group,
+                                    )
                                 )
                         elif isinstance(seg, QuadraticBezier):
                             group.append(
@@ -1188,6 +1205,7 @@ class LaserOperation(Node):
                                     seg.end,
                                     settings=settings,
                                     passes=passes,
+                                    parent=group,
                                 )
                             )
                         elif isinstance(seg, CubicBezier):
@@ -1199,6 +1217,7 @@ class LaserOperation(Node):
                                     seg.end,
                                     settings=settings,
                                     passes=passes,
+                                    parent=group,
                                 )
                             )
                     if len(group) > 0:

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -1478,50 +1478,64 @@ def bounding_box(elements):
     return xmin, ymin, xmax, ymax
 
 
-def is_inside(inner_path, outer_path):
+def is_inside(inner, outer):
     """
     Test that path1 is inside path2.
     :param inner_path: inner path
     :param outer_path: outer path
     :return: whether path1 is wholly inside path2.
     """
-    if hasattr(inner_path, "path") and inner_path.path is not None:
-        inner_path = inner_path.path
-    if hasattr(outer_path, "path") and outer_path.path is not None:
-        outer_path = outer_path.path
-    if not hasattr(inner_path, "bounding_box"):
-        inner_path.bounding_box = Group.union_bbox([inner_path])
-    if not hasattr(outer_path, "bounding_box"):
-        outer_path.bounding_box = Group.union_bbox([outer_path])
-    if outer_path.bounding_box is None:
+    inner_path = inner
+    outer_path = outer
+    if hasattr(inner, "path") and inner.path is not None:
+        inner_path = inner.path
+    if hasattr(outer, "path") and outer.path is not None:
+        outer_path = outer.path
+    if not hasattr(inner, "bounding_box"):
+        inner.bounding_box = Group.union_bbox([inner_path])
+    if not hasattr(outer, "bounding_box"):
+        outer.bounding_box = Group.union_bbox([outer_path])
+    if outer.bounding_box is None:
         return False
-    if inner_path.bounding_box is None:
+    if inner.bounding_box is None:
         return False
-    if outer_path.bounding_box[0] > inner_path.bounding_box[0]:
+    if outer.bounding_box[0] > inner.bounding_box[0]:
         # outer minx > inner minx (is not contained)
         return False
-    if outer_path.bounding_box[1] > inner_path.bounding_box[1]:
+    if outer.bounding_box[1] > inner.bounding_box[1]:
         # outer miny > inner miny (is not contained)
         return False
-    if outer_path.bounding_box[2] < inner_path.bounding_box[2]:
+    if outer.bounding_box[2] < inner.bounding_box[2]:
         # outer maxx < inner maxx (is not contained)
         return False
-    if outer_path.bounding_box[3] < inner_path.bounding_box[3]:
+    if outer.bounding_box[3] < inner.bounding_box[3]:
         # outer maxy < inner maxy (is not contained)
         return False
-    if outer_path.bounding_box == inner_path.bounding_box:
-        if outer_path == inner_path:  # This is the same object.
+    if outer.bounding_box == inner.bounding_box:
+        if outer == inner:  # This is the same object.
             return False
-    if not hasattr(outer_path, "vm"):
+
+    # Inner bbox is entirely inside outer bbox,
+    # however that does not mean that inner is actually inside outer
+    # i.e. inner could be small and between outer and the bbox corner,
+    # or small and  contained in a concave indentation.
+    #
+    # VectorMontonizer can determine whether a point is inside a polygon.
+    # The code below uses a brute force approach by considering a fixed number of points,
+    # however we should consider a future enhancement whereby we create
+    # a polygon more intelligently based on size and curvature
+    # i.e. larger bboxes need more points and
+    # tighter curves need more points (i.e. compare vector directions)
+    if not hasattr(outer, "vm"):
         outer_path = Polygon(
-            [outer_path.point(i / 100.0, error=1e4) for i in range(101)]
+            [outer_path.point(i / 1000.0, error=1e4) for i in range(1001)]
         )
         vm = VectorMontonizer()
         vm.add_cluster(outer_path)
-        outer_path.vm = vm
+        outer.vm = vm
     for i in range(101):
         p = inner_path.point(i / 100.0, error=1e4)
-        if not outer_path.vm.is_point_inside(p.x, p.y):
+        if not outer.vm.is_point_inside(p.x, p.y):
             return False
     return True
 


### PR DESCRIPTION
This PR does three things:

a. Fixes VectorMontonixer having too few polygon points to ensure that small inner burns are not mistakenly considered outside.
b. Fixes Rasters not being considered for inner burns, and treats rasters correctly as being inside even if it extends outside;
c. Improves performance by maintaining burns_done at a group level rather than iterating over segments to find out.