### PR TITLE
Make delete key usage consistent

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4459,7 +4459,6 @@ class Elemental(Modifier):
                 if n.type not in ("root", "branch elems", "branch ops"):
                     # Cannot delete structure nodes.
                     n.remove_node()
-                    break
             return "tree", [self._tree]
 
         @context.console_command(

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4452,13 +4452,14 @@ class Elemental(Modifier):
         )
         def delete(channel, _, data=None, **kwargs):
             """
-            Delete node. Due to nodes within nodes, only the first node is deleted.
+            Delete nodes.
             Structural nodes such as root, elements, and operations are not able to be deleted
             """
             for n in data:
+                # Cannot delete structure nodes.
                 if n.type not in ("root", "branch elems", "branch ops"):
-                    # Cannot delete structure nodes.
-                    n.remove_node()
+                    if n._parent is not None:
+                        n.remove_node()
             return "tree", [self._tree]
 
         @context.console_command(

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4414,11 +4414,11 @@ class Elemental(Modifier):
             input_type="tree",
             output_type="tree",
         )
-        def emphasized(channel, _, **kwargs):
+        def selected(channel, _, **kwargs):
             """
             Set tree list to selected node
             """
-            return "tree", list(self.flat(emphasized=True))
+            return "tree", list(self.flat(selected=True))
 
         @context.console_command(
             "highlighted",


### PR DESCRIPTION
`tree selected` was actually using emphasised rather than selected. So e.g. deleting an image under an image operation also deleted the image under elements.