### PR TITLE
Correct RuntimeError, dequeue mutated

### DIFF
--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -2763,7 +2763,7 @@ class Channel:
         if self.greet is not None:
             monitor_function(self.greet)
         if self.buffer is not None:
-            for line in self.buffer:
+            for line in list(self.buffer):
                 monitor_function(line)
 
     def unwatch(self, monitor_function: Callable):


### PR DESCRIPTION
In rare cases while this buffer is changing you can watch the function.

```
    self.context.channel("%s/usb" % active, buffer_size=500).watch(self.update_text)
  File "C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\kernel.py", line 2766, in watch
    for line in self.buffer:
RuntimeError: deque mutated during iteration
```