### PR TITLE
Fix CentOS build, split ci.yml into separate build platforms.

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -1,0 +1,35 @@
+# This workflow builds PyInstaller single-file executables
+# of Meerk40t for Linux (CentOS 7 self-hosted runner)
+
+name: Meerk40t (CentOS 7)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-centos7:
+    runs-on: centos7
+    steps:
+    - name: Checkout meerk40t
+      uses: actions/checkout@v2
+    
+    - name: Ensure latest meerk40t-camera
+      run: |
+        pip3 install meerk40t-camera opencv-python-headless
+
+    - name: Build Meerk40t
+      run: |
+        mv meerk40t.py mk40t.py
+        pyinstaller --windowed --onefile --name meerk40t .github/workflows/linux/meerk40t.spec
+        mv mk40t.py meerk40t.py
+        mv dist/MeerK40t dist/MeerK40t-Linux
+
+    - name: Upload Release Assets
+      id: release
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          dist/MeerK40t-Linux
+

--- a/.github/workflows/linux/meerk40t.spec
+++ b/.github/workflows/linux/meerk40t.spec
@@ -21,8 +21,8 @@ a.datas += [('locale/de/LC_MESSAGES/meerk40t.mo', 'locale/de/LC_MESSAGES/meerk40
 a.datas += [('locale/zh/LC_MESSAGES/meerk40t.mo', 'locale/zh/LC_MESSAGES/meerk40t.mo', 'DATA')]
 a.datas += [('locale/fr/LC_MESSAGES/meerk40t.mo', 'locale/fr/LC_MESSAGES/meerk40t.mo', 'DATA')]
 a.datas += [('locale/hu/LC_MESSAGES/meerk40t.mo', 'locale/hu/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt-br/LC_MESSAGES/meerk40t.mo', 'locale/pt-br/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt-pt/LC_MESSAGES/meerk40t.mo', 'locale/pt-pt/LC_MESSAGES/meerk40t.mo', 'DATA')]
+a.datas += [('locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'DATA')]
+a.datas += [('locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'DATA')]
 a.datas += [('locale/ja/LC_MESSAGES/meerk40t.mo', 'locale/ja/LC_MESSAGES/meerk40t.mo', 'DATA')]
 a.datas += [('locale/nl/LC_MESSAGES/meerk40t.mo', 'locale/nl/LC_MESSAGES/meerk40t.mo', 'DATA')]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,46 @@
+# This workflow builds PyInstaller single-file executables
+# of Meerk40t for Ubuntu (latest)
+
+name: Meerk40t (Ubuntu)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  build-ubuntu:
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout meerk40t
+      uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libgtk-3-dev
+        python3 -m pip install --upgrade pip
+        pip3 install pyinstaller wheel
+        pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
+        if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+
+    - name: Build meerk40t
+      run: |
+        mv meerk40t.py mk40t.py
+        pyinstaller --windowed --onefile --name meerk40t mk40t.py
+        mv mk40t.py meerk40t.py
+        mv dist/meerk40t dist/MeerK40t-Ubuntu-Latest
+
+# Switched to using softprops/action-gh-release@v1
+# because it supports uploading to existing release based on current tag.
+    - name: Upload Release Assets
+      id: release
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          dist/MeerK40t-Ubuntu-Latest
+

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,75 +1,13 @@
 # This workflow builds PyInstaller single-file executables
-# of Meerk40t for Windows, (and hopefully) Linux, Mac
+# of Meerk40t for Windows
 
-name: Meerk40t
+name: Meerk40t (Windows)
 
 on:
   release:
     types: [published]
 
 jobs:
-  build-centos7:
-    runs-on: centos7
-    steps:
-    - name: Checkout meerk40t
-      uses: actions/checkout@v2
-    
-    - name: Ensure latest meerk40t-camera
-      run: |
-        pip3 install meerk40t-camera opencv-python-headless
-
-    - name: Build Meerk40t
-      run: |
-        mv meerk40t.py mk40t.py
-        pyinstaller --windowed --onefile --name meerk40t .github/workflows/linux/meerk40t.spec
-        mv mk40t.py meerk40t.py
-        mv dist/MeerK40t dist/MeerK40t-Linux
-
-    - name: Upload Release Assets
-      id: release
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: |
-          dist/MeerK40t-Linux
-
-       
-  build-ubuntu:
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout meerk40t
-      uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libgtk-3-dev
-        python3 -m pip install --upgrade pip
-        pip3 install pyinstaller wheel
-        pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
-        if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-
-    - name: Build meerk40t
-      run: |
-        mv meerk40t.py mk40t.py
-        pyinstaller --windowed --onefile --name meerk40t mk40t.py
-        mv mk40t.py meerk40t.py
-        mv dist/meerk40t dist/MeerK40t-Ubuntu-Latest
-
-# Switched to using softprops/action-gh-release@v1
-# because it supports uploading to existing release based on current tag.
-    - name: Upload Release Assets
-      id: release
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: |
-          dist/MeerK40t-Ubuntu-Latest
-
-
   build-windows:
     runs-on: windows-latest
     steps:
@@ -132,4 +70,3 @@ jobs:
         files: |
           dist/MeerK40t.exe
           dist/wx-meerk40t.exe
-


### PR DESCRIPTION
Issue with locale paths in linux meerk40t.spec file highlighted issue with needing separate build yml for the different platforms.
This fixes the original issue, and also does the split.

CentOS build will need to be rerun for 0.7.5000