### PR TITLE
Selection-Rectangle: optics + make Ctrl-Key more MacOS-aware

### DIFF
--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -14,8 +14,7 @@ from meerk40t.gui.zmatrix import ZMatrix
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point, Viewbox
 
-# Comment this line out as soon as PR805 gets merged
-# from meerk40t.gui.wxutils import get_key_name
+from meerk40t.gui.wxutils import get_key_name
 
 MILS_IN_MM = 39.3701
 
@@ -40,32 +39,6 @@ ORIENTATION_VERTICAL = 0b00000010000000
 ORIENTATION_GRID = 0b00000100000000
 ORIENTATION_NO_BUFFER = 0b00001000000000
 BUFFER = 10.0
-
-# DELETE THIS ROUTINE AS SOON AS PR805 gets merged
-def get_key_name(event, return_modifier=False):
-    key = event.GetKeyCode()
-    keyvalue = ""
-    if event.RawControlDown() and not event.ControlDown():
-        keyvalue += "macctl+"  # Deliberately not macctrl+
-    elif event.ControlDown():
-        keyvalue += "ctrl+"
-    if event.AltDown() or key == wx.WXK_ALT:
-        keyvalue += "alt+"
-    if event.ShiftDown():
-        keyvalue += "shift+"
-    if event.MetaDown():
-        keyvalue += "meta+"
-    if keyvalue == "":
-        if key == wx.WXK_SHIFT:
-            keyvalue = "shift+"
-        elif key == wx.WXK_CONTROL:
-            keyvalue = "ctrl+"
-        elif key == wx.WXK_ALT:
-            keyvalue = "alt+"
-
-    # There is more in the routine, but that's enough for our purpose :-)
-    return keyvalue.lower()
-
 
 # TODO: _buffer can be updated partially rather than fully rewritten, especially with some layering.
 
@@ -180,35 +153,45 @@ class ScenePanel(wx.Panel):
 
     def on_key_down(self, evt):
         literal = get_key_name(evt, True)
-        # keycode = evt.GetKeyCode()
+        keycode = evt.GetKeyCode()
         # print("Key-Down: %f - literal: %s" % (keycode, literal))
-        if literal.startswith("shift+"):
+        if "shift+" in literal:
             if not self.isShiftPressed:  # ignore multiple calls
                 self.isShiftPressed = True
                 self.scene.event(self.scene.last_position, "kb_shift_press")
-        elif literal.startswith("ctrl+"):
+        if "ctrl+" in literal:
             if not self.isCtrlPressed:  # ignore multiple calls
                 self.isCtrlPressed = True
                 self.scene.event(self.scene.last_position, "kb_ctrl_press")
-        elif literal.startswith("alt+"):
+        if "alt+" in literal:
             if not self.isAltPressed:  # ignore multiple calls
                 self.isAltPressed = True
                 self.scene.event(self.scene.last_position, "kb_alt_press")
                 # self.scene.event(self.scene.last_position, "kb_alt_press")
 
     def on_key_up(self, evt):
-        literal = get_key_name(evt, True)
-        # keycode = evt.GetKeyCode()
-        # print("Key-Up: %f - literal: %s" % (keycode, literal))
-        if literal.startswith("shift+"):
+        # literal = get_key_name(evt, True) # Until the behaviour of multi-keypresses has been clarified
+        literal = ""
+        keystates = (evt.ShiftDown(), evt.ControlDown(), evt.AltDown())
+        if self.isShiftPressed and not keystates[0]:
+            literal += "shift+"
+        if self.isCtrlPressed and not keystates[1]:
+            literal += "ctrl+"
+        if self.isAltPressed and not keystates[2]:
+            literal += "alt+"
+
+        key = evt.GetKeyCode()
+        # print("Key-Up: %f - literal: %s" % (key, literal))
+
+        if "shift+" in literal:
             if self.isShiftPressed:  # ignore multiple calls
                 self.isShiftPressed = False
                 self.scene.event(self.scene.last_position, "kb_shift_release")
-        elif literal.startswith("ctrl+"):
+        if "ctrl+" in literal:
             if self.isCtrlPressed:  # ignore multiple calls
                 self.isCtrlPressed = False
                 self.scene.event(self.scene.last_position, "kb_ctrl_release")
-        elif literal.startswith("alt+"):
+        if "alt+" in literal:
             if self.isAltPressed:  # ignore multiple calls
                 self.isAltPressed = False
                 self.scene.event(self.scene.last_position, "kb_alt_release")

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -14,6 +14,9 @@ from meerk40t.gui.zmatrix import ZMatrix
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point, Viewbox
 
+# Comment this line out as soon as PR805 gets merged
+# from meerk40t.gui.wxutils import get_key_name
+
 MILS_IN_MM = 39.3701
 
 HITCHAIN_HIT = 0
@@ -37,6 +40,31 @@ ORIENTATION_VERTICAL = 0b00000010000000
 ORIENTATION_GRID = 0b00000100000000
 ORIENTATION_NO_BUFFER = 0b00001000000000
 BUFFER = 10.0
+
+# DELETE THIS ROUTINE AS SOON AS PR805 gets merged
+def get_key_name(event, return_modifier=False):
+    key = event.GetKeyCode()
+    keyvalue = ""
+    if event.RawControlDown() and not event.ControlDown():
+        keyvalue += "macctl+"  # Deliberately not macctrl+
+    elif event.ControlDown():
+        keyvalue += "ctrl+"
+    if event.AltDown() or key == wx.WXK_ALT:
+        keyvalue += "alt+"
+    if event.ShiftDown():
+        keyvalue += "shift+"
+    if event.MetaDown():
+        keyvalue += "meta+"
+    if keyvalue == "":
+        if key == wx.WXK_SHIFT:
+            keyvalue = "shift+"
+        elif key == wx.WXK_CONTROL:
+            keyvalue = "ctrl+"
+        elif key == wx.WXK_ALT:
+            keyvalue = "alt+"
+
+    # There is more in the routine, but that's enough for our purpose :-)
+    return keyvalue.lower()
 
 
 # TODO: _buffer can be updated partially rather than fully rewritten, especially with some layering.
@@ -151,34 +179,36 @@ class ScenePanel(wx.Panel):
     isAltPressed = False
 
     def on_key_down(self, evt):
-        keycode = evt.GetKeyCode()
-        # print("Key-Down: %f" % keycode)
-        if keycode == wx.WXK_SHIFT:
+        literal = get_key_name(evt, True)
+        # keycode = evt.GetKeyCode()
+        # print("Key-Down: %f - literal: %s" % (keycode, literal))
+        if literal.startswith("shift+"):
             if not self.isShiftPressed:  # ignore multiple calls
                 self.isShiftPressed = True
                 self.scene.event(self.scene.last_position, "kb_shift_press")
-        elif keycode == wx.WXK_CONTROL:
+        elif literal.startswith("ctrl+"):
             if not self.isCtrlPressed:  # ignore multiple calls
                 self.isCtrlPressed = True
                 self.scene.event(self.scene.last_position, "kb_ctrl_press")
-        elif keycode == wx.WXK_ALT:
+        elif literal.startswith("alt+"):
             if not self.isAltPressed:  # ignore multiple calls
                 self.isAltPressed = True
                 self.scene.event(self.scene.last_position, "kb_alt_press")
                 # self.scene.event(self.scene.last_position, "kb_alt_press")
 
     def on_key_up(self, evt):
-        keycode = evt.GetKeyCode()
-        # print("Key-Up: %f" % keycode)
-        if keycode == wx.WXK_SHIFT:
+        literal = get_key_name(evt, True)
+        # keycode = evt.GetKeyCode()
+        # print("Key-Up: %f - literal: %s" % (keycode, literal))
+        if literal.startswith("shift+"):
             if self.isShiftPressed:  # ignore multiple calls
                 self.isShiftPressed = False
                 self.scene.event(self.scene.last_position, "kb_shift_release")
-        elif keycode == wx.WXK_CONTROL:
+        elif literal.startswith("ctrl+"):
             if self.isCtrlPressed:  # ignore multiple calls
                 self.isCtrlPressed = False
                 self.scene.event(self.scene.last_position, "kb_ctrl_release")
-        elif keycode == wx.WXK_ALT:
+        elif literal.startswith("alt+"):
             if self.isAltPressed:  # ignore multiple calls
                 self.isAltPressed = False
                 self.scene.event(self.scene.last_position, "kb_alt_release")

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -150,15 +150,14 @@ class SelectionWidget(Widget):
         res = False
         matrix = self.parent.matrix
         if not space_pos is None:
-            sx = space_pos[0] 
-            sy = space_pos[1] 
+            sx = space_pos[0]
+            sy = space_pos[1]
             # print ("left=%f, right=%f, top=%f, bottom=%f, x=%f, y=%f" % (self.left, self.right, self.top, self.bottom, sx, sy))
 
             if (self.left <= sx <= self.right) and (self.top <= sy <= self.bottom):
                 # print ("inside")
                 res = True
         return res
-
 
     def event(self, window_pos=None, space_pos=None, event_type=None):
 
@@ -179,7 +178,7 @@ class SelectionWidget(Widget):
                 self.key_shift_pressed = False
                 if self.stillinside(space_pos):
                     self.scene.cursor("sizing")
-                    self.hovering  = True
+                    self.hovering = True
                     self.tool = self.tool_translate
             return RESPONSE_CHAIN
         elif event_type == "kb_shift_press":
@@ -187,7 +186,7 @@ class SelectionWidget(Widget):
                 self.key_shift_pressed = True
             # Are we hovering ? If yes reset cursor
             if self.hovering:
-                self.hovering  = False
+                self.hovering = False
                 self.scene.cursor("arrow")
             return RESPONSE_CHAIN
         elif event_type == "kb_ctrl_release":
@@ -195,7 +194,7 @@ class SelectionWidget(Widget):
                 self.key_control_pressed = False
                 if self.stillinside(space_pos):
                     self.scene.cursor("sizing")
-                    self.hovering  = True
+                    self.hovering = True
                     self.tool = self.tool_translate
             return RESPONSE_CHAIN
         elif event_type == "kb_ctrl_press":
@@ -203,7 +202,7 @@ class SelectionWidget(Widget):
                 self.key_control_pressed = True
             # Are we hovering ? If yes reset cursor
             if self.hovering:
-                self.hovering  = False
+                self.hovering = False
                 self.scene.cursor("arrow")
             return RESPONSE_CHAIN
         elif event_type == "kb_alt_release":
@@ -216,11 +215,11 @@ class SelectionWidget(Widget):
             return RESPONSE_CHAIN
         elif event_type == "hover_start":
             self.scene.cursor("sizing")
-            self.hovering  = True
+            self.hovering = True
             return RESPONSE_CHAIN
         elif event_type == "hover_end" or event_type == "lost":
             self.scene.cursor("arrow")
-            self.hovering  = False
+            self.hovering = False
             return RESPONSE_CHAIN
         elif event_type == "hover":
             if self.hovering:
@@ -694,9 +693,21 @@ class RectSelectWidget(Widget):
     SELECTION_ENCLOSE = 3
     # Color for selection rectangle (hit, cross, enclose)
     selection_style = [
-        (wx.RED, wx.PENSTYLE_DOT_DASH, "Select all elements the selection rectangle touches."),
-        (wx.GREEN, wx.PENSTYLE_DOT, "Select all elements the selection rectangle crosses."),
-        (wx.BLUE, wx.PENSTYLE_SHORT_DASH, "Select all elements the selection rectangle encloses."),
+        (
+            wx.RED,
+            wx.PENSTYLE_DOT_DASH,
+            "Select all elements the selection rectangle touches.",
+        ),
+        (
+            wx.GREEN,
+            wx.PENSTYLE_DOT,
+            "Select all elements the selection rectangle crosses.",
+        ),
+        (
+            wx.BLUE,
+            wx.PENSTYLE_SHORT_DASH,
+            "Select all elements the selection rectangle encloses.",
+        ),
     ]
     selection_text_shift = " Previously selected remain selected!"
     selection_text_control = " Invert selection state of elements!"
@@ -865,7 +876,7 @@ class RectSelectWidget(Widget):
                 # is greater than the other's maximum in
                 # that dimension.
                 if not ((sx > xmax) or (xmin > ex) or (sy > ymax) or (ymin > ey)):
-                    cover = self.SELECTION_TOUCH 
+                    cover = self.SELECTION_TOUCH
                     # If selection rect is fullly inside an object then ignore
                     if sx > xmin and ex < xmax and sy > ymin and ey < ymax:
                         cover = 0
@@ -912,11 +923,76 @@ class RectSelectWidget(Widget):
             return RESPONSE_CONSUME
         return RESPONSE_DROP
 
+    def draw_rectangle(self, gc, x0, y0, x1, y1, tcolor, tstyle):
+        matrix = self.parent.matrix
+        self.selection_pen.SetColour(tcolor)
+        self.selection_pen.SetStyle(tstyle)
+        gc.SetPen(self.selection_pen)
+
+        linewidth = 2.0 / matrix.value_scale_x()
+        if linewidth < 1:
+            linewidth = 1
+        try:
+            self.selection_pen.SetWidth(linewidth)
+        except TypeError:
+            self.selection_pen.SetWidth(int(linewidth))
+        gc.SetPen(self.selection_pen)
+        gc.StrokeLine(x0, y0, x1, y0)
+        gc.StrokeLine(x1, y0, x1, y1)
+        gc.StrokeLine(x1, y1, x0, y1)
+        gc.StrokeLine(x0, y1, x0, y0)
+
+    def draw_tiny_indicator(self, gc, symbol, x0, y0, x1, y1, tcolor, tstyle):
+        matrix = self.parent.matrix
+        self.selection_pen.SetColour(tcolor)
+        self.selection_pen.SetStyle(tstyle)
+
+        linewidth = 2.0 / matrix.value_scale_x()
+        if linewidth < 1:
+            linewidth = 1
+        try:
+            self.selection_pen.SetWidth(linewidth)
+        except TypeError:
+            self.selection_pen.SetWidth(int(linewidth))
+        gc.SetPen(self.selection_pen)
+        delta_X = 15.0 / matrix.value_scale_x()
+        delta_Y = 15.0 / matrix.value_scale_y()
+        if abs(x1 - x0) > delta_X and abs(y1 - y0) > delta_Y:  # Don't draw if too tiny
+            # Draw tiny + in Corner in corner of pointer
+            x_signum = +1 * delta_X if x0 < x1 else -1 * delta_X
+            y_signum = +1 * delta_Y if y0 < y1 else -1 * delta_X
+            ax1 = x1 - x_signum
+            ay1 = y1 - y_signum
+
+            gc.SetPen(self.selection_pen)
+            gc.StrokeLine(ax1, y1, ax1, ay1)
+            gc.StrokeLine(ax1, ay1, x1, ay1)
+            font_size = 10.0 / matrix.value_scale_x()
+            if font_size < 1.0:
+                font_size = 1.0
+            font = wx.Font(font_size, wx.SWISS, wx.NORMAL, wx.NORMAL)
+
+            gc.SetFont(font, tcolor)
+            (t_width, t_height) = gc.GetTextExtent(symbol)
+            gc.DrawText(
+                symbol, (ax1 + x1) / 2 - t_width / 2, (ay1 + y1) / 2 - t_height / 2
+            )
+            if (
+                abs(x1 - x0) > 2 * delta_X and abs(y1 - y0) > 2 * delta_Y
+            ):  # Don't draw if too tiny
+                # Draw second symbol at origin
+                ax1 = x0 + x_signum
+                ay1 = y0 + y_signum
+                gc.StrokeLine(ax1, y0, ax1, ay1)
+                gc.StrokeLine(ax1, ay1, x0, ay1)
+                gc.DrawText(
+                    symbol, (ax1 + x0) / 2 - t_width / 2, (ay1 + y0) / 2 - t_height / 2
+                )
+
     def process_draw(self, gc):
         """
         Draw the selection rectangle
         """
-        matrix = self.parent.matrix
         if self.start_location is not None and self.end_location is not None:
             x0 = self.start_location[0]
             y0 = self.start_location[1]
@@ -941,74 +1017,43 @@ class RectSelectWidget(Widget):
                 statusmsg += _(self.selection_text_control)
 
             self.update_statusmsg(statusmsg)
+            gcstyle = self.selection_style[self.selection_method[sector] - 1][0]
+            gccolor = self.selection_style[self.selection_method[sector] - 1][1]
+            self.draw_rectangle(
+                gc,
+                x0,
+                y0,
+                x1,
+                y1,
+                gcstyle,
+                gccolor,
+            )
 
             # Determine Colour on selection mode: standard (from left top to right bottom) = Blue, else Green
-
-            self.selection_pen.SetColour(
-                self.selection_style[self.selection_method[sector] - 1][0]
-            )
-            self.selection_pen.SetStyle(
-                self.selection_style[self.selection_method[sector] - 1][1]
-            )
-
-            linewidth = 2.0 / matrix.value_scale_x()
-            if linewidth < 1:
-                linewidth = 1
-            try:
-                self.selection_pen.SetWidth(linewidth)
-            except TypeError:
-                self.selection_pen.SetWidth(int(linewidth))
-            gc.SetPen(self.selection_pen)
-            gc.StrokeLine(x0, y0, x1, y0)
-            gc.StrokeLine(x1, y0, x1, y1)
-            gc.StrokeLine(x1, y1, x0, y1)
-            gc.StrokeLine(x0, y1, x0, y0)
-            matrix = self.parent.matrix
-            delta_X = 15.0 / matrix.value_scale_x()
-            delta_Y = 15.0 / matrix.value_scale_y()
             # Draw indicator...
             if self.key_shift_pressed:
-                if (
-                    abs(x1 - x0) > delta_X and abs(y1 - y0) > delta_Y
-                ):  # Don't draw if too tiny
-                    # Draw tiny + in Corner
-                    x_signum = +1 * delta_X if x0 < x1 else -1 * delta_X
-                    y_signum = +1 * delta_Y if y0 < y1 else -1 * delta_X
-                    ax1 = x1 - x_signum
-                    ay1 = y1 - y_signum
-
-                    # self.selection_pen.SetStyle(wx.PENSTYLE_SOLID)
-                    gc.SetPen(self.selection_pen)
-                    gc.StrokeLine(ax1, y1, ax1, ay1)
-                    gc.StrokeLine(ax1, ay1, x1, ay1)
-                    font_size = 10.0 / matrix.value_scale_x()
-                    if font_size<1.0:
-                        font_size=1.0
-                    font = wx.Font(font_size, wx.SWISS, wx.NORMAL, wx.NORMAL)
-                    gc.SetFont(font, self.selection_style[self.selection_method[sector] - 1][0])
-                    (t_width, t_height) = gc.GetTextExtent("+")
-                    gc.DrawText("+", (ax1+x1)/2-t_width/2, (ay1+y1)/2-t_height/2)
+                self.draw_tiny_indicator(
+                    gc,
+                    "+",
+                    x0,
+                    y0,
+                    x1,
+                    y1,
+                    gcstyle,
+                    gccolor,
+                )
 
             elif self.key_control_pressed:
-                if (
-                    abs(x1 - x0) > delta_X and abs(y1 - y0) > delta_Y
-                ):  # Don't draw if too tiny
-                    # Draw tiny - in Corner
-                    x_signum = +1 * delta_X if x0 < x1 else -1 * delta_X
-                    y_signum = +1 * delta_Y if y0 < y1 else -1 * delta_X
-                    ax1 = x1 - x_signum
-                    ay1 = y1 - y_signum
-                    # self.selection_pen.SetStyle(wx.PENSTYLE_SOLID)
-                    gc.SetPen(self.selection_pen)
-                    gc.StrokeLine(ax1, y1, ax1, ay1)
-                    gc.StrokeLine(ax1, ay1, x1, ay1)
-                    font_size = 10.0 / matrix.value_scale_x()
-                    if font_size<1.0:
-                        font_size=1.0
-                    font = wx.Font(font_size, wx.SWISS, wx.NORMAL, wx.NORMAL)
-                    gc.SetFont(font, self.selection_style[self.selection_method[sector] - 1][0])
-                    (t_width, t_height) = gc.GetTextExtent("!")
-                    gc.DrawText("!", (ax1+x1)/2-t_width/2, (ay1+y1)/2-t_height/2)
+                self.draw_tiny_indicator(
+                    gc,
+                    "^",
+                    x0,
+                    y0,
+                    x1,
+                    y1,
+                    self.selection_style[self.selection_method[sector] - 1][0],
+                    self.selection_style[self.selection_method[sector] - 1][1],
+                )
 
 
 class ReticleWidget(Widget):


### PR DESCRIPTION
a) Optics: Draw two indicators in the selection rectangle to make it clearer to see even if mouse select left up (was covered by the mouse pointer before), change symbol from ! to ^
b) Keypress-behaviour, anticipates Sophist-UKs PR for keybinds, Ctrl+ should be more consistent with other keys on MacOS