### PR TITLE
Validate Length (draft)

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3658,7 +3658,7 @@ class Elemental(Modifier):
         @context.console_command(
             "outline",
             help=_("outline the current selected elements"),
-            input_type=(
+            input_type=(            
                 None,
                 "elements",
             ),
@@ -3679,6 +3679,13 @@ class Elemental(Modifier):
             """
             if x_offset is None:
                 raise SyntaxError
+            elif not  x_offset.isValid:
+                raise SyntaxError(_("This is not a valid length"))
+            if not y_offset is None:
+                if not  y_offset.isValid:
+                    raise SyntaxError(_("This is not a valid length"))
+            
+
             bounds = self.selected_area()
             if bounds is None:
                 channel(_("Nothing Selected"))

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3210,8 +3210,13 @@ class Elemental(Modifier):
                 raise SyntaxError
             if x is None:
                 x = Length("100%")
+            else:
+                if not x.isValid:
+                    raise SyntaxError("x: " + _("This is not a valid length"))
             if y is None:
                 y = Length("100%")
+                if not y.isValid:
+                    raise SyntaxError("x: " + _("This is not a valid length"))
             try:
                 bounds = self._emphasized_bounds
                 width = bounds[2] - bounds[0]
@@ -3366,6 +3371,19 @@ class Elemental(Modifier):
             """
             if x_pos is None:
                 raise SyntaxError
+            else:
+                if not x_pos.isValid:
+                    raise SyntaxError("x_pos: " + _("This is not a valid length"))
+            if not y_pos is None:
+                if not y_pos.isValid:
+                    raise SyntaxError("y-pos: " + _("This is not a valid length"))
+            if not rx is None:
+                if not rx.isValid:
+                    raise SyntaxError("rx: " + _("This is not a valid length"))
+            if not ry is None:
+                if not ry.isValid:
+                    raise SyntaxError("ry: " + _("This is not a valid length"))
+
             rect = Rect(x=x_pos, y=y_pos, width=width, height=height, rx=rx, ry=ry)
             rect.render(
                 ppi=1000.0,
@@ -3396,6 +3414,19 @@ class Elemental(Modifier):
             """
             if y1 is None:
                 raise SyntaxError
+            if not x0 is None:
+                if not x0.isValid:
+                    raise SyntaxError("x0: " + _("This is not a valid length"))
+            if not y0 is None:
+                if not y0.isValid:
+                    raise SyntaxError("y0: " + _("This is not a valid length"))
+            if not x1 is None:
+                if not x1.isValid:
+                    raise SyntaxError("x1: " + _("This is not a valid length"))
+            if not y1 is None:
+                if not y1.isValid:
+                    raise SyntaxError("y1: " + _("This is not a valid length"))
+
             simple_line = SimpleLine(x0, y0, x1, y1)
             simple_line.render(
                 ppi=1000.0,
@@ -3523,6 +3554,9 @@ class Elemental(Modifier):
                     i += 1
                 channel("----------")
                 return
+            else:
+                if not stroke_width.isValid:
+                    raise SyntaxError("stroke-width: " + _("This is not a valid length"))
 
             if len(data) == 0:
                 channel(_("No selected elements."))
@@ -3658,7 +3692,7 @@ class Elemental(Modifier):
         @context.console_command(
             "outline",
             help=_("outline the current selected elements"),
-            input_type=(            
+            input_type=(
                 None,
                 "elements",
             ),
@@ -3679,12 +3713,12 @@ class Elemental(Modifier):
             """
             if x_offset is None:
                 raise SyntaxError
-            elif not  x_offset.isValid:
-                raise SyntaxError(_("This is not a valid length"))
+            elif not x_offset.isValid:
+                raise SyntaxError("x-offset: " + _("This is not a valid length"))
             if not y_offset is None:
-                if not  y_offset.isValid:
-                    raise SyntaxError(_("This is not a valid length"))
-            
+                if not y_offset.isValid:
+                    raise SyntaxError("y-offset: " + _("This is not a valid length"))
+
 
             bounds = self.selected_area()
             if bounds is None:
@@ -3774,15 +3808,21 @@ class Elemental(Modifier):
             rot = angle.as_degrees
 
             if cx is not None:
-                cx = cx.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
-                )
+                if cx.isValid:
+                    cx = cx.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("cx: " + _("This is not a valid length"))
             else:
                 cx = (bounds[2] + bounds[0]) / 2.0
             if cy is not None:
-                cy = cy.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
-                )
+                if cy.isValid:
+                    cy = cy.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("cy: " + _("This is not a valid length"))
             else:
                 cy = (bounds[3] + bounds[1]) / 2.0
             matrix = Matrix("rotate(%fdeg,%f,%f)" % (rot, cx, cy))
@@ -3871,15 +3911,21 @@ class Elemental(Modifier):
             if scale_y is None:
                 scale_y = scale_x
             if px is not None:
-                center_x = px.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
-                )
+                if px.isValid:
+                    center_x = px.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("px: " + _("This is not a valid length"))
             else:
                 center_x = (bounds[2] + bounds[0]) / 2.0
             if py is not None:
-                center_y = py.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
-                )
+                if py.isValid:
+                    center_y = py.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("py: " + _("This is not a valid length"))
             else:
                 center_y = (bounds[3] + bounds[1]) / 2.0
             if scale_x == 0 or scale_y == 0:
@@ -3965,15 +4011,21 @@ class Elemental(Modifier):
                 channel(_("No selected elements."))
                 return
             if tx is not None:
-                tx = tx.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
-                )
+                if tx.isValid:
+                    tx = tx.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("tx: " + _("This is not a valid length"))
             else:
                 tx = 0
             if ty is not None:
-                ty = ty.value(
-                    ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
-                )
+                if ty.isValid:
+                    ty = ty.value(
+                        ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
+                    )
+                else:
+                    raise SyntaxError("ty: " + _("This is not a valid length"))
             else:
                 ty = 0
             m = Matrix("translate(%f,%f)" % (tx, ty))
@@ -4062,6 +4114,19 @@ class Elemental(Modifier):
                 if area is None:
                     channel(_("resize: nothing selected"))
                     return
+                if not x_pos is None:
+                    if not x_pos.isValid:
+                        raise SyntaxError("x_pos: " + _("This is not a valid length"))
+                if not y_pos is None:
+                    if not y_pos.isValid:
+                        raise SyntaxError("y_pos: " + _("This is not a valid length"))
+                if not width is None:
+                    if not width.isValid:
+                        raise SyntaxError("width: " + _("This is not a valid length"))
+                if not height is None:
+                    if not height.isValid:
+                        raise SyntaxError("height: " + _("This is not a valid length"))
+
                 x_pos = x_pos.value(
                     ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
                 )
@@ -4144,6 +4209,13 @@ class Elemental(Modifier):
                 # SVG 7.15.3 defines the matrix form as:
                 # [a c  e]
                 # [b d  f]
+                if not tx is None:
+                    if not tx.isValid:
+                        raise SyntaxError("tx: " + _("This is not a valid length"))
+                if not ty is None:
+                    if not ty.isValid:
+                        raise SyntaxError("ty: " + _("This is not a valid length"))
+
                 m = Matrix(
                     sx,
                     kx,
@@ -4572,15 +4644,21 @@ class Elemental(Modifier):
                 if dx is None:
                     dx = 0
                 else:
-                    dx = dx.value(
-                        ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
-                    )
+                    if dx.isValid:
+                        dx = dx.value(
+                            ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                        )
+                    else:
+                        raise SyntaxError("dx: " + _("This is not a valid length"))
                 if dy is None:
                     dy = 0
                 else:
-                    dy = dy.value(
-                        ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
-                    )
+                    if dy.isValid:
+                        dy = dy.value(
+                            ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
+                        )
+                    else:
+                        raise SyntaxError("dy: " + _("This is not a valid length"))
                 m = Matrix("translate(%s, %s)" % (dx, dy))
                 for e in pasted:
                     e *= m

--- a/meerk40t/svgelements.py
+++ b/meerk40t/svgelements.py
@@ -564,20 +564,20 @@ class Length(object):
             if value is None:
                 self.amount = None
                 self.units = None
-                self.isValid = False
                 return
             s = str(value)
             for m in REGEX_LENGTH.findall(s):
                 self.amount = float(m[0])
                 self.units = m[1]
-                self.isValid = True
+                if len(m[1]) == 0 or m[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT):
+                    self.isValid = True
                 return
         elif len(args) == 2:
             self.amount = args[0]
             self.units = args[1]
             try:
                 x = float(args[0])
-                if (args[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT)):
+                if len(args[1]) == 0 or args[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT):
                     self.isValid = True
             except ValueError:
                 pass
@@ -585,6 +585,7 @@ class Length(object):
         self.amount = 0.0
         self.units = ""
 
+# TODO: if isValid is False either use that knowledge and / or propagate that to the results of operations
     def __float__(self):
         if self.amount is None:
             return None

--- a/meerk40t/svgelements.py
+++ b/meerk40t/svgelements.py
@@ -558,20 +558,29 @@ class Length(object):
     """
 
     def __init__(self, *args, **kwargs):
+        self.isValid = False
         if len(args) == 1:
             value = args[0]
             if value is None:
                 self.amount = None
                 self.units = None
+                self.isValid = False
                 return
             s = str(value)
             for m in REGEX_LENGTH.findall(s):
                 self.amount = float(m[0])
                 self.units = m[1]
+                self.isValid = True
                 return
         elif len(args) == 2:
             self.amount = args[0]
             self.units = args[1]
+            try:
+                x = float(args[0])
+                if (args[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT)):
+                    self.isValid = True
+            except ValueError:
+                pass
             return
         self.amount = 0.0
         self.units = ""


### PR DESCRIPTION
Meerk40t is quite lenient when it comes to checking the validity of Length parameters. Actually it converts invalid statements to a 0.0. I.e. outline blablabla is translated to outline 0.0. 
I think we should introduce some basic validity checking to address this.

The code attempts to do some basic stuff at the level of the Length class in svgelements and provides a new property isValid. I just used this as a POC in elements.py in the 'outline' command.
<img width="277" alt="image" src="https://user-images.githubusercontent.com/2670784/155548735-5f57fa94-6caf-4f6f-af09-5027642b870e.png">
