### PR TITLE
Reverts Clear Ops on Open Project introduced by #763

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6088,15 +6088,18 @@ class Elemental(Modifier):
         pass
 
     def clear_elements_and_operations(self):
-        self.clear_elements()
         self.clear_operations()
+        self.clear_elements()
 
-    def clear_all(self):
+    def clear_project(self):
         self.clear_elements()
-        self.clear_operations()
         self.clear_files()
         self.clear_note()
         self.validate_selected_area()
+
+    def clear_all(self):
+        self.clear_operations()
+        self.clear_project()
 
     def clear_note(self):
         self.note = None

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1810,15 +1810,17 @@ class MeerK40t(MWindow):
                 break
         self.populate_recent_menu()
 
-    def clear_project(self):
+    def clear_project(self, clear_ops=True):
         context = self.context
         self.working_file = None
         self.validate_save()
-        context.elements.clear_all()
+        context.elements.clear_project()
+        if clear_ops:
+            context.elements.clear_operations()
         self.context(".laserpath_clear\n")
 
     def clear_and_open(self, pathname):
-        self.clear_project()
+        self.clear_project(clear_ops=False)
         if self.load(pathname):
             try:
                 if self.context.uniform_svg and pathname.lower().endswith("svg"):


### PR DESCRIPTION
This PR reverts the Clear Operations on opening a project introduced in #763. Open Project is still different from File Import in that it clears everything else (as you would expect a project to do).

At present, I have not changed the Recent menu functionality to be consistent with this, Recent files are treated as File Imports and are loaded alongside existing files rather than as a replacement for them. I am unclear whether the Recent menu should continue to operate like a File Import, or instead operate like an Open Project or whether we might actually need two recent menus, one which acts like Open Project and one which acts like File Import. On the whole, I favour:

a. Renaming "Recent" to "Recent Projects";
b. Treating opening a recent file as if it was an Open Project. 
c. Only populating the recent file list from Open Project and Save and not from File Import.

I think this PR could include the above changes once there is consensus on approach. 

Can reviewers tagged (any anyone else interested) please give their views if you wish to contribute?