### PR TITLE
Extend grid and add circ_copy, radial and shape

### DIFF
--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7710,7 +7710,7 @@ msgstr "Ein Polygon muss mindestens drei Eckpunkte haben"
 
 #: meerk40t/core/elements.py:3404
 msgid "Alternating radius for every other vertice"
-msgstr "Alternativer Radius für alterntierrende Eckpunkte"
+msgstr "Alternativer Radius für alternierende Eckpunkte"
 
 #: meerk40t/core/elements.py:3404
 msgid "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns"
@@ -7731,3 +7731,7 @@ msgstr "Bitte geben Sie mindestens drei Werte an: corners, hops und radius"
 #: meerk40t/core/elements.py:3472
 msgid "Hops needs to be greater than 1 and smaller than corners"
 msgstr "Der Wert für hops muss größer als 1 und kleiner als die Zahl der Ecken sein"
+
+#: meerk40t/core/elements.py:3684
+msgid "You haven chosen two even numbers for corners and hops in a 'star'. This will mean that you aren't hitting the odd numbered vertices!"
+msgstr "Es wurden zwei gerade Zahlen als Werte für corners und hops gewählt. Damit werden aber ungerade Eckpunkte nicht getroffen!"

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7705,11 +7705,7 @@ msgid "Shall the polygon touch the inscribing circle?"
 msgstr "Soll das Polygon am innenliegenden Kreis ausgerichtet werden"
 
 #: meerk40t/core/elements.py:3404
-msgid "A polyshape needs to have at least three corners"
-msgstr "Ein Polygon muss mindestens drei Eckpunkte haben"
-
-#: meerk40t/core/elements.py:3404
-msgid "Alternating radius for every other vertice"
+msgid "Alternating radius for every other vertex"
 msgstr "Alternativer Radius für alternierende Eckpunkte"
 
 #: meerk40t/core/elements.py:3404
@@ -7721,16 +7717,12 @@ msgid "Amount of vertices to skip"
 msgstr "Zahl der zu überspringenden Ecken"
 
 #: meerk40t/core/elements.py:3466
-msgid "A star needs to have at least 5 corners"
-msgstr "Ein Stern muss mindestens 5 Eckpunkte haben"
-
-#: meerk40t/core/elements.py:3469
-msgid "Please provide at least three parameters: corners, density and radius"
-msgstr "Bitte geben Sie mindestens drei Werte an: corners, density und radius"
+msgid "Do you want to treat the length value for radius as the length of one edge instead?"
+msgstr "Soll der Wert für Radius stattdessen die Länge einer Seite definieren?"
 
 #: meerk40t/core/elements.py:3472
-msgid "Hops needs to be greater than 1 and smaller than corners"
-msgstr "Der Wert für hops muss größer als 1 und kleiner als die Zahl der Ecken sein"
+msgid "You have as well provided the --side_length parameter, this takes precedence, so --inscribed is ignored"
+msgstr "Neben der --inscribed Option wurde auch --side_length verwendet, diese hat Vorrang, deswegen wird --inscribed ignoriert"
 
 #: meerk40t/core/elements.py:3684
 msgid "Just for info: we have missed %d vertices..."
@@ -7738,4 +7730,5 @@ msgstr "Nur zur Info: es fehlen %d Eckpunkte gegenüber dem regulären Polygon..
 
 #: meerk40t/core/elements.py:3684
 msgid "To hit all, the density parameters should be e.g. %s"
-msgstr "Um alle Eckpunkte zu 'erwischen', sollte einer der folgenden Kombination verwendet werden: %s"
+msgstr "Um alle Eckpunkte zu 'erwischen', sollte eine der folgenden Kombinationen verwendet werden: %s"
+

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7659,3 +7659,63 @@ msgstr " Der Status wird dabei umgekehrt!"
 #: meerk40t/core/elements.py:3245
 msgid "This is not a valid length"
 msgstr "Das ist keine gültige Längenangabe"
+
+#: meerk40t/core/elements.py:3218
+msgid "Point of origin (1-9)"
+msgstr "Platzierung des Originals (1-9)"
+
+#: meerk40t/core/elements.py:3303
+msgid "Number of copies"
+msgstr "Anzahl der Kopien"
+
+#: meerk40t/core/elements.py:3304
+msgid "Start-Angle"
+msgstr "Winkel bei dem der Kreisbogen beginnt"
+
+#: meerk40t/core/elements.py:3305
+msgid "End-Angle"
+msgstr "Winkel bei dem der Kreisbogen endet"
+
+#: meerk40t/core/elements.py:3306
+msgid "Rotate copies (1=yes)"
+msgstr "Sollen Kopien rotiert werden (1=Ja)"
+
+#: meerk40t/core/elements.py:3245
+msgid "Please provide at least one additional value (which will act as radius then)"
+msgstr "Bitte geben Sie mindestens einen weiteren Wert an (der dann als Radius verwendet wird)"
+
+#: meerk40t/core/elements.py:3388
+msgid "Number of corners/vertices"
+msgstr "Anzahl der Eckpunkte"
+
+#: meerk40t/core/elements.py:3389
+msgid "X-Value of polygon's center"
+msgstr "X-Wert des Polygon-Mittelpunkts"
+
+#: meerk40t/core/elements.py:3390
+msgid "Y-Value of polygon's center"
+msgstr "Y-Wert des Polygon-Mittelpunkts"
+
+#: meerk40t/core/elements.py:3393
+msgid "Shall the polygon touch the inscribing circle (1=Yes)"
+msgstr "Soll das Polygon am innenliegenden Kreis ausgerichtet werden (1=Ja)"
+
+#: meerk40t/core/elements.py:3404
+msgid "A polyshape needs to have at least three corners"
+msgstr "Ein Polygon muss mindestens drei Eckpunkte haben"
+
+#: meerk40t/core/elements.py:3451
+msgid "Amount of vertices to skip"
+msgstr "Zahl der zu überspringenden Ecken"
+
+#: meerk40t/core/elements.py:3466
+msgid "A star needs to have at least 5 corners"
+msgstr "Ein Stern muss mindestens 5 Eckpunkte haben"
+
+#: meerk40t/core/elements.py:3469
+msgid "Please provide at least three parameters: corners, hops and radius"
+msgstr "Bitte geben Sie mindestens drei Werte an: corners, hops und radius"
+
+#: meerk40t/core/elements.py:3472
+msgid "Hops needs to be greater than 1 and smaller than corners"
+msgstr "Der Wert für hops muss größer als 1 und kleiner als die Zahl der Ecken sein"

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7661,8 +7661,8 @@ msgid "This is not a valid length"
 msgstr "Das ist keine gültige Längenangabe"
 
 #: meerk40t/core/elements.py:3218
-msgid "Point of origin (1-9)"
-msgstr "Platzierung des Originals (1-9)"
+msgid "Position of copy in matrix (e.g '2,2' or '4,3')"
+msgstr "Platzierung des Originals im neuen Gitter (z.B. '2,2' oder '4,3')"
 
 #: meerk40t/core/elements.py:3303
 msgid "Number of copies"
@@ -7677,8 +7677,12 @@ msgid "End-Angle"
 msgstr "Winkel bei dem der Kreisbogen endet"
 
 #: meerk40t/core/elements.py:3306
-msgid "Rotate copies (1=yes)"
-msgstr "Sollen Kopien rotiert werden (1=Ja)"
+msgid "Rotate copies towards center?"
+msgstr "Sollen Kopien zum Mittelpunkt hin rotiert werden?"
+
+#: meerk40t/core/elements.py:3404
+msgid "Delta-Angle (if ommited will take (end-start)/copies )"
+msgstr "Delta-Winkel (falls nicht angegeben, dann (endwinkel-startwinkel)/kopien )"
 
 #: meerk40t/core/elements.py:3245
 msgid "Please provide at least one additional value (which will act as radius then)"
@@ -7697,12 +7701,20 @@ msgid "Y-Value of polygon's center"
 msgstr "Y-Wert des Polygon-Mittelpunkts"
 
 #: meerk40t/core/elements.py:3393
-msgid "Shall the polygon touch the inscribing circle (1=Yes)"
-msgstr "Soll das Polygon am innenliegenden Kreis ausgerichtet werden (1=Ja)"
+msgid "Shall the polygon touch the inscribing circle?"
+msgstr "Soll das Polygon am innenliegenden Kreis ausgerichtet werden"
 
 #: meerk40t/core/elements.py:3404
 msgid "A polyshape needs to have at least three corners"
 msgstr "Ein Polygon muss mindestens drei Eckpunkte haben"
+
+#: meerk40t/core/elements.py:3404
+msgid "Alternating radius for every other vertice"
+msgstr "Alternativer Radius für alterntierrende Eckpunkte"
+
+#: meerk40t/core/elements.py:3404
+msgid "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns"
+msgstr "Wieviele Punkte sollen auf dem Außenkreis liegen bevor zum Innenkreis gewechselt wird (1=Stern-Figur, >=2 Zahnrad-Muster)"
 
 #: meerk40t/core/elements.py:3451
 msgid "Amount of vertices to skip"

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7661,7 +7661,7 @@ msgid "This is not a valid length"
 msgstr "Das ist keine gültige Längenangabe"
 
 #: meerk40t/core/elements.py:3218
-msgid "Position of copy in matrix (e.g '2,2' or '4,3')"
+msgid "Position of original in matrix (e.g '2,2' or '4,3')"
 msgstr "Platzierung des Originals im neuen Gitter (z.B. '2,2' oder '4,3')"
 
 #: meerk40t/core/elements.py:3303
@@ -7681,7 +7681,7 @@ msgid "Rotate copies towards center?"
 msgstr "Sollen Kopien zum Mittelpunkt hin rotiert werden?"
 
 #: meerk40t/core/elements.py:3404
-msgid "Delta-Angle (if ommited will take (end-start)/copies )"
+msgid "Delta-Angle (if omitted will take (end-start)/copies )"
 msgstr "Delta-Winkel (falls nicht angegeben, dann (endwinkel-startwinkel)/kopien )"
 
 #: meerk40t/core/elements.py:3245

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7713,7 +7713,7 @@ msgid "Alternating radius for every other vertice"
 msgstr "Alternativer Radius für alternierende Eckpunkte"
 
 #: meerk40t/core/elements.py:3404
-msgid "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns"
+msgid "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns)"
 msgstr "Wieviele Punkte sollen auf dem Außenkreis liegen bevor zum Innenkreis gewechselt wird (1=Stern-Figur, >=2 Zahnrad-Muster)"
 
 #: meerk40t/core/elements.py:3451

--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7725,13 +7725,17 @@ msgid "A star needs to have at least 5 corners"
 msgstr "Ein Stern muss mindestens 5 Eckpunkte haben"
 
 #: meerk40t/core/elements.py:3469
-msgid "Please provide at least three parameters: corners, hops and radius"
-msgstr "Bitte geben Sie mindestens drei Werte an: corners, hops und radius"
+msgid "Please provide at least three parameters: corners, density and radius"
+msgstr "Bitte geben Sie mindestens drei Werte an: corners, density und radius"
 
 #: meerk40t/core/elements.py:3472
 msgid "Hops needs to be greater than 1 and smaller than corners"
 msgstr "Der Wert für hops muss größer als 1 und kleiner als die Zahl der Ecken sein"
 
 #: meerk40t/core/elements.py:3684
-msgid "You haven chosen two even numbers for corners and hops in a 'star'. This will mean that you aren't hitting the odd numbered vertices!"
-msgstr "Es wurden zwei gerade Zahlen als Werte für corners und hops gewählt. Damit werden aber ungerade Eckpunkte nicht getroffen!"
+msgid "Just for info: we have missed %d vertices..."
+msgstr "Nur zur Info: es fehlen %d Eckpunkte gegenüber dem regulären Polygon..."
+
+#: meerk40t/core/elements.py:3684
+msgid "To hit all, the density parameters should be e.g. %s"
+msgstr "Um alle Eckpunkte zu 'erwischen', sollte einer der folgenden Kombination verwendet werden: %s"

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3272,8 +3272,14 @@ class Elemental(Modifier):
             y = y.value(ppi=1000, relative_length=height)
             if isinstance(x, Length) or isinstance(y, Length):
                 raise SyntaxError
+            if origin is None:
+                origin = (1,1)
             cx, cy = origin
             data_out = list(data)
+            if cx is None:
+                cx = 1
+            if cy is None:
+                cy = 1
             # Tell whether original is at the left / middle / or right
             start_x = -1 * x * (cx - 1)
             start_y = -1 * y * (cy - 1)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3224,7 +3224,7 @@ class Elemental(Modifier):
             "o",
             type=int,
             nargs=2,
-            help=_("Position of copy in matrix (e.g '2,2' or '4,3')"),
+            help=_("Position of original in matrix (e.g '2,2' or '4,3')"),
         )
         @context.console_command(
             "grid",

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3515,7 +3515,7 @@ class Elemental(Modifier):
                     )
 
             if alternate_seq is None:
-                alternate_seq = 1
+                alternate_seq = 0
 
             x_pos = x_pos.value(
                 ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM
@@ -3538,14 +3538,17 @@ class Elemental(Modifier):
             radius_inner = radius_inner.value(ppi=1000, relative_length=radius)
             if isinstance(radius_inner, Length):
                 radius_inner = radius
-            if alternate_seq < 2:
+            if alternate_seq < 1:
                 radius_inner = radius
 
             # print("These are your parameters:")
             # print("Vertices: %d, Center: X=%.2f Y=%.2f" % (corners, x_pos, y_pos))
             # print("Radius: Outer=%.2f Inner=%.2f" % (radius, radius_inner))
             # print("Inscribe: %s" % inscribed)
-            # print("Startangle: %.2f, Alternate-Seq: %d" % (startangle.as_degrees, alternate_seq) )
+            # print(
+            #    "Startangle: %.2f, Alternate-Seq: %d"
+            #    % (startangle.as_degrees, alternate_seq)
+            # )
 
             pts = []
             myangle = startangle.as_radians

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3721,9 +3721,9 @@ class Elemental(Modifier):
                         j = i + 2
                         if gcd(j, corners) == 1:
                             if ct % 3 == 0:
-                                possible_combinations += "\n star %d %d ... " % (corners, j)
+                                possible_combinations += "\n shape %d ... -d %d" % (corners, j)
                             else:
-                                possible_combinations += ", star %d %d ... " % (corners, j)
+                                possible_combinations += ", shape %d ... -d %d " % (corners, j)
                             ct += 1
                     channel(
                         _("Just for info: we have missed %d vertices...")

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3222,7 +3222,8 @@ class Elemental(Modifier):
         @context.console_option(
             "origin",
             "o",
-            type=str,
+            type=int,
+            nargs=2,
             help=_("Position of copy in matrix (e.g '2,2' or '4,3')"),
         )
         @context.console_command(
@@ -3271,30 +3272,7 @@ class Elemental(Modifier):
             y = y.value(ppi=1000, relative_length=height)
             if isinstance(x, Length) or isinstance(y, Length):
                 raise SyntaxError
-
-            cx = 1
-            cy = 1
-            if origin is None:
-                origin = "1,1"
-            subtext = origin.split(",")
-            if len(subtext) < 2:  # make sure we have something for y
-                subtext.append("1")
-            if subtext[0].isdigit():
-                cx = int(subtext[0])
-                if cx < 1:
-                    cx = 1
-                elif cx > c:
-                    cx = c
-            if subtext[1].isdigit():
-                cy = int(subtext[1])
-                if cy < 1:
-                    cy = 1
-                elif cy > r:
-                    cy = r
-            # print("Cx=%d, Cy=%d" % (cx, cy))
-            # origin defines where the original elements will be placed in the to created grid
-            # i.e. (1, 1) is the 'old' way create copies to the right and to the bottom,
-
+            cx, cy = origin
             data_out = list(data)
             # Tell whether original is at the left / middle / or right
             start_x = -1 * x * (cx - 1)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3251,7 +3251,7 @@ class Elemental(Modifier):
             else:
                 if not y.is_valid_length:
                     raise SyntaxError("y: " + _("This is not a valid length"))
-                    
+
             try:
                 bounds = self._emphasized_bounds
                 width = bounds[2] - bounds[0]
@@ -3335,9 +3335,8 @@ class Elemental(Modifier):
             if radius is None:
                 radius = Length(0)
             else:
-                pass
-#                if not radius.is_valid_length:
-#                   raise SyntaxError("radius: " + _("This is not a valid length"))
+                if not radius.is_valid_length:
+                   raise SyntaxError("radius: " + _("This is not a valid length"))
             if startangle is None:
                 startangle = Angle.parse("0deg")
             if endangle is None:

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3308,7 +3308,7 @@ class Elemental(Modifier):
             "deltaangle",
             "d",
             type=Angle.parse,
-            help=_("Delta-Angle (if ommited will take (end-start)/copies )"),
+            help=_("Delta-Angle (if omitted will take (end-start)/copies )"),
         )
         @context.console_command(
             "circ_copy",

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3429,7 +3429,7 @@ class Elemental(Modifier):
         )
         @context.console_argument("radius", type=Length, help=_("Radius"))
         @context.console_option(
-            "startangle", "a", type=Angle.parse, help=_("Start-Angle")
+            "startangle", "s", type=Angle.parse, help=_("Start-Angle")
         )
         @context.console_option(
             "inscribed",
@@ -3446,7 +3446,7 @@ class Elemental(Modifier):
         )
         @context.console_option(
             "alternate_seq",
-            "s",
+            "a",
             type=int,
             help=_(
                 "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns)"

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3374,13 +3374,10 @@ class Elemental(Modifier):
                 rotate = False
 
             # print ("Segment to cover: %f - %f" % (startangle.as_degrees, endangle.as_degrees))
-
-            try:
-                bounds = self._emphasized_bounds
-                width = bounds[2] - bounds[0]
-                height = bounds[3] - bounds[1]
-            except Exception:
-                raise SyntaxError
+            bounds = Group.union_bbox(data, with_stroke=True)
+            if bounds is None:
+                return
+            width = bounds[2] - bounds[0]
             radius = radius.value(ppi=1000, relative_length=width)
             if isinstance(radius, Length):
                 raise SyntaxError
@@ -3393,7 +3390,7 @@ class Elemental(Modifier):
             # Notabene: we are following the cartesian system here, but as the Y-Axis is top screen to bottom screen,
             # the perceived angle travel is CCW (which is counter-intuitive)
             currentangle = startangle.as_radians
-            bounds = self._emphasized_bounds
+            # bounds = self._emphasized_bounds
             center_x = (bounds[2] + bounds[0]) / 2.0
             center_y = (bounds[3] + bounds[1]) / 2.0
             for cc in range(copies):

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3429,7 +3429,7 @@ class Elemental(Modifier):
         )
         @context.console_argument("radius", type=Length, help=_("Radius"))
         @context.console_option(
-            "startangle", "ang", type=Angle.parse, help=_("Start-Angle")
+            "startangle", "a", type=Angle.parse, help=_("Start-Angle")
         )
         @context.console_option(
             "inscribed",
@@ -3446,10 +3446,10 @@ class Elemental(Modifier):
         )
         @context.console_option(
             "alternate_seq",
-            "a",
+            "s",
             type=int,
             help=_(
-                "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns"
+                "Length of alternating sequence (1 for starlike figures, >=2 for more gear-like patterns)"
             ),
         )
         @context.console_command(

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3273,7 +3273,7 @@ class Elemental(Modifier):
             if isinstance(x, Length) or isinstance(y, Length):
                 raise SyntaxError
             if origin is None:
-                origin = (1,1)
+                origin = (1, 1)
             cx, cy = origin
             data_out = list(data)
             if cx is None:
@@ -3938,12 +3938,24 @@ class Elemental(Modifier):
         )
         def element_polygon(args=tuple(), **kwargs):
             try:
-                element = Polygon(list(map(float, args)))
+                mlist = list(map(str, args))
+                for ct, e in enumerate(mlist):
+                    ll = Length(e)
+                    # print("e=%s, ll=%s, valid=%s" % (e, ll, ll.is_valid_length))
+                    if ct % 2 == 0:
+                        x = ll.value(
+                            ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                        )
+                    else:
+                        x = ll.value(
+                            ppi=1000.0, relative_length=bed_dim.bed_height * MILS_IN_MM
+                        )
+                    mlist[ct] = x
+                    ct += 1
+                element = Polygon(mlist)
             except ValueError:
                 raise SyntaxError(
-                    _(
-                        "Must be a list of spaced delimited floating point numbers values."
-                    )
+                    _("Must be a list of spaced delimited floating point length pairs.")
                 )
             self.add_element(element)
 
@@ -3954,13 +3966,24 @@ class Elemental(Modifier):
         )
         def element_polyline(command, channel, _, args=tuple(), **kwargs):
             try:
-                element = Polyline(list(map(float, args)))
+                mlist = list(map(str, args))
+                for ct, e in enumerate(mlist):
+                    ll = Length(e)
+                    # print("e=%s, ll=%s, valid=%s" % (e, ll, ll.is_valid_length))
+                    if ct % 2 == 0:
+                        x = ll.value(
+                            ppi=1000.0, relative_length=bed_dim.bed_width * MILS_IN_MM
+                        )
+                    else:
+                        x = ll.value(
+                            ppi=1000.0,
+                            relative_length=bed_dim.bed_height * MILS_IN_MM,
+                        )
+                    mlist[ct] = x
+                    ct += 1
+                element = Polyline(mlist)
             except ValueError:
-                raise SyntaxError(
-                    _(
-                        "Must be a list of spaced delimited floating point numbers values."
-                    )
-                )
+                raise SyntaxError(_("Must be a list of spaced delimited length pairs."))
             self.add_element(element)
 
         @context.console_command(

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3271,7 +3271,7 @@ class Elemental(Modifier):
             # origin defines where the original elements will be placed in the to created grid
             #  1 2 3                  i.e. 1 is the 'old' way create copies to the right and to the bottom,
             #  4 5 6                  9 is creating copies to the left and upwards
-            #  7 8 9                  NB: if use a center position then eerything works fine for odd c and r
+            #  7 8 9                  NB: if use a center position then everything works fine for odd c and r
             #                         for even values we are taking a precedence to put the original just left
             #                         respectively just above the center
             pos_idx_x = (0, max(0, c // 2 + c % 2 - 1), c - 1)
@@ -3385,12 +3385,12 @@ class Elemental(Modifier):
             self.context.signal("refresh_scene")
             return "elements", data_out
 
-        @context.console_argument("corners", type=int)
-        @context.console_argument("x_pos", type=Length)
-        @context.console_argument("y_pos", type=Length)
-        @context.console_argument("radius", type=Length)
-        @context.console_argument("startangle", type=Angle.parse)
-        @context.console_argument("inscribed", type=int)
+        @context.console_argument("corners", type=int, help=_("Number of corners/vertices"))
+        @context.console_argument("x_pos", type=Length, help=_("X-Value of polygon's center"))
+        @context.console_argument("y_pos", type=Length, help=_("Y-Value of polygon's center"))
+        @context.console_argument("radius", type=Length, help=_("Radius"))
+        @context.console_argument("startangle", type=Angle.parse, help=_("Start-Angle"))
+        @context.console_argument("inscribed", type=int, help=_("Shall the polygon touch the inscribing circle (1=Yes)"))
         @context.console_command(
             "polyshape",
             help=_("polyshape <corners> <x> <y> <r> <startangle> <inscribed> or polyshape <corners> <r>"),
@@ -3446,13 +3446,13 @@ class Elemental(Modifier):
                 data.append(pts)
                 return "elements", data
 
-        @context.console_argument("corners", type=int)
-        @context.console_argument("hops", type=int)
-        @context.console_argument("x_pos", type=Length)
-        @context.console_argument("y_pos", type=Length)
-        @context.console_argument("radius", type=Length)
-        @context.console_argument("startangle", type=Angle.parse)
-        @context.console_argument("inscribed", type=int)
+        @context.console_argument("corners", type=int, help=_("Number of corners/vertices"))
+        @context.console_argument("hops", type=int, help=_("Amount of vertices to skip"))
+        @context.console_argument("x_pos", type=Length, help=_("X-Value of polygon's center"))
+        @context.console_argument("y_pos", type=Length, help=_("Y-Value of polygon's center"))
+        @context.console_argument("radius", type=Length, help=_("Radius"))
+        @context.console_argument("startangle", type=Angle.parse, help=_("Start-Angle"))
+        @context.console_argument("inscribed", type=int, help=_("Shall the polygon touch the inscribing circle (1=Yes)"))
         @context.console_command(
             "star",
             help=_("star <corners> <hops> <x> <y> <r> <startangle> <inscribed> or star <corners> <hops> <r>"),

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3390,13 +3390,14 @@ class Elemental(Modifier):
         @context.console_argument("y_pos", type=Length)
         @context.console_argument("radius", type=Length)
         @context.console_argument("startangle", type=Angle.parse)
+        @context.console_argument("inscribed", type=int)
         @context.console_command(
             "polyshape",
-            help=_("polyshape <corners> <x> <y> <r> <startangle> or polyshape <corners> <r>"),
+            help=_("polyshape <corners> <x> <y> <r> <startangle> <inscribed> or polyshape <corners> <r>"),
             input_type=("elements", None),
             output_type="elements",
         )
-        def element_polyshape(corners, x_pos, y_pos, radius, startangle, data=None, **kwargs):
+        def element_polyshape(corners, x_pos, y_pos, radius, startangle, inscribed, data=None, **kwargs):
             if corners is None:
                 raise SyntaxError
             if corners < 3:
@@ -3414,12 +3415,16 @@ class Elemental(Modifier):
                 y_pos = Length(0)
             if startangle is None:
                 startangle = Angle.parse("0deg")
+            if inscribed is None: # Use circumscribed circle by default
+                inscribed = 0
+
             x_pos = x_pos.value(ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM)
             y_pos = y_pos.value(ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM)
             radius = radius.value(ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM)
             if isinstance(radius, Length) or isinstance(x_pos, Length) or isinstance(y_pos, Length):
                 raise SyntaxError
-
+            if inscribed != 0:
+                radius = radius / cos(pi / corners)
             pts = []
             myangle = startangle.as_radians
             deltaangle = 2 * pi / corners
@@ -3447,13 +3452,14 @@ class Elemental(Modifier):
         @context.console_argument("y_pos", type=Length)
         @context.console_argument("radius", type=Length)
         @context.console_argument("startangle", type=Angle.parse)
+        @context.console_argument("inscribed", type=int)
         @context.console_command(
             "star",
-            help=_("star <corners> <hops> <x> <y> <r> <startangle> or star <corners> <hops> <r>"),
+            help=_("star <corners> <hops> <x> <y> <r> <startangle> <inscribed> or star <corners> <hops> <r>"),
             input_type=("elements", None),
             output_type="elements",
         )
-        def element_star(corners, hops, x_pos, y_pos, radius, startangle, data=None, **kwargs):
+        def element_star(corners, hops, x_pos, y_pos, radius, startangle, inscribed, data=None, **kwargs):
             if corners is None:
                 raise SyntaxError
             if corners < 5:
@@ -3479,6 +3485,10 @@ class Elemental(Modifier):
             radius = radius.value(ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM)
             if isinstance(radius, Length) or isinstance(x_pos, Length) or isinstance(y_pos, Length):
                 raise SyntaxError
+            if inscribed is None: # Use circumscribed circle by default
+                inscribed = 0
+            if inscribed != 0:
+                radius = radius / cos(pi / corners)
 
             pts = []
             myangle = startangle.as_radians

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3506,6 +3506,12 @@ class Elemental(Modifier):
             if inscribed is None:  # Use circumscribed circle by default
                 inscribed = False
 
+            if alternate_seq is None:
+                if radius_inner is None:
+                    alternate_seq = 0
+                else:
+                    alternate_seq = 1
+
             if radius_inner is None:
                 radius_inner = radius
             else:
@@ -3513,9 +3519,6 @@ class Elemental(Modifier):
                     raise SyntaxError(
                         "radius_inner: " + _("This is not a valid length")
                     )
-
-            if alternate_seq is None:
-                alternate_seq = 0
 
             x_pos = x_pos.value(
                 ppi=1000, relative_length=bed_dim.bed_width * MILS_IN_MM

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3684,9 +3684,10 @@ class Elemental(Modifier):
                 if idx >= corners:
                     idx -= corners
 
-            self.add_element(Polygon(starpts))
+            star_path = Polygon(starpts)
+            self.add_element(star_path)
             if data is None:
-                return "elements", [starpts]
+                return "elements", [star_path]
             else:
                 data.append(pts)
                 return "elements", data

--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -2164,6 +2164,8 @@ class Kernel:
                         opt_name = b.get("name", "")
                         opt_short = b.get("short", "")
                         opt_type = b.get("type", type(None)).__name__
+                        opt_nargs = int(b.get("nargs", 1))
+                        opt_type = ",".join([opt_type] * opt_nargs)
                         opt_help = b.get("help")
                         opt_help = (
                             ":\n\t\t%s" % opt_help if opt_help is not None else ""

--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -1364,8 +1364,10 @@ class Kernel:
                         for pk in options:
                             if value == pk["short"]:
                                 if pk.get("action") != "store_true":
-                                    stack.insert(opt_index, pk)
-                                    opt_index += 1
+                                    count = pk.get("nargs", 1)
+                                    for n in range(count):
+                                        stack.insert(opt_index, pk)
+                                        opt_index += 1
                                 kwargs[pk["name"]] = True
                                 break
 


### PR DESCRIPTION
In preparation for some graphical tools I've extended 
## The existing grid -command 
by a new parameter origin, that describes where the orginal element(s) shall be located in respect to the grid . The parameter needs to be provided in the format:
````
grid ... --origin ox,oy    or       grid ... -o ox,oy
````
so e.g. 
````
grid  3 3 -o "2,2"
````
will create a 3x3 grid with the original elements right in the middle.
<img width="631" alt="image" src="https://user-images.githubusercontent.com/2670784/157057752-2c42df58-376b-4c1d-aa75-8ca346e023ad.png">

## A new circ_copy - command
that takes some parameters to create (potentially rotated) copies on a circular arc around the orginal element(s)
<img width="599" alt="image" src="https://user-images.githubusercontent.com/2670784/157058280-411695d1-5fe0-4693-a5c4-aaadcee6bf51.png">
```
circ_copy <copies> <radius> [ <startangle> <endangle> <rotate> <deltaangle> ]
```
The optional parameters can be provided like:
--rotate --startangle 0deg etc.
<img width="262" alt="image" src="https://user-images.githubusercontent.com/2670784/157059433-5d055323-af31-4acd-b25a-76037a3915fd.png">
Notabene: normally you will equally distribute the amount of copies between startangle and endangle. If you omit the endangle and provide the optional _deltaangle_, then the amount of copies will be created starting from the _startangle_ every one _deltaangle_ apart:
![grafik](https://user-images.githubusercontent.com/2670784/157075081-24466851-7c48-4813-880b-adf4ff0be136.png)

## A new radial- command
that takes some parameters to create (potentially rotated) copies on a circular arc with the orginal element(s) being one of these
```
radial <repeats> <radius> [ <startangle> <endangle> <rotate> <deltaangle> ]
```
The optional parameters can be provided like:
--rotate --startangle 0deg etc.
<img width="395" alt="image" src="https://user-images.githubusercontent.com/2670784/157548376-7087cd96-c26e-4ddb-b880-7ebf306b6a7b.png">

Notabene: While circ_copy is creating copies around the original elements, radial is creating all the copies around a center just -1*radius to the left. So the original elements will be part of the circle.


## A new shape - command
that takes some parameters to create a [regular polygon](https://en.wikipedia.org/wiki/Regular_polygon) or regular star polygons (see below)
<img width="525" alt="image" src="https://user-images.githubusercontent.com/2670784/157543255-3f740ba4-9a72-4d14-9483-d345a7695ab0.png">

```
shape <corners> <x> <y> <radius> <startangle> <inscribed>
```
- \<corners\> defines the amount of vertices of the polygon. 
These lie all on a circle around _x_, _y_  with radius _radius_ (see also _inscribe_ below)
- \<startangle\> (optional) defines where to start with the polygon: <br>
<img width="381" alt="image" src="https://user-images.githubusercontent.com/2670784/157543827-66ed5b5a-de82-4d01-bd28-eeb275b55960.png">

- \<inscribed\> (optional) as indicated above the vertices lie on a circumscribing circle of the polygon. If you want to have the polygon outside of the inscribing circle you can use the _inscribed_ parameter :
````
shape 3 2in 2in 1in --inscribed
````
<img width="323" alt="image" src="https://user-images.githubusercontent.com/2670784/157544641-4106aa99-5a5d-4c50-b87e-8c5ab6a2708c.png">

If you do provide the additional parameter "_radius_inner_" then every other point will lie on the inner circle providing a more star-like figure:
```
shape 8 5cm 2cm 1cm --radius_inner 50%
````
![grafik](https://user-images.githubusercontent.com/2670784/157079311-3ee8eec5-4aa3-44eb-bc30-2be8ade1db0c.png)
You may specify actually the alternating sequence with the _alternate_seq_ option in conjunction with the aforementioned  _radius_inner_ option. This will create somewhat gear-like shapes:
<img width="386" alt="Gears" src="https://user-images.githubusercontent.com/2670784/157545282-cb92b724-d45d-4c90-a1f1-adfdf737cae4.png">

If you provide the optional parameter "--density" then you will create a [regular star polygon](https://en.wikipedia.org/wiki/Star_polygon) 
```
shape <corners> <x> <y> <radius> [ <startangle> ] --density num
```
<img width="150" alt="image" src="https://user-images.githubusercontent.com/2670784/157546288-e25480e0-9c7e-41f9-8840-4be32e7cfae8.png">

- \<corners\> defines the amount of vertices of the polygon. 
- \<density\> define the line to draw from one vertice to the one \<density\> points away.
- These lie all on a circle around \<x\>, \<y\> with radius \<radius\>
- \<startangle\> (optional) defines where to start with the polygon

Please note that these **may** give some nice stars if the values for corners and density are an odd/even combination (if you want to know more read the wikipedia article linked above about those two numbers supposed to be coprimes). Meerk40t will provide some feedback if the chosen parameters are suboptimal:
<img width="416" alt="density" src="https://user-images.githubusercontent.com/2670784/157542101-d507a104-bed6-4c2f-89ae-ae64a8cff902.png">

You can combine and experiment with all parameters to get some nice looking polygons, i.e.
<img width="265" alt="image" src="https://user-images.githubusercontent.com/2670784/157542754-5d56f65b-1a2b-4110-947e-0988706c9df4.png">

NB: you may invoke shape with 1 corner and 2 corners as well: these will result in 1 single point, a line with length _radius_ respectively
<img src="https://user-images.githubusercontent.com/2670784/157540787-a6641f08-9fe7-4d42-8e04-d7a69ad63ea4.png" >

## polygon and polyline
allow now tuples of valid Lengths as parameter
so 
```
polyline 0 0 1000 1000  1000 0 
```
is equivalent to 
```
polyline 0cm 0cm 1in 1in 1in 0mm
```