### PR TITLE
Add raster optimisation on/off switch (no gui)

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -44,6 +44,7 @@ class CutPlan:
         self.original = []
         self.commands = []
         self.channel = context.channel("optimize", timestamp=True)
+        self.context.setting(bool, "opt_rasters_split", True)
 
     def __str__(self):
         parts = []
@@ -465,15 +466,19 @@ class CutPlan:
         if reverse:
             nodes = list(reversed(nodes))
 
-        dx, dy = self.get_raster_margins(op.settings)
+        raster_opt = self.context.opt_rasters_split
+        if raster_opt:
+            dx, dy = self.get_raster_margins(op.settings)
 
-        def adjust_bbox(bbox):
-            x1, y1, x2, y2 = bbox
-            return x1 - dx, y1 - dy, x2 + dx, y2 + dy
+            def adjust_bbox(bbox):
+                x1, y1, x2, y2 = bbox
+                return x1 - dx, y1 - dy, x2 + dx, y2 + dy
 
-        groups = group_overlapped_rasters(
-            [(node, adjust_bbox(node.object.bbox(with_stroke=True))) for node in nodes]
-        )
+            groups = group_overlapped_rasters(
+                [(node, adjust_bbox(node.object.bbox(with_stroke=True))) for node in nodes]
+            )
+        else:
+            groups = [[(node, None) for node in nodes]]
 
         step = max(1, op.settings.raster_step)
         images = []

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -411,8 +411,8 @@ class CutPlan:
             return dx, dy
 
         # set minimum margins otherwise
-        dx = 256 if h_sweep else 0
-        dy = 256 if v_sweep else 0
+        dx = 500 if h_sweep else 0
+        dy = 500 if v_sweep else 0
 
         # Get device and check for lhystudios
         try:

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -400,7 +400,7 @@ class CutPlan:
         h_sweep = direction in (0, 1, 4)
         v_sweep = direction in (2, 3, 4)
 
-        # set minimum margins
+        # set minimum margins for inners_grouped
         dx = op_settings.overscan if h_sweep else 0
         dy = op_settings.overscan if v_sweep else 0
 
@@ -409,6 +409,10 @@ class CutPlan:
         root = context.root
         if smallest and context.opt_inner_first and context.opt_inners_grouped:
             return dx, dy
+
+        # set minimum margins otherwise
+        dx = 256 if h_sweep else 0
+        dy = 256 if v_sweep else 0
 
         # Get device and check for lhystudios
         try:

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -355,6 +355,7 @@ class PlannerPanel(wx.Panel):
         self.context.setting(bool, "opt_reduce_directions", False)
         self.context.setting(bool, "opt_remove_overlap", False)
         self.context.setting(bool, "opt_rapid_between", True)
+        self.context.setting(bool, "opt_rasters_split", True)
         self.context.setting(int, "opt_jog_minimum", 256)
         self.context.setting(int, "opt_jog_mode", 0)
 


### PR DESCRIPTION
I haven't added a GUI because I am hopeful that this will be robust and just work correctly - but just in case, here is a setting that you can use (via console) to turn it off and go back to a single raster image per Raster op.