### PR TITLE
Draft: Airassist

### DIFF
--- a/meerk40t/core/airassist.py
+++ b/meerk40t/core/airassist.py
@@ -4,85 +4,41 @@ AirAssist contains basic code to externally turn on / off air assist .
 """
 from subprocess import run
 from threading import Timer
-
+from time import sleep
+from io import open
+import paho.mqtt.client as mqtt
 
 AA_METHOD_NONE = 0
 AA_METHOD_MQTT = 1
 AA_METHOD_SHELL = 2
 AA_METHOD_RPI_GPIO = 3
 
-
-class AirAssist:
-
+# Overarching class with logic and timer control
+class onoff:
     myTimer = None
     overshoot = 5.0
-    shell_command_on = "turn_aa_on.cmd"
-    shell_command_off = "turn_aa_off.cmd"
 
     def __init__(self):
-        self._method = AA_METHOD_NONE
         self._status = False
 
-    # function to get value of _method
-    @property
-    def method(self):
-        return self._method
+    def cmd_on(self):
+        return
 
-    # function to set value of _method
-    @method.setter
-    def method(self, a):
-        if (a < AA_METHOD_NONE) or (a > AA_METHOD_RPI_GPIO):
-            raise ValueError("Sorry this AirAssist-method isn't supported")
-
-        if a == AA_METHOD_NONE:
-            pass
-        elif a == AA_METHOD_MQTT:
-            print("MQTT-Method called, need to establish connectivity")
-        elif a == AA_METHOD_SHELL:
-            print("Shell-Method called")
-        elif a == AA_METHOD_RPI_GPIO:
-            print("RPI-Method called")
-
-        self._method = a
+    def cmd_off(self):
+        return
 
     @property
     def status(self):
         return self._status
 
-    @method.setter
+    @status.setter
     def status(self, a):
         if a:
             self._status = True
+            self.cmd_on()
         else:
             self._status = False
-        if self._method == AA_METHOD_NONE:
-            print(
-                "AirAssist ignored, would have been set to %s"
-                % ("ON" if self._status else "OFF")
-            )
-        elif self._method == AA_METHOD_MQTT:
-            print(
-                "AirAssist MQTT, would have been set to %s"
-                % ("ON" if self._status else "OFF")
-            )
-        elif self._method == AA_METHOD_SHELL:
-            print(
-                "AirAssist shell, would have been set to %s"
-                % ("ON" if self._status else "OFF")
-            )
-            try:
-                if self._status:
-                    rc = run(shell_command_on)
-                else:
-                    rc = run(shell_command_off)
-                print("Return-Code: %d" % rc.returncode)
-            except:
-                print("Shell command could not be executed...")
-        elif self._method == AA_METHOD_RPI_GPIO:
-            print(
-                "AirAssist RPI, would have been set to %s"
-                % ("ON" if self._status else "OFF")
-            )
+            self.cmd_off()
 
     def turn_on(self):
         print("AA turn on")
@@ -120,3 +76,184 @@ class AirAssist:
                 self.status = False
                 self.myTimer.cancel()
                 self.myTimer = None
+
+
+# Just do nothing...
+class onoff_none(onoff):
+    def __init__(self, *args, **kwargs):
+        # Call super_init...
+        super().__init__(*args, **kwargs)
+
+    def cmd_on(self):
+        print("On: doing nothing")
+
+    def cmd_off(self):
+        print("Off: doing nothing")
+
+
+# Use Paho mqtt
+class onoff_mqtt(onoff):
+    server = "192.168.0.38"
+    port = 1883  # Standard
+    subject_publish_on = "cmnd/gosund4/POWER1"
+    subject_publish_off = "cmnd/gosund4/POWER1"
+    subject_subscribe = "stat/gosund4/POWER1"
+    msg_on = "ON"
+    msg_off = "OFF"
+
+    def __init__(self, *args, **kwargs):
+        # Call super_init...
+        super().__init__(*args, **kwargs)
+        print("MQTT-Establish")
+        self.client = mqtt.Client("meerk40t")
+        self.client.connect(self.server, self.port)
+        self.client.subscribe(self.subject_subscribe)
+        self.client.on_message = self.on_subscribe
+        self.client.loop_start()
+
+    def on_subscribe(self, client, userdata, msg):
+        print(f"Received `{msg.payload.decode()}` from `{msg.topic}` topic")
+
+    def cmd_on(self):
+        print("MQTT-turnon")
+        if not self.client is None:
+            print("Will publish %s : %s" % (self.subject_publish_on, self.msg_on))
+            for i in range(5):
+                result = self.client.publish(self.subject_publish_on, self.msg_on)
+                if result[0] == 0:
+                    continue
+                else:
+                    print("Failed, another attempt %d" % i)
+                    self.client.loop()
+                    sleep(0.1)
+
+    def cmd_off(self):
+        print("MQTT-turnoff")
+        if not self.client is None:
+            print("Will publish %s : %s" % (self.subject_publish_off, self.msg_off))
+            for i in range(5):
+                result = self.client.publish(self.subject_publish_off, self.msg_off)
+                if result[0] == 0:
+                    continue
+                else:
+                    print("Failed, another attempt %d" % i)
+                    self.client.loop()
+                    sleep(0.1)
+
+    def __del__(self):
+        if not self.client is None:
+            self.client.loop_stop()
+            self.client.disconnect()
+
+
+# Raspberry PI GPIO
+"""
+class onoff_rpi(onoff):
+
+import RPi.GPIO as GPIO
+
+    RELAIS_1_GPIO = 17
+    GPIO_INVERTED = False
+
+    def __init__(self, *args, **kwargs):
+        # Call super_init...
+        super().__init__(*args, **kwargs)
+        if is_raspberrypi():
+            GPIO.setmode(GPIO.BCM)  # GPIO Numbers instead of board numbers
+            GPIO.setup(self.RELAIS_1_GPIO, GPIO.OUT)  # GPIO Modus zuweisen
+            if self.GPIO_INVERTED:
+                g_low = GPIO.HIGH
+                g_high = GPIO.LOW
+            else:
+                g_low = GPIO.LOW
+                g_high = GPIO.HIGH
+
+    def cmd_on(self):
+        print("On: rpi setting pin %d" % self.RELAIS_1_GPIO)
+        if is_raspberrypi():
+            GPIO.output(self.RELAIS_1_GPIO, self.g_high)  # an
+
+    def cmd_off(self):
+        print("On: rpi setting pin %d" % self.RELAIS_1_GPIO)
+        if is_raspberrypi():
+            GPIO.output(self.RELAIS_1_GPIO, self.g_low)  # aus
+"""
+
+# Call external routine on computer
+class onoff_shell(onoff):
+    shell_command_on = "turn_aa_on.cmd"
+    shell_command_off = "turn_aa_off.cmd"
+
+    def __init__(self, *args, **kwargs):
+        # Call super_init...
+        super().__init__(*args, **kwargs)
+
+    def cmd_on(self):
+        try:
+            rc = run(self.shell_command_on)
+            # print("Return-Code: %d" % rc.returncode)
+        except:
+            print("Shell command could not be executed...")
+
+    def cmd_off(self):
+        try:
+            rc = run(self.shell_command_off)
+            # print("Return-Code: %d" % rc.returncode)
+        except:
+            print("Shell command could not be executed...")
+
+
+class AirAssist:
+
+    handler = None
+
+    def __init__(self):
+        self._method = AA_METHOD_NONE
+        self._status = False
+
+    @property
+    def method(self):
+        return self._method
+
+    @method.setter
+    def method(self, a):
+        if (a < AA_METHOD_NONE) or (a > AA_METHOD_RPI_GPIO):
+            raise ValueError("Sorry this AirAssist-method isn't supported")
+        if a == AA_METHOD_NONE:
+            self.handler = onoff_none()
+        elif a == AA_METHOD_MQTT:
+            print("MQTT-Method called, need to establish connectivity")
+            self.handler = onoff_mqtt()
+        elif a == AA_METHOD_SHELL:
+            print("Shell-Method called")
+            self.handler = onoff_shell()
+        elif a == AA_METHOD_RPI_GPIO:
+            print("RPI-Method called")
+            self.handler = onoff_none()  # onoff_rpi()
+
+        self._method = a
+
+    @property
+    def status(self):
+        if self.handler is None:
+            print("getstatus failed")
+            return False
+        else:
+            print("getstatus")
+            return self.handler.status
+
+    @status.setter
+    def status(self, a):
+        if not self.handler is None:
+            print("setstatus")
+            self.handler.status = a
+
+    def turn_on(self):
+        if not self.handler is None:
+            print("turnon")
+            self.handler.turn_on()
+
+    def turn_off(self, immediately=None):
+        if not self.handler is None:
+            print("turnoff")
+            self.handler.turn_off(immediately)

--- a/meerk40t/core/airassist.py
+++ b/meerk40t/core/airassist.py
@@ -1,0 +1,122 @@
+"""
+AirAssist contains basic code to externally turn on / off air assist .
+
+"""
+from subprocess import run
+from threading import Timer
+
+
+AA_METHOD_NONE = 0
+AA_METHOD_MQTT = 1
+AA_METHOD_SHELL = 2
+AA_METHOD_RPI_GPIO = 3
+
+
+class AirAssist:
+
+    myTimer = None
+    overshoot = 5.0
+    shell_command_on = "turn_aa_on.cmd"
+    shell_command_off = "turn_aa_off.cmd"
+
+    def __init__(self):
+        self._method = AA_METHOD_NONE
+        self._status = False
+
+    # function to get value of _method
+    @property
+    def method(self):
+        return self._method
+
+    # function to set value of _method
+    @method.setter
+    def method(self, a):
+        if (a < AA_METHOD_NONE) or (a > AA_METHOD_RPI_GPIO):
+            raise ValueError("Sorry this AirAssist-method isn't supported")
+
+        if a == AA_METHOD_NONE:
+            pass
+        elif a == AA_METHOD_MQTT:
+            print("MQTT-Method called, need to establish connectivity")
+        elif a == AA_METHOD_SHELL:
+            print("Shell-Method called")
+        elif a == AA_METHOD_RPI_GPIO:
+            print("RPI-Method called")
+
+        self._method = a
+
+    @property
+    def status(self):
+        return self._status
+
+    @method.setter
+    def status(self, a):
+        if a:
+            self._status = True
+        else:
+            self._status = False
+        if self._method == AA_METHOD_NONE:
+            print(
+                "AirAssist ignored, would have been set to %s"
+                % ("ON" if self._status else "OFF")
+            )
+        elif self._method == AA_METHOD_MQTT:
+            print(
+                "AirAssist MQTT, would have been set to %s"
+                % ("ON" if self._status else "OFF")
+            )
+        elif self._method == AA_METHOD_SHELL:
+            print(
+                "AirAssist shell, would have been set to %s"
+                % ("ON" if self._status else "OFF")
+            )
+            try:
+                if self._status:
+                    rc = run(shell_command_on)
+                else:
+                    rc = run(shell_command_off)
+                print("Return-Code: %d" % rc.returncode)
+            except:
+                print("Shell command could not be executed...")
+        elif self._method == AA_METHOD_RPI_GPIO:
+            print(
+                "AirAssist RPI, would have been set to %s"
+                % ("ON" if self._status else "OFF")
+            )
+
+    def turn_on(self):
+        print("AA turn on")
+        self.status = True
+        if not self.myTimer is None:
+            self.myTimer.cancel()
+            self.myTimer = None
+
+    def turn_off_timer(self):
+        print("Turn-off of AA after %.0f seconds" % self.overshoot)
+        self.status = False
+        self.myTimer.cancel()
+        self.myTimer = None
+
+    def turn_off(self, immediately=None):
+        # This will turn off the airassist after xx seconds by default...
+        # If you want to turn off the airassist immediately you can provide the parameter
+        if immediately is None:
+            immediately = False
+        if self.overshoot <= 0:
+            immediately = True
+
+        if immediately:
+            print("AA turn off, immediate")
+            self.status = False
+        else:
+            print("AA turn off, Timer started")
+            if self.myTimer is None:
+                self.myTimer = Timer(
+                    interval=self.overshoot, function=self.turn_off_timer
+                )
+                self.myTimer.start()
+            else:  # Hmm, second call lets kill the timer and stop AA
+                print("Forced turn-off of AA")
+                self.status = False
+                self.myTimer.cancel()
+                self.myTimer = None

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -6,6 +6,7 @@ from ..core.cutcode import LaserSettings
 from ..device.lasercommandconstants import *
 from ..kernel import Modifier
 from .plotplanner import PlotPlanner
+from meerk40t.core.airassist import *
 
 DRIVER_STATE_RAPID = 0
 DRIVER_STATE_FINISH = 1
@@ -44,6 +45,9 @@ class Driver:
         self.name = name
         self.root_context = context.root
         self.settings = LaserSettings()
+        self.AAssist = AirAssist()
+        self.AAssist.method = AA_METHOD_SHELL
+        self.AAssist.overshoot = 15.0  # let the airassist run for another 15 seconds
 
         self.next = None
         self.prev = None
@@ -290,6 +294,12 @@ class Driver:
                     os.system("afplay /System/Library/Sounds/Ping.aiff")
                 else:  # Assuming other linux like system
                     print("\a")  # Beep.
+            elif command == COMMAND_AIRASSIST_ON:
+                self.AAssist.turn_on()
+            elif command == COMMAND_AIRASSIST_OFF:
+                self.AAssist.turn_off(immediately=False)
+            elif command == COMMAND_AIRASSIST_OFF_NOW:
+                self.AAssist.turn_off(immediately=True)
             elif command == COMMAND_FUNCTION:
                 if len(values) >= 1:
                     t = values[0]
@@ -353,6 +363,12 @@ class Driver:
 
     def data_output(self, e):
         self.output.write(e)
+
+    def airassist(self, value):
+        if value:
+            self.AAssist.turn_on()
+        else:
+            self.AAssist.turn_off(immediately=True)
 
     def hold(self):
         """

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -46,7 +46,7 @@ class Driver:
         self.root_context = context.root
         self.settings = LaserSettings()
         self.AAssist = AirAssist()
-        self.AAssist.method = AA_METHOD_SHELL
+        self.AAssist.method = AA_METHOD_MQTT
         self.AAssist.overshoot = 15.0  # let the airassist run for another 15 seconds
 
         self.next = None

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4,6 +4,8 @@ import re
 from copy import copy
 
 from ..device.lasercommandconstants import (
+    COMMAND_AIRASSIST_ON,
+    COMMAND_AIRASSIST_OFF,
     COMMAND_BEEP,
     COMMAND_CONSOLE,
     COMMAND_FUNCTION,
@@ -105,13 +107,17 @@ class Length(SVGLength):
                 return
             s = str(value)
             for m in REGEX_LENGTH.findall(s):
-                if len(m[1]) == 0 or m[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT):
+                if len(m[1]) == 0 or m[1] in (
+                    PATTERN_LENGTH_UNITS + "|" + PATTERN_PERCENT
+                ):
                     self.is_valid_length = True
                 return
         elif len(args) == 2:
             try:
                 x = float(args[0])
-                if len(args[1]) == 0 or args[1] in (PATTERN_LENGTH_UNITS + "|"  + PATTERN_PERCENT):
+                if len(args[1]) == 0 or args[1] in (
+                    PATTERN_LENGTH_UNITS + "|" + PATTERN_PERCENT
+                ):
                     self.is_valid_length = True
             except ValueError:
                 pass
@@ -3587,7 +3593,9 @@ class Elemental(Modifier):
                 return
             else:
                 if not stroke_width.is_valid_length:
-                    raise SyntaxError("stroke-width: " + _("This is not a valid length"))
+                    raise SyntaxError(
+                        "stroke-width: " + _("This is not a valid length")
+                    )
 
             if len(data) == 0:
                 channel(_("No selected elements."))
@@ -3749,7 +3757,6 @@ class Elemental(Modifier):
             if not y_offset is None:
                 if not y_offset.is_valid_length:
                     raise SyntaxError("y-offset: " + _("This is not a valid length"))
-
 
             bounds = self.selected_area()
             if bounds is None:
@@ -5296,6 +5303,26 @@ class Elemental(Modifier):
             )
 
         @self.tree_submenu(_("Append special operation(s)"))
+        @self.tree_operation(_("Append Air-Assist On"), node_type="branch ops", help="")
+        def append_operation_airassiston(node, pos=None, **kwargs):
+            self.context.elements.op_branch.add(
+                CommandOperation("Air-Assist On", COMMAND_AIRASSIST_ON, True),
+                type="cmdop",
+                pos=pos,
+            )
+
+        @self.tree_submenu(_("Append special operation(s)"))
+        @self.tree_operation(
+            _("Append Air-Assist Off"), node_type="branch ops", help=""
+        )
+        def append_operation_airassistoff(node, pos=None, **kwargs):
+            self.context.elements.op_branch.add(
+                CommandOperation("Air-Assist Off", COMMAND_AIRASSIST_OFF, False),
+                type="cmdop",
+                pos=pos,
+            )
+
+        @self.tree_submenu(_("Append special operation(s)"))
         @self.tree_operation(
             _("Append Interrupt (console)"), node_type="branch ops", help=""
         )
@@ -5506,6 +5533,16 @@ class Elemental(Modifier):
         @self.tree_operation(_("Add Beep"), node_type="op", help="")
         def add_operation_beep(node, **kwargs):
             append_operation_beep(node, pos=add_after_index(self), **kwargs)
+
+        @self.tree_submenu(_("Add special operation(s)"))
+        @self.tree_operation(_("Add Airassist On"), node_type="op", help="")
+        def add_operation_airassiston(node, **kwargs):
+            append_operation_airassiston(node, pos=add_after_index(self), **kwargs)
+
+        @self.tree_submenu(_("Add special operation(s)"))
+        @self.tree_operation(_("Add Airassist Off"), node_type="op", help="")
+        def add_operation_airassistoff(node, **kwargs):
+            append_operation_airassistoff(node, pos=add_after_index(self), **kwargs)
 
         @self.tree_submenu(_("Add special operation(s)"))
         @self.tree_operation(_("Add Interrupt"), node_type="op", help="")

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -11,6 +11,8 @@ from ..device.lasercommandconstants import (
     COMMAND_UNLOCK,
     COMMAND_WAIT,
     COMMAND_WAIT_FINISH,
+    COMMAND_AIRASSIST_ON,
+    COMMAND_AIRASSIST_OFF,
 )
 from ..kernel import Modifier
 from ..svgelements import Length
@@ -34,6 +36,8 @@ def plugin(kernel, lifecycle=None):
         kernel.register("plan/beep", beep)
         kernel.register("function/interrupt", interrupt_text)
         kernel.register("plan/interrupt", interrupt)
+        kernel.register("plan/airassiston", airassist_on)
+        kernel.register("plan/airassistoff", airassist_off)
 
         def shutdown():
             yield COMMAND_WAIT_FINISH
@@ -902,6 +906,14 @@ def offset(x, y):
         yield COMMAND_SET_POSITION, -int(x), -int(y)
 
     return offset_value
+
+
+def airassist_on():
+    yield COMMAND_AIRASSIST_ON
+
+
+def airassist_off():
+    yield COMMAND_AIRASSIST_OFF
 
 
 def wait():

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -484,6 +484,28 @@ class Spoolers(Modifier):
             spooler.job(COMMAND_LOCK)
             return "spooler", data
 
+        @context.console_argument(
+            "onoff", type=int, help=_("Turn Air Assist on (1=Yes)")
+        )
+        @context.console_command(
+            "air_assist",
+            input_type=("spooler", None),
+            output_type="spooler",
+            help=_("Turns Air-Assist on/off"),
+        )
+        def airassist(onoff=None, data=None, **kwgs):
+            if data is None:
+                data = self.default_spooler(), self.context.root.active
+            spooler, device_name = data
+            if onoff is None:
+                onoff = True
+            if onoff:
+                spooler.job(COMMAND_AIRASSIST_ON)
+            else:
+                spooler.job(COMMAND_AIRASSIST_OFF_NOW)
+
+            return "spooler", data
+
         for i in range(5):
             self.get_or_make_spooler(str(i))
 

--- a/meerk40t/device/grbl/grbldevice.py
+++ b/meerk40t/device/grbl/grbldevice.py
@@ -368,11 +368,12 @@ def get_command_code(lines):
                     yield COMMAND_LASER_OFF
                 elif v == 7:
                     #  Coolant control.
-                    pass
+                    yield COMMAND_SIGNAL, ("airassiston")
                 elif v == 8:
                     yield COMMAND_SIGNAL, ("coolant", True)
                 elif v == 9:
                     yield COMMAND_SIGNAL, ("coolant", False)
+                    yield COMMAND_SIGNAL, ("airassistoff")
                 elif v == 56:
                     pass  # Parking motion override control.
                 elif v == 911:
@@ -823,11 +824,14 @@ class GRBLEmulator(Module):
                     self.spooler.job(COMMAND_LASER_OFF)
                 elif v == 7:
                     #  Coolant control.
-                    pass
+                    self.spooler.job(COMMAND_AIRASSIST_ON)
                 elif v == 8:
                     self.spooler.job(COMMAND_SIGNAL, ("coolant", True))
+                    # coolant is not yet recognised afais, so will be translated temporarily to airassist
+                    self.spooler.job(COMMAND_AIRASSIST_ON)
                 elif v == 9:
                     self.spooler.job(COMMAND_SIGNAL, ("coolant", False))
+                    self.spooler.job(COMMAND_AIRASSIST_OFF)
                 elif v == 56:
                     pass  # Parking motion override control.
                 elif v == 911:

--- a/meerk40t/device/lasercommandconstants.py
+++ b/meerk40t/device/lasercommandconstants.py
@@ -55,6 +55,9 @@ COMMAND_BEEP = 320  # Beep.
 COMMAND_FUNCTION = 350  # Execute the function given by this command. Blocking.
 COMMAND_CONSOLE = 355  # Execute the specified console command.
 COMMAND_SIGNAL = 360  # Sends the signal, given: "signal_name", operands.
+COMMAND_AIRASSIST_ON = 365  # Turns air-assist on
+COMMAND_AIRASSIST_OFF = 370  # Turns air-assist off (delayed)
+COMMAND_AIRASSIST_OFF_NOW = 375  # Turns air-assist off (immediately)
 
 REALTIME_RESET = 1000  # Resets the state, purges buffers
 REALTIME_PAUSE = 1010  # Issue a pause command.
@@ -146,6 +149,10 @@ def lasercode_string(code):
         return "COMMAND_UNLOCK"  # Unlocks the rail.
     if code == COMMAND_BEEP:
         return "COMMAND_BEEP"  # Beep.
+    if code == COMMAND_AIRASSIST_ON:
+        return "COMMAND_AIRASSIST_ON"  # AirAssist
+    if code == COMMAND_AIRASSIST_OFF:
+        return "COMMAND_AIRASSIST_OFF"  # AirAssist
     if code == COMMAND_FUNCTION:
         return (
             "COMMAND_FUNCTION"  # Execute the function given by this command. Blocking.

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -263,6 +263,14 @@ class PlannerPanel(wx.Panel):
         self.context("plan%s command -o beep\n" % self.plan_name)
         self.update_gui()
 
+    def jobadd_airassist_on(self, event=None):
+        self.context("plan%s command -o airassiston\n" % self.plan_name)
+        self.update_gui()
+
+    def jobadd_airassist_off(self, event=None):
+        self.context("plan%s command -o airassistoff\n" % self.plan_name)
+        self.update_gui()
+
     def jobadd_interrupt(self, event=None):
         self.context("plan%s command -o interrupt\n" % self.plan_name)
         self.update_gui()
@@ -537,6 +545,16 @@ class ExecuteJob(MWindow):
             wx.EVT_MENU,
             self.panel.jobadd_beep,
             wx_menu.Append(wx.ID_ANY, _("Beep"), _("Add a beep")),
+        )
+        self.Bind(
+            wx.EVT_MENU,
+            self.panel.jobadd_airassist_on,
+            wx_menu.Append(wx.ID_ANY, _("Air-Assist On"), _("Turn air-assist on")),
+        )
+        self.Bind(
+            wx.EVT_MENU,
+            self.panel.jobadd_airassist_off,
+            wx_menu.Append(wx.ID_ANY, _("Air-Assist Off"), _("Turn air-assist off")),
         )
         self.Bind(
             wx.EVT_MENU,

--- a/meerk40t/gui/icons.py
+++ b/meerk40t/gui/icons.py
@@ -2020,3 +2020,22 @@ icons8_image_50 = PyEmbeddedImage(
     b"rpkAl8w/EAKcAm9VRVYtYeYR2FMyu8BDFZEY93wzI+BMyTSAC8q9NUSV0JkCN8AmFYgtYeYV"
     b"OC4jkdI/xEqk9hWlNCKSGiKSGiKSGiIiCIIQhV9aqvtgADl99gAAAABJRU5ErkJggg=="
 )
+
+icons8_air_50 = PyEmbeddedImage(
+    b"iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABmJLR0QA/wD/AP+gvaeTAAAD"
+    b"BElEQVRoge3az6tUZRzH8dfMFUwLTbCw1I0tJFwWLQKxRYsQ+6EFaV5sWdcgEwNX+jdIbfwB"
+    b"geKuhRQt1NCNUBYkgoJukuA6/bAsQsrkOt4W32c8s9CZc+acmXMvzBsOMzDf7/f5fOc8z3Oe"
+    b"5/scxvTlcezCGfyOGbRwGlNYXJ+0/GwT4md7XC28UZfAPOyTiT2LN/EUJrAS7+Db9Ps97K5H"
+    b"Zm+2yQR+1MOuIRK4m2xfH760/CzBTZHIrpw+u5P9dXNozOwUon5AM6dPA+eT3/tD0lWY58SY"
+    b"eL6g33aRyMnKFY2YVbLuNa9ZKBL5r0yQvH15mDyRPv8oE2QuJPJS+rxcq4qSNPCd6Frv1ayl"
+    b"FHtEEtNYVLOWgWiIJO6ijdfqlVOMCTHVTsq6U1vvpUwhLuq9Sh3WNY1Xq0pigVi0jYI2fsMl"
+    b"nMAx3B5R22PGjBkzx2jgKtbWLeQhzIjnzU+ijPQ5rj3M+Ip6HoiDXG18hqcH/2/qoVNCegWH"
+    b"8K9I6AZerFFXaVbhC5HMbayvV045mjggkvlV3LF5SxNfimSO1qylNKvFmGljbVNMv4PMIPfw"
+    b"M74W1fVHR5mFmJaPi7vzFtVNvy1sGV0eYGNq+1yZIE1Zdf0b2V3aU1ZdATrFvemqAjbElrVT"
+    b"Xd9cVeA+VFLcexCd6nrLaKrrK1J7v1QduLu6PtXH9skK2tuQ2vq+6krjLD5N33sdq+0Q+/d3"
+    b"S7bXKV6cKRnngXQGYKuHzeZkc8XgZdtlsoOlokcZucgzACfwY7LbOWA7R5L/VwP69yXvecem"
+    b"ZPcPXijYxsfJ95ace6lFit/6ydRInhOoT5Lt3yKxfizBYdneJNch6jL8mQQ18jgoXl2fEBul"
+    b"zurgBF4W3bObddgvO7u/pcCzaqGYn2fxYU6fQavrU/hLltAdMYYui67XvRQ6hWcLxAZvJ+cZ"
+    b"fNDDrorq+nLsxYUUp1v8dRxUciO1vyvgOWzFM3jE8Krri7FGdKnHKoh3n0nZnD2S6vowWSp7"
+    b"2+eG7G2fk2Jgz8sTpzHD4n8WsDeRPrIFMAAAAABJRU5ErkJggg=="
+)

--- a/meerk40t/gui/panes/laserpanel.py
+++ b/meerk40t/gui/panes/laserpanel.py
@@ -9,6 +9,7 @@ from meerk40t.gui.icons import (
     icons8_laser_beam_hazard2_50,
     icons8_pause_50,
     icons8_pentagon_50,
+    icons8_air_50,
 )
 from meerk40t.gui.propertiespanel import PropertiesPanel
 
@@ -145,6 +146,11 @@ class LaserPanel(wx.Panel):
         )
         sizer_control_misc.Add(self.button_simulate, 1, 0, 0)
 
+        self.air_toggle = wx.ToggleButton(self, wx.ID_ANY, _("Air-Assist"))
+        self.air_toggle.SetToolTip(_("Toggle Air-Assist"))
+        self.air_toggle.SetBitmap(icons8_air_50.GetBitmap(resize=25))
+        sizer_control_misc.Add(self.air_toggle, 1, 0, 0)
+
         # self.button_save_file = wx.Button(self, wx.ID_ANY, _("Save"))
         # self.button_save_file.SetToolTip(_("Save the job"))
         # self.button_save_file.SetBitmap(icons8_save_50.GetBitmap())
@@ -199,6 +205,8 @@ class LaserPanel(wx.Panel):
         self.Bind(wx.EVT_BUTTON, self.on_button_pause, self.button_pause)
         self.Bind(wx.EVT_BUTTON, self.on_button_stop, self.button_stop)
         self.Bind(wx.EVT_TOGGLEBUTTON, self.on_check_arm, self.arm_toggle)
+        self.Bind(wx.EVT_TOGGLEBUTTON, self.on_air_toggle, self.air_toggle)
+
         self.Bind(wx.EVT_RIGHT_DOWN, self.on_menu_arm, self)
         self.Bind(wx.EVT_BUTTON, self.on_button_outline, self.button_outline)
         # self.Bind(wx.EVT_BUTTON, self.on_button_save, self.button_save_file)
@@ -216,6 +224,7 @@ class LaserPanel(wx.Panel):
         self.context.listen("plan", self.plan_update)
         self.context.listen("active", self.active_update)
         self.context.listen("legacy_spooler_label", self.spooler_label_update)
+        # self.context.listen("airassist", self.airassist_update)
 
     def finalize(self):
         self.context.unlisten("laserpane_arm", self.check_laser_arm)
@@ -407,3 +416,11 @@ class LaserPanel(wx.Panel):
             self.connected_output,
         ) = self.available_devices[index]
         self.context("device activate %s\n" % str(index))
+
+    def on_air_toggle(self, event):  # wxGlade: LaserPanel.<event_handler>
+        if self.air_toggle.GetValue():
+            self.air_toggle.SetBackgroundColour(wx.GREEN)
+            self.context("air_assist 1\n")
+        else:
+            self.air_toggle.SetBackgroundColour(wx.Colour(240, 240, 240))
+            self.context("air_assist 0\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Pillow
 pyusb
 wxPython
+paho-mqtt

--- a/turn_aa_off.cmd
+++ b/turn_aa_off.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo "All done, turning air assist OFF !"

--- a/turn_aa_on.cmd
+++ b/turn_aa_on.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo "Here I am, turning air assist on"


### PR DESCRIPTION
### This a draft PR for discussion mostly

I've added (mostly for my own benefit) some basic air-assist support.
It adds additional special operations (Air Assist On, Air-Assist off) 
![grafik](https://user-images.githubusercontent.com/2670784/156848123-92a736c2-a8a4-416d-98a4-8ddab9854cfb.png)
as well as a console command
![grafik](https://user-images.githubusercontent.com/2670784/156848203-acf9d78e-2c8c-46dd-b449-0069b6107487.png).

There is a minimal GUI apart from issuing the command in the console or via the Job Execution inside the laser-panel:
![grafik](https://user-images.githubusercontent.com/2670784/156848157-71b034be-59ad-4a11-a39d-3b2579584200.png)

There are currently three (the RPI one is commented out) methods to switch AirAssist on / off:
- Issuing a shell command, so you could call whatever you like
- A mqtt connection to a broker to publish values to turn e.g. a Tasmota Switch on (my use-case to turn on/off the air-pump)
- Switching a relay via one of the Raspberry PIs GPIO pins (commented out as I need to build a relay board and a raspberry installation first)
What is missing:
a) Any GUI to make the parameters customisable - currently they are hardcoded in core/airassist.py - so if you want to test it in your environment you have to amend them in the code.
b) Better recovery from errors (my MQTT server is rather sluggish and needs sometimes several attempts to acknowledge the command)
c) Reading the current status of the Air-Assist
d) some signals to snychronize the button in laserpanel.py to the commands in the console

This is more a hack intended to work for my environment than anything else (and it does work here - so happy to be able to programmatically switch my airpump on and off) . So some feedback on the structure how to tie the events to the drivers etc would be welcome. I will stop to invest more effort into this until there is a consensus whether this approach would make any sense or not (you could argue that's what MK plugins are for and I don't disagree, but you would still need the integration part as (inelegantly) done here)
