### PR TITLE
Fix errormessage when using abbreviated options 

### DIFF
--- a/meerk40t/kernel.py
+++ b/meerk40t/kernel.py
@@ -1285,7 +1285,7 @@ class Kernel:
             elif kind == "OPT":
                 value = match.group()
                 for letter in value[1:]:
-                    yield kind, letter, start, start + 1
+                    yield kind, letter, start, pos
                     start += 1
 
     def console_command(


### PR DESCRIPTION
When using abbreviated options i.e. 'rotate 30deg -a' they get recognized but cause an additional errromessage to be displayed (in this instance "a is not a registered command...").
This change should fix it