### PR TITLE
Ultimate fix for CH341A.dll issues

### DIFF
--- a/meerk40t/device/ch341/windll.py
+++ b/meerk40t/device/ch341/windll.py
@@ -1,4 +1,4 @@
-from ctypes import c_byte, windll
+from ctypes import c_byte, WinDLL
 
 from .ch341 import Connection as CH341Connection
 from .ch341 import Handler as CH341Handler
@@ -148,7 +148,7 @@ class Handler(CH341Handler):
     def __init__(self, channel, status):
         CH341Handler.__init__(self, channel=channel, status=status)
         try:
-            self.driver = windll.LoadLibrary("CH341DLL.dll")
+            self.driver = WinDLL("CH341DLL.dll", winmode=0)
         except FileNotFoundError as e:
             self.channel("%s: %s" % (str(type(e)), str(e)))
             raise ImportError(


### PR DESCRIPTION
Addresses multiple issues: #459 #844

1. Make CH341A.dll available to folks running from source on Windows
2. Only try to use it for 32-bit Python on Windows
3. Create 64-bit Windows executables without it