### PR TITLE
Fix errormessage when using abbreviated options

### DIFF
--- a/meerk40t/kernel/functions.py
+++ b/meerk40t/kernel/functions.py
@@ -306,7 +306,7 @@ def _cmd_cli_parser(
             elif kind == "OPT":
                 value = match.group()
                 for letter in value[1:]:
-                    yield kind, letter, start, start + 1
+                    yield kind, letter, start, pos
                     start += 1
 
 
@@ -343,5 +343,5 @@ def _cmd_parser(text: str) -> Generator[Tuple[str, str, int, int], None, None]:
         elif kind == "OPT":
             value = match.group()
             for letter in value[1:]:
-                yield kind, letter, start, start + 1
+                yield kind, letter, start, pos
                 start += 1


### PR DESCRIPTION
This fixing the same issue in 0.8 that we already covered in PR#877 for the legacy7 branch