### PR TITLE
Make sure delete operation appears in menu

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3803,7 +3803,7 @@ class Elemental(Service):
         # ==========
         # REMOVE ELEMENTS
         # ==========
-        @self.tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 1)
+        @self.tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 0)
         @self.tree_calc("ecount", lambda i: len(list(self.elems(emphasized=True))))
         @self.tree_operation(
             _("Remove %s elements") % "{ecount}",


### PR DESCRIPTION
If you  right-click on a selected element in the scene, then there's no option to remove the element. This has been changed.