### PR TITLE
Bypass ctrl, control confusion

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -288,9 +288,25 @@ class Bind(Service):
         if not len(self.keymap):
             self.default_keymap()
 
+    # help transition from old definitions of control-key-combinations
+    def is_found(self, keyvalue, target):
+        valu = False
+        if not keyvalue is None:
+            s = keyvalue
+            if s in target:
+                valu = True
+            else:
+                s = keyvalue.replace("ctrl", "control")
+                if s in target:
+                    keyvalue = s
+                    valu = True
+        return valu, keyvalue
+
     def trigger(self, keyvalue):
-        if keyvalue in self.keymap:
-            if keyvalue not in self.triggered:
+        fnd, keyvalue = self.is_found(keyvalue, self.keymap)
+        if fnd:
+            fnd, keyvalue = self.is_found(keyvalue, self.triggered)
+            if not fnd:
                 self.triggered[keyvalue] = 1
                 action = self.keymap[keyvalue]
                 cmds = (action,) if action[0] in "+-" else action.split(";")
@@ -301,8 +317,10 @@ class Bind(Service):
 
     def untrigger(self, keyvalue):
         keymap = self.keymap
-        if keyvalue in keymap:
-            if keyvalue in self.triggered:
+        fnd, keyvalue = self.is_found(keyvalue, self.keymap)
+        if fnd:
+            fnd, keyvalue = self.is_found(keyvalue, self.triggered)
+            if fnd:
                 del self.triggered[keyvalue]
             action = keymap[keyvalue]
             if action.startswith("+"):


### PR DESCRIPTION
Keybind gets a "ctrl+letter" delivered while the majority of the predefined binds expect a "control+letter". This code translates these two into each other (well only ctrl to control, not vice versa).
Can be disregarded if theres consensus about the new terminology - I found it very annoying myself ...