### PR TITLE
2nd attempt at getting CommandSyntaxError correct

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1,11 +1,12 @@
 import functools
 import os.path
+from os.path import realpath
 import re
 from copy import copy
 from math import cos, gcd, pi, sin, tau
 
-from meerk40t.kernel import CommandSyntaxError
-from meerk40t.kernel import Service, Settings
+from meerk40t.core.exceptions import BadFileError
+from meerk40t.kernel import CommandSyntaxError, Service, Settings
 
 from ..svgelements import (
     PATTERN_FLOAT,
@@ -46,11 +47,11 @@ from .units import UNITS_PER_INCH, UNITS_PER_PIXEL, Length
 
 
 def plugin(kernel, lifecycle=None):
+    _ = kernel.translation
     if lifecycle == "register":
         kernel.add_service("elements", Elemental(kernel))
         # kernel.add_service("elements", Elemental(kernel,1))
     elif lifecycle == "postboot":
-        _ = kernel.root._
         elements = kernel.elements
         choices = [
             {
@@ -88,17 +89,20 @@ def plugin(kernel, lifecycle=None):
     elif lifecycle == "prestart":
         if hasattr(kernel.args, "input") and kernel.args.input is not None:
             # Load any input file
-            from os.path import realpath
-
             elements = kernel.elements
 
-            elements.load(realpath(kernel.args.input.name))
-            elements.classify(list(elements.elems()))
+            try:
+                elements.load(realpath(kernel.args.input.name))
+            except BadFileError as e:
+                kernel._console_channel(
+                    _("File is Malformed")
+                    + ": " + str(e)
+                )
+            else:
+                elements.classify(list(elements.elems()))
     elif lifecycle == "poststart":
         if hasattr(kernel.args, "output") and kernel.args.output is not None:
             # output the file you have at this point.
-            from os.path import realpath
-
             elements = kernel.elements
 
             elements.save(realpath(kernel.args.output.name))
@@ -172,10 +176,11 @@ class Elemental(Service):
                 channel(_("No such file."))
                 return
             try:
-                self.load(new_file)
+                result = self.load(new_file)
+                if result:
+                    channel(_("loading..."))
             except AttributeError:
                 raise CommandSyntaxError(_("Loading files was not defined"))
-            channel(_("loading..."))
             return "file", new_file
 
         # ==========
@@ -6085,6 +6090,7 @@ class Elemental(Service):
 
     def load(self, pathname, **kwargs):
         kernel = self.kernel
+        _ = kernel.translation
         for loader, loader_name, sname in kernel.find("load"):
             for description, extensions, mimetype in loader.load_types():
                 if str(pathname).lower().endswith(extensions):
@@ -6092,12 +6098,17 @@ class Elemental(Service):
                         results = loader.load(self, self, pathname, **kwargs)
                     except FileNotFoundError:
                         return False
+                    except BadFileError as e:
+                        kernel._console_channel(
+                            _("File is Malformed")
+                            + ": " + str(e)
+                        )
                     except OSError:
                         return False
-                    if results:
-                        self.signal("tree_changed\n")
-                        self("scene focus -4% -4% 104% 104%\n")
-                        return True
+                    else:
+                        if results:
+                            self.signal("tree_changed\n")
+                            return True
         return False
 
     def load_types(self, all=True):

--- a/meerk40t/core/exceptions.py
+++ b/meerk40t/core/exceptions.py
@@ -1,0 +1,11 @@
+class Meerk40tError(Exception):
+    """
+    This root Meerk40t exception is provided in case we ever want to provide common functionality
+    across all Meerk40t exceptions.
+    """
+
+
+class BadFileError(Meerk40tError):
+    """Abort loading a malformed file"""
+
+

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -3,6 +3,9 @@ import os
 from base64 import b64encode
 from io import BytesIO
 from xml.etree.cElementTree import Element, ElementTree, SubElement
+from xml.etree.ElementTree import ParseError
+
+from meerk40t.core.exceptions import BadFileError
 
 from ..svgelements import (
     SVG,
@@ -275,15 +278,18 @@ class SVGLoader:
         source = pathname
         if pathname.lower().endswith("svgz"):
             source = gzip.open(pathname, "rb")
-        svg = SVG.parse(
-            source=source,
-            reify=True,
-            width=str(context.device.width_as_mm),
-            height=str(context.device.height_as_mm),
-            ppi=ppi,
-            color="none",
-            transform="scale(%f)" % scale_factor,
-        )
+        try:
+            svg = SVG.parse(
+                source=source,
+                reify=True,
+                width=str(context.device.width_as_mm),
+                height=str(context.device.height_as_mm),
+                ppi=ppi,
+                color="none",
+                transform="scale(%f)" % scale_factor,
+            )
+        except ParseError as e:
+            raise BadFileError(str(e)) from e
         context_node = elements_modifier.get(type="branch elems")
         basename = os.path.basename(pathname)
         file_node = context_node.add(type="file", label=basename)

--- a/meerk40t/dxf/dxf_io.py
+++ b/meerk40t/dxf/dxf_io.py
@@ -330,6 +330,7 @@ class DxfLoader:
                 DxfLoader.entity_to_svg(elements, dxf, e, scale, translate_y)
             return
         else:
+            # We need a channel comment here so that this is not silently ignored.
             return  # Might be something unsupported.
 
         if entity.rgb is not None:

--- a/meerk40t/extra/inkscape.py
+++ b/meerk40t/extra/inkscape.py
@@ -2,6 +2,7 @@ import os.path
 import platform
 from subprocess import PIPE, run
 
+from meerk40t.core.exceptions import BadFileError
 
 def plugin(kernel, lifecycle):
     if lifecycle == "register":
@@ -16,8 +17,15 @@ def plugin(kernel, lifecycle):
         def inscape_load(channel, _, data=None, **kwargs):
             inkscape_path, filename = data
             channel(_("inkscape load - loading the previous conversion..."))
-            e = kernel.root
-            e.elements.load(filename)
+            try:
+                kernel.root.elements.load(filename)
+            except BadFileError as e:
+                channel("\n".join(
+                    _("File is Malformed."),
+                    str(e),
+                ))
+            else:
+                kernel.root.elements.classify(list(elements.elems()))
             return "inkscape", data
 
         @kernel.console_command(

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -7,7 +7,7 @@ import wx
 from PIL import Image
 from wx import aui
 
-from meerk40t.kernel import CommandSyntaxError
+from meerk40t.core.exceptions import BadFileError
 from meerk40t.kernel import lookup_listener, signal_listener
 
 from ..core.cutcode import CutCode
@@ -1913,29 +1913,31 @@ class MeerK40t(MWindow):
                 pass
 
     def load(self, pathname):
-        with wx.BusyInfo(_("Loading File...")):
-            n = self.context.elements.note
-            try:
+        try:
+            with wx.BusyInfo(
+                wx.BusyInfoFlags()
+                    .Title(_("Loading File..."))
+                    .Label(pathname)
+                ):
+                n = self.context.elements.note
                 results = self.context.elements.load(
                     pathname,
                     channel=self.context.channel("load"),
                     svg_ppi=self.context.elements.svg_ppi,
                 )
-            # Note: I cannot see how loading a file can run commands that raise CommandSyntaxError
-            # and this exception is not raised outside commands and
-            # is not raised in svg or dxf file loading code,
-            # however this code is left in just in case.
-            except CommandSyntaxError as e:
-                dlg = wx.MessageDialog(
-                    None,
-                    str(e),
-                    _("File is Malformed."),
-                    wx.OK | wx.ICON_WARNING,
-                )
-                dlg.ShowModal()
-                dlg.Destroy()
-                return False
+        except BadFileError as e:
+            dlg = wx.MessageDialog(
+                None,
+                str(e),
+                _("File is Malformed"),
+                wx.OK | wx.ICON_WARNING,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+            return False
+        else:
             if results:
+                self("scene focus -4% -4% 104% 104%\n")
                 self.set_file_as_recently_used(pathname)
                 if n != self.context.elements.note and self.context.elements.auto_note:
                     self.context("window open Notes\n")  # open/not toggle.

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1921,10 +1921,14 @@ class MeerK40t(MWindow):
                     channel=self.context.channel("load"),
                     svg_ppi=self.context.elements.svg_ppi,
                 )
+            # Note: I cannot see how loading a file can run commands that raise CommandSyntaxError
+            # and this exception is not raised outside commands and
+            # is not raised in svg or dxf file loading code,
+            # however this code is left in just in case.
             except CommandSyntaxError as e:
                 dlg = wx.MessageDialog(
                     None,
-                    str(e.msg),
+                    str(e),
                     _("File is Malformed."),
                     wx.OK | wx.ICON_WARNING,
                 )

--- a/meerk40t/kernel/exceptions.py
+++ b/meerk40t/kernel/exceptions.py
@@ -1,19 +1,22 @@
 class KernelError(Exception):
-    pass
+    """
+    This root Kernel exception is provided in case we ever want to provide common functionality
+    across all Kernel exceptions.
+    """
 
 
 class KernelImportAbort(ImportError, KernelError):
     """
-    MkImportAbort should be used as follows in plugins that import an optional prerequisite Pypi package:
+    KernelImportAbort should be used as follows in plugins that import an optional prerequisite Pypi package:
 
     try:
         import wx
     except ImportError as e:
-        raise Mk40tImportAbort("wx") from e
+        raise KernelImportAbort("wx") from e
     """
 
 
-class CommandSyntaxError(Exception):
+class CommandSyntaxError(KernelError):
     """
     Exception to be raised by a registered console command if the parameters provided are erroneous.
 
@@ -25,13 +28,13 @@ class CommandSyntaxError(Exception):
         return str(self)
 
 
-class CommandMatchRejected(Exception):
+class CommandMatchRejected(KernelError):
     """
     Exception to be raised by a registered console command if the match to the command was erroneous
     """
 
 
-class MalformedCommandRegistration(Exception):
+class MalformedCommandRegistration(KernelError):
     """
     Exception raised by the Kernel if the registration of the console command is malformed.
     """

--- a/meerk40t/kernel/exceptions.py
+++ b/meerk40t/kernel/exceptions.py
@@ -13,12 +13,16 @@ class KernelImportAbort(ImportError, KernelError):
     """
 
 
-class CommandSyntaxError(SyntaxError):
+class CommandSyntaxError(Exception):
     """
     Exception to be raised by a registered console command if the parameters provided are erroneous.
 
     An explanatory message can be provided when this exception is raised.
     """
+    @property
+    def msg(self):
+        """Backwards compatibility with SyntaxError undocumented property."""
+        return str(self)
 
 
 class CommandMatchRejected(Exception):

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2097,8 +2097,8 @@ class Kernel(Settings):
                     # Don't use command help, which is or should be descriptive - use command syntax instead
                     # If CommandSyntaxError has a msg then that needs to be provided AS WELL as the syntax.
                     message = command_funct.help
-                    if e.msg:
-                        message = e.msg
+                    if str(e):
+                        message = str(e)
                     channel(
                         "[red][bold]" + _("Syntax Error (%s): %s") % (command, message)
                     )

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -2,7 +2,6 @@ import os
 from io import BytesIO
 from typing import Tuple, Union
 
-from meerk40t.kernel import CommandSyntaxError
 from meerk40t.kernel import Module, Service
 
 from ..core.cutcode import CutCode, LineCut, PlotCut
@@ -169,6 +168,12 @@ def plugin(kernel, lifecycle=None):
                     path=d, suffix=suffix
                 )
             )
+
+
+class RuidaCommandError(Exception):
+    """
+    Exception raised when an invalid Ruida command is received.
+    """
 
 
 class RuidaDevice(Service, ViewPort):
@@ -520,7 +525,7 @@ class RuidaEmulator(Module, Parameters):
         for array in self.parse_commands(data):
             try:
                 self.process(array)
-            except CommandSyntaxError:
+            except RuidaCommandError:
                 self.ruida_channel("Process Failure: %s" % str(bytes(array).hex()))
             except Exception as e:
                 self.ruida_channel("Crashed processing: %s" % str(bytes(array).hex()))
@@ -543,7 +548,7 @@ class RuidaEmulator(Module, Parameters):
             self.filestream.write(self.swizzle(array))
         if array[0] < 0x80:
             self.ruida_channel("NOT A COMMAND: %d" % array[0])
-            raise CommandSyntaxError
+            raise RuidaCommandError
         elif array[0] == 0x80:
             value = self.abscoord(array[2:7])
             if array[1] == 0x00:


### PR DESCRIPTION
1. Separate out Console and Python Syntax Errors.
2. Provide a msg property for backwards compatibility for any non-MK plugins that still use a msg property.
3. Replace CommandSyntaxError in ruida device with a ruida specific exception because this is not a Console Command Syntax error.
4. Switch CommandSyntaxError handling to use `str(e)` rather than e.msg.

Unit tests pass, so this is not repeating the problems with #892.