### PR TITLE
Switch from cElementTree to ElementTree

### DIFF
--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -2,8 +2,7 @@ import gzip
 import os
 from base64 import b64encode
 from io import BytesIO
-from xml.etree.cElementTree import Element, ElementTree, SubElement
-from xml.etree.ElementTree import ParseError
+from xml.etree.ElementTree import Element, ElementTree, ParseError, SubElement
 
 from meerk40t.core.exceptions import BadFileError
 


### PR DESCRIPTION
Deprecated since Python 3.3.