### PR TITLE
Raster optimization ported to v0.8

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -412,9 +412,9 @@ class CutCode(CutGroup):
         distance = 0
         if include_start:
             if self.start is not None:
-                distance += abs(complex(self.start) - complex(cutcode[0].start))
+                distance += abs(complex(*self.start) - complex(*cutcode[0].start))
             else:
-                distance += abs(0 - complex(cutcode[0].start))
+                distance += abs(0 - complex(*cutcode[0].start))
         for i in range(1, len(cutcode)):
             prev = cutcode[i - 1]
             curr = cutcode[i]

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -45,7 +45,7 @@ class CutPlan:
         self.original = list()
         self.commands = list()
         self.channel = self.context.channel("optimize", timestamp=True)
-        self.setting(bool, "opt_rasters_split", True)
+        self.context.setting(bool, "opt_rasters_split", True)
 
     def __str__(self):
         parts = list()
@@ -388,7 +388,7 @@ class CutPlan:
 
     def make_image_from_raster(self, nodes, step=1):
         make_raster = self.context.lookup("render-op/make_raster")
-        objs = [n.object for s in nodes]
+        objs = [n.object for n in nodes]
         bounds = Group.union_bbox(objs, with_stroke=True)
         if bounds is None:
             return None
@@ -445,20 +445,6 @@ class CutPlan:
                 op.children.clear()
                 for image in images:
                     op.add(image, type="opnode")
-
-            # if op.type == "op raster":
-                # if len(op.children) == 1 and isinstance(op.children[0], SVGImage):
-                    # continue
-                # image_element = self._make_image_for_op(op)
-                # if image_element is None:
-                    # continue
-                # if image_element.image_width == 1 and image_element.image_height == 1:
-                    TODO: Solve this is a less kludgy manner. The call to make the image can fail the first time
-                     around because the renderer is what sets the size of the text. If the size hasn't already
-                     been set, the initial bounds are wrong.
-                    # image_element = self._make_image_for_op(op)
-                # op.children.clear()
-                # op.add(image_element, type="ref elem")
 
     def actualize(self):
         """

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -7,6 +7,7 @@ from math import cos, gcd, pi, sin, tau
 
 from meerk40t.core.exceptions import BadFileError
 from meerk40t.kernel import CommandSyntaxError, Service, Settings
+from meerk40t.tools.rastergrouping import group_overlapped_rasters
 
 from ..svgelements import (
     PATTERN_FLOAT,
@@ -5923,27 +5924,7 @@ class Elemental(Service):
 
         # This is a list of groups, where each group is a list of tuples, each an element and its bbox.
         # Initial list has a separate group for each element.
-        raster_groups = [[e] for e in raster_elements]
-        raster_elements = [e[0] for e in raster_elements]
-        # print("initial", list(map(lambda g: list(map(lambda e: e[0].id,g)), raster_groups)))
-
-        # We are using old fashioned iterators because Python cannot cope with consolidating a list whilst iterating over it.
-        for i in range(len(raster_groups) - 2, -1, -1):
-            g1 = raster_groups[i]
-            for j in range(len(raster_groups) - 1, i, -1):
-                g2 = raster_groups[j]
-                if self.group_elements_overlap(g1, g2):
-                    # print("g1", list(map(lambda e: e[0].id,g1)))
-                    # print("g2", list(map(lambda e: e[0].id,g2)))
-
-                    # if elements in the group overlap
-                    # add the element tuples from group 2 to group 1
-                    g1.extend(g2)
-                    # and remove group 2
-                    del raster_groups[j]
-
-                    # print("g1+g2", list(map(lambda e: e[0].id,g1)))
-                    # print("reduced", list(map(lambda g: list(map(lambda e: e[0].id,g)), raster_groups)))
+        raster_groups = group_overlapped_rasters([(e, e.bbox()) for e in raster_elements])
 
         debug(
             "classify: condensed to {n} raster groups".format(

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1937,7 +1937,7 @@ class MeerK40t(MWindow):
             return False
         else:
             if results:
-                self("scene focus -4% -4% 104% 104%\n")
+                self.context("scene focus -4% -4% 104% 104%\n")
                 self.set_file_as_recently_used(pathname)
                 if n != self.context.elements.note and self.context.elements.auto_note:
                     self.context("window open Notes\n")  # open/not toggle.


### PR DESCRIPTION
This PR is equivalent to PRs #795, #796, #869 with whatever changes are needed to fit this into v0.8.

When I get to the appropriate stage, I will consider how we can provide standardised driver methods for obtaining hardware metrics, and build a first solution to this that can be expanded with more values as and when we have the metrics available.

I will approach this by recreating the above 3 PRs on a commit by commit basis, and then make further tweaks for 0.8 afterwards. I am sharing this now so that anyone can comment on the overall approach if they have any concerns before I have put the full effort into recreating this.

### Algorithm explanation
The raster optimisations are effectively in two stages:

1. Group rasters in an individual raster operation into overlapping groups, each of which can be burned separately. Groups are separated if their bounding boxes do not overlap - no account is taken of raster speed etc., they are just separated into multiple smaller separated non-overlapping raster images. This is at the opposite end of the scale from the existing single huge raster approach - neither is optimised, both  have example use cases which are good and bad - they are simply at opposite extremes (though I would argue that in practice in the majority of cases, several smaller rasters are likely to be done quicker than one large one with big empty gaps).

    I would therefore argue that this is the baseline to compare against when considering the impact of knowing / not knowing the acceleration characteristics of the specific laser being used.

    In any case, with Grouped Inner and Merge Operations, both set, you need to ensure that groups are as small as possible so that the raster images are contained inside the fewest outer cuts, so the above approach is the necessary default in this circumstance. 

2. If we know enough about the performance characteristics of the laser being driven, it is then possible to further optimise the rasters by combining them where the time taken to cover the distance between them on each sweep at the fixed speed is less than the time taken to accelerate and decelerate the head at the inner ends of each of the smaller sweeps. 

    Note: This calculation does **not** need to be precise - it does **not** affect the end results, only the effectiveness of the optimisation - the original code (in the absence of a better driver architecture in 0.7) attempted to use reasonable defaults for non m2-nano, and in 0.8 it should be possible to structure this code better. and to make a reasonable guesses at the values if we do not have measurements to allow us to calculate it more accurately. This is particularly important when considering e.g. m2-nano, moshi, galvo and g-code based drivers whose metrics and approach vary so widely. In the end, however, if we simply raster each group separately, it would not be the end of the world, and would still likely be better than a single large raster on all these types of laser.

    It should be noted that when Grouped Inner and Merge Operations are both set, you can use the same acceleration / deceleration values to determine when to merge the small rasters into slightly larger ones. When these are not the case, then you can either optimise the single large raster into optimised smaller rasters (taking into account acceleration/deceleration) or chop them into the smallest non-overlapping pieces and then combine them using acceleration / 
deceleration values as a second stage but ignoring whether they share bounding cuts or not - I think these should be functionally identical, though I haven't tried it to find out.