### PR TITLE
Smooth raster intergrations for ruidacontrol+

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -54,6 +54,7 @@ class LaserSettings:
 
         self.force_twitchless = False
         self.raster_alt = False
+        self.smooth_raster = 0
         self.raster_step = 0
         self.raster_direction = 1  # Bottom To Top - Default.
         self.raster_swing = False  # False = bidirectional, True = Unidirectional
@@ -919,6 +920,7 @@ class PlotCut(CutObject):
         @return: whether the plot can travel
         """
         self.settings.raster_alt = False
+        self.settings.smooth_raster = 0
         self.settings.raster_step = 0
         self.settings.force_twitchless = True
         if (
@@ -936,6 +938,10 @@ class PlotCut(CutObject):
             return False
         self.settings.raster_step = min(self.max_dx, self.max_dy)
         self.settings.raster_alt = True
+        if self.horizontal_raster:
+            self.settings.smooth_raster = 1
+        else:
+            self.settings.smooth_raster = 2
         return True
 
     def plot_extend(self, plot):

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -916,7 +916,8 @@ class PlotCut(CutObject):
 
     def check_if_rasterable(self):
         """
-        Rasterable plotcuts must have a max step of less than 15 and must have an unused travel direction.
+        Rasterable plotcuts are heuristically defined as having a max step of less than 15 and
+        must have an unused travel direction.
 
         @return: whether the plot can travel
         """

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -54,7 +54,8 @@ class LaserSettings:
 
         self.force_twitchless = False
         self.raster_alt = False
-        self.smooth_raster = 0
+        self.constant_move_x = False
+        self.constant_move_y = False
         self.raster_step = 0
         self.raster_direction = 1  # Bottom To Top - Default.
         self.raster_swing = False  # False = bidirectional, True = Unidirectional
@@ -920,7 +921,8 @@ class PlotCut(CutObject):
         @return: whether the plot can travel
         """
         self.settings.raster_alt = False
-        self.settings.smooth_raster = 0
+        self.settings.constant_move_x = False
+        self.settings.constant_move_y = False
         self.settings.raster_step = 0
         self.settings.force_twitchless = True
         if (
@@ -939,9 +941,9 @@ class PlotCut(CutObject):
         self.settings.raster_step = min(self.max_dx, self.max_dy)
         self.settings.raster_alt = True
         if self.horizontal_raster:
-            self.settings.smooth_raster = 1
+            self.settings.constant_move_x = True
         else:
-            self.settings.smooth_raster = 2
+            self.settings.constant_move_y = True
         return True
 
     def plot_extend(self, plot):

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -1058,59 +1058,15 @@ class PlotCut(CutObject):
         last_yy = None
         ix = 0
         iy = 0
-        # last_dx = None
-        # last_dy = None
         for x, y, on in self.plot:
             idx = int(round(x - ix))
             idy = int(round(y - iy))
             ix += idx
             iy += idy
             if last_xx is not None:
-                # if self.horizontal_raster and idx:
-                #     if idx > 0 > last_dx or idx < 0 < last_dx:
-                #         # If this idx is different direction as the last one, we step y first
-                #         if idy:
-                #             # step y
-                #             for zx, zy in ZinglPlotter.plot_line(last_xx, last_yy, last_xx, iy):
-                #                 yield zx, zy, on
-                #         # step x
-                #         for zx, zy in ZinglPlotter.plot_line(last_xx, iy, ix, iy):
-                #             yield zx, zy, on
-                #     else:
-                #         # If this idx is the same direction as the last one, we step x first
-                #         # step x
-                #         for zx, zy in ZinglPlotter.plot_line(last_xx, last_yy, ix, last_yy):
-                #             yield zx, zy, on
-                #         if idy:
-                #             # step y
-                #             for zx, zy in ZinglPlotter.plot_line(ix, last_yy, ix, iy):
-                #                 yield zx, zy, on
-                # elif self.vertical_raster and idy:
-                #     if idy > 0 > last_dy or idy < 0 < last_dy:
-                #         # If this idy is different direction as the last one, we step x first
-                #         if idx:
-                #             # step x
-                #             for zx, zy in ZinglPlotter.plot_line(last_xx, last_yy, ix, last_yy):
-                #                 yield zx, zy, on
-                #         # step y
-                #         for zx, zy in ZinglPlotter.plot_line(ix, last_yy, ix, iy):
-                #             yield zx, zy, on
-                #     else:
-                #         # If this idy is the same direction as the last one, we step y first
-                #         # step y
-                #         for zx, zy in ZinglPlotter.plot_line(last_xx, last_yy, last_xx, iy):
-                #             yield zx, zy, on
-                #         if idx:
-                #             #step y
-                #             for zx, zy in ZinglPlotter.plot_line(ix, last_yy, ix, iy):
-                #                 yield zx, zy, on
-                # else:
-                #     # Non-raster go directly to result.
                 for zx, zy in ZinglPlotter.plot_line(last_xx, last_yy, ix, iy):
                     yield zx, zy, on
             last_xx = ix
             last_yy = iy
-            # last_dx = idx
-            # last_dy = idy
 
         return self.plot

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -45,7 +45,6 @@ class PlotPlanner:
         self.abort = False
         self.force_shift = False
         self.group_enabled = True  # Grouped Output Required for Lhymicro-gl.
-        self.smooth_mode = -1
 
         self.queue = []
 
@@ -382,7 +381,8 @@ class Smooth(PlotManipulation):
         px = None
         py = None
         for x, y, on in plot:
-            if self.planner.smooth_mode == -1:
+            mode = self.planner.settings.smooth_raster
+            if not mode:
                 yield x, y, on
             if px is not None and py is not None:
                 # Ensure we are single stepped values.
@@ -401,7 +401,8 @@ class Smooth(PlotManipulation):
             dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
             self.goal_x = x
             self.goal_y = y
-            if self.planner.smooth_mode == 0 and dx == 0 or self.planner.smooth_mode == 1 and dy == 0:
+            mode = self.planner.settings.smooth_raster
+            if mode == 1 and dx == 0 or mode == 2 and dy == 0:
                 continue
             self.smooth_x += dx
             self.smooth_y += dy

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -381,9 +381,13 @@ class Smooth(PlotManipulation):
         px = None
         py = None
         for x, y, on in plot:
+            if x is None or y is None:
+                yield x, y, on
+                continue
             mode = self.planner.settings.smooth_raster
             if not mode:
                 yield x, y, on
+                continue
             if px is not None and py is not None:
                 # Ensure we are single stepped values.
                 assert abs(px - x) <= 1 or abs(py - y) <= 1
@@ -402,7 +406,7 @@ class Smooth(PlotManipulation):
             self.goal_x = x
             self.goal_y = y
             mode = self.planner.settings.smooth_raster
-            if mode == 1 and dx == 0 or mode == 2 and dy == 0:
+            if (mode == 1 and dy == 0) or (mode == 2 and dx == 0):
                 continue
             self.smooth_x += dx
             self.smooth_y += dy

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -367,10 +367,7 @@ class Smooth(PlotManipulation):
         )
 
     def flushed(self):
-        return (
-                self.goal_x == self.smooth_x
-                and self.goal_y == self.smooth_y
-        )
+        return self.goal_x == self.smooth_x and self.goal_y == self.smooth_y
 
     def process(self, plot):
         """
@@ -386,10 +383,12 @@ class Smooth(PlotManipulation):
                 yield from self.flush()
                 yield x, y, on
                 continue
-            mode = self.planner.settings.smooth_raster
-            if not mode:
+            if (
+                not self.planner.settings.constant_move_x
+                and not self.planner.settings.constant_move_y
+            ):
                 yield x, y, on
-                continue
+                continue  # We are not smoothing.
             if px is not None and py is not None:
                 # Ensure we are single stepped values.
                 assert abs(px - x) <= 1 or abs(py - y) <= 1
@@ -407,12 +406,13 @@ class Smooth(PlotManipulation):
             dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
             self.goal_x = x
             self.goal_y = y
-            mode = self.planner.settings.smooth_raster
-            if (mode == 1 and dy == 0) or (mode == 2 and dx == 0):
+            if (self.planner.settings.constant_move_x and dx == 0) or (
+                self.planner.settings.constant_move_y and dy == 0
+            ):
                 continue
             self.smooth_x += dx
             self.smooth_y += dy
-            yield self.smooth_x , self.smooth_y, on
+            yield self.smooth_x, self.smooth_y, on
 
     def flush(self):
         if not self.flushed():

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -382,6 +382,8 @@ class Smooth(PlotManipulation):
         py = None
         for x, y, on in plot:
             if x is None or y is None:
+                # flush the process when if sent a None value.
+                yield from self.flush()
                 yield x, y, on
                 continue
             mode = self.planner.settings.smooth_raster
@@ -414,6 +416,8 @@ class Smooth(PlotManipulation):
 
     def flush(self):
         if not self.flushed():
+            if self.goal_x is None or self.goal_y is None:
+                return
             total_dx = self.goal_x - self.smooth_x
             total_dy = self.goal_y - self.smooth_y
             cx = self.smooth_x
@@ -428,6 +432,8 @@ class Smooth(PlotManipulation):
                 self.smooth_x = cx + (i * dx)
                 self.smooth_y = cy + (i * dy)
                 yield self.smooth_x, self.smooth_y, 0
+            self.goal_x = None
+            self.goal_y = None
 
     def warp(self, x, y):
         self.smooth_x = x

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -45,10 +45,12 @@ class PlotPlanner:
         self.abort = False
         self.force_shift = False
         self.group_enabled = True  # Grouped Output Required for Lhymicro-gl.
+        self.smooth_mode = -1
 
         self.queue = []
 
         self.single = Single(self)
+        self.smooth = Smooth(self)
         self.ppi = PPI(self)
         self.shift = Shift(self)
         self.group = Group(self)
@@ -199,7 +201,14 @@ class PlotPlanner:
                         self.shift.process(
                             debug(
                                 self.ppi.process(
-                                    debug(self.single.process(plot), self.single)
+                                    debug(
+                                        self.smooth.process(
+                                            debug(
+                                                self.single.process(plot), self.single
+                                            )
+                                        ),
+                                        self.smooth,
+                                    )
                                 ),
                                 self.ppi,
                             )
@@ -210,7 +219,9 @@ class PlotPlanner:
                 self.group,
             )
         return self.group.process(
-            self.shift.process(self.ppi.process(self.single.process(plot)))
+            self.shift.process(
+                self.ppi.process(self.smooth.process(self.single.process(plot)))
+            )
         )
 
     def step_move(self, x0, y0, x1, y1):
@@ -231,12 +242,14 @@ class PlotPlanner:
         self.pos_x = x
         self.pos_y = y
         self.single.warp(x, y)
+        self.smooth.warp(x, y)
         self.ppi.warp(x, y)
         self.shift.warp(x, y)
         self.group.warp(x, y)
 
     def reset(self):
         self.single.clear()
+        self.smooth.clear()
         self.shift.clear()
         self.ppi.clear()
         self.group.clear()
@@ -336,6 +349,90 @@ class Single(PlotManipulation):
     def clear(self):
         self.single_x = None
         self.single_y = None
+
+
+class Smooth(PlotManipulation):
+    def __init__(self, planner: PlotPlanner):
+        super().__init__(planner)
+        self.goal_x = None
+        self.goal_y = None
+
+        self.smooth_x = None
+        self.smooth_y = None
+
+    def __str__(self):
+        return "%s(%s,%s)" % (
+            self.__class__.__name__,
+            str(self.smooth_x),
+            str(self.smooth_y),
+        )
+
+    def flushed(self):
+        return (
+                self.goal_x == self.smooth_x
+                and self.goal_y == self.smooth_y
+        )
+
+    def process(self, plot):
+        """
+
+        :param plot: single stepped plots to be smoothed into orth/diag sequences.
+        :return:
+        """
+        px = None
+        py = None
+        for x, y, on in plot:
+            if self.planner.smooth_mode == -1:
+                yield x, y, on
+            if px is not None and py is not None:
+                # Ensure we are single stepped values.
+                assert abs(px - x) <= 1 or abs(py - y) <= 1
+            px = x
+            py = y
+            if self.smooth_x is None:
+                self.smooth_x = x
+            if self.smooth_y is None:
+                self.smooth_y = y
+            total_dx = x - self.smooth_x
+            total_dy = y - self.smooth_y
+            if total_dx == 0 and total_dy == 0:
+                continue
+            dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+            dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+            self.goal_x = x
+            self.goal_y = y
+            if self.planner.smooth_mode == 0 and dx == 0 or self.planner.smooth_mode == 1 and dy == 0:
+                continue
+            self.smooth_x += dx
+            self.smooth_y += dy
+            yield self.smooth_x , self.smooth_y, on
+
+    def flush(self):
+        if not self.flushed():
+            total_dx = self.goal_x - self.smooth_x
+            total_dy = self.goal_y - self.smooth_y
+            cx = self.smooth_x
+            cy = self.smooth_y
+            dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+            dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+            for i in range(1, max(abs(total_dx), abs(total_dy)) + 1):
+                if self.planner.abort:
+                    self.smooth_x = None
+                    self.smooth_y = None
+                    return
+                self.smooth_x = cx + (i * dx)
+                self.smooth_y = cy + (i * dy)
+                yield self.smooth_x, self.smooth_y, 0
+
+    def warp(self, x, y):
+        self.smooth_x = x
+        self.smooth_y = y
+        self.goal_x = x
+        self.goal_y = y
+
+    def clear(self):
+        self.smooth_x = None
+        self.smooth_y = None
 
 
 class PPI(PlotManipulation):

--- a/meerk40t/device/lhystudios/lhystudiosdevice.py
+++ b/meerk40t/device/lhystudios/lhystudiosdevice.py
@@ -792,7 +792,6 @@ class LhystudiosDriver(Driver):
         for x, y, on in self.plot:
             sx = self.current_x
             sy = self.current_y
-            # print("x: %s, y: %s -- c: %s, %s" % (str(x), str(y), str(sx), str(sy)))
             on = int(on)
             if on > 1:
                 # Special Command.
@@ -1175,7 +1174,9 @@ class LhystudiosDriver(Driver):
         """
         Vector Mode implies but doesn't discount rastering. Twitches are used if twitchfull is set to True.
 
-        @param values:
+        @param values: passed information from the driver command
+        @param dx: change in dx that should be made while switching to program mode.
+        @param dy: change in dy that should be made while switching to program mode.
         @return:
         """
         if self.state == DRIVER_STATE_PROGRAM:
@@ -1242,9 +1243,10 @@ class LhystudiosDriver(Driver):
         """
         NSE h_switches replace the mere reversal of direction with N<v><distance>SE
 
-        If a G-value is set we should subtract that from the step for our movement.
+        If a G-value is set we should subtract that from the step for our movement. Since triggering NSE will cause
+        that step to occur.
 
-        @param dy: The amount along the directional axis we should move.
+        @param dy: The amount along the directional axis we should move during this step.
 
         @return:
         """
@@ -1285,7 +1287,7 @@ class LhystudiosDriver(Driver):
         """
         NSE v_switches replace the mere reversal of direction with N<h><distance>SE
 
-        @param dx: The amount along the directional axis we should move.
+        @param dx: The amount along the directional axis we should move during this step.
 
         @return:
         """

--- a/test/test_core_plotplanner.py
+++ b/test/test_core_plotplanner.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 
 from PIL import Image, ImageDraw
@@ -11,101 +12,14 @@ from meerk40t.svgelements import Circle, Path, Point, SVGImage
 
 class TestPlotplanner(unittest.TestCase):
 
-    def test_plotplanner_rastersmooth_0(self):
-        """
-        Tests default smooth_raster settings the given values should travel both x and y solo.
-
-        @return:
-        """
-        plan = PlotPlanner(LaserSettings(power=1000))
-        settings = LaserSettings(power=1000)
-        settings.smooth_raster = 0
-        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
-        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
-        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
-        last_x = None
-        last_y = None
-        dx0 = False
-        dy0 = False
-        for x, y, on in plan.gen():
-            if on == 4:
-                last_x = x
-                last_y = y
-            if on > 1:
-                continue
-            cx = x
-            cy = y
-            if cx is None:
-                continue
-            if last_x is not None:
-                total_dx = cx - last_x
-                total_dy = cy - last_y
-                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
-                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
-                if dx == 0:
-                    dx0 = True
-                if dy == 0:
-                    dy0 = True
-                for i in range(0, max(abs(total_dx), abs(total_dy))):
-                    nx = last_x + (i * dx)
-                    ny = last_y + (i * dy)
-                    print(nx, ny, on)
-            print(x, y, on)
-            last_x = cx
-            last_y = cy
-            print(f"Moving to {x} {y}")
-        self.assertTrue(dx0)
-        self.assertTrue(dy0)
-
-    def test_plotplanner_rastersmooth_1(self):
+    def test_plotplanner_constant_move_x(self):
         """
         With raster_smooth set to 1 we should smooth the x axis so that no y=0 occurs.
         @return:
         """
         plan = PlotPlanner(LaserSettings(power=1000))
         settings = LaserSettings(power=1000)
-        settings.smooth_raster = 1
-        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
-        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
-        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
-        last_x = None
-        last_y = None
-        for x, y, on in plan.gen():
-            if on == 4:
-                last_x = x
-                last_y = y
-            if on > 1:
-                continue
-            cx = x
-            cy = y
-            if cx is None:
-                continue
-            if last_x is not None:
-                total_dx = cx - last_x
-                total_dy = cy - last_y
-                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
-                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
-                self.assertFalse(dy == 0)
-                for i in range(1, max(abs(total_dx), abs(total_dy))+1):
-                    nx = last_x + (i * dx)
-                    ny = last_y + (i * dy)
-                    print(nx, ny, on)
-            print(x, y, on)
-            last_x = cx
-            last_y = cy
-            print(f"Moving to {x} {y}")
-        plan.flush()
-        for x, y, on in plan.gen():
-            print(x, y, on)
-
-    def test_plotplanner_rastersmooth_2(self):
-        """
-        With smooth_raster set to 2 we should never have x = 0. The x should *always* be in motion.
-        @return:
-        """
-        plan = PlotPlanner(LaserSettings(power=1000))
-        settings = LaserSettings(power=1000)
-        settings.smooth_raster = 2
+        settings.constant_move_x = True
         plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
         plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
         plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
@@ -128,6 +42,44 @@ class TestPlotplanner(unittest.TestCase):
                 dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
                 if x < 10:
                     self.assertFalse(dx == 0)
+                for i in range(1, max(abs(total_dx), abs(total_dy))+1):
+                    nx = last_x + (i * dx)
+                    ny = last_y + (i * dy)
+                    print(nx, ny, on)
+            print(x, y, on)
+            last_x = cx
+            last_y = cy
+            print(f"Moving to {x} {y}")
+
+    def test_plotplanner_constant_move_y(self):
+        """
+        With smooth_raster set to 2 we should never have x = 0. The x should *always* be in motion.
+        @return:
+        """
+        plan = PlotPlanner(LaserSettings(power=1000))
+        settings = LaserSettings(power=1000)
+        settings.constant_move_y = True
+        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
+        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
+        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
+        last_x = None
+        last_y = None
+        for x, y, on in plan.gen():
+            if on == 4:
+                last_x = x
+                last_y = y
+            if on > 1:
+                continue
+            cx = x
+            cy = y
+            if cx is None:
+                continue
+            if last_x is not None:
+                total_dx = cx - last_x
+                total_dy = cy - last_y
+                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+                self.assertFalse(dy == 0)
                 for i in range(0, max(abs(total_dx), abs(total_dy))):
                     nx = last_x + (i * dx)
                     ny = last_y + (i * dy)
@@ -136,9 +88,44 @@ class TestPlotplanner(unittest.TestCase):
             last_x = cx
             last_y = cy
             print(f"Moving to {x} {y}")
-        plan.flush()
+
+    def test_plotplanner_constant_move_xy(self):
+        """
+        With raster_smooth set to 1 we should smooth the x axis so that no y=0 occurs.
+        @return:
+        """
+        plan = PlotPlanner(LaserSettings(power=1000))
+        settings = LaserSettings(power=1000)
+        settings.constant_move_x = True
+        settings.constant_move_y = True
+        for i in range(100):
+            plan.push(LineCut(Point(random.randint(0, 1000), random.randint(0,1000)), Point(random.randint(0,1000), random.randint(0,1000)), settings=settings))
+        last_x = None
+        last_y = None
         for x, y, on in plan.gen():
-            print(x, y, on)
+            if on == 4:
+                last_x = x
+                last_y = y
+            if on > 1:
+                continue
+            cx = x
+            cy = y
+            if cx is None:
+                continue
+            if last_x is not None:
+                total_dx = cx - last_x
+                total_dy = cy - last_y
+                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+                for i in range(1, max(abs(total_dx), abs(total_dy))+1):
+                    nx = last_x + (i * dx)
+                    ny = last_y + (i * dy)
+                    # print(nx, ny, on)
+            # print(x, y, on)
+            last_x = cx
+            last_y = cy
+            print(f"Moving to {x} {y}")
+
 
     def test_plotplanner_flush(self):
         """

--- a/test/test_core_plotplanner.py
+++ b/test/test_core_plotplanner.py
@@ -4,31 +4,141 @@ from PIL import Image, ImageDraw
 
 from meerk40t.core.cutcode import CutCode, LaserSettings, LineCut
 from meerk40t.core.elements import LaserOperation
-from meerk40t.core.plotplanner import PlotPlanner
+from meerk40t.core.plotplanner import PlotPlanner, Single
 from meerk40t.device.basedevice import PLOT_AXIS, PLOT_SETTING
 from meerk40t.svgelements import Circle, Path, Point, SVGImage
 
 
 class TestPlotplanner(unittest.TestCase):
 
-    def test_plotplanner_rastersmooth(self):
+    def test_plotplanner_rastersmooth_0(self):
+        """
+        Tests default smooth_raster settings the given values should travel both x and y solo.
+
+        @return:
+        """
+        plan = PlotPlanner(LaserSettings(power=1000))
+        settings = LaserSettings(power=1000)
+        settings.smooth_raster = 0
+        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
+        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
+        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
+        last_x = None
+        last_y = None
+        dx0 = False
+        dy0 = False
+        for x, y, on in plan.gen():
+            if on == 4:
+                last_x = x
+                last_y = y
+            if on > 1:
+                continue
+            cx = x
+            cy = y
+            if cx is None:
+                continue
+            if last_x is not None:
+                total_dx = cx - last_x
+                total_dy = cy - last_y
+                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+                if dx == 0:
+                    dx0 = True
+                if dy == 0:
+                    dy0 = True
+                for i in range(0, max(abs(total_dx), abs(total_dy))):
+                    nx = last_x + (i * dx)
+                    ny = last_y + (i * dy)
+                    print(nx, ny, on)
+            print(x, y, on)
+            last_x = cx
+            last_y = cy
+            print(f"Moving to {x} {y}")
+        self.assertTrue(dx0)
+        self.assertTrue(dy0)
+
+    def test_plotplanner_rastersmooth_1(self):
+        """
+        With raster_smooth set to 1 we should smooth the x axis so that no y=0 occurs.
+        @return:
+        """
         plan = PlotPlanner(LaserSettings(power=1000))
         settings = LaserSettings(power=1000)
         settings.smooth_raster = 1
-        for i in range(100):
-            plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
-            plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
-            plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
-            q = 0
-            for x, y, on in plan.gen():
-                print(x, y, on)
-                if q == i:
-                    for x, y, on in plan.process_plots(None):
-                        print("FLUSH!", x, y, on)
-                    plan.clear()
-                    break
-                q += 1
+        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
+        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
+        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
+        last_x = None
+        last_y = None
+        for x, y, on in plan.gen():
+            if on == 4:
+                last_x = x
+                last_y = y
+            if on > 1:
+                continue
+            cx = x
+            cy = y
+            if cx is None:
+                continue
+            if last_x is not None:
+                total_dx = cx - last_x
+                total_dy = cy - last_y
+                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+                self.assertFalse(dy == 0)
+                for i in range(1, max(abs(total_dx), abs(total_dy))+1):
+                    nx = last_x + (i * dx)
+                    ny = last_y + (i * dy)
+                    print(nx, ny, on)
+            print(x, y, on)
+            last_x = cx
+            last_y = cy
+            print(f"Moving to {x} {y}")
+        plan.flush()
+        for x, y, on in plan.gen():
+            print(x, y, on)
 
+    def test_plotplanner_rastersmooth_2(self):
+        """
+        With smooth_raster set to 2 we should never have x = 0. The x should *always* be in motion.
+        @return:
+        """
+        plan = PlotPlanner(LaserSettings(power=1000))
+        settings = LaserSettings(power=1000)
+        settings.smooth_raster = 2
+        plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
+        plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
+        plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
+        last_x = None
+        last_y = None
+        for x, y, on in plan.gen():
+            if on == 4:
+                last_x = x
+                last_y = y
+            if on > 1:
+                continue
+            cx = x
+            cy = y
+            if cx is None:
+                continue
+            if last_x is not None:
+                total_dx = cx - last_x
+                total_dy = cy - last_y
+                dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
+                dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
+                if x < 10:
+                    self.assertFalse(dx == 0)
+                for i in range(0, max(abs(total_dx), abs(total_dy))):
+                    nx = last_x + (i * dx)
+                    ny = last_y + (i * dy)
+                    print(nx, ny, on)
+
+            last_x = cx
+            last_y = cy
+            print(f"Moving to {x} {y}")
+        plan.flush()
+        for x, y, on in plan.gen():
+            print(x, y, on)
 
     def test_plotplanner_flush(self):
         """

--- a/test/test_core_plotplanner.py
+++ b/test/test_core_plotplanner.py
@@ -10,6 +10,26 @@ from meerk40t.svgelements import Circle, Path, Point, SVGImage
 
 
 class TestPlotplanner(unittest.TestCase):
+
+    def test_plotplanner_rastersmooth(self):
+        plan = PlotPlanner(LaserSettings(power=1000))
+        settings = LaserSettings(power=1000)
+        settings.smooth_raster = 1
+        for i in range(100):
+            plan.push(LineCut(Point(0, 0), Point(2, 20), settings=settings))
+            plan.push(LineCut(Point(2, 20), Point(5, 20), settings=settings))
+            plan.push(LineCut(Point(5, 20), Point(10, 100), settings=settings))
+            q = 0
+            for x, y, on in plan.gen():
+                print(x, y, on)
+                if q == i:
+                    for x, y, on in plan.process_plots(None):
+                        print("FLUSH!", x, y, on)
+                    plan.clear()
+                    break
+                q += 1
+
+
     def test_plotplanner_flush(self):
         """
         Intro test for plotplanner.


### PR DESCRIPTION
The idea is to fix the clickity clack on ruidacontrol rasters. We do this by refusing direct moves along certain axis, but only as smooth moves at an angle when we travel along the other axis.