### PR TITLE
Add magnet functionality to grid and make grid more flexible

### DIFF
--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -77,6 +77,7 @@ class Scene(Module, Job):
         self.magnet_y = []
         self.magnet_attraction = 2 # 0 off, 1..3 increasing strength
         self.tick_distance = 0
+        self.auto_tick = False # by definition do not auto_tick
 
     def clear_magnets(self):
         self.magnet_x = []

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -73,6 +73,54 @@ class Scene(Module, Job):
 
         self.screen_refresh_is_requested = True
         self.background_brush = wx.Brush("Grey")
+        self.magnet_x = []
+        self.magnet_y = []
+        self.use_magnet = True
+
+    def clear_magnets(self):
+        self.magnet_x = []
+        self.magnet_y = []
+        # print("Clear all magnets")
+
+    def toggle_x_magnet(self, x_value):
+        if x_value in self.magnet_x:
+            self.magnet_x.remove(x_value)
+            # print("Remove x magnet for %.1f" % x_value)
+        else:
+            self.magnet_x += [x_value]
+            # print("Add x magnet for %.1f" % x_value)
+
+    def toggle_y_magnet(self, y_value):
+        if y_value in self.magnet_y:
+            self.magnet_y.remove(y_value)
+            # print("Remove y magnet for %.1f" % y_value)
+        else:
+            self.magnet_y += [y_value]
+            # print("Add y magnet for %.1f" % y_value)
+
+    def attracted_x(self, x_value):  # TODO
+        delta = float("inf")
+        x_val = None
+        for mag_x in self.magnet_y:
+            if abs(x_value - mag_x) < delta:
+                delta = abs(x_value - mag_x)
+                x_val = mag_x
+        # Is it less than xx away?
+        if delta > 1000:
+            x_val = x_value
+        return x_val
+
+    def attracted_y(self, y_value):  # TODO
+        delta = float("inf")
+        y_val = None
+        for mag_y in self.magnet_y:
+            if abs(y_value - mag_y) < delta:
+                delta = abs(y_value - mag_y)
+                y_val = mag_y
+        # Is it less than xx away?
+        if delta > 1000:
+            y_val = y_value
+        return y_val
 
     def module_open(self, *args, **kwargs):
         context = self.context

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -106,7 +106,7 @@ class Scene(Module, Job):
             if abs(x_value - mag_x) < delta:
                 delta = abs(x_value - mag_x)
                 x_val = mag_x
-        return x_val
+        return delta, x_val
 
     def magnet_attracted_y(self, y_value):  # TODO
         delta = float("inf")
@@ -115,14 +115,62 @@ class Scene(Module, Job):
             if abs(y_value - mag_y) < delta:
                 delta = abs(y_value - mag_y)
                 y_val = mag_y
-        return y_val
+        return delta, y_val
 
     def revised_magnet_bound(self, bounds = None):
+        from meerk40t.core.units import Length
         dx = 0
         dy = 0
         if self.use_magnet:
-            pass
+            if self.tick_distance > 0:
+                s = "{amount}{units}".format(amount=self.tick_distance, units=self.context.units_name)
+                attraction_len = 0.25 * float(Length(s))
+                print ("Attraction len=%s, %.1f" % (s, attraction_len))
+            else:
+                attraction_len = float(Length("1mm"))
+            delta_x1, x1 = self.magnet_attracted_x(bounds[0])
+            delta_x2, x2 = self.magnet_attracted_x(bounds[2])
+            delta_x3, x3 = self.magnet_attracted_x((bounds[0] + bounds[2])/2)
+            delta_y1, y1 = self.magnet_attracted_y(bounds[1])
+            delta_y2, y2 = self.magnet_attracted_y(bounds[3])
+            delta_y3, y3 = self.magnet_attracted_y((bounds[1] + bounds[3])/2)
+            if not x1 is None:
+                print("X-left: delta=%.1f, x-nearest=%.1f" % ( delta_x1, x1))
+                print("X-right: delta=%.1f, x-nearest=%.1f" % ( delta_x2, x2))
+                print("X-center: delta=%.1f, x-nearest=%.1f" % ( delta_x3, x3))
+                if delta_x1 < delta_x2 and delta_x1<delta_x3:
+                    if delta_x1<attraction_len:
+                        dx = x1 - bounds[0]
+                        print ("Take left side, x=%.1f, dx=%.1f" % (bounds[0], dx))
+                elif delta_x2 < delta_x1 and delta_x2<delta_x3:
+                    if delta_x2<attraction_len:
+                        dx = x2 - bounds[2]
+                        print ("Take right side, x=%.1f, dx=%.1f" % (bounds[2], dx))
+                else:
+                    if delta_x3<attraction_len:
+                        dx = x3 - (bounds[0]+bounds[2]) / 2
+                        print ("Take center , x=%.1f, dx=%.1f" % ((bounds[0]+bounds[2])/2, dx))
+            if not y1 is None:
+                print("Y-top: delta=%.1f, y-nearest=%.1f" % ( delta_y1, y1))
+                print("Y-bottom: delta=%.1f, y-nearest=%.1f" % ( delta_y2, y2))
+                print("Y-center: delta=%.1f, x-nearest=%.1f" % ( delta_y3, y3))
+                if delta_y1 < delta_y2 and delta_y1<delta_y3:
+                    if delta_y1<attraction_len:
+                        dy = y1 - bounds[1]
+                        print ("Take top side, y=%.1f, dy=%.1f" % (bounds[1], dy))
+                elif delta_y2 < delta_y1 and delta_y2<delta_y3:
+                    if delta_y2<attraction_len:
+                        dy = y2 - bounds[3]
+                        print ("Take bottom side, y=%.1f, dy=%.1f" % (bounds[3], dy))
+                else:
+                    if delta_y3<attraction_len:
+                        dy = y3 - (bounds[1]+bounds[3]) / 2
+                        print ("Take center , x=%.1f, dx=%.1f" % ((bounds[1]+bounds[3])/2, dy))
+
         return dx, dy
+
+    def has_magnets(self):
+        return len(self.magnet_x) + len(self.magnet_y) > 0
 
     def module_open(self, *args, **kwargs):
         context = self.context

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -99,29 +99,30 @@ class Scene(Module, Job):
             self.magnet_y += [y_value]
             # print("Add y magnet for %.1f" % y_value)
 
-    def attracted_x(self, x_value):  # TODO
+    def magnet_attracted_x(self, x_value):
         delta = float("inf")
         x_val = None
-        for mag_x in self.magnet_y:
+        for mag_x in self.magnet_x:
             if abs(x_value - mag_x) < delta:
                 delta = abs(x_value - mag_x)
                 x_val = mag_x
-        # Is it less than xx away?
-        if delta > 1000:
-            x_val = x_value
         return x_val
 
-    def attracted_y(self, y_value):  # TODO
+    def magnet_attracted_y(self, y_value):  # TODO
         delta = float("inf")
         y_val = None
         for mag_y in self.magnet_y:
             if abs(y_value - mag_y) < delta:
                 delta = abs(y_value - mag_y)
                 y_val = mag_y
-        # Is it less than xx away?
-        if delta > 1000:
-            y_val = y_value
         return y_val
+
+    def revised_magnet_bound(self, bounds = None):
+        dx = 0
+        dy = 0
+        if self.use_magnet:
+            pass
+        return dx, dy
 
     def module_open(self, *args, **kwargs):
         context = self.context

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -76,6 +76,7 @@ class Scene(Module, Job):
         self.magnet_x = []
         self.magnet_y = []
         self.use_magnet = True
+        self.tick_distance = 0
 
     def clear_magnets(self):
         self.magnet_x = []

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -120,7 +120,7 @@ class Scene(Module, Job):
                 x_val = mag_x
         return delta, x_val
 
-    def magnet_attracted_y(self, y_value):  # TODO
+    def magnet_attracted_y(self, y_value):
         delta = float("inf")
         y_val = None
         for mag_y in self.magnet_y:

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -56,22 +56,27 @@ class GridWidget(Widget):
         context = self.scene.context
         units_width = float(context.device.unit_width)
         units_height = float(context.device.unit_height)
-        step = float(Length("10mm"))
+        step = 0
+        if self.scene.tick_distance > 0:
+            s = "{dist}{unit}".format(dist=self.scene.tick_distance, unit=context.units_name)
+            step = float(Length(s))
+            # The very first time we get absurd values, so let's do as if nothing had happened...
+            divider = units_width / step
+            if divider > 1000:
+                print ("Something strange happened: %s" %s)
+                step = 0
+        if step==0:
+            # print ("Default kicked in")
+            step = float(Length("10mm"))
 
-        #if self.scene.tick_distance > 0:
-        #    s = "{value}{units}".format(value=self.scene.tick_distance, units=context.units_name)
-        #    print ("Step should become %s" % s)
-        #    step = float(Length(s))
-        #else:
-        #    step = float(Length("10mm"))
-        #print ("step=%.3f" % step)
         starts = []
         ends = []
         starts_hi = []
         ends_hi = []
         if step == 0:
             self.grid = None
-            return starts, ends, starts_hi, ends_hi
+            return
+
         x = 0.0
         while x < units_width:
             starts.append((x, 0.0))
@@ -96,6 +101,8 @@ class GridWidget(Widget):
         """
         Draw the grid on the scene.
         """
+        print ("GridWidget draw")
+
         if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
             context = self.scene.context
             unit_width = context.device.unit_width
@@ -113,6 +120,7 @@ class GridWidget(Widget):
         if self.scene.context.draw_mode & DRAW_MODE_GRID == 0:
             if self.grid is None:
                 self.calculate_grid()
+
             starts, ends, starts_hi, ends_hi = self.grid
             matrix = self.scene.widget_root.scene_widget.matrix
             try:
@@ -140,5 +148,6 @@ class GridWidget(Widget):
         """
         if signal == "grid":
             self.grid = None
+
         elif signal == "background":
             self.background = args[0]

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -63,7 +63,7 @@ class GridWidget(Widget):
             # The very first time we get absurd values, so let's do as if nothing had happened...
             divider = units_width / step
             if divider > 1000:
-                print ("Something strange happened: %s" %s)
+                # print ("Something strange happened: %s" %s)
                 step = 0
         if step==0:
             # print ("Default kicked in")

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -56,6 +56,7 @@ class GridWidget(Widget):
         step = 0
         if self.scene.tick_distance > 0:
             s = "{dist}{unit}".format(dist=self.scene.tick_distance, unit=context.units_name)
+            # print ("Calculate grid with %s" %s)
             step = float(Length(s))
             # The very first time we get absurd values, so let's do as if nothing had happened...
             divider = units_width / step
@@ -148,8 +149,9 @@ class GridWidget(Widget):
             else:
                 gc.DrawBitmap(background, 0, 0, unit_width, unit_height)
         # Get proper gridsize
-        w, h = gc.Size
-        self.calculate_gridsize(w, h)
+        if self.scene.auto_tick:
+            w, h = gc.Size
+            self.calculate_gridsize(w, h)
 
         if self.scene.context.draw_mode & DRAW_MODE_GRID == 0:
             if self.grid is None:

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -18,6 +18,9 @@ class GridWidget(Widget):
         self.grid_line_pen = wx.Pen()
         self.grid_line_pen.SetColour(wx.Colour(0xA0, 0xA0, 0xA0))
         self.grid_line_pen.SetWidth(1)
+        self.grid_line_high_pen = wx.Pen()
+        self.grid_line_high_pen.SetColour(wx.Colour(0xFF, 0xA0, 0xA0))
+        self.grid_line_high_pen.SetWidth(2)
 
     def hit(self):
         return HITCHAIN_HIT
@@ -56,20 +59,30 @@ class GridWidget(Widget):
         step = float(Length("10mm"))
         starts = []
         ends = []
+        starts_hi = []
+        ends_hi = []
         if step == 0:
             self.grid = None
-            return starts, ends
+            return starts, ends, starts_hi, ends_hi
         x = 0.0
         while x < units_width:
             starts.append((x, 0.0))
             ends.append((x, units_height))
             x += step
+        for x in self.scene.magnet_x:
+            starts_hi.append((x, 0.0))
+            ends_hi.append((x, units_height))
+
         y = 0.0
         while y < units_height:
             starts.append((0.0, y))
             ends.append((units_width, y))
             y += step
-        self.grid = starts, ends
+        for y in self.scene.magnet_y:
+            starts_hi.append((0.0, y))
+            ends_hi.append((units_width, y))
+
+        self.grid = starts, ends, starts_hi, ends_hi
 
     def process_draw(self, gc):
         """
@@ -92,7 +105,7 @@ class GridWidget(Widget):
         if self.scene.context.draw_mode & DRAW_MODE_GRID == 0:
             if self.grid is None:
                 self.calculate_grid()
-            starts, ends = self.grid
+            starts, ends, starts_hi, ends_hi = self.grid
             matrix = self.scene.widget_root.scene_widget.matrix
             try:
                 scale_x = matrix.value_scale_x()
@@ -107,6 +120,9 @@ class GridWidget(Widget):
                 gc.SetPen(self.grid_line_pen)
                 if starts and ends:
                     gc.StrokeLineSegments(starts, ends)
+                gc.SetPen(self.grid_line_high_pen)
+                if starts_hi and ends_hi:
+                    gc.StrokeLineSegments(starts_hi, ends_hi)
             except (OverflowError, ValueError, ZeroDivisionError):
                 matrix.reset()
 

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -20,7 +20,7 @@ class GridWidget(Widget):
         self.grid_line_pen.SetWidth(1)
         self.grid_line_high_pen = wx.Pen()
         self.grid_line_high_pen.SetColour(wx.Colour(0xFF, 0xA0, 0xA0))
-        self.grid_line_high_pen.SetWidth(2)
+        self.grid_line_high_pen.SetWidth(3)
 
     def hit(self):
         return HITCHAIN_HIT
@@ -57,6 +57,14 @@ class GridWidget(Widget):
         units_width = float(context.device.unit_width)
         units_height = float(context.device.unit_height)
         step = float(Length("10mm"))
+
+        #if self.scene.tick_distance > 0:
+        #    s = "{value}{units}".format(value=self.scene.tick_distance, units=context.units_name)
+        #    print ("Step should become %s" % s)
+        #    step = float(Length(s))
+        #else:
+        #    step = float(Length("10mm"))
+        #print ("step=%.3f" % step)
         starts = []
         ends = []
         starts_hi = []

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -106,8 +106,8 @@ class GridWidget(Widget):
         factor = 1
         if x >= 1:
             while (x>=10):
-              x *= 0.1
-              factor *= 10
+                x *= 0.1
+                factor *= 10
         else:
             while x<1:
                 x *= 10

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -56,6 +56,22 @@ class GuideWidget(Widget):
         value = self.options[id]
         self.set_auto_tick(value)
 
+    def fill_magnets(self):
+        # Lets set the full grid
+        p = self.scene.context
+        tlen= float(Length("{value}{units}".format(value=self.scene.tick_distance, units=p.units_name)))
+
+        x = 0
+        while x <= p.device.unit_width:
+            self.scene.toggle_x_magnet(x)
+            x += tlen
+
+        y = 0
+        while y <= p.device.unit_height:
+            self.scene.toggle_y_magnet(y)
+            y += tlen
+
+
     def event(self, window_pos=None, space_pos=None, event_type=None):
         """
         Capture and deal with the doubleclick event.
@@ -90,8 +106,12 @@ class GuideWidget(Widget):
             item = menu.Append(wx.ID_ANY, "{amount:.2f}{units}".format(amount=self.options[3], units=units), "")
             self.scene.context.gui.Bind(wx.EVT_MENU, lambda e: self.menu_event(3), id=item.GetId(),)
             menu.AppendSeparator()
-            item = menu.Append(wx.ID_ANY, _("Clear all magnets"), "")
-            self.scene.context.gui.Bind(wx.EVT_MENU, lambda e: self.scene.clear_magnets(), id=item.GetId(),)
+            if self.scene.has_magnets():
+                item = menu.Append(wx.ID_ANY, _("Clear all magnets"), "")
+                self.scene.context.gui.Bind(wx.EVT_MENU, lambda e: self.scene.clear_magnets(), id=item.GetId(),)
+            else:
+                item = menu.Append(wx.ID_ANY, _("Create magnets along grid"), "")
+                self.scene.context.gui.Bind(wx.EVT_MENU, lambda e: self.fill_magnets(), id=item.GetId(),)
 
             self.scene.context.gui.PopupMenu(menu)
             menu.Destroy()
@@ -126,18 +146,7 @@ class GuideWidget(Widget):
                 if self.scene.has_magnets():
                     self.scene.clear_magnets()
                 else:
-                    # Lets set the full grid
-                    tlen= float(Length("{value}{units}".format(value=self.scene.tick_distance, units=p.units_name)))
-
-                    x = 0
-                    while x <= p.device.unit_width:
-                        self.scene.toggle_x_magnet(x)
-                        x += tlen
-
-                    y = 0
-                    while y <= p.device.unit_height:
-                        self.scene.toggle_y_magnet(y)
-                        y += tlen
+                    self.fill_magnets()
             elif is_x:
                 # Get the X coordinate from space_pos [0]
                 value = float(Length("%.1f%s"%(mark_point_x, self.units)))

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -5,7 +5,7 @@ import wx
 from meerk40t.gui.laserrender import DRAW_MODE_GUIDES
 from meerk40t.gui.scene.widget import Widget
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN, RESPONSE_CONSUME
-from meerk40t.core.units import PX_PER_UNIT, UNITS_PER_PIXEL, Length
+from meerk40t.core.units import Length
 
 
 class GuideWidget(Widget):
@@ -52,8 +52,8 @@ class GuideWidget(Widget):
             self.scene.auto_tick = False
             self.scene.tick_distance = value
 
-    def menu_event(self, id):
-        value = self.options[id]
+    def menu_event(self, idx):
+        value = self.options[idx]
         self.set_auto_tick(value)
 
     def fill_magnets(self):

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -52,6 +52,8 @@ class GuideWidget(Widget):
             return RESPONSE_CHAIN
         elif event_type == "doubleclick":
             value = 0
+            is_y = self.scale_x_lower <= space_pos[0] <= self.scale_x_upper
+            is_x = self.scale_y_lower <= space_pos[1] <= self.scale_y_upper
             p = self.scene.context
             scaled_conversion = (
                 p.device.length(str(1) + p.units_name, as_float=True)
@@ -64,7 +66,8 @@ class GuideWidget(Widget):
                 ]
             )
             mark_point_x = (window_pos[0] - sx) / scaled_conversion
-            mark_point_y = (window_pos[0] - sx) / scaled_conversion
+            mark_point_y = (window_pos[1] - sy) / scaled_conversion
+
             print(
                 "Coordinates: x=%.1f, y=%.1f, sx=%.1f, sy=%.1f, mark-x=%.1f, y=%.1f"
                 % (window_pos[0], window_pos[1], sx, sy, mark_point_x, mark_point_y)
@@ -74,8 +77,6 @@ class GuideWidget(Widget):
                 window_pos[0] - sx, window_pos[1] - sy, UNITS_PER_PIXEL
             )
             print("cx=%.1f, cy=%.1f" % (cx, cy))
-            is_y = self.scale_x_lower <= space_pos[0] <= self.scale_x_upper
-            is_x = self.scale_y_lower <= space_pos[1] <= self.scale_y_upper
             if is_x and is_y:
                 self.scene.clear_magnets()
             elif is_x:

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -118,7 +118,6 @@ class GuideWidget(Widget):
         # points = scaled_conversion * round(points / scaled_conversion * 10.0) / 10.0
         delta = points / self.scaled_conversion
         # Lets establish a proper delta: we want to understand the log and x.yyy multiplikator
-        print("Delta=%.3f, log=%.3f, 0.1=%.3f, 0.01=%.3f" % (delta, math.log10(delta), math.log10(0.1), math.log10(0.01)))
         x = delta
         factor = 1
         if x >= 1:
@@ -140,7 +139,7 @@ class GuideWidget(Widget):
             l_pref = 5.0
 
         delta = l_pref * factor
-        print ("New Delta={delta}".format(delta=delta))
+        # print ("New Delta={delta}".format(delta=delta))
         # points = self.scaled_conversion * float("{:.1g}".format(points / self.scaled_conversion))
 
         self.scene.tick_distance = delta

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -4,6 +4,8 @@ import wx
 
 from meerk40t.gui.laserrender import DRAW_MODE_GUIDES
 from meerk40t.gui.scene.widget import Widget
+from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN, RESPONSE_CONSUME
+from meerk40t.core.units import PX_PER_UNIT, UNITS_PER_PIXEL, Length
 
 
 class GuideWidget(Widget):
@@ -16,6 +18,79 @@ class GuideWidget(Widget):
     def __init__(self, scene):
         Widget.__init__(self, scene, all=False)
         self.scene.context.setting(bool, "show_negative_guide", True)
+        self.edge_gap = 5
+        self.line_length = 20
+        self.scale_x_lower = self.edge_gap
+        self.scale_x_upper = self.scale_x_lower + self.line_length
+        self.scale_y_lower = self.edge_gap
+        self.scale_y_upper = self.scale_y_lower + self.line_length
+
+    def hit(self):
+        return HITCHAIN_HIT
+
+    def contains(self, x, y=None):
+        # Slightly more complex than usual due to left, top area
+        value = False
+        if y is None:
+            y = x.y
+            x = x.x
+
+        if (
+            self.scale_x_lower <= x <= self.scale_x_upper
+            or self.scale_y_lower <= y <= self.scale_y_upper
+        ):
+            value = True
+        return value
+
+    def event(self, window_pos=None, space_pos=None, event_type=None):
+        """
+        Capture and deal with the doubleclick event.
+
+        Doubleclick in the grid loads a menu to remove the background.
+        """
+        if event_type == "hover":
+            return RESPONSE_CHAIN
+        elif event_type == "doubleclick":
+            value = 0
+            p = self.scene.context
+            scaled_conversion = (
+                p.device.length(str(1) + p.units_name, as_float=True)
+                * self.scene.widget_root.scene_widget.matrix.value_scale_x()
+            )
+            sx, sy = self.scene.convert_scene_to_window(
+                [
+                    p.device.unit_width * p.device.origin_x,
+                    p.device.unit_height * p.device.origin_y,
+                ]
+            )
+            mark_point_x = (window_pos[0] - sx) / scaled_conversion
+            mark_point_y = (window_pos[0] - sx) / scaled_conversion
+            print(
+                "Coordinates: x=%.1f, y=%.1f, sx=%.1f, sy=%.1f, mark-x=%.1f, y=%.1f"
+                % (window_pos[0], window_pos[1], sx, sy, mark_point_x, mark_point_y)
+            )
+
+            cx, cy = p.device.physical_to_scene_position(
+                window_pos[0] - sx, window_pos[1] - sy, UNITS_PER_PIXEL
+            )
+            print("cx=%.1f, cy=%.1f" % (cx, cy))
+            is_y = self.scale_x_lower <= space_pos[0] <= self.scale_x_upper
+            is_x = self.scale_y_lower <= space_pos[1] <= self.scale_y_upper
+            if is_x and is_y:
+                self.scene.clear_magnets()
+            elif is_x:
+                # Get the X coordinate from space_pos [0]
+                value = cx
+                self.scene.toggle_x_magnet(value)
+            elif is_y:
+                # Get the Y coordinate form space_pos [1]
+                value = cy
+                self.scene.toggle_y_magnet(value)
+
+            self.scene.request_refresh()
+            return RESPONSE_CONSUME
+        else:
+            return RESPONSE_CHAIN
 
     def process_draw(self, gc):
         """
@@ -32,7 +107,6 @@ class GuideWidget(Widget):
         )
         if scaled_conversion == 0:
             return
-        edge_gap = 5
         wpoints = w / 15.0
         hpoints = h / 15.0
         points = min(wpoints, hpoints)
@@ -53,7 +127,8 @@ class GuideWidget(Widget):
         starts = []
         ends = []
         x = offset_x
-        length = 20
+        length = self.line_length
+        edge_gap = self.edge_gap
         font = wx.Font(10, wx.SWISS, wx.NORMAL, wx.BOLD)
         gc.SetFont(font, wx.BLACK)
         gc.DrawText(p.units_name, edge_gap, edge_gap)

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1089,12 +1089,26 @@ class MoveWidget(Widget):
     def hit(self):
         return HITCHAIN_HIT
 
+    def check_for_magnets(self):
+        elements = self.scene.context.elements
+        b = elements._emphasized_bounds
+        dx, dy = self.scene.revised_magnet_bound(b)
+        if dx != 0 or dy !=0:
+            for e in elements.flat(types=("elem",), emphasized=True):
+                obj = e.object
+                obj.transform.post_translate(dx, dy)
+
+            self.translate(dx, dy)
+
+            elements.update_bounds([b[0] + dx, b[1] + dy, b[2] + dx, b[3] + dy])
+
     def tool(self, position, dx, dy, event=0):
         """
         Change the position of the selected elements.
         """
         elements = self.scene.context.elements
         if event == 1:  # end
+            self.check_for_magnets()
             for e in elements.flat(types=("elem", "group", "file"), emphasized=True):
                 obj = e.object
                 try:

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1090,17 +1090,19 @@ class MoveWidget(Widget):
         return HITCHAIN_HIT
 
     def check_for_magnets(self):
-        elements = self.scene.context.elements
-        b = elements._emphasized_bounds
-        dx, dy = self.scene.revised_magnet_bound(b)
-        if dx != 0 or dy !=0:
-            for e in elements.flat(types=("elem",), emphasized=True):
-                obj = e.object
-                obj.transform.post_translate(dx, dy)
+        # print ("Shift-key-Status: self=%g, master=%g" % (self.key_shift_pressed, self.master.key_shift_pressed))
+        if not self.master.key_shift_pressed: # if Shift-Key pressed then ignore Magnets...
+            elements = self.scene.context.elements
+            b = elements._emphasized_bounds
+            dx, dy = self.scene.revised_magnet_bound(b)
+            if dx != 0 or dy !=0:
+                for e in elements.flat(types=("elem",), emphasized=True):
+                    obj = e.object
+                    obj.transform.post_translate(dx, dy)
 
-            self.translate(dx, dy)
+                self.translate(dx, dy)
 
-            elements.update_bounds([b[0] + dx, b[1] + dy, b[2] + dx, b[3] + dy])
+                elements.update_bounds([b[0] + dx, b[1] + dy, b[2] + dx, b[3] + dy])
 
     def tool(self, position, dx, dy, event=0):
         """

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -18,6 +18,7 @@ from .scene.scenepanel import ScenePanel
 from .scene.widget import Widget
 from .scenewidgets.gridwidget import GridWidget
 from .wxutils import disable_window
+from meerk40t.core.units import Length
 
 _ = wx.GetTranslation
 
@@ -117,6 +118,10 @@ class SimulationPanel(wx.Panel, Job):
         self.widget_scene.add_scenewidget(
             SimulationTravelWidget(self.widget_scene, self)
         )
+        # Don't let grid resize itself
+        self.widget_scene.auto_tick = False
+        self.widget_scene.tick_distance = 10 # mm
+
         self.widget_scene.add_scenewidget(GridWidget(self.widget_scene))
         self.reticle = SimReticleWidget(self.widget_scene, self)
         self.widget_scene.add_interfacewidget(self.reticle)

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -18,7 +18,6 @@ from .scene.scenepanel import ScenePanel
 from .scene.widget import Widget
 from .scenewidgets.gridwidget import GridWidget
 from .wxutils import disable_window
-from meerk40t.core.units import Length
 
 _ = wx.GetTranslation
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -182,7 +182,7 @@ class CustomStatusBar(wx.StatusBar):
         needed_size += self.cb_rotate.GetRect().width
         needed_size += self.cb_skew.GetRect().width
         needed_size += self.combo_magnet.GetRect().width
-        print ("Needed size for window: %g" % needed_size)
+        # print ("Needed size for window: %g" % needed_size)
         self.combo_magnet.SetSelection(2)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_move, self.cb_move)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_handle, self.cb_handle)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1937,7 +1937,7 @@ class MeerK40t(MWindow):
         self.main_statusbar.cb_enabled = valu
 
     @signal_listener("magnets")
-    def on_update_magnets(self, origin, has_magnets=False, *args):
+    def on_update_magnets(self, origin, has_magnets, *args):
         self.main_statusbar.with_magnets = has_magnets
 
     def __set_titlebar(self):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -10,7 +10,6 @@ from wx import aui
 from meerk40t.core.exceptions import BadFileError
 from meerk40t.kernel import lookup_listener, signal_listener
 
-
 from ..core.units import UNITS_PER_INCH, Length
 from ..svgelements import (
     Color,
@@ -161,8 +160,9 @@ class CustomStatusBar(wx.StatusBar):
         sizes = [-2] * self.panelct
         # Make the first Panel large
         sizes[0] = -3
-        # Make the last Panel smaller
-        sizes[self.panelct - 1] = -1
+        # Traditionally we made the last Panel smaller, but now no longer with Magnets...
+        # The most intelligent way would be  to calculate the needed size...
+        # sizes[self.panelct - 1] = -1
         self.SetStatusWidths(sizes)
         self.sizeChanged = False
         self.Bind(wx.EVT_SIZE, self.OnSize)
@@ -173,10 +173,22 @@ class CustomStatusBar(wx.StatusBar):
         self.cb_handle = wx.CheckBox(self, id=wx.ID_ANY, label=_("Resize"))
         self.cb_rotate = wx.CheckBox(self, id=wx.ID_ANY, label=_("Rotate"))
         self.cb_skew = wx.CheckBox(self, id=wx.ID_ANY, label=_("Skew"))
+        magnets = [_("Off"), _("Weak"), _("Normal"), _("Strong")]
+
+        self.combo_magnet = wx.ComboBox(self, wx.ID_ANY, choices=magnets, style=wx.CB_DROPDOWN)
+        needed_size = 0
+        needed_size += self.cb_move.GetRect().width
+        needed_size += self.cb_handle.GetRect().width
+        needed_size += self.cb_rotate.GetRect().width
+        needed_size += self.cb_skew.GetRect().width
+        needed_size += self.combo_magnet.GetRect().width
+        print ("Needed size for window: %g" % needed_size)
+        self.combo_magnet.SetSelection(2)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_move, self.cb_move)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_handle, self.cb_handle)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_rotate, self.cb_rotate)
         self.Bind(wx.EVT_CHECKBOX, self.on_toggle_skew, self.cb_skew)
+        self.Bind(wx.EVT_COMBOBOX, self.on_magnet_combo, self.combo_magnet)
         self.context.setting(bool, "enable_sel_move", True)
         self.context.setting(bool, "enable_sel_size", True)
         self.context.setting(bool, "enable_sel_rotate", True)
@@ -185,7 +197,13 @@ class CustomStatusBar(wx.StatusBar):
         self.cb_handle.SetValue(self.context.enable_sel_size)
         self.cb_rotate.SetValue(self.context.enable_sel_rotate)
         self.cb_skew.SetValue(self.context.enable_sel_skew)
+        self.cb_move.SetToolTip(_("Toggle visibility of Move-Indicator"))
+        self.cb_handle.SetToolTip(_("Toggle visibility of Resize-handles"))
+        self.cb_rotate.SetToolTip(_("Toggle visibility of Rotation-handles"))
+        self.cb_skew.SetToolTip(_("Toggle visibility of Skew-handles"))
+        self.combo_magnet.SetToolTip(_("Set attraction strength of magnet lines"))
         self.cb_enabled = False
+        self.with_magnets = False
 
         # set the initial position of the checkboxes
         self.Reposition()
@@ -202,12 +220,24 @@ class CustomStatusBar(wx.StatusBar):
             self.cb_handle.Show()
             self.cb_rotate.Show()
             self.cb_skew.Show()
+            if self.with_magnets:
+                self.combo_magnet.Show()
         else:
             self.cb_move.Hide()
             self.cb_handle.Hide()
             self.cb_rotate.Hide()
             self.cb_skew.Hide()
+            self.combo_magnet.Hide()
         self._cb_enabled = cb_enabled
+
+    @property
+    def with_magnets(self):
+        return self._with_magnets
+
+    @with_magnets.setter
+    def with_magnets(self, value):
+        self._with_magnets = value
+        self.Reposition()
 
     # the checkbox was clicked
     def on_toggle_move(self, event):
@@ -234,6 +264,13 @@ class CustomStatusBar(wx.StatusBar):
             self.context.enable_sel_skew = valu
             self.context.signal("refresh_scene", "Scene")
 
+    def on_magnet_combo(self, event):
+        if not self.startup:
+            value = self.combo_magnet.GetSelection()
+            if value is None:
+                value = 0
+            self.context.signal("magnet-attraction", value)
+
     def OnSize(self, evt):
         evt.Skip()
         self.Reposition()  # for normal size events
@@ -246,7 +283,11 @@ class CustomStatusBar(wx.StatusBar):
     # reposition the checkboxes
     def Reposition(self):
         rect = self.GetFieldRect(self.panelct - 1)
-        wd = rect.width / 4
+        if self.with_magnets:
+            ct = 5
+        else:
+            ct = 4
+        wd = rect.width / ct
         rect.x += 1
         rect.y += 1
         rect.width = wd
@@ -257,6 +298,8 @@ class CustomStatusBar(wx.StatusBar):
         self.cb_rotate.SetRect(rect)
         rect.x += wd
         self.cb_skew.SetRect(rect)
+        rect.x += wd
+        self.combo_magnet.SetRect(rect)
         self.sizeChanged = False
 
 
@@ -1892,6 +1935,10 @@ class MeerK40t(MWindow):
         elements = self.context.elements
         valu = elements.has_emphasis()
         self.main_statusbar.cb_enabled = valu
+
+    @signal_listener("magnets")
+    def on_update_magnets(self, origin, has_magnets=False, *args):
+        self.main_statusbar.with_magnets = has_magnets
 
     def __set_titlebar(self):
         device_name = ""

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -243,7 +243,7 @@ class MeerK40tScenePanel(wx.Panel):
         if scene_name == "Scene":
             self.request_refresh()
 
-    def on_magnet(self, origin, strength=0, *args):
+    def on_magnet(self, origin, strength, *args):
         strength = int(strength)
         if strength<0:
             strength=0

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -240,10 +240,17 @@ class MeerK40tScenePanel(wx.Panel):
         if scene_name == "Scene":
             self.request_refresh()
 
+    def on_magnet(self, origin, strength=0, *args):
+        strength = int(strength)
+        if strength<0:
+            strength=0
+        self.scene.scene.magnet_attraction = strength
+
     def pane_show(self, *args):
         context = self.context
         context.listen("driver;mode", self.on_driver_mode)
         context.listen("refresh_scene", self.on_refresh_scene)
+        context.listen("magnet-attraction", self.on_magnet)
         context.listen("background", self.on_background_signal)
         context.listen("bed_size", self.bed_changed)
         context.listen("emphasized", self.on_emphasized_elements_changed)

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -78,6 +78,9 @@ class MeerK40tScenePanel(wx.Panel):
         self.widget_scene.add_scenewidget(
             ElementsWidget(self.widget_scene, LaserRender(context))
         )
+        # Let the grid resize itself
+        self.widget_scene.auto_tick = True
+
         self.widget_scene.add_scenewidget(GridWidget(self.widget_scene))
         self.widget_scene.add_interfacewidget(GuideWidget(self.widget_scene))
         self.widget_scene.add_interfacewidget(ReticleWidget(self.widget_scene))


### PR DESCRIPTION
### Grid / Ruler behaviour
Some fixes / improvements about the drawing of the grid and the rulers on the sides of the scene:

- The grid was always showing a 10x10 mm grid and was not linked to the rulers . They are now synchronised.
- The rulers tickmarks were somewhat arbitrary they are now showing more 'usual segmentation'
- If you are zooming in/out of the scene then the scale of the rulers / grid follow that zoom factor and try to provide a meaningful segmentation
- This autoscale feature can be turned off by rightclicking on the ruler area on the top / left:
![scaling](https://user-images.githubusercontent.com/2670784/161030725-5a877cdc-586d-4deb-b7ee-e1354d0a38d7.png)

### Magnet-Lines
There is a new functionality now to quickly align elements: magnet-lines. You are creating them by double-clicking on the ruler-area (and if you click on that area again then the line will be removed).
![magnets](https://user-images.githubusercontent.com/2670784/161030963-fb73907c-bdb0-47dc-b0da-b9b207025dbe.png)
Whenever you move an element (group of elements), if you move it close to a magnet line then the selection will be attracted to it: the left side, the center or the right side for a vertical magnet line, the top side, the center or the bottom side to a horizontal magnet line.
(You can overrule this behaviour if you press the shift-key while moving - then there will be no position adjustment at all).

The "Strength of the attraction" (i.e. how close does a border need to be influenced by a magnet line), can be changed on the fly by using the combobox in the statusbar just right to the regular manipulation-options):
![attraction](https://user-images.githubusercontent.com/2670784/161031054-e38d0cc6-b2d9-4407-9230-e5ca765e251b.png)

You can have as many magnet-lines as you want. You can get rid of all of them if you dbl-click on the units indicator (left top side of the screen) or if you use the context-menu on the rulers. If there weren't any magnet lines then a magnetline for every grid line will be created instead.
![magnet](https://user-images.githubusercontent.com/2670784/161031110-016eb860-7321-4a11-a074-f64effb0a589.gif)

NB: the method for creating a magnetline by double clicking on the ruler area will focus on full tickmarks (i.e. grid lines) and the middle of two adjacent grid lines. If you need something finer, then just zoom in into the scene, this will permit finer positioning of the magnet lines.


