### PR TITLE
Lock selection to laser movement

### DIFF
--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -1,4 +1,3 @@
-from wsgiref import validate
 import wx
 from wx import aui
 

--- a/meerk40t/gui/scenewidgets/laserpathwidget.py
+++ b/meerk40t/gui/scenewidgets/laserpathwidget.py
@@ -47,7 +47,9 @@ class LaserPathWidget(Widget):
         """
         context = self.scene.context
         if context.draw_mode & DRAW_MODE_LASERPATH == 0:
-            gc.SetPen(wx.BLUE_PEN)
+            mycol = wx.Colour(0x00, 0x00, 0xFF, 0x40)
+            pen = wx.Pen(mycol)
+            gc.SetPen(pen)
             starts, ends = self.laserpath
             try:
                 gc.StrokeLineSegments(starts, ends)


### PR DESCRIPTION
### Lock the selection to the laser position:
If you right click on one of the alignment buttons then the laser will move to the indicated position of the selected elements (regular click behaviour so far), but from then on the selection will remain at its relative position to the laser head, so if you move the laser then the selection will follow the movement. This behaviour ends when you either right click the same button again (laser head remains at its current position) or do a normal click of an alignment button (laser head will move).
![Locked button](https://user-images.githubusercontent.com/2670784/161376165-7f7ce6bf-5db5-4e61-9ef1-8d0cdb774180.png)
The current lock state will be indicated by highlighting the button (visually not extremely appealing but a clear indicator).
![locked_laser](https://user-images.githubusercontent.com/2670784/161376105-a17abf21-dfb3-4ea7-b175-ef7508a3a0ff.gif)

NB there might be some limits to this when it comes to manual physical movement of the laserhead.
### Laserpath appearance
Additionally the laserpath has become less obtrusive and therefore easier to distinguish from regular elements.


