### PR TITLE
User defined color (0.7)

### DIFF
--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -52,7 +52,7 @@ def str_to_color(value):
     if len(value)<=8:
         value = value + "FF" # append opacity
     result = value[:2] + value[8:] + value[6:8] + value[4:6]+ value[2:4]
-    return eval(result)
+    return int(result, base=16)
 
 class ElementsWidget(Widget):
     """

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -106,10 +106,13 @@ class SelectionWidget(Widget):
         self.last_angle = None
         self.start_angle = None
         self.elements = scene.context.elements
-        self.color_selection = None
+        self.color_border = None
+        self.color_handle = None
 
         self.selection_pen = wx.Pen()
         self.selection_pen.SetStyle(wx.PENSTYLE_DOT)
+        self.handle_pen = wx.Pen()
+        self.handle_pen.SetStyle(wx.PENSTYLE_SOLID)
         self.save_width = None
         self.save_height = None
         self.tool = self.tool_translate
@@ -125,12 +128,18 @@ class SelectionWidget(Widget):
     def set_colors(self, default=False):
         color_manipulation = "#A07FA0"
         self.scene.context.setting(str, "color_manipulation", color_manipulation)
+        self.scene.context.setting(str, "color_manipulation_handles", color_manipulation)
         if default:
             self.scene.context.color_manipulation = color_manipulation
+            self.scene.context.color_manipulation_handles = color_manipulation
         try:
-            color = wx.Colour(str_to_color(self.scene.context.color_manipulation))
-            self.selection_pen.SetColour(color)
-            self.color_selection = color
+            color1 = wx.Colour(str_to_color(self.scene.context.color_manipulation))
+            self.selection_pen.SetColour(color1)
+            self.color_border = color1
+
+            color2 = wx.Colour(str_to_color(self.scene.context.color_manipulation_handles))
+            self.handle_pen.SetColour(color2)
+            self.color_handle = color2
         except (ValueError, TypeError):
             pass
 
@@ -1200,9 +1209,8 @@ class SelectionWidget(Widget):
                         x = xx + signx * self.arcsegment[idx][0]
                         y = yy + signy * self.arcsegment[idx][1]
                         segment += [(x, y)]
-                    pen = wx.Pen(self.color_selection, 2, wx.SOLID)
+                    pen = self.handle_pen
                     pen.SetWidth(0.75 * self.selection_pen.GetWidth())
-                    pen.SetStyle(wx.PENSTYLE_SOLID)
                     gc.SetPen(pen)
                     gc.StrokeLines(segment)
 
@@ -1260,9 +1268,9 @@ class SelectionWidget(Widget):
             )  # skew y
 
         if len(corners) > 0:
-            pen = wx.Pen(self.color_selection, 1, wx.SOLID)
-            pen.SetStyle(wx.PENSTYLE_SOLID)
-            brush = wx.Brush(self.color_selection, wx.SOLID)
+
+            pen = self.handle_pen
+            brush = wx.Brush(self.color_handle, wx.SOLID)
             gc.SetPen(pen)
             gc.SetBrush(brush)
 
@@ -1313,7 +1321,7 @@ class SelectionWidget(Widget):
             except TypeError:
                 font = wx.Font(int(font_size), wx.SWISS, wx.NORMAL, wx.BOLD)
 
-            gc.SetFont(font, self.color_selection)
+            gc.SetFont(font, self.color_border)
             gc.SetPen(self.selection_pen)
             x0, y0, x1, y1 = bounds
             center_x = (x0 + x1) / 2.0

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -117,7 +117,7 @@ class SelectionWidget(Widget):
         self.elements = scene.context.elements
         # Make sure selection color is a setting
         self.color_selection = LINECOL_DEFAULT
-        scene.context.setting("str", "color_selection_rect", color_to_str(self.color_selection.GetRGBA()))
+        scene.context.setting(str, "color_selection_rect", color_to_str(self.color_selection.GetRGBA()))
         # print("Default-Value for Color %s" % scene.context.color_selection_rect)
         try:
             self.color_selection.SetRGB(str_to_color(scene.context.color_selection_rect))
@@ -1899,8 +1899,8 @@ class GridWidget(Widget):
         self.background = None
         self.col_default = wx.Colour(0xA0, 0xA0, 0xA0)
         self.color_grid = self.col_default
-        scene.context.setting("str", "color_grid_line", color_to_str(self.color_grid.GetRGBA()))
-        # print("Default-Value for Color %s" % scene.context.color_grid_rect)
+        scene.context.setting(str, "color_grid_line", color_to_str(self.color_grid.GetRGBA()))
+        # print("Default-Value for Color %s" % scene.context.color_grid_line)
         try:
             self.color_grid.SetRGB(str_to_color(scene.context.color_grid_line))
         except (ValueError, TypeError):

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -117,15 +117,15 @@ class SelectionWidget(Widget):
         self.elements = scene.context.elements
         # Make sure selection color is a setting
         self.color_selection = LINECOL_DEFAULT
-        scene.context.setting(str, "color_selection_rect", color_to_str(self.color_selection.GetRGBA()))
-        # print("Default-Value for Color %s" % scene.context.color_selection_rect)
+        scene.context.setting(str, "color_manipulation", color_to_str(self.color_selection.GetRGBA()))
+        # print("Default-Value for Color %s" % scene.context.color_manipulation)
         try:
-            self.color_selection.SetRGB(str_to_color(scene.context.color_selection_rect))
+            self.color_selection.SetRGB(str_to_color(scene.context.color_manipulation))
         except (ValueError, TypeError):
             self.color_selection = None
         if self.color_selection is None:
             self.color_selection = LINECOL_DEFAULT
-            scene.context.color_selection_rect = color_to_str(self.color_selection.GetRGBA())
+            scene.context.color_manipulation = color_to_str(self.color_selection.GetRGBA())
 
         self.selection_pen = wx.Pen()
         self.selection_pen.SetColour(self.color_selection)
@@ -1280,7 +1280,7 @@ class SelectionWidget(Widget):
         draw_mode = context.draw_mode
         elements = self.scene.context.elements
         try:
-            self.color_selection.SetRGBA(str_to_color(context.color_selection_rect))
+            self.color_selection.SetRGBA(str_to_color(context.color_manipulation))
         except (ValueError, TypeError):
             self.color_selection = LINECOL_DEFAULT
 
@@ -1899,15 +1899,15 @@ class GridWidget(Widget):
         self.background = None
         self.col_default = wx.Colour(0xA0, 0xA0, 0xA0)
         self.color_grid = self.col_default
-        scene.context.setting(str, "color_grid_line", color_to_str(self.color_grid.GetRGBA()))
-        # print("Default-Value for Color %s" % scene.context.color_grid_line)
+        scene.context.setting(str, "color_grid", color_to_str(self.color_grid.GetRGBA()))
+        # print("Default-Value for Color %s" % scene.context.color_grid)
         try:
-            self.color_grid.SetRGB(str_to_color(scene.context.color_grid_line))
+            self.color_grid.SetRGB(str_to_color(scene.context.color_grid))
         except (ValueError, TypeError):
             self.color_grid = None
         if self.color_grid is None:
             self.color_grid = self.col_default
-            scene.context.color_grid_line = color_to_str(self.color_grid.GetRGBA())
+            scene.context.color_grid = color_to_str(self.color_grid.GetRGBA())
 
         self.grid_line_pen = wx.Pen()
         self.grid_line_pen.SetColour(self.color_grid)
@@ -1979,7 +1979,7 @@ class GridWidget(Widget):
         """
         context = self.scene.context
         try:
-            self.color_grid.SetRGB(str_to_color(context.color_grid_line))
+            self.color_grid.SetRGB(str_to_color(context.color_grid))
         except (ValueError, TypeError):
             self.color_grid = self.col_default
         self.grid_line_pen.SetColour(self.color_grid)


### PR DESCRIPTION
Subset of [PR#977](https://github.com/meerk40t/meerk40t/pull/977) - limited to manipulation and grid color:

Syntax: you can specifiy the colour for an element by providing a color_code for it (hex representation in the format: 0xRRGGBBAA with RR the 2-digit hexvalue for the red component, GG for the green component, BB for the blue component and AA for the transparency (00 invisible to FF fully opaque))

```
set color_xxxx 0xRRGGBBAA
```
The following elements can be user-colored:
- color_manipulation - The manipulation rectangle plus modification elements
- color_grid - Grid-Lines