### PR TITLE
Make Scene colors configurable

### DIFF
--- a/meerk40t/gui/scene/guicolors.py
+++ b/meerk40t/gui/scene/guicolors.py
@@ -20,50 +20,50 @@ class GuiColors():
     '''
     def __init__(self, context):
         self.context = context
-        self.default_color = (
-            wx.Colour(0xA0, 0x7F, 0xA0),
-            wx.Colour(0x00, 0x00, 0xFF, 0x40),
-            wx.Colour(0xA0, 0xA0, 0xA0, 128),
-            wx.Colour(0x00, 0x00, 0x00),
-            wx.Colour("Grey"),
-            wx.Colour(0xFF, 0xA0, 0xA0, 0x60),
-            wx.Colour(0xA0, 0xA0, 0xA0, 0x40),
-            wx.Colour(0x00, 0xFF, 0x00, 0xA0),
-            wx.Colour(0xFF, 0x00, 0x00),
-            wx.Colour(0x00, 0xFF, 0x00),
-            wx.Colour(0x00, 0x00, 0xFF),
-            wx.Colour(0xFF, 0xFF, 0xFF)
-        )
+        self.default_color = {
+            "manipulation": wx.Colour(0xA0, 0x7F, 0xA0),
+            "laserpath": wx.Colour(0x00, 0x00, 0xFF, 0x40),
+            "grid": wx.Colour(0xA0, 0xA0, 0xA0, 128),
+            "guide": wx.Colour(0x00, 0x00, 0x00),
+            "background": wx.Colour("Grey"),
+            "magnetline": wx.Colour(0xFF, 0xA0, 0xA0, 0x60),
+            "snap_visible": wx.Colour(0xA0, 0xA0, 0xA0, 0x40),
+            "snap_closeup": wx.Colour(0x00, 0xFF, 0x00, 0xA0),
+            "selection1": wx.Colour(0xFF, 0x00, 0x00),
+            "selection2": wx.Colour(0x00, 0xFF, 0x00),
+            "selection3": wx.Colour(0x00, 0x00, 0xFF),
+            "bed": wx.Colour(0xFF, 0xFF, 0xFF)
+        }
 
-        self.context.setting(str, "color_manipulation", color_to_str(self.default_color[0].GetRGBA()))
-        self.context.setting(str, "color_laserpath", color_to_str(self.default_color[1].GetRGBA()))
-        self.context.setting(str, "color_grid", color_to_str(self.default_color[2].GetRGBA()))
-        self.context.setting(str, "color_guide", color_to_str(self.default_color[3].GetRGBA()))
-        self.context.setting(str, "color_background", color_to_str(self.default_color[4].GetRGBA()))
-        self.context.setting(str, "color_magnetline", color_to_str(self.default_color[5].GetRGBA()))
-        self.context.setting(str, "color_snap_visible", color_to_str(self.default_color[6].GetRGBA()))
-        self.context.setting(str, "color_snap_closeup", color_to_str(self.default_color[7].GetRGBA()))
-        self.context.setting(str, "color_selection1", color_to_str(self.default_color[8].GetRGBA()))
-        self.context.setting(str, "color_selection2", color_to_str(self.default_color[9].GetRGBA()))
-        self.context.setting(str, "color_selection3", color_to_str(self.default_color[10].GetRGBA()))
-        self.context.setting(str, "color_bed", color_to_str(self.default_color[11].GetRGBA()))
+        self.context.setting(str, "color_manipulation", color_to_str(self.default_color["manipulation"].GetRGBA()))
+        self.context.setting(str, "color_laserpath", color_to_str(self.default_color["laserpath"].GetRGBA()))
+        self.context.setting(str, "color_grid", color_to_str(self.default_color["grid"].GetRGBA()))
+        self.context.setting(str, "color_guide", color_to_str(self.default_color["guide"].GetRGBA()))
+        self.context.setting(str, "color_background", color_to_str(self.default_color["background"].GetRGBA()))
+        self.context.setting(str, "color_magnetline", color_to_str(self.default_color["magnetline"].GetRGBA()))
+        self.context.setting(str, "color_snap_visible", color_to_str(self.default_color["snap_visible"].GetRGBA()))
+        self.context.setting(str, "color_snap_closeup", color_to_str(self.default_color["snap_closeup"].GetRGBA()))
+        self.context.setting(str, "color_selection1", color_to_str(self.default_color["selection1"].GetRGBA()))
+        self.context.setting(str, "color_selection2", color_to_str(self.default_color["selection2"].GetRGBA()))
+        self.context.setting(str, "color_selection3", color_to_str(self.default_color["selection3"].GetRGBA()))
+        self.context.setting(str, "color_bed", color_to_str(self.default_color["bed"].GetRGBA()))
 
     def set_default_colors(self):
         '''
         Reset all colors to default values...
         '''
-        self.context("set color_manipulation %s" % color_to_str(self.default_color[0].GetRGBA()))
-        self.context("set color_laserpath %s" % color_to_str(self.default_color[1].GetRGBA()))
-        self.context("set color_grid %s" % color_to_str(self.default_color[2].GetRGBA()))
-        self.context("set color_guide %s" % color_to_str(self.default_color[3].GetRGBA()))
-        self.context("set color_background %s" % color_to_str(self.default_color[4].GetRGBA()))
-        self.context("set color_magnetline %s" % color_to_str(self.default_color[5].GetRGBA()))
-        self.context("set color_snap_visible %s" % color_to_str(self.default_color[6].GetRGBA()))
-        self.context("set color_snap_closeup %s" % color_to_str(self.default_color[7].GetRGBA()))
-        self.context("set color_selection1 %s" % color_to_str(self.default_color[8].GetRGBA()))
-        self.context("set color_selection2 %s" % color_to_str(self.default_color[9].GetRGBA()))
-        self.context("set color_selection3 %s" % color_to_str(self.default_color[10].GetRGBA()))
-        self.context("set color_bed %s" % color_to_str(self.default_color[11].GetRGBA()))
+        self.context.color_manipulation = color_to_str(self.default_color["manipulation"].GetRGBA())
+        self.context.color_laserpath = color_to_str(self.default_color["laserpath"].GetRGBA())
+        self.context.color_grid = color_to_str(self.default_color["grid"].GetRGBA())
+        self.context.color_guide = color_to_str(self.default_color["guide"].GetRGBA())
+        self.context.color_background = color_to_str(self.default_color["background"].GetRGBA())
+        self.context.color_magnetline = color_to_str(self.default_color["magnetline"].GetRGBA())
+        self.context.color_snap_visible = color_to_str(self.default_color["snap_visible"].GetRGBA())
+        self.context.color_snap_closeup = color_to_str(self.default_color["snap_closeup"].GetRGBA())
+        self.context.color_selection1 = color_to_str(self.default_color["selection1"].GetRGBA())
+        self.context.color_selection2 = color_to_str(self.default_color["selection2"].GetRGBA())
+        self.context.color_selection3 = color_to_str(self.default_color["selection3"].GetRGBA())
+        self.context.color_bed = color_to_str(self.default_color["bed"].GetRGBA())
 
     @property
     def color_manipulation(self):
@@ -71,7 +71,8 @@ class GuiColors():
             value = str_to_color(self.context.color_manipulation)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[0].GetRGBA())
+            result = wx.Colour(self.default_color["manipulation"].GetRGBA())
+            self.context.color_manipulation = color_to_str(self.default_color["manipulation"].GetRGBA())
         return result
 
     @property
@@ -80,7 +81,8 @@ class GuiColors():
             value = str_to_color(self.context.color_laserpath)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[1].GetRGBA())
+            result = wx.Colour(self.default_color["laserpath"].GetRGBA())
+            self.context.color_laserpath = color_to_str(self.default_color["laserpath"].GetRGBA())
         return result
 
     @property
@@ -89,7 +91,8 @@ class GuiColors():
             value = str_to_color(self.context.color_grid)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[2].GetRGBA())
+            result = wx.Colour(self.default_color["grid"].GetRGBA())
+            self.context.color_grid = color_to_str(self.default_color["grid"].GetRGBA())
         return result
 
     @property
@@ -98,7 +101,8 @@ class GuiColors():
             value = str_to_color(self.context.color_guide)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[3].GetRGBA())
+            result = wx.Colour(self.default_color["guide"].GetRGBA())
+            self.context.color_guide = color_to_str(self.default_color["guide"].GetRGBA())
         return result
 
     @property
@@ -107,7 +111,8 @@ class GuiColors():
             value = str_to_color(self.context.color_background)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[4].GetRGBA())
+            result = wx.Colour(self.default_color["background"].GetRGBA())
+            self.context.color_background = color_to_str(self.default_color["background"].GetRGBA())
         return result
 
     @property
@@ -116,7 +121,8 @@ class GuiColors():
             value = str_to_color(self.context.color_magnetline)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[5].GetRGBA())
+            result = wx.Colour(self.default_color["magnetline"].GetRGBA())
+            self.context.color_magnetline = color_to_str(self.default_color["magnetline"].GetRGBA())
         return result
 
     @property
@@ -125,7 +131,8 @@ class GuiColors():
             value = str_to_color(self.context.color_snap_visible)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[6].GetRGBA())
+            result = wx.Colour(self.default_color["snap_visible"].GetRGBA())
+            self.context.color_snap_visible = color_to_str(self.default_color["snap_visible"].GetRGBA())
         return result
 
     @property
@@ -134,7 +141,8 @@ class GuiColors():
             value = str_to_color(self.context.color_snap_closeup)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[7].GetRGBA())
+            result = wx.Colour(self.default_color["snap_closeup"].GetRGBA())
+            self.context.color_snap_closeup = color_to_str(self.default_color["snap_closeup"].GetRGBA())
         return result
 
     @property
@@ -143,7 +151,8 @@ class GuiColors():
             value = str_to_color(self.context.color_selection1)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[8].GetRGBA())
+            result = wx.Colour(self.default_color["selection1"].GetRGBA())
+            self.context.color_selection1 = color_to_str(self.default_color["selection1"].GetRGBA())
         return result
 
     @property
@@ -152,7 +161,8 @@ class GuiColors():
             value = str_to_color(self.context.color_selection2)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[9].GetRGBA())
+            result = wx.Colour(self.default_color["selection2"].GetRGBA())
+            self.context.color_selection2 = color_to_str(self.default_color["selection2"].GetRGBA())
         return result
 
     @property
@@ -161,7 +171,8 @@ class GuiColors():
             value = str_to_color(self.context.color_selection3)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[10].GetRGBA())
+            result = wx.Colour(self.default_color["selection3"].GetRGBA())
+            self.context.color_selection3 = color_to_str(self.default_color["selection3"].GetRGBA())
         return result
 
     @property
@@ -170,5 +181,6 @@ class GuiColors():
             value = str_to_color(self.context.color_bed)
             result = wx.Colour(value)
         except (ValueError, TypeError):
-            result = wx.Colour(self.default_color[11].GetRGBA())
+            result = wx.Colour(self.default_color["bed"].GetRGBA())
+            self.context.color_bed = color_to_str(self.default_color["bed"].GetRGBA())
         return result

--- a/meerk40t/gui/scene/guicolors.py
+++ b/meerk40t/gui/scene/guicolors.py
@@ -1,0 +1,174 @@
+import wx
+
+def color_to_str(value):
+    temp = hex(value)
+    # The representation is backwards ABGR --> change
+    result = temp[:2] + temp[8:] + temp[6:8] + temp[4:6]+ temp[2:4]
+    # print("c2s from %s = %s" % (hex(value), result))
+    return result
+
+def str_to_color(value):
+    # The representation needs to be ABGR --> change
+    if len(value)<=8:
+        value = value + "FF" # append opacity
+    result = value[:2] + value[8:] + value[6:8] + value[4:6]+ value[2:4]
+    return int(result, base=16)
+
+class GuiColors():
+    '''
+    Provides and stores all relevant colors for a scene
+    '''
+    def __init__(self, context):
+        self.context = context
+        self.default_color = (
+            wx.Colour(0xA0, 0x7F, 0xA0),
+            wx.Colour(0x00, 0x00, 0xFF, 0x40),
+            wx.Colour(0xA0, 0xA0, 0xA0, 128),
+            wx.Colour(0x00, 0x00, 0x00),
+            wx.Colour("Grey"),
+            wx.Colour(0xFF, 0xA0, 0xA0, 0x60),
+            wx.Colour(0xA0, 0xA0, 0xA0, 0x40),
+            wx.Colour(0x00, 0xFF, 0x00, 0xA0),
+            wx.Colour(0xFF, 0x00, 0x00),
+            wx.Colour(0x00, 0xFF, 0x00),
+            wx.Colour(0x00, 0x00, 0xFF),
+            wx.Colour(0xFF, 0xFF, 0xFF)
+        )
+
+        self.context.setting(str, "color_manipulation", color_to_str(self.default_color[0].GetRGBA()))
+        self.context.setting(str, "color_laserpath", color_to_str(self.default_color[1].GetRGBA()))
+        self.context.setting(str, "color_grid", color_to_str(self.default_color[2].GetRGBA()))
+        self.context.setting(str, "color_guide", color_to_str(self.default_color[3].GetRGBA()))
+        self.context.setting(str, "color_background", color_to_str(self.default_color[4].GetRGBA()))
+        self.context.setting(str, "color_magnetline", color_to_str(self.default_color[5].GetRGBA()))
+        self.context.setting(str, "color_snap_visible", color_to_str(self.default_color[6].GetRGBA()))
+        self.context.setting(str, "color_snap_closeup", color_to_str(self.default_color[7].GetRGBA()))
+        self.context.setting(str, "color_selection1", color_to_str(self.default_color[8].GetRGBA()))
+        self.context.setting(str, "color_selection2", color_to_str(self.default_color[9].GetRGBA()))
+        self.context.setting(str, "color_selection3", color_to_str(self.default_color[10].GetRGBA()))
+        self.context.setting(str, "color_bed", color_to_str(self.default_color[11].GetRGBA()))
+
+    def set_default_colors(self):
+        '''
+        Reset all colors to default values...
+        '''
+        self.context("set color_manipulation %s" % color_to_str(self.default_color[0].GetRGBA()))
+        self.context("set color_laserpath %s" % color_to_str(self.default_color[1].GetRGBA()))
+        self.context("set color_grid %s" % color_to_str(self.default_color[2].GetRGBA()))
+        self.context("set color_guide %s" % color_to_str(self.default_color[3].GetRGBA()))
+        self.context("set color_background %s" % color_to_str(self.default_color[4].GetRGBA()))
+        self.context("set color_magnetline %s" % color_to_str(self.default_color[5].GetRGBA()))
+        self.context("set color_snap_visible %s" % color_to_str(self.default_color[6].GetRGBA()))
+        self.context("set color_snap_closeup %s" % color_to_str(self.default_color[7].GetRGBA()))
+        self.context("set color_selection1 %s" % color_to_str(self.default_color[8].GetRGBA()))
+        self.context("set color_selection2 %s" % color_to_str(self.default_color[9].GetRGBA()))
+        self.context("set color_selection3 %s" % color_to_str(self.default_color[10].GetRGBA()))
+        self.context("set color_bed %s" % color_to_str(self.default_color[11].GetRGBA()))
+
+    @property
+    def color_manipulation(self):
+        try:
+            value = str_to_color(self.context.color_manipulation)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[0].GetRGBA())
+        return result
+
+    @property
+    def color_laserpath(self):
+        try:
+            value = str_to_color(self.context.color_laserpath)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[1].GetRGBA())
+        return result
+
+    @property
+    def color_grid(self):
+        try:
+            value = str_to_color(self.context.color_grid)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[2].GetRGBA())
+        return result
+
+    @property
+    def color_guide(self):
+        try:
+            value = str_to_color(self.context.color_guide)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[3].GetRGBA())
+        return result
+
+    @property
+    def color_background(self):
+        try:
+            value = str_to_color(self.context.color_background)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[4].GetRGBA())
+        return result
+
+    @property
+    def color_magnetline(self):
+        try:
+            value = str_to_color(self.context.color_magnetline)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[5].GetRGBA())
+        return result
+
+    @property
+    def color_snap_visible(self):
+        try:
+            value = str_to_color(self.context.color_snap_visible)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[6].GetRGBA())
+        return result
+
+    @property
+    def color_snap_closeup(self):
+        try:
+            value = str_to_color(self.context.color_snap_closeup)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[7].GetRGBA())
+        return result
+
+    @property
+    def color_selection1(self):
+        try:
+            value = str_to_color(self.context.color_selection1)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[8].GetRGBA())
+        return result
+
+    @property
+    def color_selection2(self):
+        try:
+            value = str_to_color(self.context.color_selection2)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[9].GetRGBA())
+        return result
+
+    @property
+    def color_selection3(self):
+        try:
+            value = str_to_color(self.context.color_selection3)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[10].GetRGBA())
+        return result
+
+    @property
+    def color_bed(self):
+        try:
+            value = str_to_color(self.context.color_bed)
+            result = wx.Colour(value)
+        except (ValueError, TypeError):
+            result = wx.Colour(self.default_color[11].GetRGBA())
+        return result

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -30,6 +30,7 @@ from meerk40t.gui.zmatrix import ZMatrix
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point, Viewbox, Polygon, Circle, Ellipse, Arc
 from meerk40t.core.units import Length
+from meerk40t.gui.scene.guicolors import GuiColors
 
 # TODO: _buffer can be updated partially rather than fully rewritten, especially with some layering.
 
@@ -75,8 +76,10 @@ class Scene(Module, Job):
         self.attraction_points = []  # Clear all
         self.compute = True
 
+        self.colors = GuiColors(self.context)
+
         self.screen_refresh_is_requested = True
-        self.background_brush = wx.Brush("Grey")
+        self.background_brush = wx.Brush(self.colors.color_background)
         self.magnet_x = []
         self.magnet_y = []
         self.magnet_attraction = 2
@@ -303,6 +306,7 @@ class Scene(Module, Job):
             buf = self.gui._Buffer
         dc = wx.MemoryDC()
         dc.SelectObject(buf)
+        self.background_brush.SetColour(self.colors.color_background)
         dc.SetBackground(self.background_brush)
         dc.Clear()
         w, h = dc.Size

--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -24,9 +24,9 @@ class AttractionWidget(Widget):
         self.grid_points = None # Clear all
         self.my_x = None
         self.my_y = None
-        self.visible_pen = wx.Pen(wx.Colour(0xA0, 0xA0, 0xA0, 0x40))
+        self.visible_pen = wx.Pen(self.scene.colors.color_snap_visible)
         self.visible_pen.SetWidth(1)
-        self.closeup_pen = wx.Pen(wx.Colour(0x00, 0xFF, 0x00, 0xA0))
+        self.closeup_pen = wx.Pen(self.scene.colors.color_snap_closeup)
         self.closeup_pen.SetWidth(1)
         self.symbol_size = 1  # Will be replaced anyway
         self.display_points = []
@@ -211,6 +211,8 @@ class AttractionWidget(Widget):
         Draw all attraction points on the scene.
         """
         if self.show_snap_points:
+            self.visible_pen.SetColour(self.scene.colors.color_snap_visible)
+            self.closeup_pen.SetColour(self.scene.colors.color_snap_closeup)
             matrix = self.parent.matrix
             try:
                 # Intentionally big to clearly see shape

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -16,7 +16,7 @@ class GridWidget(Widget):
         self.grid = None
         self.background = None
         self.grid_line_pen = wx.Pen()
-        self.grid_line_pen.SetColour(wx.Colour(0xA0, 0xA0, 0xA0, 128))
+        self.grid_line_pen.SetColour(self.scene.colors.color_grid)
         self.grid_line_pen.SetWidth(1)
         self.last_ticksize = 0
 
@@ -138,6 +138,7 @@ class GridWidget(Widget):
         Draw the grid on the scene.
         """
         # print ("GridWidget draw")
+        self.grid_line_pen.SetColour(self.scene.colors.color_grid)
 
         if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
             context = self.scene.context
@@ -145,7 +146,8 @@ class GridWidget(Widget):
             unit_height = context.device.unit_height
             background = self.background
             if background is None:
-                gc.SetBrush(wx.WHITE_BRUSH)
+                brush = wx.Brush(colour=self.scene.colors.color_bed, style=wx.BRUSHSTYLE_SOLID)
+                gc.SetBrush(brush)
                 gc.DrawRectangle(0, 0, unit_width, unit_height)
             elif isinstance(background, int):
                 gc.SetBrush(wx.Brush(wx.Colour(swizzlecolor(background))))

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -395,7 +395,8 @@ class GuideWidget(Widget):
         if self.scene.context.draw_mode & DRAW_MODE_GUIDES != 0:
             return
         # print ("GuideWidget Draw")
-        gc.SetPen(wx.BLACK_PEN)
+        pen = wx.Pen(self.scene.colors.color_guide)
+        gc.SetPen(pen)
         w, h = gc.Size
         p = self.scene.context
         self.scaled_conversion = (
@@ -429,7 +430,7 @@ class GuideWidget(Widget):
         length = self.line_length
         edge_gap = self.edge_gap
         font = wx.Font(10, wx.SWISS, wx.NORMAL, wx.BOLD)
-        gc.SetFont(font, wx.BLACK)
+        gc.SetFont(font, self.scene.colors.color_guide)
         gc.DrawText(self.units, edge_gap, edge_gap)
         (t_width, t_height) = gc.GetTextExtent("0")
         while x < w:
@@ -498,7 +499,7 @@ class GuideWidget(Widget):
             ends_hi.append((w - length - edge_gap, sy))
 
         grid_line_high_pen = wx.Pen()
-        grid_line_high_pen.SetColour(wx.Colour(0xFF, 0xA0, 0xA0, 0x60))  # With alpha
+        grid_line_high_pen.SetColour(self.scene.colors.color_magnetline)
         grid_line_high_pen.SetWidth(2)
 
         gc.SetPen(grid_line_high_pen)

--- a/meerk40t/gui/scenewidgets/laserpathwidget.py
+++ b/meerk40t/gui/scenewidgets/laserpathwidget.py
@@ -47,7 +47,7 @@ class LaserPathWidget(Widget):
         """
         context = self.scene.context
         if context.draw_mode & DRAW_MODE_LASERPATH == 0:
-            mycol = wx.Colour(0x00, 0x00, 0xFF, 0x40)
+            mycol = self.scene.colors.color_laserpath
             pen = wx.Pen(mycol)
             gc.SetPen(pen)
             starts, ends = self.laserpath

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -20,24 +20,6 @@ class RectSelectWidget(Widget):
     SELECTION_TOUCH = 1
     SELECTION_CROSS = 2
     SELECTION_ENCLOSE = 3
-    # Color for selection rectangle (hit, cross, enclose)
-    selection_style = [
-        (
-            wx.RED,
-            wx.PENSTYLE_DOT_DASH,
-            "Select all elements the selection rectangle touches.",
-        ),
-        (
-            wx.GREEN,
-            wx.PENSTYLE_DOT,
-            "Select all elements the selection rectangle crosses.",
-        ),
-        (
-            wx.BLUE,
-            wx.PENSTYLE_SHORT_DASH,
-            "Select all elements the selection rectangle encloses.",
-        ),
-    ]
     selection_text_shift = " Previously selected remain selected!"
     selection_text_control = " Invert selection state of elements!"
 
@@ -59,6 +41,24 @@ class RectSelectWidget(Widget):
 
     def __init__(self, scene):
         Widget.__init__(self, scene, all=True)
+        # Color for selection rectangle (hit, cross, enclose)
+        self.selection_style = [
+            [
+                self.scene.colors.color_selection1,
+                wx.PENSTYLE_DOT_DASH,
+                "Select all elements the selection rectangle touches.",
+            ],
+            [
+                self.scene.colors.color_selection2,
+                wx.PENSTYLE_DOT,
+                "Select all elements the selection rectangle crosses.",
+            ],
+            [
+                self.scene.colors.color_selection3,
+                wx.PENSTYLE_SHORT_DASH,
+                "Select all elements the selection rectangle encloses.",
+            ],
+        ]
         self.selection_pen = wx.Pen()
         self.selection_pen.SetColour(self.selection_style[0][0])
         self.selection_pen.SetWidth(25)
@@ -326,6 +326,9 @@ class RectSelectWidget(Widget):
         Draw the selection rectangle
         """
         if self.start_location is not None and self.end_location is not None:
+            self.selection_style[0][0] = self.scene.colors.color_selection1
+            self.selection_style[1][0] = self.scene.colors.color_selection2
+            self.selection_style[2][0] = self.scene.colors.color_selection3
             x0 = self.start_location[0]
             y0 = self.start_location[1]
             x1 = self.end_location[0]

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -15,9 +15,6 @@ from meerk40t.gui.wxutils import create_menu_for_node
 
 from meerk40t.svgelements import Rect, Point
 
-TEXT_COLOR = wx.Colour(0xA0, 0x7F, 0xA0)
-LINE_COLOR = wx.Colour(0x7F, 0x7F, 0x7F)
-
 
 def process_event(
     widget,
@@ -227,7 +224,7 @@ class BorderWidget(Widget):
                 font = wx.Font(self.master.font_size, wx.SWISS, wx.NORMAL, wx.BOLD)
             except TypeError:
                 font = wx.Font(int(self.master.font_size), wx.SWISS, wx.NORMAL, wx.BOLD)
-            gc.SetFont(font, TEXT_COLOR)
+            gc.SetFont(font, self.scene.colors.color_manipulation)
             gc.DrawText(
                 str(Length(amount=self.top, digits=3, preferred_units=units)),
                 center_x,
@@ -266,10 +263,10 @@ class BorderWidget(Widget):
                 font = wx.Font(
                     int(0.75 * self.master.font_size), wx.SWISS, wx.NORMAL, wx.BOLD
                 )
-            gc.SetFont(font, LINE_COLOR)
+            gc.SetFont(font, self.scene.colors.color_manipulation)
             symbol = "%.0f°" % (360 * self.master.rotated_angle / math.tau)
             pen = wx.Pen()
-            pen.SetColour(LINE_COLOR)
+            pen.SetColour(self.scene.colors.color_manipulation)
             pen.SetStyle(wx.PENSTYLE_SOLID)
             gc.SetPen(pen)
             brush = wx.Brush(wx.WHITE, wx.SOLID)
@@ -343,7 +340,7 @@ class RotationWidget(Widget):
         if self.master.tool_running:  # We don't need that overhead
             return
         pen = wx.Pen()
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(0.75 * self.master.line_width)
         except TypeError:
@@ -643,9 +640,9 @@ class CornerWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        brush = wx.Brush(LINE_COLOR, wx.SOLID)
+        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
         pen = wx.Pen()
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(self.master.line_width)
         except TypeError:
@@ -824,9 +821,9 @@ class SideWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        brush = wx.Brush(LINE_COLOR, wx.SOLID)
+        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
         pen = wx.Pen()
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(self.master.line_width)
         except TypeError:
@@ -970,14 +967,14 @@ class SkewWidget(Widget):
 
         self.update()  # make sure coords are valid
         pen = wx.Pen()
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(self.master.line_width)
         except TypeError:
             pen.SetWidth(int(self.master.line_width))
         pen.SetStyle(wx.PENSTYLE_SOLID)
         gc.SetPen(pen)
-        brush = wx.Brush(LINE_COLOR, wx.SOLID)
+        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
         gc.SetBrush(brush)
         gc.DrawRectangle(self.left, self.top, self.width, self.height)
 
@@ -1119,14 +1116,14 @@ class MoveWidget(Widget):
 
         self.update()  # make sure coords are valid
         pen = wx.Pen()
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(self.master.line_width)
         except TypeError:
             pen.SetWidth(int(self.master.line_width))
         pen.SetStyle(wx.PENSTYLE_SOLID)
         gc.SetPen(pen)
-        brush = wx.Brush(LINE_COLOR, wx.SOLID)
+        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
         gc.SetBrush(brush)
         gc.DrawRectangle(
             self.left + self.half_x - self.drawhalf,
@@ -1243,7 +1240,7 @@ class MoveRotationOriginWidget(Widget):
         self.update()  # make sure coords are valid
         pen = wx.Pen()
         # pen.SetColour(wx.RED)
-        pen.SetColour(LINE_COLOR)
+        pen.SetColour(self.scene.colors.color_manipulation)
         try:
             pen.SetWidth(0.75 * self.master.line_width)
         except TypeError:
@@ -1330,7 +1327,7 @@ class ReferenceWidget(Widget):
             bgcol = wx.YELLOW
             fgcol = wx.RED
         else:
-            bgcol = LINE_COLOR
+            bgcol = self.scene.colors.color_manipulation
             fgcol = wx.BLACK
         pen.SetColour(bgcol)
         try:
@@ -1573,7 +1570,7 @@ class SelectionWidget(Widget):
     def __init__(self, scene):
         Widget.__init__(self, scene, all=False)
         self.selection_pen = wx.Pen()
-        self.selection_pen.SetColour(LINE_COLOR)
+        self.selection_pen.SetColour(self.scene.colors.color_manipulation)
         self.selection_pen.SetStyle(wx.PENSTYLE_DOT)
         self.popupID1 = None
         self.popupID2 = None
@@ -1936,7 +1933,7 @@ class SelectionWidget(Widget):
                 font = wx.Font(self.font_size, wx.SWISS, wx.NORMAL, wx.BOLD)
             except TypeError:
                 font = wx.Font(int(self.font_size), wx.SWISS, wx.NORMAL, wx.BOLD)
-            gc.SetFont(font, TEXT_COLOR)
+            gc.SetFont(font, self.scene.colors.color_manipulation)
             gc.SetPen(self.selection_pen)
             self.left = bounds[0]
             self.top = bounds[1]

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -45,7 +45,8 @@ from .icons import (
     icons_centerize,
     icons_evenspace_horiz,
     icons_evenspace_vert,
-
+    icons8_rotate_left_50,
+    icons8_rotate_right_50,
 )
 from .laserrender import (
     DRAW_MODE_ALPHABLACK,
@@ -554,7 +555,26 @@ class MeerK40t(MWindow):
                 "size": buttonsize
             },
         )
-
+        kernel.register(
+            "button/modify/Rotate90CW",
+            {
+                "label": _("Rotate CW"),
+                "icon": icons8_rotate_right_50,
+                "tip": _("Rotate the selected element clockwise by 90 deg"),
+                "action": lambda v: kernel.elements("rotate 90deg\n"),
+                "size": buttonsize
+            },
+        )
+        kernel.register(
+            "button/modify/Rotate90CCW",
+            {
+                "label": _("Rotate CCW"),
+                "icon": icons8_rotate_left_50,
+                "tip": _("Rotate the selected element counterclockwise by 90 deg"),
+                "action": lambda v: kernel.elements("rotate -90deg\n"),
+                "size": buttonsize
+            },
+        )
         kernel.register(
             "button/geometry/Union",
             {

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -53,7 +53,8 @@ class RibbonPanel(wx.Panel):
             | RB.RIBBON_BAR_SHOW_PAGE_LABELS
             | RB.RIBBON_BAR_SHOW_PANEL_EXT_BUTTONS
             | RB.RIBBON_BAR_SHOW_TOGGLE_BUTTON
-            | RB.RIBBON_BAR_SHOW_HELP_BUTTON,
+            | RB.RIBBON_BAR_SHOW_HELP_BUTTON
+            | RB.RIBBON_BAR_SHOW_PANEL_MINIMISE_BUTTONS,
         )
         self.__set_ribbonbar()
 
@@ -295,6 +296,7 @@ class RibbonPanel(wx.Panel):
             wx.ID_ANY,
             "" if self.is_dark else _("Modification"),
             icons8_opened_folder_50.GetBitmap(),
+            style = RB.RIBBON_PANEL_MINIMISE_BUTTON,
             # style=RB.RIBBON_PANEL_NO_AUTO_MINIMISE,
         )
         button_bar = RB.RibbonButtonBar(self.modify_panel)
@@ -305,7 +307,8 @@ class RibbonPanel(wx.Panel):
             wx.ID_ANY,
             "" if self.is_dark else _("Geometry"),
             icons8_opened_folder_50.GetBitmap(),
-            style=RB.RIBBON_PANEL_NO_AUTO_MINIMISE,
+            style = RB.RIBBON_PANEL_MINIMISE_BUTTON,
+            # style=RB.RIBBON_PANEL_NO_AUTO_MINIMISE,
         )
         button_bar = RB.RibbonButtonBar(self.geometry_panel)
         self.geometry_button_bar = button_bar
@@ -315,6 +318,7 @@ class RibbonPanel(wx.Panel):
             wx.ID_ANY,
             "" if self.is_dark else _("Alignment"),
             icons8_opened_folder_50.GetBitmap(),
+            style = RB.RIBBON_PANEL_MINIMISE_BUTTON,
             # style=RB.RIBBON_PANEL_NO_AUTO_MINIMISE,
         )
         button_bar = RB.RibbonButtonBar(self.align_panel)

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -234,6 +234,11 @@ class MeerK40tScenePanel(wx.Panel):
             channel(str(data.matrix))
             return "scene", data
 
+        @context.console_command("colors_reset", hidden=True)
+        def reset_colors(**kwargs):
+            self.widget_scene.colors.set_default_colors()
+            self.request_refresh()
+
     @signal_listener("refresh_scene")
     def on_refresh_scene(self, origin, scene_name=None, *args):
         """


### PR DESCRIPTION
Nearly all colors used in the scene by different gui elements are now configurable:
![Colorful scene](https://user-images.githubusercontent.com/2670784/162631043-4fddf5ee-5020-4cd5-82e0-ded7e21fa776.png)

Syntax: you can specifiy the colour for an element by providing a color_code for it (hex representation in the format: 0xRRGGBBAA with RR the 2-digit hexvalue for the red component, GG for the green component, BB for the blue component and AA for the transparency (00 invisible to FF fully opaque))

```
set color_xxxx 0xRRGGBBAA
```
The following elements can be user-colored:
- color_manipulation - The manipulation rectangle plus modification elements
- color_laserpath - The laserpath
- color_grid - Grid-Lines
- color_guide - The guide on top / to the left of the scene
- color_background - The background beyond the bed
- color_magnetline - Magnetlines
- color_snap_visible - Color for visible snap-indicators
- color_snap_closeup - Color for snap-indicators that would be used
- color_selection1 - Color for regular selection rectangle (left to right)
- color_selection2 - Color for selection rectangle (right to left)
- color_selection3 - Color for selection rectangle (inverting status)
- color_bed - The bed background

A new console command 'colors_reset' has been added, that will reset all colors to their defaults:
```
[19:03:47] colors_reset
[19:03:47] set color_manipulation 0xa07fa0ff
[19:03:47] set color_laserpath 0x0000ff40
[19:03:47] set color_grid 0xa0a0a080
[19:03:47] set color_guide 0x000000ff
[19:03:47] set color_background 0x808080ff
[19:03:47] set color_magnetline 0xffa0a060
[19:03:47] set color_snap_visible 0xa0a0a040
[19:03:47] set color_snap_closeup 0x00ff00a0
[19:03:47] set color_selection1 0xff0000ff
[19:03:48] set color_selection2 0x00ff00ff
[19:03:48] set color_selection3 0x0000ffff
[19:03:48] set color_bed 0xffffffff
```
BTW: if you want to reset a single color then just provide:
```
set color_manipulation reset
```
