### PR TITLE
Tweaks to 0.7.x Color Selection Tweaks

### DIFF
--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -49,6 +49,7 @@ def str_to_color(value):
     c = Color(value)
     return c.alpha << 24 | c.bgr
 
+
 class ElementsWidget(Widget):
     """
     The ElementsWidget is tasked with drawing the elements within the scene. It also
@@ -110,7 +111,7 @@ class SelectionWidget(Widget):
         self.last_angle = None
         self.start_angle = None
         self.elements = scene.context.elements
-        self.color_selection = LINECOL_DEFAULT
+        self.color_selection = None
 
         self.selection_pen = wx.Pen()
         self.selection_pen.SetStyle(wx.PENSTYLE_DOT)
@@ -126,11 +127,13 @@ class SelectionWidget(Widget):
         self.draw_border = True
         self.set_colors()
 
-    def set_colors(self):
-        color = LINECOL_DEFAULT
+    def set_colors(self, default=False):
+        color_manipulation = "#A07FA0"
+        self.scene.context.setting(str, "color_manipulation", color_manipulation)
+        if default:
+            self.scene.context.color_manipulation = color_manipulation
         try:
-            self.scene.context.setting(str, "color_manipulation", color_to_str(color.GetRGBA()))
-            color.SetRGBA(str_to_color(self.scene.context.color_manipulation))
+            color = wx.Colour(str_to_color(self.scene.context.color_manipulation))
             self.selection_pen.SetColour(color)
             self.color_selection = color
         except (ValueError, TypeError):
@@ -182,7 +185,7 @@ class SelectionWidget(Widget):
         Signal commands which draw the background and updates the grid when needed recalculate the lines
         """
         if signal == "theme":
-            self.set_colors()
+            self.set_colors(args[0])
 
     def contains(self, x, y=None):
         """
@@ -1896,11 +1899,13 @@ class GridWidget(Widget):
         self.grid_line_pen.SetWidth(1)
         self.set_colors()
 
-    def set_colors(self):
-        grid_color = wx.Colour(0xA0, 0xA0, 0xA0)
+    def set_colors(self, default=False):
+        color_grid = "#A0A0A0"
+        self.scene.context.setting(str, "color_grid", color_grid)
+        if default:
+            self.scene.context.color_grid = color_grid
         try:
-            self.scene.context.setting(str, "color_grid", color_to_str(grid_color.GetRGBA()))
-            grid_color.SetRGBA(str_to_color(self.scene.context.color_grid))
+            grid_color = wx.Colour(str_to_color(self.scene.context.color_grid))
             self.grid_line_pen.SetColour(grid_color)
         except (ValueError, TypeError):
             pass
@@ -2018,7 +2023,7 @@ class GridWidget(Widget):
         elif signal == "background":
             self.background = args[0]
         elif signal == "theme":
-            self.set_colors()
+            self.set_colors(args[0])
 
 
 class GuideWidget(Widget):

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -1892,21 +1892,18 @@ class GridWidget(Widget):
         Widget.__init__(self, scene, all=True)
         self.grid = None
         self.background = None
-        self.col_default = wx.Colour(0xA0, 0xA0, 0xA0)
-        self.color_grid = self.col_default
-        scene.context.setting(str, "color_grid", color_to_str(self.color_grid.GetRGBA()))
-        # print("Default-Value for Color %s" % scene.context.color_grid)
-        try:
-            self.color_grid.SetRGBA(str_to_color(scene.context.color_grid))
-        except (ValueError, TypeError):
-            self.color_grid = None
-        if self.color_grid is None:
-            self.color_grid = self.col_default
-            scene.context.color_grid = color_to_str(self.color_grid.GetRGBA())
-
         self.grid_line_pen = wx.Pen()
-        self.grid_line_pen.SetColour(self.color_grid)
         self.grid_line_pen.SetWidth(1)
+        self.set_colors()
+
+    def set_colors(self):
+        grid_color = wx.Colour(0xA0, 0xA0, 0xA0)
+        try:
+            self.scene.context.setting(str, "color_grid", color_to_str(grid_color.GetRGBA()))
+            grid_color.SetRGBA(str_to_color(self.scene.context.color_grid))
+            self.grid_line_pen.SetColour(grid_color)
+        except (ValueError, TypeError):
+            pass
 
     def hit(self):
         return HITCHAIN_HIT
@@ -1973,11 +1970,6 @@ class GridWidget(Widget):
         Draw the grid on the scene.
         """
         context = self.scene.context
-        try:
-            self.color_grid.SetRGBA(str_to_color(context.color_grid))
-        except (ValueError, TypeError):
-            self.color_grid = self.col_default
-        self.grid_line_pen.SetColour(self.color_grid)
 
         if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
             if context is not None:
@@ -2025,6 +2017,8 @@ class GridWidget(Widget):
             self.grid = None
         elif signal == "background":
             self.background = args[0]
+        elif signal == "theme":
+            self.set_colors()
 
 
 class GuideWidget(Widget):

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -42,17 +42,12 @@ BUFFER = 10.0
 LINECOL_DEFAULT = wx.Colour(0xA0, 0x7F, 0xA0)
 
 def color_to_str(value):
-    temp = hex(value)
-    # The representation is backwards ABGR --> change
-    result = temp[:2] + temp[8:] + temp[6:8] + temp[4:6]+ temp[2:4]
-    return result
+    c = Color(rgba=value)
+    return c.hexa
 
 def str_to_color(value):
-    # The representation needs to be ABGR --> change
-    if len(value)<=8:
-        value = value + "FF" # append opacity
-    result = value[:2] + value[8:] + value[6:8] + value[4:6]+ value[2:4]
-    return int(result, base=16)
+    c = Color(value)
+    return c.alpha << 24 | c.bgr
 
 class ElementsWidget(Widget):
     """
@@ -120,7 +115,7 @@ class SelectionWidget(Widget):
         scene.context.setting(str, "color_manipulation", color_to_str(self.color_selection.GetRGBA()))
         # print("Default-Value for Color %s" % scene.context.color_manipulation)
         try:
-            self.color_selection.SetRGB(str_to_color(scene.context.color_manipulation))
+            self.color_selection.SetRGBA(str_to_color(scene.context.color_manipulation))
         except (ValueError, TypeError):
             self.color_selection = None
         if self.color_selection is None:
@@ -1902,7 +1897,7 @@ class GridWidget(Widget):
         scene.context.setting(str, "color_grid", color_to_str(self.color_grid.GetRGBA()))
         # print("Default-Value for Color %s" % scene.context.color_grid)
         try:
-            self.color_grid.SetRGB(str_to_color(scene.context.color_grid))
+            self.color_grid.SetRGBA(str_to_color(scene.context.color_grid))
         except (ValueError, TypeError):
             self.color_grid = None
         if self.color_grid is None:
@@ -1979,7 +1974,7 @@ class GridWidget(Widget):
         """
         context = self.scene.context
         try:
-            self.color_grid.SetRGB(str_to_color(context.color_grid))
+            self.color_grid.SetRGBA(str_to_color(context.color_grid))
         except (ValueError, TypeError):
             self.color_grid = self.col_default
         self.grid_line_pen.SetColour(self.color_grid)

--- a/meerk40t/gui/scene/scenewidgets.py
+++ b/meerk40t/gui/scene/scenewidgets.py
@@ -39,11 +39,6 @@ ORIENTATION_GRID = 0b00000100000000
 ORIENTATION_NO_BUFFER = 0b00001000000000
 BUFFER = 10.0
 
-LINECOL_DEFAULT = wx.Colour(0xA0, 0x7F, 0xA0)
-
-def color_to_str(value):
-    c = Color(rgba=value)
-    return c.hexa
 
 def str_to_color(value):
     c = Color(value)

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -2,7 +2,7 @@ import wx
 from wx import aui
 
 from ..core.bindalias import keymap_execute
-from ..svgelements import Angle, Length
+from ..svgelements import Angle, Length, Color
 from .icons import icon_meerk40t
 from .laserrender import LaserRender
 from .mwindow import MWindow
@@ -125,6 +125,29 @@ class MeerK40tScenePanel(wx.Panel):
         def scene(command, _, channel, **kwargs):
             channel("scene: %s" % str(self.widget_scene))
             return "scene", self.widget_scene
+
+        @self.context.console_argument(
+            "aspect", type=str, help="aspect of the scene to color"
+        )
+        @self.context.console_argument(
+            "color", type=Color, help="color to apply to scene"
+        )
+        @self.context.console_command("color", input_type="scene")
+        def scene_color(command, _, channel, data, aspect=None, color=None, **kwargs):
+            if aspect is None:
+                for key in dir(self.context):
+                    if key.startswith("color_"):
+                        channel(key[6:])
+            else:
+                color_key = f"color_{aspect}"
+                if hasattr(self.context, color_key):
+                    setattr(self.context, color_key, color.hexa)
+                    channel(_("Scene aspect color is set."))
+                    data.request_refresh()  # 0.8.x has this changed.
+                else:
+                    channel(_("%s is not a known scene color command") % aspect)
+
+            return "scene", data
 
         @self.context.console_argument(
             "zoom_x", type=float, help="zoom amount from current"

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -143,7 +143,7 @@ class MeerK40tScenePanel(wx.Panel):
                 if hasattr(self.context, color_key):
                     setattr(self.context, color_key, color.hexa)
                     channel(_("Scene aspect color is set."))
-                    data.request_refresh()  # 0.8.x has this changed.
+                    self.context.signal("theme", color_key)
                 else:
                     channel(_("%s is not a known scene color command") % aspect)
 
@@ -243,6 +243,7 @@ class MeerK40tScenePanel(wx.Panel):
         context.listen("driver;mode", self.on_driver_mode)
         context.listen("refresh_scene", self.on_refresh_scene)
         context.listen("background", self.on_background_signal)
+        context.listen("theme", self.on_theme_change)
         context.listen("bed_size", self.bed_changed)
         context.listen("emphasized", self.on_emphasized_elements_changed)
         context.listen("modified", self.on_element_modified)
@@ -255,6 +256,7 @@ class MeerK40tScenePanel(wx.Panel):
         context.unlisten("driver;mode", self.on_driver_mode)
         context.unlisten("refresh_scene", self.on_refresh_scene)
         context.unlisten("background", self.on_background_signal)
+        context.unlisten("theme", self.on_theme_change)
         context.unlisten("bed_size", self.bed_changed)
         context.unlisten("emphasized", self.on_emphasized_elements_changed)
         context.unlisten("modified", self.on_element_modified)
@@ -274,6 +276,10 @@ class MeerK40tScenePanel(wx.Panel):
         else:
             self.widget_scene.background_brush = wx.Brush("Red")
         self.widget_scene.request_refresh_for_animation()
+
+    def on_theme_change(self, origin, theme=None):
+        self.scene.signal("theme", theme)
+        self.request_refresh(origin)
 
     def on_background_signal(self, origin, background):
         background = wx.Bitmap.FromBuffer(*background)

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -139,11 +139,16 @@ class MeerK40tScenePanel(wx.Panel):
                     if key.startswith("color_"):
                         channel(key[6:])
             else:
+                if aspect == "unset":
+                    self.context.signal("theme", True)
+                    return "scene", data
+                if color is None:
+                    raise SyntaxError(_("No color given."))
                 color_key = f"color_{aspect}"
                 if hasattr(self.context, color_key):
                     setattr(self.context, color_key, color.hexa)
                     channel(_("Scene aspect color is set."))
-                    self.context.signal("theme", color_key)
+                    self.context.signal("theme", False)
                 else:
                     channel(_("%s is not a known scene color command") % aspect)
 


### PR DESCRIPTION
* adds in command `scene color` which lets you list the colors that can be changed or do `scene color unset`.
* Does not create pens or colors during the drawing cycle.
* Implements a theme signal to update the scene information of different colors.