### PR TITLE
Color-Scheme changes

### DIFF
--- a/meerk40t/gui/scene/guicolors.py
+++ b/meerk40t/gui/scene/guicolors.py
@@ -1,5 +1,4 @@
 import wx
-from meerk40t.kernel import signal_listener
 from meerk40t.svgelements import Color
 
 class GuiColors():

--- a/meerk40t/gui/scene/guicolors.py
+++ b/meerk40t/gui/scene/guicolors.py
@@ -1,18 +1,6 @@
 import wx
-
-def color_to_str(value):
-    temp = hex(value)
-    # The representation is backwards ABGR --> change
-    result = temp[:2] + temp[8:] + temp[6:8] + temp[4:6]+ temp[2:4]
-    # print("c2s from %s = %s" % (hex(value), result))
-    return result
-
-def str_to_color(value):
-    # The representation needs to be ABGR --> change
-    if len(value)<=8:
-        value = value + "FF" # append opacity
-    result = value[:2] + value[8:] + value[6:8] + value[4:6]+ value[2:4]
-    return int(result, base=16)
+from meerk40t.kernel import signal_listener
+from meerk40t.svgelements import Color
 
 class GuiColors():
     '''
@@ -21,166 +9,92 @@ class GuiColors():
     def __init__(self, context):
         self.context = context
         self.default_color = {
-            "manipulation": wx.Colour(0xA0, 0x7F, 0xA0),
-            "laserpath": wx.Colour(0x00, 0x00, 0xFF, 0x40),
-            "grid": wx.Colour(0xA0, 0xA0, 0xA0, 128),
-            "guide": wx.Colour(0x00, 0x00, 0x00),
-            "background": wx.Colour("Grey"),
-            "magnetline": wx.Colour(0xFF, 0xA0, 0xA0, 0x60),
-            "snap_visible": wx.Colour(0xA0, 0xA0, 0xA0, 0x40),
-            "snap_closeup": wx.Colour(0x00, 0xFF, 0x00, 0xA0),
-            "selection1": wx.Colour(0xFF, 0x00, 0x00),
-            "selection2": wx.Colour(0x00, 0xFF, 0x00),
-            "selection3": wx.Colour(0x00, 0x00, 0xFF),
-            "bed": wx.Colour(0xFF, 0xFF, 0xFF)
+            "manipulation": "#A07FA0",
+            "manipulation_handle": "#A07FA0",
+            "laserpath": "#FF000040",
+            "grid": "#A0A0A080",
+            "guide": "#000000",
+            "background": "#7F7F7F",
+            "magnetline": "#A0A0FF60",
+            "snap_visible": "#A0A0A040",
+            "snap_closeup": "#00FF00A0",
+            "selection1": "#0000FF",
+            "selection2": "#00FF00",
+            "selection3": "#FF0000",
+            "bed": "#FFFFFF",
         }
-
-        self.context.setting(str, "color_manipulation", color_to_str(self.default_color["manipulation"].GetRGBA()))
-        self.context.setting(str, "color_laserpath", color_to_str(self.default_color["laserpath"].GetRGBA()))
-        self.context.setting(str, "color_grid", color_to_str(self.default_color["grid"].GetRGBA()))
-        self.context.setting(str, "color_guide", color_to_str(self.default_color["guide"].GetRGBA()))
-        self.context.setting(str, "color_background", color_to_str(self.default_color["background"].GetRGBA()))
-        self.context.setting(str, "color_magnetline", color_to_str(self.default_color["magnetline"].GetRGBA()))
-        self.context.setting(str, "color_snap_visible", color_to_str(self.default_color["snap_visible"].GetRGBA()))
-        self.context.setting(str, "color_snap_closeup", color_to_str(self.default_color["snap_closeup"].GetRGBA()))
-        self.context.setting(str, "color_selection1", color_to_str(self.default_color["selection1"].GetRGBA()))
-        self.context.setting(str, "color_selection2", color_to_str(self.default_color["selection2"].GetRGBA()))
-        self.context.setting(str, "color_selection3", color_to_str(self.default_color["selection3"].GetRGBA()))
-        self.context.setting(str, "color_bed", color_to_str(self.default_color["bed"].GetRGBA()))
+        for key in self.default_color:
+            self.context.setting(str, "color_{key}".format(key=key), self.default_color[key])
 
     def set_default_colors(self):
         '''
         Reset all colors to default values...
         '''
-        self.context.color_manipulation = color_to_str(self.default_color["manipulation"].GetRGBA())
-        self.context.color_laserpath = color_to_str(self.default_color["laserpath"].GetRGBA())
-        self.context.color_grid = color_to_str(self.default_color["grid"].GetRGBA())
-        self.context.color_guide = color_to_str(self.default_color["guide"].GetRGBA())
-        self.context.color_background = color_to_str(self.default_color["background"].GetRGBA())
-        self.context.color_magnetline = color_to_str(self.default_color["magnetline"].GetRGBA())
-        self.context.color_snap_visible = color_to_str(self.default_color["snap_visible"].GetRGBA())
-        self.context.color_snap_closeup = color_to_str(self.default_color["snap_closeup"].GetRGBA())
-        self.context.color_selection1 = color_to_str(self.default_color["selection1"].GetRGBA())
-        self.context.color_selection2 = color_to_str(self.default_color["selection2"].GetRGBA())
-        self.context.color_selection3 = color_to_str(self.default_color["selection3"].GetRGBA())
-        self.context.color_bed = color_to_str(self.default_color["bed"].GetRGBA())
+        for key in self.default_color:
+            color_key = f"color_{key}"
+            setattr(self.context, color_key, self.default_color[key])
+
+    def _get_color(self, key):
+        color_key = f"color_{key}"
+        if hasattr(self.context, color_key):
+            s = getattr(self.context, color_key)
+            if len(s) == 0 or s == "default":
+                # print ("Reset requested for color: %s" % color_key)
+                s = self.default_color[key]
+                setattr(self.context, color_key, s)
+        else:
+            s = self.default_color[key]
+        c = Color(s)
+        return wx.Colour(red=c.red, green=c.green, blue=c.blue, alpha=c.alpha)
 
     @property
     def color_manipulation(self):
-        try:
-            value = str_to_color(self.context.color_manipulation)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["manipulation"].GetRGBA())
-            self.context.color_manipulation = color_to_str(self.default_color["manipulation"].GetRGBA())
-        return result
+        return self._get_color("manipulation")
+
+    @property
+    def color_manipulation_handle(self):
+        return self._get_color("manipulation_handle")
 
     @property
     def color_laserpath(self):
-        try:
-            value = str_to_color(self.context.color_laserpath)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["laserpath"].GetRGBA())
-            self.context.color_laserpath = color_to_str(self.default_color["laserpath"].GetRGBA())
-        return result
+        return self._get_color("laserpath")
 
     @property
     def color_grid(self):
-        try:
-            value = str_to_color(self.context.color_grid)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["grid"].GetRGBA())
-            self.context.color_grid = color_to_str(self.default_color["grid"].GetRGBA())
-        return result
+        return self._get_color("grid")
 
     @property
     def color_guide(self):
-        try:
-            value = str_to_color(self.context.color_guide)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["guide"].GetRGBA())
-            self.context.color_guide = color_to_str(self.default_color["guide"].GetRGBA())
-        return result
+        return self._get_color("guide")
 
     @property
     def color_background(self):
-        try:
-            value = str_to_color(self.context.color_background)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["background"].GetRGBA())
-            self.context.color_background = color_to_str(self.default_color["background"].GetRGBA())
-        return result
+        return self._get_color("background")
 
     @property
     def color_magnetline(self):
-        try:
-            value = str_to_color(self.context.color_magnetline)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["magnetline"].GetRGBA())
-            self.context.color_magnetline = color_to_str(self.default_color["magnetline"].GetRGBA())
-        return result
+        return self._get_color("magnetline")
 
     @property
     def color_snap_visible(self):
-        try:
-            value = str_to_color(self.context.color_snap_visible)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["snap_visible"].GetRGBA())
-            self.context.color_snap_visible = color_to_str(self.default_color["snap_visible"].GetRGBA())
-        return result
+        return self._get_color("snap_visible")
 
     @property
     def color_snap_closeup(self):
-        try:
-            value = str_to_color(self.context.color_snap_closeup)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["snap_closeup"].GetRGBA())
-            self.context.color_snap_closeup = color_to_str(self.default_color["snap_closeup"].GetRGBA())
-        return result
+        return self._get_color("snap_closeup")
 
     @property
     def color_selection1(self):
-        try:
-            value = str_to_color(self.context.color_selection1)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["selection1"].GetRGBA())
-            self.context.color_selection1 = color_to_str(self.default_color["selection1"].GetRGBA())
-        return result
+        return self._get_color("selection1")
 
     @property
     def color_selection2(self):
-        try:
-            value = str_to_color(self.context.color_selection2)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["selection2"].GetRGBA())
-            self.context.color_selection2 = color_to_str(self.default_color["selection2"].GetRGBA())
-        return result
+        return self._get_color("selection2")
 
     @property
     def color_selection3(self):
-        try:
-            value = str_to_color(self.context.color_selection3)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["selection3"].GetRGBA())
-            self.context.color_selection3 = color_to_str(self.default_color["selection3"].GetRGBA())
-        return result
+        return self._get_color("selection3")
 
     @property
     def color_bed(self):
-        try:
-            value = str_to_color(self.context.color_bed)
-            result = wx.Colour(value)
-        except (ValueError, TypeError):
-            result = wx.Colour(self.default_color["bed"].GetRGBA())
-            self.context.color_bed = color_to_str(self.default_color["bed"].GetRGBA())
-        return result
+        return self._get_color("bed")

--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -24,10 +24,11 @@ class AttractionWidget(Widget):
         self.grid_points = None # Clear all
         self.my_x = None
         self.my_y = None
-        self.visible_pen = wx.Pen(self.scene.colors.color_snap_visible)
+        self.visible_pen = wx.Pen()
         self.visible_pen.SetWidth(1)
-        self.closeup_pen = wx.Pen(self.scene.colors.color_snap_closeup)
+        self.closeup_pen = wx.Pen()
         self.closeup_pen.SetWidth(1)
+        self.load_colors()
         self.symbol_size = 1  # Will be replaced anyway
         self.display_points = []
         self.show_attract_len = 0
@@ -44,6 +45,11 @@ class AttractionWidget(Widget):
 
         self.snap_grid = self.scene.context.snap_grid
         self.snap_points = self.scene.context.snap_points
+
+
+    def load_colors(self):
+        self.visible_pen.SetColour(self.scene.colors.color_snap_visible)
+        self.closeup_pen.SetColour(self.scene.colors.color_snap_closeup)
 
     def hit(self):
         """
@@ -393,5 +399,9 @@ class AttractionWidget(Widget):
         if signal in ("grid", "guide"):
             consumed = True
             self.grid_points = None
+        if signal == "theme":
+            consumed = True
+            self.load_colors()
         if not consumed:
-            print ("Dont know what to do with signal %s" % signal)
+            # print ("Dont know what to do with signal %s" % signal)
+            pass

--- a/meerk40t/gui/scenewidgets/gridwidget.py
+++ b/meerk40t/gui/scenewidgets/gridwidget.py
@@ -16,9 +16,12 @@ class GridWidget(Widget):
         self.grid = None
         self.background = None
         self.grid_line_pen = wx.Pen()
+        self.last_ticksize = 0
+        self.set_colors()
+
+    def set_colors(self):
         self.grid_line_pen.SetColour(self.scene.colors.color_grid)
         self.grid_line_pen.SetWidth(1)
-        self.last_ticksize = 0
 
     def hit(self):
         return HITCHAIN_HIT
@@ -138,7 +141,6 @@ class GridWidget(Widget):
         Draw the grid on the scene.
         """
         # print ("GridWidget draw")
-        self.grid_line_pen.SetColour(self.scene.colors.color_grid)
 
         if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
             context = self.scene.context
@@ -192,6 +194,7 @@ class GridWidget(Widget):
         """
         if signal == "grid":
             self.grid = None
-
         elif signal == "background":
             self.background = args[0]
+        elif signal == "theme":
+            self.set_colors()

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -27,6 +27,17 @@ class GuideWidget(Widget):
         self.scaled_conversion = 0
         self.units = None
         self.options = []
+        self.pen_guide = wx.Pen()
+        self.pen_magnets = wx.Pen()
+        self.color_guide = None
+        self.set_colors()
+
+    def set_colors(self):
+        self.color_guide = self.scene.colors.color_guide
+        self.pen_guide.SetColour(self.color_guide)
+        self.pen_magnets.SetColour(self.scene.colors.color_magnetline)
+        self.pen_magnets.SetWidth(2)
+
 
     def hit(self):
         return HITCHAIN_HIT
@@ -395,8 +406,7 @@ class GuideWidget(Widget):
         if self.scene.context.draw_mode & DRAW_MODE_GUIDES != 0:
             return
         # print ("GuideWidget Draw")
-        pen = wx.Pen(self.scene.colors.color_guide)
-        gc.SetPen(pen)
+        gc.SetPen(self.pen_guide)
         w, h = gc.Size
         p = self.scene.context
         self.scaled_conversion = (
@@ -430,7 +440,7 @@ class GuideWidget(Widget):
         length = self.line_length
         edge_gap = self.edge_gap
         font = wx.Font(10, wx.SWISS, wx.NORMAL, wx.BOLD)
-        gc.SetFont(font, self.scene.colors.color_guide)
+        gc.SetFont(font, self.color_guide)
         gc.DrawText(self.units, edge_gap, edge_gap)
         (t_width, t_height) = gc.GetTextExtent("0")
         while x < w:
@@ -498,11 +508,7 @@ class GuideWidget(Widget):
             starts_hi.append((length + edge_gap, sy))
             ends_hi.append((w - length - edge_gap, sy))
 
-        grid_line_high_pen = wx.Pen()
-        grid_line_high_pen.SetColour(self.scene.colors.color_magnetline)
-        grid_line_high_pen.SetWidth(2)
-
-        gc.SetPen(grid_line_high_pen)
+        gc.SetPen(self.pen_magnets)
         if starts_hi and ends_hi:
             gc.StrokeLineSegments(starts_hi, ends_hi)
 
@@ -512,3 +518,5 @@ class GuideWidget(Widget):
         """
         if signal == "guide":
             pass
+        elif signal == "theme":
+            self.set_colors()

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -339,15 +339,7 @@ class RotationWidget(Widget):
     def process_draw(self, gc):
         if self.master.tool_running:  # We don't need that overhead
             return
-        pen = wx.Pen()
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(0.75 * self.master.line_width)
-        except TypeError:
-            pen.SetWidth(0.75 * int(self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
         self.update()  # make sure coords are valid
-        gc.SetPen(pen)
 
         cx = (self.left + self.right) / 2
         cy = (self.top + self.bottom) / 2
@@ -396,7 +388,7 @@ class RotationWidget(Widget):
         ]
         segment += [(x, y)]
         segment += [(x + signx * 1 / 2 * self.inner, y - signy * 1 / 2 * self.inner)]
-        gc.SetPen(pen)
+        gc.SetPen(self.master.handle_pen)
         gc.StrokeLines(segment)
 
     def tool(self, position, dx, dy, event=0):
@@ -640,15 +632,8 @@ class CornerWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
-        pen = wx.Pen()
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(self.master.line_width)
-        except TypeError:
-            pen.SetWidth(int(self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
-        gc.SetPen(pen)
+        brush = wx.Brush(self.scene.colors.color_manipulation_handle, wx.SOLID)
+        gc.SetPen(self.master.handle_pen)
         gc.SetBrush(brush)
         gc.DrawRectangle(self.left, self.top, self.width, self.height)
 
@@ -821,15 +806,8 @@ class SideWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
-        pen = wx.Pen()
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(self.master.line_width)
-        except TypeError:
-            pen.SetWidth(int(self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
-        gc.SetPen(pen)
+        brush = wx.Brush(self.scene.colors.color_manipulation_handle, wx.SOLID)
+        gc.SetPen(self.master.handle_pen)
         gc.SetBrush(brush)
         gc.DrawRectangle(self.left, self.top, self.width, self.height)
 
@@ -966,15 +944,8 @@ class SkewWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        pen = wx.Pen()
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(self.master.line_width)
-        except TypeError:
-            pen.SetWidth(int(self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
-        gc.SetPen(pen)
-        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
+        gc.SetPen(self.master.handle_pen)
+        brush = wx.Brush(self.scene.colors.color_manipulation_handle, wx.SOLID)
         gc.SetBrush(brush)
         gc.DrawRectangle(self.left, self.top, self.width, self.height)
 
@@ -1115,15 +1086,8 @@ class MoveWidget(Widget):
             return
 
         self.update()  # make sure coords are valid
-        pen = wx.Pen()
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(self.master.line_width)
-        except TypeError:
-            pen.SetWidth(int(self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
-        gc.SetPen(pen)
-        brush = wx.Brush(self.scene.colors.color_manipulation, wx.SOLID)
+        gc.SetPen(self.master.handle_pen)
+        brush = wx.Brush(self.scene.colors.color_manipulation_handle, wx.SOLID)
         gc.SetBrush(brush)
         gc.DrawRectangle(
             self.left + self.half_x - self.drawhalf,
@@ -1240,13 +1204,7 @@ class MoveRotationOriginWidget(Widget):
         self.update()  # make sure coords are valid
         pen = wx.Pen()
         # pen.SetColour(wx.RED)
-        pen.SetColour(self.scene.colors.color_manipulation)
-        try:
-            pen.SetWidth(0.75 * self.master.line_width)
-        except TypeError:
-            pen.SetWidth(int(0.75 * self.master.line_width))
-        pen.SetStyle(wx.PENSTYLE_SOLID)
-        gc.SetPen(pen)
+        gc.SetPen(self.master.handle_pen)
         gc.SetBrush(wx.TRANSPARENT_BRUSH)
         gc.StrokeLine(
             self.left,
@@ -1327,7 +1285,7 @@ class ReferenceWidget(Widget):
             bgcol = wx.YELLOW
             fgcol = wx.RED
         else:
-            bgcol = self.scene.colors.color_manipulation
+            bgcol = self.scene.colors.color_manipulation_handle
             fgcol = wx.BLACK
         pen.SetColour(bgcol)
         try:
@@ -1572,6 +1530,10 @@ class SelectionWidget(Widget):
         self.selection_pen = wx.Pen()
         self.selection_pen.SetColour(self.scene.colors.color_manipulation)
         self.selection_pen.SetStyle(wx.PENSTYLE_DOT)
+        self.handle_pen = wx.Pen()
+        self.handle_pen.SetColour(self.scene.colors.color_manipulation_handle)
+        self.handle_pen.SetStyle(wx.PENSTYLE_SOLID)
+
         self.popupID1 = None
         self.popupID2 = None
         self.popupID3 = None
@@ -1923,10 +1885,14 @@ class SelectionWidget(Widget):
             except ZeroDivisionError:
                 matrix.reset()
                 return
+            self.selection_pen.SetColour(self.scene.colors.color_manipulation)
+            self.handle_pen.SetColour(self.scene.colors.color_manipulation_handle)
             try:
                 self.selection_pen.SetWidth(self.line_width)
+                self.handle_pen.SetWidth(0.75*self.line_width)
             except TypeError:
                 self.selection_pen.SetWidth(int(self.line_width))
+                self.handle_pen.SetWidth(int(0.75*self.line_width))
             if self.font_size < 1.0:
                 self.font_size = 1.0  # Mac does not allow values lower than 1.
             try:


### PR DESCRIPTION
(Applied the same logic as in PR979 for the legacy branch)
NB: breaking change for the internal storage of the colors, so please use 'scene color unset' if you have already used a previous version.

Nearly all colors used in the scene by different gui elements are now configurable:
<img width="421" alt="Colorful scene" src="https://user-images.githubusercontent.com/2670784/162995439-3b99907f-f594-4da3-b754-69c2cd5eeae6.png">

Syntax: you can specifiy the colour for an element by providing a color_code for it: 
- either as a hex representation in the format: #RRGGBBAA with RR the 2-digit hexvalue for the red component, GG for the green component, BB for the blue component and AA for the transparency (00 invisible to FF fully opaque))
- or as 'regular' colorcode: yellow, green, red, blue...

```
scene color <aspect> #RRGGBBAA
```
The following elements can be user-colored (aspect):
- manipulation - The manipulation rectangle 
- manipulation_handle - plus modification elements
- laserpath - The laserpath
- grid - Grid-Lines
- guide - The guide on top / to the left of the scene
- background - The background beyond the bed
- magnetline - Magnetlines
- snap_visible - Color for visible snap-indicators
- snap_closeup - Color for snap-indicators that would be used
- selection1 - Color for regular selection rectangle (left to right)
- selection2 - Color for selection rectangle (right to left)
- selection3 - Color for selection rectangle (inverting status)
- bed - The bed background

If you want to reset a single color to its default value then provide:
```
scene color <aspect> unset
```
if you want to reset the complete color-scheme:
```
scene color unset
```
