### PR TITLE
Allow simultaneous sizing of opposing sides/corners

### DIFF
--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -112,7 +112,14 @@ class RectSelectWidget(Widget):
         elif event_type == "kb_shift_press":
             if not self.key_shift_pressed:
                 self.key_shift_pressed = True
+                ignore = False
                 if self.start_location is None:
+                    ignore = True
+                if self.key_control_pressed or self.key_alt_pressed:
+                    # Dont care about multi-keypresses
+                    ignore = True
+
+                if ignore:
                     return RESPONSE_CHAIN
                 else:
                     self.scene.request_refresh()
@@ -132,7 +139,14 @@ class RectSelectWidget(Widget):
         elif event_type == "kb_ctrl_press":
             if not self.key_control_pressed:
                 self.key_control_pressed = True
+                ignore = False
                 if self.start_location is None:
+                    ignore = True
+                if self.key_shift_pressed or self.key_alt_pressed:
+                    # Dont care about multi-keypresses
+                    ignore = True
+
+                if ignore:
                     return RESPONSE_CHAIN
                 else:
                     self.scene.request_refresh()

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -726,7 +726,7 @@ class CornerWidget(Widget):
                 orgx = self.master.left
 
             grow = 1
-            # If the alt-Key is pressed then size equally on both sides at the same time
+            # If the crtl+shift-Keys are pressed then size equally on both opposing sides at the same time
             if self.master.key_shift_pressed and self.master.key_control_pressed:
                 orgy  = (self.master.bottom + self.master.top) / 2
                 orgx  = (self.master.left + self.master.right) / 2
@@ -776,7 +776,7 @@ class CornerWidget(Widget):
             window_pos=window_pos,
             space_pos=space_pos,
             event_type=event_type,
-            helptext="Size element (with Alt-Key freely)",
+            helptext="Size element (with Alt-Key freely, with Ctrl+shift from center)",
         )
         return response
 
@@ -924,7 +924,7 @@ class SideWidget(Widget):
             else:
                 orgx = self.master.left
             grow = 1
-            # If the alt-Key is pressed then size equally on both sides at the same time
+            # If the Ctr+Shift-Keys are pressed then size equally on both opposing sides at the same time
             if self.master.key_shift_pressed and self.master.key_control_pressed:
                 orgy  = (self.master.bottom + self.master.top) / 2
                 orgx  = (self.master.left + self.master.right) / 2
@@ -969,7 +969,8 @@ class SideWidget(Widget):
 
     def event(self, window_pos=None, space_pos=None, event_type=None):
         s_me = "side"
-        s_help = "Size element in %s-direction" % ("Y" if self.index in (0, 2) else "X")
+        s_help = "Size element in %s-direction (with Ctrl+shift from center)" % ("Y" if self.index in (0, 2) else "X")
+
         response = process_event(
             widget=self,
             widget_identifier=s_me,


### PR DESCRIPTION
If you click ctrl+shift while resizing then the resizing operations will affect opposing sides / corners simultaneously allowing a resize operation with the center remaining unchanged:
![resizing](https://user-images.githubusercontent.com/2670784/163138637-745a8cf0-9610-4152-9eb0-172a8e451ea8.gif)

