### PR TITLE
Quick color / stroke selector

### DIFF
--- a/meerk40t/gui/position.py
+++ b/meerk40t/gui/position.py
@@ -216,13 +216,13 @@ class PositionPanel(wx.Panel):
             "resize %f%s %f%s %f%s %f%s\n"
             % (
                 self.position_x,
-                self.position_name,
+                self.position_units,
                 self.position_y,
-                self.position_name,
+                self.position_units,
                 self.position_w,
-                self.position_name,
+                self.position_units,
                 self.position_h,
-                self.position_name,
+                self.position_units,
             )
         )
         self._update_position()

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -910,7 +910,7 @@ class MeerK40t(MWindow):
 
         @context.console_command("dialog_import", hidden=True)
         def import_dialog(**kwargs):
-            files = context.load_types()
+            files = context.elements.load_types()
             with wx.FileDialog(
                 gui,
                 _("Import"),

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -2,7 +2,7 @@ import wx
 from wx import aui
 
 from meerk40t.gui.icons import icon_meerk40t
-from meerk40t.gui.laserrender import LaserRender, swizzlecolor
+from meerk40t.gui.laserrender import LaserRender
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.scene.scenepanel import ScenePanel
 from meerk40t.gui.scenewidgets.elementswidget import ElementsWidget

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -26,6 +26,7 @@ from meerk40t.gui.toolwidgets.toolvector import VectorTool
 from meerk40t.gui.wxutils import get_key_name
 from meerk40t.kernel import CommandSyntaxError
 from meerk40t.kernel import signal_listener
+from meerk40t.core.units import Length
 from meerk40t.svgelements import Angle, Color, SVG_ATTR_FILL, SVG_ATTR_STROKE
 
 _ = wx.GetTranslation
@@ -376,14 +377,13 @@ class MeerK40tScenePanel(wx.Panel):
         for e in self.context.elements.flat(types=("elem"), emphasized=True):
             obj = e.object
             try:
-                if color is not None:
-                    obj.stroke = color
-                    obj.values[SVG_ATTR_STROKE] = color.hex
-                    e.altered()
-                else:
+                if color is None:
                     obj.stroke = Color("none")
                     obj.values[SVG_ATTR_STROKE] = "none"
-                    e.altered()
+                else:
+                    obj.stroke = color
+                    obj.values[SVG_ATTR_STROKE] = color.hex
+                e.altered()
             except AttributeError:
                 # Ignore and carry on...
                 continue
@@ -402,19 +402,33 @@ class MeerK40tScenePanel(wx.Panel):
         for e in self.context.elements.flat(types=("elem"), emphasized=True):
             obj = e.object
             try:
-                if color is not None:
-                    obj.fill = color
-                    obj.values[SVG_ATTR_FILL] = color.hex
-                    e.altered()
-                else:
+                if color is None:
                     obj.fill = Color("none")
                     obj.values[SVG_ATTR_FILL] = "none"
-                    e.altered()
+                else:
+                    obj.fill = color
+                    obj.values[SVG_ATTR_FILL] = color.hex
+                e.altered()
             except AttributeError:
                 # Ignore and carry on...
                 continue
         # Reclassify selection...
         self.context("declassify\nclassify\n")
+        self.request_refresh()
+
+    @signal_listener("selstrokewidth")
+    def on_selstrokewidth(self, origin, stroke_width, *args):
+        # Stroke_width is a text
+        # print("Signal with %s" % stroke_width)
+        sw = float(Length(stroke_width))
+        for e in self.context.elements.flat(types=("elem"), emphasized=True):
+            obj = e.object
+            try:
+                obj.stroke_width = sw
+                e.altered()
+            except AttributeError:
+                # Ignore and carry on...
+                continue
         self.request_refresh()
 
     def on_key_down(self, event):


### PR DESCRIPTION
- Two fixes (File Import + Position Panel) plus

Addition of a quick color selector for stroke and fill (including reclassification) and an option to change the stroke-width:
![colorbar](https://user-images.githubusercontent.com/2670784/163574558-a898aeea-0dee-4d7e-a572-cde4613b3985.gif)

Left click on the color will change the stroke-color of all selected elements, right click the fill-color.
![grafik](https://user-images.githubusercontent.com/2670784/163574606-6b931e9d-a736-4164-827a-2468d67155da.png)

You may change the stroke-width for the selected elements as well:
![grafik](https://user-images.githubusercontent.com/2670784/163670677-597e655f-09c2-4096-b7d4-5d04c0bc7583.png)


You may turn this feature off in preferences:
![grafik](https://user-images.githubusercontent.com/2670784/163574664-91dab832-bb3c-43d6-8477-1ae02f9dd1a5.png)
