### PR TITLE
Rebuild tree after dnd operations

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3188,6 +3188,7 @@ class Elemental(Service):
                 drop_node.drop(drag_node)
             except (IndexError, AttributeError, ValueError):
                 raise CommandSyntaxError
+            self.signal("tree_changed")
             return "tree", data
 
         @self.console_argument("node", help="Node address for menu")
@@ -3337,6 +3338,7 @@ class Elemental(Service):
             Structural nodes such as root, elements branch, and operations branch are not able to be deleted
             """
             self.remove_nodes(data)
+            self.signal("tree_changed")
             self.signal("refresh_scene", 0)
             return "tree", [self._tree]
 

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3601,6 +3601,16 @@ class Elemental(Service):
         _ = kernel.translation
         # --------------------------- TREE OPERATIONS ---------------------------
 
+        def is_regmark(node):
+            result = False
+            try:
+                if node._parent.type=="branch reg":
+                    result = True
+            except AttributeError:
+                pass
+            return result
+
+
         @self.tree_separator_after()
         @self.tree_conditional(lambda node: len(list(self.ops(emphasized=True))) == 1)
         @self.tree_operation(
@@ -3648,6 +3658,7 @@ class Elemental(Service):
             if activate is not None:
                 activate(node)
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_operation(
             _("Ungroup elements"), node_type=("group", "file"), help=""
         )
@@ -3656,6 +3667,7 @@ class Elemental(Service):
                 node.insert_sibling(n)
             node.remove_node()  # Removing group/file node.
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_operation(_("Group elements"), node_type=elem_nodes, help="")
         def group_elements(node, **kwargs):
             # group_node = node.parent.add_sibling(node, type="group", name="Group")
@@ -4346,11 +4358,13 @@ class Elemental(Service):
 
                 open_in_shell("xdg-open '{file}'".format(file=normalized))
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_submenu(_("Duplicate element(s)"))
         @self.tree_operation(_("Make 1 copy"), node_type=elem_nodes, help="")
         def duplicate_element_1(node, **kwargs):
             duplicate_element_n(node, copies=1, **kwargs)
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_submenu(_("Duplicate element(s)"))
         @self.tree_iterate("copies", 2, 10)
         @self.tree_operation(
@@ -4364,6 +4378,7 @@ class Elemental(Service):
             self.classify(adding_elements)
             self.set_emphasis(None)
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional(
             lambda node: isinstance(node.object, Shape)
             and not isinstance(node.object, Path)
@@ -4375,6 +4390,7 @@ class Elemental(Service):
 
         @self.tree_submenu(_("Flip"))
         @self.tree_separator_before()
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_operation(
             _("Horizontally"),
@@ -4391,6 +4407,7 @@ class Elemental(Service):
             center_y = (bounds[3] + bounds[1]) / 2.0
             self("scale -1 1 %f %f\n" % (center_x, center_y))
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_submenu(_("Flip"))
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_operation(
@@ -4409,6 +4426,7 @@ class Elemental(Service):
             self("scale 1 -1 %f %f\n" % (center_x, center_y))
 
         # @self.tree_conditional(lambda node: isinstance(node.object, SVGElement))
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_submenu(_("Scale"))
         @self.tree_iterate("scale", 25, 1, -1)
@@ -4430,7 +4448,8 @@ class Elemental(Service):
             self("scale %f %f %f %f\n" % (scale, scale, center_x, center_y))
 
         # @self.tree_conditional(lambda node: isinstance(node.object, SVGElement))
-        @self.tree_conditional_try(lambda node: not node.object.lock)
+        @self.tree_conditional(lambda node: not is_regmark(node) )
+        @self.tree_conditional_try(lambda node: not node.object.lock )
         @self.tree_submenu(_("Rotate"))
         @self.tree_values(
             "angle",
@@ -4478,6 +4497,7 @@ class Elemental(Service):
             self("rotate %fturn %f %f\n" % (turns, center_x, center_y))
             self.signal("ext-modified")
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_operation(
             _("Reify User Changes"), node_type=elem_group_nodes, help=""
@@ -4486,12 +4506,14 @@ class Elemental(Service):
             self("reify\n")
             self.signal("ext-modified")
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional(lambda node: isinstance(node.object, Path))
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_operation(_("Break Subpaths"), node_type=elem_nodes, help="")
         def break_subpath_elem(node, **kwargs):
             self("element subpath\n")
 
+        @self.tree_conditional(lambda node: not is_regmark(node) )
         @self.tree_conditional(lambda node: isinstance(node.object, SVGElement))
         @self.tree_conditional_try(lambda node: not node.object.lock)
         @self.tree_operation(
@@ -4508,6 +4530,24 @@ class Elemental(Service):
         )
         def merge_elements(node, **kwargs):
             self("element merge\n")
+
+        @self.tree_conditional(lambda node: is_regmark(node) )
+        @self.tree_separator_before()
+        @self.tree_operation(_("Move back to elements"), node_type=elem_group_nodes, help="")
+        def move_back(node, copies=1, **kwargs):
+            # Drag and Drop
+            drop_node = self.elem_branch
+            drop_node.drop(node)
+            self.signal("tree_changed")
+
+        @self.tree_conditional(lambda node: not is_regmark(node) )
+        @self.tree_separator_before()
+        @self.tree_operation(_("Move to regmarks"), node_type=elem_group_nodes, help="")
+        def move_to_regmark(node, copies=1, **kwargs):
+            # Drag and Drop
+            drop_node = self.reg_branch
+            drop_node.drop(node)
+            self.signal("tree_changed")
 
         def radio_match(node, i=0, **kwargs):
             if "raster_step" in node.object.values:
@@ -4929,6 +4969,7 @@ class Elemental(Service):
             return func
 
         return decor
+
 
     @staticmethod
     def tree_reference(node):

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -803,6 +803,7 @@ class ShadowTree:
             event.Skip()
         else:
             event.Allow()
+            self.rebuild_tree()
         self.dragging_nodes = None
 
     def on_item_right_click(self, event):


### PR DESCRIPTION
A couple of behavioural inconsistencies removed:
a) Context-menus for element-nodes do no longer show non-working actions if a node is a regmark
<img width="147" alt="image" src="https://user-images.githubusercontent.com/2670784/164515117-0829676a-021d-4794-ac5d-5350d30fbf56.png">
b) Adding menu-items to easily move nodes into/out regmark
<img width="138" alt="image" src="https://user-images.githubusercontent.com/2670784/164515029-543d2ebe-2408-40c7-8811-35ef6fd919e4.png">
c) Refresh the tree after node-modifying operations (i.e. dnd, delete and others)
