### PR TITLE
Fix/Extend trace functionality

### DIFF
--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -198,6 +198,7 @@ class LaserPanel(wx.Panel):
         self.Bind(wx.EVT_TOGGLEBUTTON, self.on_check_arm, self.arm_toggle)
         self.Bind(wx.EVT_RIGHT_DOWN, self.on_menu_arm, self)
         self.Bind(wx.EVT_BUTTON, self.on_button_outline, self.button_outline)
+        self.button_outline.Bind(wx.EVT_RIGHT_DOWN, self.on_button_outline_right)
         # self.Bind(wx.EVT_BUTTON, self.on_button_save, self.button_save_file)
         # self.Bind(wx.EVT_BUTTON, self.on_button_load, self.button_load)
         self.Bind(wx.EVT_BUTTON, self.on_button_clear, self.button_clear)
@@ -305,7 +306,10 @@ class LaserPanel(wx.Panel):
         self.context("estop\n")
 
     def on_button_outline(self, event):  # wxGlade: LaserPanel.<event_handler>
-        self.context("element* trace_hull\n")
+        self.context("element* trace hull\n")
+
+    def on_button_outline_right(self, event):  # wxGlade: LaserPanel.<event_handler>
+        self.context("element* trace complex\n")
 
     def on_button_save(self, event):  # wxGlade: LaserPanel.<event_handler>
         pass

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -253,14 +253,14 @@ class Drag(wx.Panel):
             self.on_button_align_corner_br,
             self.button_align_corner_bottom_right,
         )
-        self.Bind(
-            wx.EVT_BUTTON, self.on_button_align_trace_hull, self.button_align_trace_hull
-        )
+        self.Bind(wx.EVT_BUTTON, self.on_button_align_trace_hull, self.button_align_trace_hull)
+        self.button_align_trace_hull.Bind(wx.EVT_RIGHT_DOWN, self.on_button_align_trace_complex)
         self.Bind(
             wx.EVT_BUTTON,
             self.on_button_align_trace_quick,
             self.button_align_trace_quick,
         )
+        self.button_align_trace_quick.Bind(wx.EVT_RIGHT_DOWN, self.on_button_align_trace_circle)
         # Right Button Events
         self.button_align_corner_top_left.Bind(
             wx.EVT_RIGHT_DOWN, self.on_button_lock_tl
@@ -339,11 +339,11 @@ class Drag(wx.Panel):
             self.button_align_first_position.GetBestSize()
         )
         self.button_align_trace_hull.SetToolTip(
-            _("Perform a convex hull trace of the selection")
+            _("Perform a convex hull trace of the selection (Right different alogorithm)")
         )
         self.button_align_trace_hull.SetSize(self.button_align_trace_hull.GetBestSize())
         self.button_align_trace_quick.SetToolTip(
-            _("Perform a simple trace of the selection")
+            _("Perform a simple trace of the selection (Right=Circle around)")
         )
         self.button_align_trace_quick.SetSize(
             self.button_align_trace_quick.GetBestSize()
@@ -527,15 +527,17 @@ class Drag(wx.Panel):
         )
         self.drag_ready(True)
 
-    def on_button_align_trace_hull(
-        self, event=None
-    ):  # wxGlade: Navigation.<event_handler>
-        self.context("trace_hull\n")
+    def on_button_align_trace_hull(self, event=None):
+        self.context("trace hull\n")
 
-    def on_button_align_trace_quick(
-        self, event=None
-    ):  # wxGlade: Navigation.<event_handler>
-        self.context("trace_quick\n")
+    def on_button_align_trace_complex(self, event=None):
+        self.context("trace complex\n")
+
+    def on_button_align_trace_circle(self, event=None):
+        self.context("trace circle\n")
+
+    def on_button_align_trace_quick(self, event=None):
+        self.context("trace quick\n")
         self.drag_ready(True)
 
     def pane_show(self, *args):


### PR DESCRIPTION
All trace commands have been consolidated into a single trace command:
```
trace <method>
```
where method is being one of: hull, quick, complex, circle (and for completeness and backwards compatibility segment, although that is not real useful imho). If omitted method defaults to hull.
- hull is using the point representation of all elements and creating a complex hull around it
- quick is using the bounding box of the elements
- complex is very similar to hull but is dealing better with arcs (i.e. circles, ellipses, bezier shapes etc.)
- circle is using the smallest circle containing all the elements
- segments is just following the segments of all elements - a bit of a preview of the actual burn 
![2022-04-29 16_14_57-MeerK40t v0 8 0006 RC5 git      m2nano](https://user-images.githubusercontent.com/2670784/165965207-6967c22c-7d6a-440a-8b7d-a6e69a8fa063.png)

There is as well a command to create this hulls:
```
tracegen <method>
```
with the very same parameters as above. This will create the hull-shapes but will not move the laser.
