### PR TITLE
Penbox: Settings Resources

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -315,13 +315,14 @@ class Elemental(Service):
         @self.console_argument("index", help=_("Penbox index"), type=int)
         @self.console_argument("key", help=_("Penbox key"), type=str)
         @self.console_argument("value", help=_("Penbox key"), type=str)
+        @self.console_option("end", "e", help=_("Penbox to-index"), type=float)
         @self.console_command(
             "set",
             help=_("set value in penbox"),
             input_type="penbox",
             output_type="penbox",
         )
-        def penbox_set(command, channel, _, index=0, to=None, key=None, value=None, data=None, remainder=None, **kwargs):
+        def penbox_set(command, channel, _, index=0, to=None, key=None, value=None, end=None, data=None, remainder=None, **kwargs):
             if value is None:
                 raise CommandSyntaxError
             else:
@@ -330,8 +331,18 @@ class Elemental(Service):
                 else:
                     if to > index:
                         step = 1 if index < to else -1
-                        for i in range(index, to + step, step):
-                            self.penbox[data][i][key] = value
+                        if end is None:
+                            for i in range(index, to + step, step):
+                                self.penbox[data][i][key] = value
+                        else:
+                            value = float(value)
+                            end = float(end)
+                            r = abs(to-index)
+                            s = (end - value) / r
+                            d = 0
+                            for i in range(index, to + step, step):
+                                self.penbox[data][i][key] = value + d
+                                d += s
             return "penbox", data
 
         # ==========

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -296,11 +296,15 @@ class Elemental(Service):
         @self.console_command(
             "penbox",
             help=_("Penbox base operation"),
-            input_type=None,
+            input_type=(None, "ops"),
             output_type="penbox",
         )
-        def penbox(command, channel, _, key=None, remainder=None, **kwargs):
-            if remainder is None:
+        def penbox(command, channel, _, key=None, remainder=None, data=None, **kwargs):
+            if data is not None:
+                for op in data:
+                    op.settings["penbox"] = key
+                    channel(f"{str(op)} penbox changed to {key}.")
+            elif remainder is None:
                 channel("----------")
                 if key is None:
                     for key in self.penbox:

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -152,6 +152,7 @@ class Elemental(Service):
 
         self.op_data = Settings(self.kernel.name, "operations.cfg")
 
+        self.penbox = {"value": [{"power": str(1000.0 * i / 255.0)} for i in range(256)]}
         self.wordlists = {"version": [1, self.kernel.version]}
 
         self._init_commands(kernel)
@@ -287,6 +288,44 @@ class Elemental(Service):
             channel("----------")
             return "wordlist", data
 
+        # ==========
+        # PENBOX COMMANDS
+        # ==========
+
+        @self.console_argument("key", help=_("Penbox key"))
+        @self.console_command(
+            "penbox",
+            help=_("Penbox base operation"),
+            input_type=None,
+            output_type="penbox",
+        )
+        def penbox(command, channel, _, key=None, remainder=None, **kwargs):
+            if remainder is None:
+                channel("----------")
+                if key is None:
+                    for key in self.penbox:
+                        channel(str(key))
+                else:
+                    for i, value in enumerate(self.penbox[key]):
+                        channel(f"{i}: {str(value)}")
+                channel("----------")
+            return "penbox", key
+
+        @self.console_argument("index", help=_("Penbox index"), type=int)
+        @self.console_argument("key", help=_("Penbox key"), type=str)
+        @self.console_argument("value", help=_("Penbox key"), type=str)
+        @self.console_command(
+            "set",
+            help=_("set value in penbox"),
+            input_type="penbox",
+            output_type="penbox",
+        )
+        def penbox_set(command, channel, _, index=0, key=None, value=None, data=None, remainder=None, **kwargs):
+            if value is None:
+                raise CommandSyntaxError
+            else:
+                self.penbox[data][index][key] = value
+            return "penbox", data
 
         # ==========
         # MATERIALS COMMANDS

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -311,6 +311,7 @@ class Elemental(Service):
                 channel("----------")
             return "penbox", key
 
+        @self.console_option("to", "t", help=_("Penbox to-index"), type=int)
         @self.console_argument("index", help=_("Penbox index"), type=int)
         @self.console_argument("key", help=_("Penbox key"), type=str)
         @self.console_argument("value", help=_("Penbox key"), type=str)
@@ -320,11 +321,17 @@ class Elemental(Service):
             input_type="penbox",
             output_type="penbox",
         )
-        def penbox_set(command, channel, _, index=0, key=None, value=None, data=None, remainder=None, **kwargs):
+        def penbox_set(command, channel, _, index=0, to=None, key=None, value=None, data=None, remainder=None, **kwargs):
             if value is None:
                 raise CommandSyntaxError
             else:
-                self.penbox[data][index][key] = value
+                if to is None:
+                    self.penbox[data][index][key] = value
+                else:
+                    if to > index:
+                        step = 1 if index < to else -1
+                        for i in range(index, to + step, step):
+                            self.penbox[data][i][key] = value
             return "penbox", data
 
         # ==========

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -391,11 +391,14 @@ class Elemental(Service):
             if current is None:
                 current = list()
                 self.penbox[data] = current
-            value = value.split(",")
+            value = list(value.split(","))
             if len(value) == 1:
                 value = float(value[0])
                 for i in index:
-                    current[i][key] = value
+                    try:
+                        current[i][key] = value
+                    except IndexError:
+                        pass
             else:
                 end = float(value[1])
                 value = float(value[0])
@@ -406,7 +409,10 @@ class Elemental(Service):
                     s = 0
                 d = 0
                 for i in index:
-                    current[i][key] = value + d
+                    try:
+                        current[i][key] = value + d
+                    except IndexError:
+                        pass
                     d += s
             return "penbox", data
 

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -194,7 +194,11 @@ class HatchOpNode(Node, Parameters):
                 h_dist = settings.get("hatch_distance", "1mm")
                 h_angle = settings.get("hatch_angle", "0deg")
                 distance_y = float(Length(h_dist))
-                angle = Angle.parse(h_angle)
+                if isinstance(h_angle, float):
+                    angle = Angle.degrees(h_angle)
+                    h_angle = str(h_angle)
+                else:
+                    angle = Angle.parse(h_angle)
 
                 key = f"{h_angle},{h_dist}"
                 if key in polyline_lookup:

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -856,17 +856,6 @@ class HatchSettingsPanel(wx.Panel):
         self.slider_angle = wx.Slider(self, wx.ID_ANY, 0, 0, 360)
         sizer_angle.Add(self.slider_angle, 3, wx.EXPAND, 0)
 
-        sizer_pass_inc = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, "Pass Angle Increment"), wx.HORIZONTAL
-        )
-        raster_sizer.Add(sizer_pass_inc, 1, wx.EXPAND, 0)
-
-        self.text_pass_inc = wx.TextCtrl(self, wx.ID_ANY, "0deg")
-        sizer_pass_inc.Add(self.text_pass_inc, 1, 0, 0)
-
-        self.slider_pass_inc = wx.Slider(self, wx.ID_ANY, 0, -180, 180)
-        sizer_pass_inc.Add(self.slider_pass_inc, 3, wx.EXPAND, 0)
-
         sizer_fill = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, "Fill Style"), wx.VERTICAL
         )
@@ -887,8 +876,6 @@ class HatchSettingsPanel(wx.Panel):
         self.Bind(wx.EVT_TEXT, self.on_text_distance, self.text_distance)
         self.Bind(wx.EVT_TEXT, self.on_text_angle, self.text_angle)
         self.Bind(wx.EVT_COMMAND_SCROLL, self.on_slider_angle, self.slider_angle)
-        self.Bind(wx.EVT_TEXT, self.on_text_pass_inc, self.text_pass_inc)
-        self.Bind(wx.EVT_COMMAND_SCROLL, self.on_slider_pass_inc, self.slider_pass_inc)
         self.Bind(wx.EVT_COMBOBOX, self.on_combo_fill, self.combo_fill_style)
         # end wxGlade
 
@@ -901,14 +888,8 @@ class HatchSettingsPanel(wx.Panel):
     def set_widgets(self, node):
         self.operation = node
         self.combo_fill_style.SetSelection(self.operation.hatch_type)
-        self.text_pass_inc.SetValue(self.operation.hatch_angle_inc)
         self.text_angle.SetValue(self.operation.hatch_angle)
         self.text_distance.SetValue(str(self.operation.hatch_distance))
-        try:
-            angle = float(Angle.parse(self.operation.hatch_angle_inc).as_degrees)
-            self.slider_pass_inc.SetValue(int(angle))
-        except ValueError:
-            pass
         try:
             angle_inc = float(Angle.parse(self.operation.hatch_angle).as_degrees)
             self.slider_angle.SetValue(int(angle_inc))
@@ -932,16 +913,6 @@ class HatchSettingsPanel(wx.Panel):
     def on_slider_angle(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
         value = self.slider_angle.GetValue()
         self.text_angle.SetValue(f"{value}deg")
-
-    def on_text_pass_inc(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
-        try:
-            self.operation.hatch_angle_inc = f"{Angle.parse(self.text_pass_inc.GetValue()).as_degrees}deg"
-        except ValueError:
-            return
-
-    def on_slider_pass_inc(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
-        value = self.slider_pass_inc.GetValue()
-        self.text_pass_inc.SetValue(f"{value}deg")
 
     def on_combo_fill(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
         self.operation.hatch_type = int(self.combo_fill_style.GetSelection())


### PR DESCRIPTION
* Adds in penbox commands. This is chiefly to set `penbox value` commands and should be used to test `rainbow rastering` where each value of a raster image results in a different set of settings. This would permit an image to have 255 different settings one for each level of grey in an image.
* This should add in enough cursory setting commands to set the penboxes and to let you set settings, perhaps loading and saving, and connect the penbox value to the lookup table if a value penbox is set on a particular operation. In theory, we could a series of penboxes for hatches and hatch them repeatedly, with each iteration using the next set of values. A pass-penbox rather than pixel value one.

This might also be useful for setting values if these can be defined for particular colors etc.