### PR TITLE
SVG-io Fixes / extensions: colors, font attributes

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4971,10 +4971,17 @@ class Elemental(Service):
             _("Make %s copies") % "{copies}", node_type=elem_nodes, help=""
         )
         def duplicate_element_n(node, copies, **kwargs):
-            copy_nodes = [copy(e) for e in list(self.elems(emphasized=True)) * copies]
-            for n in copy_nodes:
-                node.parent.add_node(n)
+            copy_nodes = list()
+            for e in list(self.elems(emphasized=True)):
+                for n in range(copies):
+                    copy_node = copy(e)
+                    if hasattr(e, "wxfont"):
+                        copy_node.wxfont = e.wxfont
+                    node.parent.add_node(copy_node)
+                    copy_nodes.append(copy_node)
+
             self.classify(copy_nodes)
+
             self.set_emphasis(None)
 
         @self.tree_conditional(lambda node: not is_regmark(node))

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6048,13 +6048,13 @@ class Elemental(Service):
                     op = ImageOpNode(output=False)
                 elif node.type == "elem point":
                     op = DotsOpNode(output=False)
-                elif node.stroke is not None and node.stroke.value is not None:
+                elif hasattr(node, "stroke") and node.stroke is not None and node.stroke.value is not None:
                     op = EngraveOpNode(color=node.stroke, speed=35.0)
                 if op is not None:
                     add_op_function(op)
                     op.add_reference(node)
                     operations.append(op)
-                if node.fill is not None and node.fill.argb is not None:
+                if hasattr(node, "fill") and node.fill is not None and node.fill.argb is not None:
                     op = RasterOpNode(color=0, output=False)
                     add_op_function(op)
                     op.add_reference(node)

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -37,6 +37,7 @@ class TextNode(Node):
             self.stroke_width = text.stroke_width
         else:
             self.stroke_width = stroke_width
+        self.font_style = "normal"  # normal / italic / oblique
         self.lock = False
 
     def __copy__(self):
@@ -46,6 +47,7 @@ class TextNode(Node):
             fill=copy(self.fill),
             stroke=copy(self.stroke),
             stroke_width=self.stroke_width,
+            font_style=self.font_style,
             **self.settings,
         )
 

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -137,10 +137,18 @@ class SVGWriter:
         @param elem_tree:
         @return:
         """
+        def copy_attributes(source, target):
+            #
+            if hasattr(source, "stroke"):
+                target.stroke = source.stroke
+            if hasattr(source, "fill"):
+                target.fill = source.fill
+
         scale = Matrix.scale(1.0 / UNITS_PER_PIXEL)
         for c in elem_tree.children:
             if c.type == "elem ellipse":
                 element = abs(Path(c.shape) * scale)
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_PATH)
                 subelement.set(SVG_ATTR_DATA, element.d(transformed=False))
             elif c.type == "elem image":
@@ -162,10 +170,12 @@ class SVGWriter:
                 )
             elif c.type == "elem line":
                 element = abs(Path(c.shape) * scale)
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_PATH)
                 subelement.set(SVG_ATTR_DATA, element.d(transformed=False))
             elif c.type == "elem path":
                 element = abs(c.path * scale)
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_PATH)
                 subelement.set(SVG_ATTR_DATA, element.d(transformed=False))
             elif c.type == "elem point":
@@ -174,14 +184,17 @@ class SVGWriter:
                 return
             elif c.type == "elem polyline":
                 element = abs(Path(c.shape) * scale)
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_PATH)
                 subelement.set(SVG_ATTR_DATA, element.d(transformed=False))
             elif c.type == "elem rect":
                 element = abs(Path(c.shape) * scale)
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_PATH)
                 subelement.set(SVG_ATTR_DATA, element.d(transformed=False))
             elif c.type == "elem text":
                 element = c.text
+                copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_TEXT)
                 subelement.text = element.text
                 t = Matrix(element.transform)

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -228,10 +228,13 @@ class SVGWriter:
                     ("font_style", "font-style") # Not implemented yet afaics
                     ]
                 for attrib in attribs:
-                    if hasattr(c, attrib[0]):
+                    val = None
+                    if hasattr(element, attrib[0]):
+                        val = getattr(element, attrib[0])
+                    if val is None and hasattr(c, attrib[0]):
                         val = getattr(c, attrib[0])
-                        if not val is None:
-                            subelement.set(attrib[1], str(val))
+                    if not val is None:
+                        subelement.set(attrib[1], str(val))
             elif c.type == "group":
                 # This is a structural group node of elements. Recurse call to write flat values.
                 SVGWriter._write_elements(xml_tree, c)

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -419,6 +419,9 @@ class LaserRender:
                     f.append(str(text.font_face))
                 if text.font_weight is not None:
                     f.append(str(text.font_weight))
+                if node.font_style is not None:
+                    f.append(str(node.font_style))
+
                 f.append("%d" % text.font_size)
                 font.SetNativeFontInfoUserDesc(" ".join(f))
             except Exception:

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -226,54 +226,54 @@ class TextPropertyPanel(wx.Panel):
                 color = swizzlecolor(rgb)
                 color = Color(color, 1.0)
                 self.node.fill = color
-                # Translate wxFont to SVG font....
-                self.node.font_size = font.GetPointSize()
-
-                fw = font.GetWeight()
-                if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
-                    fontweight = "lighter"
-                elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
-                    fontweight = "normal"
-                elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
-                    fontweight = "bold"
-                elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
-                    fontweight = "bolder"
-                else:
-                    fontweight = "normal"
-                self.node.font_weight = fontweight
-
-                self.node.font_face = font.GetFaceName()
-                ff = font.GetFamily()
-                if ff == wx.FONTFAMILY_DECORATIVE:
-                    family = "fantasy"
-                elif ff == wx.FONTFAMILY_ROMAN:
-                    family = "serif"
-                elif ff == wx.FONTFAMILY_SCRIPT:
-                    family = "cursive"
-                elif ff == wx.FONTFAMILY_SWISS:
-                    family = "sans-serif"
-                elif ff == wx.FONTFAMILY_MODERN:
-                    family = "sans-serif"
-                elif ff == wx.FONTFAMILY_TELETYPE:
-                    family = "monospace"
-                else:
-                    family = "sans-serif"
-                self.node.font_family = family
-
-                ff = font.GetStyle()
-                if ff == wx.FONTSTYLE_NORMAL:
-                    fontstyle = "normal"
-                elif ff ==wx.FONTSTYLE_ITALIC:
-                    fontstyle = "italic"
-                elif ff == wx.FONTSTYLE_SLANT:
-                    fontstyle = "oblique"
-                else:
-                    fontstyle = "normal"
-
-                self.node.font_style = fontstyle
                 self.node.modified()
             except Exception:  # rgb get failed.
                 pass
+            # Translate wxFont to SVG font....
+            self.node.text.font_size = font.GetPointSize()
+
+            fw = font.GetWeight()
+            if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
+                fontweight = "lighter"
+            elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
+                fontweight = "normal"
+            elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
+                fontweight = "bold"
+            elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
+                fontweight = "bolder"
+            else:
+                fontweight = "normal"
+            self.node.text.font_weight = fontweight
+
+            self.node.font_face = font.GetFaceName()
+            ff = font.GetFamily()
+            if ff == wx.FONTFAMILY_DECORATIVE:
+                family = "fantasy"
+            elif ff == wx.FONTFAMILY_ROMAN:
+                family = "serif"
+            elif ff == wx.FONTFAMILY_SCRIPT:
+                family = "cursive"
+            elif ff == wx.FONTFAMILY_SWISS:
+                family = "sans-serif"
+            elif ff == wx.FONTFAMILY_MODERN:
+                family = "sans-serif"
+            elif ff == wx.FONTFAMILY_TELETYPE:
+                family = "monospace"
+            else:
+                family = "sans-serif"
+            self.node.text.font_family = family
+
+            ff = font.GetStyle()
+            if ff == wx.FONTSTYLE_NORMAL:
+                fontstyle = "normal"
+            elif ff ==wx.FONTSTYLE_ITALIC:
+                fontstyle = "italic"
+            elif ff == wx.FONTSTYLE_SLANT:
+                fontstyle = "oblique"
+            else:
+                fontstyle = "normal"
+
+            self.node.font_style = fontstyle
 
 
             self.node.wxfont = font

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -226,10 +226,58 @@ class TextPropertyPanel(wx.Panel):
                 color = swizzlecolor(rgb)
                 color = Color(color, 1.0)
                 self.node.fill = color
+                # Translate wxFont to SVG font....
+                self.node.font_size = font.GetPointSize()
+
+                fw = font.GetWeight()
+                if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
+                    fontweight = "lighter"
+                elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
+                    fontweight = "normal"
+                elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
+                    fontweight = "bold"
+                elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
+                    fontweight = "bolder"
+                else:
+                    fontweight = "normal"
+                self.node.font_weight = fontweight
+
+                self.node.font_face = font.GetFaceName()
+                ff = font.GetFamily()
+                if ff == wx.FONTFAMILY_DECORATIVE:
+                    family = "fantasy"
+                elif ff == wx.FONTFAMILY_ROMAN:
+                    family = "serif"
+                elif ff == wx.FONTFAMILY_SCRIPT:
+                    family = "cursive"
+                elif ff == wx.FONTFAMILY_SWISS:
+                    family = "sans-serif"
+                elif ff == wx.FONTFAMILY_MODERN:
+                    family = "sans-serif"
+                elif ff == wx.FONTFAMILY_TELETYPE:
+                    family = "monospace"
+                else:
+                    family = "sans-serif"
+                self.node.font_family = family
+
+                ff = font.GetStyle()
+                if ff == wx.FONTSTYLE_NORMAL:
+                    fontstyle = "normal"
+                elif ff ==wx.FONTSTYLE_ITALIC:
+                    fontstyle = "italic"
+                elif ff == wx.FONTSTYLE_SLANT:
+                    fontstyle = "oblique"
+                else:
+                    fontstyle = "normal"
+
+                self.node.font_style = fontstyle
                 self.node.modified()
             except Exception:  # rgb get failed.
                 pass
+
+
             self.node.wxfont = font
+
             self.update_label()
             self.refresh()
         dialog.Destroy()

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -226,55 +226,54 @@ class TextPropertyPanel(wx.Panel):
                 color = swizzlecolor(rgb)
                 color = Color(color, 1.0)
                 self.node.fill = color
+                # Translate wxFont to SVG font....
+                self.node.text.font_size = font.GetPointSize()
+
+                fw = font.GetWeight()
+                if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
+                    fontweight = "lighter"
+                elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
+                    fontweight = "normal"
+                elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
+                    fontweight = "bold"
+                elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
+                    fontweight = "bolder"
+                else:
+                    fontweight = "normal"
+                self.node.text.font_weight = fontweight
+
+                self.node.text.font_face = font.GetFaceName()
+                ff = font.GetFamily()
+                if ff == wx.FONTFAMILY_DECORATIVE:
+                    family = "fantasy"
+                elif ff == wx.FONTFAMILY_ROMAN:
+                    family = "serif"
+                elif ff == wx.FONTFAMILY_SCRIPT:
+                    family = "cursive"
+                elif ff == wx.FONTFAMILY_SWISS:
+                    family = "sans-serif"
+                elif ff == wx.FONTFAMILY_MODERN:
+                    family = "sans-serif"
+                elif ff == wx.FONTFAMILY_TELETYPE:
+                    family = "monospace"
+                else:
+                    family = "sans-serif"
+                self.node.text.font_family = family
+
+                ff = font.GetStyle()
+                if ff == wx.FONTSTYLE_NORMAL:
+                    fontstyle = "normal"
+                elif ff ==wx.FONTSTYLE_ITALIC:
+                    fontstyle = "italic"
+                elif ff == wx.FONTSTYLE_SLANT:
+                    fontstyle = "oblique"
+                else:
+                    fontstyle = "normal"
+
+                self.node.font_style = fontstyle
                 self.node.modified()
             except Exception:  # rgb get failed.
                 pass
-            # Translate wxFont to SVG font....
-            self.node.text.font_size = font.GetPointSize()
-
-            fw = font.GetWeight()
-            if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
-                fontweight = "lighter"
-            elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
-                fontweight = "normal"
-            elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
-                fontweight = "bold"
-            elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
-                fontweight = "bolder"
-            else:
-                fontweight = "normal"
-            self.node.text.font_weight = fontweight
-
-            self.node.font_face = font.GetFaceName()
-            ff = font.GetFamily()
-            if ff == wx.FONTFAMILY_DECORATIVE:
-                family = "fantasy"
-            elif ff == wx.FONTFAMILY_ROMAN:
-                family = "serif"
-            elif ff == wx.FONTFAMILY_SCRIPT:
-                family = "cursive"
-            elif ff == wx.FONTFAMILY_SWISS:
-                family = "sans-serif"
-            elif ff == wx.FONTFAMILY_MODERN:
-                family = "sans-serif"
-            elif ff == wx.FONTFAMILY_TELETYPE:
-                family = "monospace"
-            else:
-                family = "sans-serif"
-            self.node.text.font_family = family
-
-            ff = font.GetStyle()
-            if ff == wx.FONTSTYLE_NORMAL:
-                fontstyle = "normal"
-            elif ff ==wx.FONTSTYLE_ITALIC:
-                fontstyle = "italic"
-            elif ff == wx.FONTSTYLE_SLANT:
-                fontstyle = "oblique"
-            else:
-                fontstyle = "normal"
-
-            self.node.font_style = fontstyle
-
 
             self.node.wxfont = font
 


### PR DESCRIPTION
a) stroke and fill colors were not always properly saved - fixed
b) save and load text-font-attributes properly 
c) Fixed copying of a text element
d) Fixed invalid node.fill check for images in elements.classify leading to a duplicate loading of the file

A technical comment: the italic state font_style is attached to the node and not to the text element (that would have required a change to svgelements as far as I could see) - I may have overlooked something essential here, so if there's a better i.e. consistent way then please let me know.