### PR TITLE
Fix for refobject align

### DIFF
--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1703,7 +1703,7 @@ class SelectionWidget(Widget):
         elements = self.scene.context.elements
         if refob is None:
             return
-        bb = refob.bbox()
+        bb = refob.bounds
 
         cc = elements.selected_area()
 
@@ -1743,7 +1743,7 @@ class SelectionWidget(Widget):
         refob = self.scene.reference_object
         if refob is None:
             return
-        bb = refob.bbox()
+        bb = refob.bounds
         elements = self.scene.context.elements
         cc = elements.selected_area()
 
@@ -1768,7 +1768,7 @@ class SelectionWidget(Widget):
         refob = self.scene.reference_object
         if refob is None:
             return
-        bb = refob.bbox()
+        bb = refob.bounds
         elements = self.scene.context.elements
         cc = elements.selected_area()
 


### PR DESCRIPTION
Was still using node.bbox() ...