### PR TITLE
Fix sizing of fonts

### DIFF
--- a/meerk40t/core/fonts.py
+++ b/meerk40t/core/fonts.py
@@ -69,25 +69,6 @@ def svgfont_to_wx(svgtextnode):
     if not hasattr(svgtextnode, "wxfont"):
         svgtextnode.wxfont = wx.Font()
     wxfont = svgtextnode.wxfont
-    # A point is 1/72 of an inch
-    factor = 72 / PX_PER_INCH
-    fsize = svgtextnode.text.font_size * factor
-    if fsize < 1:
-        if fsize > 0:
-            textx = 0
-            texty = 0
-            if hasattr(svgtextnode.text, "x"):
-                textx = svgtextnode.text.x
-            if hasattr(svgtextnode.text, "y"):
-                texty = svgtextnode.text.y
-            svgtextnode.matrix.pre_scale(fsize, fsize, textx, texty)
-            fsize = 1
-            svgtextnode.text.font_size = fsize  # No zero sized fonts.
-    try:
-        wxfont.SetFractionalPointSize(fsize)
-    except AttributeError:
-        wxfont.SetSize(int(fsize))
-
     fw = svgtextnode.text.font_weight
     if fw == "lighter":
         fontweight = wx.FONTWEIGHT_THIN
@@ -141,3 +122,21 @@ def svgfont_to_wx(svgtextnode):
     else:
         fontstyle = wx.FONTSTYLE_NORMAL
     wxfont.SetStyle(fontstyle)
+    # A point is 1/72 of an inch
+    factor = 72 / PX_PER_INCH
+    fsize = svgtextnode.text.font_size * factor
+    if fsize < 1:
+        if fsize > 0:
+            textx = 0
+            texty = 0
+            if hasattr(svgtextnode.text, "x"):
+                textx = svgtextnode.text.x
+            if hasattr(svgtextnode.text, "y"):
+                texty = svgtextnode.text.y
+            svgtextnode.matrix.pre_scale(fsize, fsize, textx, texty)
+            fsize = 1
+            svgtextnode.text.font_size = fsize  # No zero sized fonts.
+    try:
+        wxfont.SetFractionalPointSize(fsize)
+    except AttributeError:
+        wxfont.SetSize(int(fsize))

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -16,6 +16,7 @@ class TextNode(Node):
         fill=None,
         stroke=None,
         stroke_width=None,
+        font_style = None,
         **kwargs,
     ):
         super(TextNode, self).__init__(type="elem text", **kwargs)
@@ -37,7 +38,10 @@ class TextNode(Node):
             self.stroke_width = text.stroke_width
         else:
             self.stroke_width = stroke_width
-        self.font_style = "normal"  # normal / italic / oblique
+        if font_style is None:
+            self.font_style = font_style
+        else:
+            self.font_style = text.font_style  # normal / italic / oblique
         self.lock = False
 
     def __copy__(self):

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -1,4 +1,5 @@
 from math import ceil, floor, sqrt
+import platform
 
 import wx
 from PIL import Image
@@ -75,6 +76,24 @@ class LaserRender:
         self.pen = wx.Pen()
         self.brush = wx.Brush()
         self.color = wx.Colour()
+        system = platform.system()
+        if system == "Darwin":
+            # to be verified
+            factor = 2.0
+            delta = 0.5
+        elif system == "Windows":
+            factor = 2.0
+            delta = 0.5
+        elif system == "Linux":
+            # Dont ask me why its not 2.0...
+            # Might be just my GTK...
+            factor = 1.75
+            delta = 0.45
+        else:
+            factor = 2.0
+            delta = 0.5   
+        self.fontdescent_factor = factor  
+        self.fontdescent_delta = delta 
 
     def render(self, nodes, gc, draw_mode=None, zoomscale=1.0, alpha=255):
         """
@@ -435,19 +454,18 @@ class LaserRender:
         y = text.y
         if text.text is not None:
             f_width, f_height, f_descent, f_externalLeading = gc.GetFullTextExtent(text.text)
-
-            f_height -= 2 * f_descent
+            f_height -= self.fontdescent_factor * f_descent
             text.width = f_width
             text.height = f_height
 
             if not hasattr(text, "anchor") or text.anchor == "start":
-                y -= text.height + f_descent
+                y -= text.height + self.fontdescent_factor * self.fontdescent_delta * f_descent
             elif text.anchor == "middle":
                 x -= text.width / 2
-                y -= text.height + f_descent
+                y -= text.height + self.fontdescent_factor * self.fontdescent_delta * f_descent
             elif text.anchor == "end":
                 x -= text.width
-                y -= text.height + f_descent
+                y -= text.height + self.fontdescent_factor * self.fontdescent_delta * f_descent
             gc.DrawText(text.text, x, y)
         gc.PopState()
 

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -434,15 +434,20 @@ class LaserRender:
         x = text.x
         y = text.y
         if text.text is not None:
-            text.width, text.height = gc.GetTextExtent(text.text)
+            f_width, f_height, f_descent, f_externalLeading = gc.GetFullTextExtent(text.text)
+
+            f_height -= 2 * f_descent
+            text.width = f_width
+            text.height = f_height
+
             if not hasattr(text, "anchor") or text.anchor == "start":
-                y -= text.height
+                y -= text.height + f_descent
             elif text.anchor == "middle":
                 x -= text.width / 2
-                y -= text.height
+                y -= text.height + f_descent
             elif text.anchor == "end":
                 x -= text.width
-                y -= text.height
+                y -= text.height + f_descent
             gc.DrawText(text.text, x, y)
         gc.PopState()
 


### PR DESCRIPTION
- Assigning font-properties could have reset the font-size. The order has been changed, so stuff should look better now...
E.g. the famous wiki-svg-file (https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg) looks now:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/2670784/168773425-c62b5c64-72b0-461c-90c1-546fabd30899.png">

- The text bboxes take now the font-attribute descent into consideration:
before:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/2670784/168772549-4eb0defc-f0f7-4782-b58e-d61dbe733d3e.png">
now:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/2670784/168772191-0183c1ab-43ae-44bf-a358-5754d73388a1.png">

