### PR TITLE
Extended Text-Entry + some fixes

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -290,8 +290,11 @@ class Elemental(Service):
                     for key in self.wordlists:
                         channel(str(key))
                 else:
-                    for value in self.wordlists[key][1:]:
-                        channel(str(value))
+                    if key in self.wordlists:
+                        for value in self.wordlists[key][1:]:
+                            channel(str(value))
+                    else:
+                        channel(_("Key not found: '%s'") % key)
                 channel("----------")
 
             return "wordlist", key

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1,6 +1,7 @@
 import functools
 import os.path
 import re
+from datetime import datetime
 from copy import copy
 from math import cos, gcd, isinf, pi, sin, sqrt, tau
 from os.path import realpath
@@ -156,7 +157,9 @@ class Elemental(Service):
         self.penbox = {
             "value": [{"power": str(1000.0 * i / 255.0)} for i in range(256)]
         }
-        self.wordlists = {"version": [1, self.kernel.version]}
+        self.wordlists = {"version": [1, self.kernel.version],
+        "date": [1, self.wordlist_datestr()],
+        "time": [1, self.wordlist_timestr()]}
 
         self._init_commands(kernel)
         self._init_tree(kernel)
@@ -190,6 +193,14 @@ class Elemental(Service):
         if key not in self.wordlists:
             self.wordlists[key] = [1]
         self.wordlists[key].append(value)
+
+    def wordlist_datestr(self):
+        time = datetime.now()
+        return time.strftime("%x")
+
+    def wordlist_timestr(self):
+        time = datetime.now()
+        return time.strftime("%X")
 
     def index_range(self, index_string):
         """

--- a/meerk40t/gui/toolwidgets/tooltext.py
+++ b/meerk40t/gui/toolwidgets/tooltext.py
@@ -2,9 +2,162 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.svgelements import SVGText
-
+from meerk40t.svgelements import SVGText, Color
+from meerk40t.gui.laserrender import swizzlecolor
+from meerk40t.core.fonts import wxfont_to_svg
 from ...core.units import UNITS_PER_PIXEL
+
+class TextEntry(wx.Dialog):
+
+    def __init__(self, context, defaultstring = None, *args, **kwds):
+        # begin wxGlade: TextEntry.__init__
+        if defaultstring is None:
+            defaultstring = ""
+        self.context = context
+        _ = context._
+        kwds["style"] = kwds.get("style", 0) | wx.DEFAULT_DIALOG_STYLE
+        wx.Dialog.__init__(self, *args, **kwds)
+        self.SetSize((518, 380))
+        self.SetTitle(_("Add a Text-element"))
+
+        self.result_text = ""
+        self.result_font = wx.Font(14, wx.SWISS, wx.NORMAL, wx.BOLD)
+        self.result_colour = wx.BLACK
+
+        sizer_1 = wx.BoxSizer(wx.VERTICAL)
+
+        sizer_3 = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_1.Add(sizer_3, 0, wx.EXPAND, 0)
+
+        label_1 = wx.StaticText(self, wx.ID_ANY, _("Text"))
+        sizer_3.Add(label_1, 0, 0, 0)
+
+        self.txt_Text = wx.TextCtrl(self, wx.ID_ANY, defaultstring)
+        sizer_3.Add(self.txt_Text, 1, 0, 0)
+
+        self.btn_choose_font = wx.Button(self, wx.ID_ANY, _("Select Font"))
+        sizer_3.Add(self.btn_choose_font, 0, 0, 0)
+
+        sizer_5 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Available Variables")), wx.HORIZONTAL)
+        sizer_1.Add(sizer_5, 1, wx.EXPAND, 0)
+
+        # populate listbox
+        choices = []
+        for skey in self.context.elements.wordlists:
+            value = self.context.elements.wordlist_fetch(skey)
+            svalue = skey + " (" + value + ")"
+            choices.append(svalue)
+        self.lb_variables = wx.ListBox(self, wx.ID_ANY, choices=choices)
+        self.lb_variables.SetToolTip(_("Double click a variable to add it to the text"))
+        sizer_5.Add(self.lb_variables, 1, wx.EXPAND, 0)
+
+        self.preview = wx.StaticText(self, wx.ID_ANY, _("<Preview>"), style=wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE)
+        self.preview.SetFont(self.result_font)
+        sizer_1.Add(self.preview, 1, wx.EXPAND, 1)
+
+        sizer_4 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Last Font-Entries")), wx.HORIZONTAL)
+        sizer_1.Add(sizer_4, 0, wx.EXPAND, 0)
+
+        self.last_font_1 = wx.StaticText(self, wx.ID_ANY, _("<empty>"), style=wx.ALIGN_CENTER_HORIZONTAL | wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE)
+        self.last_font_1.SetMinSize((120, 90))
+        self.last_font_1.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, 0, "Segoe UI"))
+        self.last_font_1.SetToolTip(_("Choose last used font-settings"))
+        sizer_4.Add(self.last_font_1, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 1)
+
+        self.last_font_2 = wx.StaticText(self, wx.ID_ANY, _("<empty>"), style=wx.ALIGN_CENTER_HORIZONTAL | wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE)
+        self.last_font_2.SetMinSize((120, 90))
+        self.last_font_2.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, 0, "Segoe UI"))
+        self.last_font_2.SetToolTip(_("Choose last used font-settings"))
+        sizer_4.Add(self.last_font_2, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 1)
+
+        self.last_font_3 = wx.StaticText(self, wx.ID_ANY, _("<empty>"), style=wx.ALIGN_CENTER_HORIZONTAL | wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE)
+        self.last_font_3.SetMinSize((120, 90))
+        self.last_font_3.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, 0, "Segoe UI"))
+        self.last_font_3.SetToolTip(_("Choose last used font-settings"))
+        sizer_4.Add(self.last_font_3, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 1)
+
+        self.last_font_4 = wx.StaticText(self, wx.ID_ANY, _("<empty>"), style=wx.ALIGN_CENTER_HORIZONTAL | wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE)
+        self.last_font_4.SetMinSize((120, 90))
+        self.last_font_4.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, 0, "Segoe UI"))
+        self.last_font_4.SetToolTip(_("Choose last used font-settings"))
+        sizer_4.Add(self.last_font_4, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 1)
+
+        sizer_2 = wx.StdDialogButtonSizer()
+        sizer_1.Add(sizer_2, 0, wx.ALIGN_RIGHT | wx.ALL, 4)
+
+        self.button_OK = wx.Button(self, wx.ID_OK, "")
+        self.button_OK.SetDefault()
+        sizer_2.AddButton(self.button_OK)
+
+        self.button_CANCEL = wx.Button(self, wx.ID_CANCEL, "")
+        sizer_2.AddButton(self.button_CANCEL)
+        sizer_2.Realize()
+
+        self.SetSizer(sizer_1)
+
+        self.SetAffirmativeId(self.button_OK.GetId())
+        self.SetEscapeId(self.button_CANCEL.GetId())
+
+        self.Layout()
+        self.Centre()
+
+        self.btn_choose_font.Bind(wx.EVT_BUTTON, self.on_choose_font)
+        self.lb_variables.Bind(wx.EVT_LISTBOX_DCLICK, self.on_variable_dclick)
+        self.last_font_1.Bind(wx.EVT_LEFT_DOWN, self.on_last_font)
+        self.last_font_2.Bind(wx.EVT_LEFT_DOWN, self.on_last_font)
+        self.last_font_3.Bind(wx.EVT_LEFT_DOWN, self.on_last_font)
+        self.last_font_4.Bind(wx.EVT_LEFT_DOWN, self.on_last_font)
+        self.txt_Text.Bind(wx.EVT_TEXT, self.on_text_change)
+        # end wxGlade
+
+    def on_text_change(self, event):
+        svalue = self.txt_Text.GetValue()
+        self.preview.Label = svalue
+        self.last_font_1.Label = svalue
+        self.last_font_2.Label = svalue
+        self.last_font_3.Label = svalue
+        self.last_font_4.Label = svalue
+        self.result_text = svalue
+        event.Skip()
+
+    def on_choose_font(self, event):  # wxGlade: TextEntry.<event_handler>
+        data = wx.FontData()
+        data.EnableEffects(True)
+        data.SetColour(self.result_colour)         # set colour
+        data.SetInitialFont(self.result_font)
+
+        dlg = wx.FontDialog(self, data)
+
+        if dlg.ShowModal() == wx.ID_OK:
+            data = dlg.GetFontData()
+            self.result_font = data.GetChosenFont()
+            self.result_colour = data.GetColour()
+
+            self.preview.SetFont(self.result_font)
+            self.preview.ForegroundColour = self.result_colour
+            self.preview.Refresh()
+
+        dlg.Destroy()
+        event.Skip()
+
+    def on_variable_dclick(self, event):  # wxGlade: TextEntry.<event_handler>
+        svalue = event.GetString()
+        svalue = svalue[0:svalue.find(" (")]
+        svalue = self.txt_Text.GetValue() + " {" + svalue + "}"
+        self.txt_Text.SetValue(svalue.strip(" "))
+        event.Skip()
+
+    def on_last_font(self, event):  # wxGlade: TextEntry.<event_handler>
+        # print("Event handler 'on_self.last_font' not implemented!")
+        obj = event.event.EventObject
+        self.result_colour = obj.GetForegroundColour()
+        self.result_font = obj.GetFont()
+        self.preview.ForegroundColour = self.result_colour
+        self.preview.Font = self.result_font
+        self.preview.Refresh()
+        event.Skip()
+
+# end of class TextEntry
 
 
 class TextTool(ToolWidget):
@@ -40,16 +193,20 @@ class TextTool(ToolWidget):
             self.text *= "translate({x}, {y}) scale({scale})".format(
                 x=x, y=y, scale=UNITS_PER_PIXEL
             )
-            dlg = wx.TextEntryDialog(
-                self.scene.gui, _("What text message"), _("Text"), ""
-            )
-            dlg.SetValue("")
+            dlg = TextEntry(self.scene.context, "", None, wx.ID_ANY, "")
             if dlg.ShowModal() == wx.ID_OK:
-                self.text.text = dlg.GetValue()
+                self.text.text = dlg.result_text
                 elements = self.scene.context.elements
                 node = elements.elem_branch.add(text=self.text, type="elem text")
+                color = dlg.result_colour
+                rgb = color.GetRGB()
+                color = swizzlecolor(rgb)
+                color = Color(color, 1.0)
+                node.fill = color
+                # Translate wxFont to SVG font....
+                node.wxfont = dlg.result_font
+                wxfont_to_svg(node)
                 elements.classify([node])
-                self.text = None
                 self.notify_created()
             dlg.Destroy()
             response = RESPONSE_CONSUME

--- a/meerk40t/kernel/settings.py
+++ b/meerk40t/kernel/settings.py
@@ -1,4 +1,4 @@
-from configparser import ConfigParser, NoSectionError
+from configparser import ConfigParser, NoSectionError, MissingSectionHeaderError
 from pathlib import Path
 from typing import Any, Dict, Generator, Optional, Union
 
@@ -32,7 +32,7 @@ class Settings:
                         config_section = dict()
                         self._config_dict[section] = config_section
                     config_section[option] = parser.get(section, option)
-        except PermissionError:
+        except (PermissionError, NoSectionError, MissingSectionHeaderError):
             return
 
     def write_configuration(self):


### PR DESCRIPTION
- Survive a corrupted configuration file (happened during a computer crash)
- Fix one wordlist issue (there are more...)
- Extended the Text-Tool (a simple textentry so far):

<img width="378" alt="image" src="https://user-images.githubusercontent.com/2670784/169061015-1a03acc9-c7b9-4e9c-b837-039cb0fc663d.png">
