### PR TITLE
Add linecap and linejoin for lines/paths

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -15,7 +15,7 @@ from ..svgelements import Angle, Color, Matrix, SVGElement, Viewbox
 from .cutcode import CutCode
 from .element_types import *
 from .node.elem_image import ImageNode
-from .node.node import Node
+from .node.node import Node, Linecap, Linejoin
 from .node.op_console import ConsoleOperation
 from .node.op_cut import CutOpNode
 from .node.op_dots import DotsOpNode
@@ -2903,6 +2903,142 @@ class Elemental(Service):
                 e.stroke_width = stroke_width
                 e.altered()
             return "elements", data
+
+        @self.console_option("filter", "f", type=str, help="Filter indexes")
+        @self.console_argument(
+            "cap", type=str, help=_("Linecap to apply to the path (one of butt, round, square)")
+        )
+        @self.console_command(
+            "linecap",
+            help=_("linecap <cap>"),
+            input_type=(
+                None,
+                "elements",
+            ),
+            output_type="elements",
+        )
+        def element_cap(
+            command, channel, _, cap=None, data=None, filter=None, **kwargs
+        ):
+            if data is None:
+                data = list(self.elems(emphasized=True))
+            apply = data
+            if filter is not None:
+                apply = list()
+                for value in filter.split(","):
+                    try:
+                        value = int(value)
+                    except ValueError:
+                        continue
+                    try:
+                        apply.append(data[value])
+                    except IndexError:
+                        channel(_("index %d out of range") % value)
+            if cap is None:
+                channel("----------")
+                channel(_("Linecaps:"))
+                i = 0
+                for e in self.elems():
+                    name = str(e)
+                    if len(name) > 50:
+                        name = name[:50] + "…"
+                    if hasattr(e, "linecap"):
+                        if e.linecap == Linecap.CAP_SQUARE:
+                            capname = "square"
+                        elif e.linecap == Linecap.CAP_BUTT:
+                            capname = "butt"
+                        else:
+                            capname = "round"
+                        channel(_("%d: linecap = %s - %s") % (i, capname, name))
+                    i += 1
+                channel("----------")
+                return
+            else:
+                capvalue = None
+                if cap.lower() == "butt":
+                    capvalue = Linecap.CAP_BUTT
+                elif cap.lower() == "round":
+                    capvalue = Linecap.CAP_ROUND
+                elif cap.lower() == "square":
+                    capvalue = Linecap.CAP_SQUARE
+                if not capvalue is None:
+                    for e in apply:
+                        if hasattr(e, "linecap"):
+                            e.linecap = capvalue
+                            e.altered()
+                return "elements", data
+
+        @self.console_option("filter", "f", type=str, help="Filter indexes")
+        @self.console_argument(
+            "join", type=str, help=_("jointype to apply to the path (one of arcs, bevel, miter, miter-clip, round)")
+        )
+        @self.console_command(
+            "linejoin",
+            help=_("linejoin <join>"),
+            input_type=(
+                None,
+                "elements",
+            ),
+            output_type="elements",
+        )
+        def element_join(
+            command, channel, _, join=None, data=None, filter=None, **kwargs
+        ):
+            if data is None:
+                data = list(self.elems(emphasized=True))
+            apply = data
+            if filter is not None:
+                apply = list()
+                for value in filter.split(","):
+                    try:
+                        value = int(value)
+                    except ValueError:
+                        continue
+                    try:
+                        apply.append(data[value])
+                    except IndexError:
+                        channel(_("index %d out of range") % value)
+            if join is None:
+                channel("----------")
+                channel(_("Linejoins:"))
+                i = 0
+                for e in self.elems():
+                    name = str(e)
+                    if len(name) > 50:
+                        name = name[:50] + "…"
+                    if hasattr(e, "linejoin"):
+                        if e.linejoin == Linejoin.JOIN_ARCS:
+                            joinname = "arcs"
+                        elif e.linejoin == Linejoin.JOIN_BEVEL:
+                            joinname = "bevel"
+                        elif e.linejoin == Linejoin.JOIN_MITER_CLIP:
+                            joinname = "miter-clip"
+                        elif e.linejoin == Linejoin.JOIN_MITER:
+                            joinname = "miter"
+                        elif e.linejoin == Linejoin.JOIN_ROUND:
+                            joinname = "round"
+                        channel(_("%d: linejoin = %s - %s") % (i, joinname, name))
+                    i += 1
+                channel("----------")
+                return
+            else:
+                joinvalue = None
+                if join.lower() == "arcs":
+                    joinvalue = Linejoin.JOIN_ARCS
+                elif join.lower() == "bevel":
+                    joinvalue = Linejoin.JOIN_BEVEL
+                elif join.lower() == "miter":
+                    joinvalue = Linejoin.JOIN_MITER
+                elif join.lower() == "miter-clip":
+                    joinvalue = Linejoin.JOIN_MITER_CLIP
+                elif join.lower() == "round":
+                    joinvalue = Linejoin.JOIN_ROUND
+                if not joinvalue is None:
+                    for e in apply:
+                        if hasattr(e, "linejoin"):
+                            e.linejoin = joinvalue
+                            e.altered()
+                return "elements", data
 
         @self.console_option("filter", "f", type=str, help="Filter indexes")
         @self.console_argument(

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linecap, Linejoin
 from meerk40t.svgelements import Path
 
 
@@ -16,6 +16,8 @@ class LineNode(Node):
         fill=None,
         stroke=None,
         stroke_width=None,
+        linecap = None,
+        linejoin = None,
         **kwargs,
     ):
         super(LineNode, self).__init__(type="elem line", **kwargs)
@@ -37,6 +39,14 @@ class LineNode(Node):
             self.stroke_width = shape.stroke_width
         else:
             self.stroke_width = stroke_width
+        if linecap is None:
+            self.linecap = Linecap.CAP_BUTT
+        else:
+            self.linecap = linecap
+        if linejoin is None:
+            self.linejoin = Linejoin.JOIN_MITER
+        else:
+            self.linejoin = linejoin
         self.lock = False
 
     def __copy__(self):
@@ -124,4 +134,6 @@ class LineNode(Node):
     def as_path(self):
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
+        self.shape.linecap = self.linecap
+        self.shape.linejoin = self.linejoin
         return abs(Path(self.shape))

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linejoin, Linecap
 
 
 class PathNode(Node):
@@ -15,6 +15,8 @@ class PathNode(Node):
         fill=None,
         stroke=None,
         stroke_width=None,
+        linecap = None,
+        linejoin = None,
         **kwargs,
     ):
         super(PathNode, self).__init__(type="elem path")
@@ -36,6 +38,15 @@ class PathNode(Node):
             self.stroke_width = path.stroke_width
         else:
             self.stroke_width = stroke_width
+        if linecap is None:
+            self.linecap = Linecap.CAP_BUTT
+        else:
+            self.linecap = linecap
+        if linejoin is None:
+            self.linejoin = Linejoin.JOIN_MITER
+        else:
+            self.linejoin = linejoin
+
         self.lock = False
 
     def __copy__(self):
@@ -123,4 +134,6 @@ class PathNode(Node):
     def as_path(self):
         self.path.transform = self.matrix
         self.path.stroke_width = self.stroke_width
+        self.path.linecap = self.linecap
+        self.path.linejoin = self.linejoin
         return abs(self.path)

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linejoin, Linecap
 from meerk40t.svgelements import Path
 
 
@@ -16,6 +16,8 @@ class PolylineNode(Node):
         fill=None,
         stroke=None,
         stroke_width=None,
+        linecap = None,
+        linejoin = None,
         **kwargs,
     ):
         super(PolylineNode, self).__init__(type="elem polyline", **kwargs)
@@ -37,6 +39,15 @@ class PolylineNode(Node):
             self.stroke_width = shape.stroke_width
         else:
             self.stroke_width = stroke_width
+        if linecap is None:
+            self.linecap = Linecap.CAP_BUTT
+        else:
+            self.linecap = linecap
+        if linejoin is None:
+            self.linejoin = Linejoin.JOIN_MITER
+        else:
+            self.linejoin = linejoin
+
         self.lock = False
 
     def __copy__(self):
@@ -123,4 +134,6 @@ class PolylineNode(Node):
     def as_path(self):
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
+        self.shape.linecap = self.linecap
+        self.shape.linejoin = self.linejoin
         return abs(Path(self.shape))

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linejoin
 from meerk40t.svgelements import Path
 
 
@@ -16,6 +16,7 @@ class RectNode(Node):
         fill=None,
         stroke=None,
         stroke_width=None,
+        linejoin = None,
         **kwargs,
     ):
         super(RectNode, self).__init__(type="elem rect", **kwargs)

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -18,6 +18,24 @@ rasternode: theoretical: would store all the refelems to be rastered. Such that 
 
 Tree Functions are to be stored: tree/command/type. These store many functions like the commands.
 """
+from enum import Enum
+# LINEJOIN
+# Value	arcs | bevel |miter | miter-clip | round
+# Default value	miter
+class Linejoin(Enum):
+    JOIN_ARCS = 0
+    JOIN_BEVEL = 1
+    JOIN_MITER = 2
+    JOIN_MITER_CLIP = 3
+    JOIN_ROUND = 4
+
+# LINECAP
+# Value	butt | round | square
+# Default value	butt
+class Linecap(Enum):
+    CAP_BUTT = 0
+    CAP_ROUND = 1
+    CAP_SQUARE = 2
 
 
 class Node:

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -56,7 +56,7 @@ from .units import DEFAULT_PPI, UNITS_PER_PIXEL
 from meerk40t.core.node.node import Linecap, Linejoin
 
 SVG_ATTR_STROKE_JOIN = "stroke-linejoin"
-SVG_ATTR_STROKE_CAP = "stroke-LINECAP"
+SVG_ATTR_STROKE_CAP = "stroke-linecap"
 
 
 def plugin(kernel, lifecycle=None):


### PR DESCRIPTION
Addresses issue https://github.com/meerk40t/meerk40t/issues/1019
<img width="745" alt="2022-05-18 21_33_59-MeerK40t v0 8 0006 RC5 git      m2nano" src="https://user-images.githubusercontent.com/2670784/169142246-b31c3e2c-2980-4380-b323-2905d22382cf.png">
Recognises SVG stroke-linecap and stroke-linejoin attributes 
Adds linecap and linejoin commands:
```
[21:39:50] help linecap
[21:39:50]     	linecap <cap:str>
[21:39:50]     	(elements) -> linecap -> (elements)
[21:39:50]     	Argument: str 'cap':
[21:39:50]     		Linecap to apply to the path (one of butt, round, square)
[21:39:50]     	Option: str ('--filter', '-f'):
[21:39:50]     		Filter indexes
[21:39:57] help linejoin
[21:39:57]     	linejoin <join:str>
[21:39:57]     	(None) -> linejoin -> (elements)
[21:39:57]     	Argument: str 'join':
[21:39:57]     		jointype to apply to the path (one of arcs, bevel, miter, miter-clip, round)
[21:39:57]     	Option: str ('--filter', '-f'):
[21:39:57]     		Filter indexes
[21:39:57]     
```
