### PR TITLE
Increase raster merge margins...

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -476,7 +476,7 @@ class CutPlan:
 
             def adjust_bbox(bbox):
                 x1, y1, x2, y2 = bbox
-                return x1 - dx, y1 - dy, x2 + dx, y2 + dy
+                return x1 - dx - 50, y1 - dy - 50, x2 + dx + 50, y2 + dy + 50
 
             groups = group_overlapped_rasters(
                 [

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -392,6 +392,8 @@ class CutPlan:
             3. Device type - only have accel values for lhy devices
             4. Acceleration number (manual or automatic)
             5. Actual raster speed (adjusted if necessary from Op speed)
+        If choice between merged or separated is evenly balanced, we prefer merged
+        by adding a constant value of 50 (mils) to the margins.
         """
 
         # Determine raster direction(s)
@@ -411,8 +413,8 @@ class CutPlan:
             return dx, dy
 
         # set minimum margins otherwise
-        dx = 500 if h_sweep else 0
-        dy = 500 if v_sweep else 0
+        dx = 500 if h_sweep else 50
+        dy = 500 if v_sweep else 50
 
         # Get device and check for lhystudios
         try:
@@ -446,9 +448,9 @@ class CutPlan:
 
         # Calculate margins
         if h_sweep:
-            dx = max(dx, CutPlan.sweep_distance(speed, h_accel))
+            dx = max(dx, CutPlan.sweep_distance(speed, h_accel)) + 50
         if v_sweep:
-            dy = max(dy, CutPlan.sweep_distance(speed, v_accel))
+            dy = max(dy, CutPlan.sweep_distance(speed, v_accel)) + 50
 
         return dx, dy
 
@@ -476,7 +478,7 @@ class CutPlan:
 
             def adjust_bbox(bbox):
                 x1, y1, x2, y2 = bbox
-                return x1 - dx - 50, y1 - dy - 50, x2 + dx + 50, y2 + dy + 50
+                return x1 - dx, y1 - dy, x2 + dx, y2 + dy
 
             groups = group_overlapped_rasters(
                 [


### PR DESCRIPTION
... so as not to split raster ops when areas are only just further apart than acceleration/deceleration gaps.

The extra margin needs to be applied in both directions so I decided to use an absolute of 1/20" rather than e.g. doubling dx/dy.