### PR TITLE
Lock pyinstaller to v4.9 to fix issue with Icon not found in v4.10

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -35,11 +35,13 @@ jobs:
 
 # Compile bootloaders in order to reduce virus totals
 # PYTHONHASHSEED is an attempt to get deterministic builds for VirusTotal
+# 05/28/2022 JS - Locked pyinstaller at v4.9 because 4.10 couldn't find the icon 
+# when it branch v4 updated to commit e319ae3d00. Fixes made in v5 branches, not v4
     - name: Build pyinstaller, generate bootloaders
       env:
         PYTHONHASHSEED: 12506
       run: |
-        git clone --depth=1 --branch=v4 https://github.com/pyinstaller/pyinstaller
+        git clone --depth=1 --branch=v4.9 https://github.com/pyinstaller/pyinstaller
         cd pyinstaller/bootloader
         python3 ./waf distclean all --target-arch=32bit
         cd ..


### PR DESCRIPTION
pyinstaller 4.10 updated to commit e319ae3d00 which implemented
a normalize icon function, but fixes for bug introduced there
(assuming $PWD instead of $SPECPATH) were added to 5.0 branch not v4.
Locking to v4.9 for now.