### PR TITLE
Change single click selection

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6513,7 +6513,7 @@ class Elemental(Service):
         if self.has_emphasis():
             if self._emphasized_bounds is not None and contains(
                 self._emphasized_bounds, position
-            ):
+            ) and not keep_old_selection:
                 return  # Select by position aborted since selection position within current select bounds.
         # Remember previous selection, in case we need to append...
         e_list = []
@@ -6521,15 +6521,15 @@ class Elemental(Service):
         if keep_old_selection:
             for node in self.elems(emphasized=True):
                 e_list.append(node)
-        for e in self.elems_nodes(depth=None):
+        for node in self.elems_nodes(emphasized=False):
             try:
-                bounds = e.bounds
+                bounds = node.bounds
             except AttributeError:
                 continue  # No bounds.
             if bounds is None:
                 continue
             if contains(bounds, position):
-                f_list.append(e)
+                f_list.append(node)
 
         if len(f_list) > 0:
             # We checked that before, f_list contains only elements with valid bounds...
@@ -6538,17 +6538,17 @@ class Elemental(Service):
                 e_area = float("inf")
             else:
                 e_area = -float("inf")
-            for elem in f_list:
-                cc = elem.bounds
+            for node in f_list:
+                cc = node.bounds
                 f_area = (cc[2]-cc[0]) * (cc[3] - cc[1])
                 if use_smallest:
                     if f_area<e_area:
                         e_area = f_area
-                        e = elem
+                        e = node
                 else:
                     if f_area>e_area:
                         e_area = f_area
-                        e = elem
+                        e = node
             if not e is None:
                 bounds = e.bounds
                 e_list.append(e)

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -13,7 +13,7 @@ class ElementsWidget(Widget):
         Widget.__init__(self, scene, all=True)
         self.renderer = renderer
         self.key_shift_pressed = False
-        self.ctrl_shift_pressed = False
+        self.key_ctrl_pressed = False
 
     def hit(self):
         return HITCHAIN_HIT

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -13,6 +13,7 @@ class ElementsWidget(Widget):
         Widget.__init__(self, scene, all=True)
         self.renderer = renderer
         self.key_shift_pressed = False
+        self.ctrl_shift_pressed = False
 
     def hit(self):
         return HITCHAIN_HIT
@@ -59,10 +60,17 @@ class ElementsWidget(Widget):
         elif event_type == "kb_shift_press":
             if not self.key_shift_pressed:
                 self.key_shift_pressed = True
+        elif event_type == "kb_ctrl_press":
+            if not self.key_ctrl_pressed:
+                self.key_ctrl_pressed = True
+        elif event_type == "kb_ctrl_release":
+            if self.key_ctrl_pressed:
+                self.key_ctrl_pressed = False
         elif event_type == "leftclick":
             elements = self.scene.context.elements
             keep_old = self.key_shift_pressed
-            elements.set_emphasized_by_position(space_pos, keep_old)
+            smallest = not self.key_ctrl_pressed
+            elements.set_emphasized_by_position(space_pos, keep_old, smallest)
             elements.signal("select_emphasized_tree", 0)
             return RESPONSE_CONSUME
         return RESPONSE_DROP


### PR DESCRIPTION
Allow two fundamentally different single-click selections:
- left-click - choose the smallest element under the mouse-cursor
- ctrl+left-click - choose the largest element under the mouse-cursor
This default behaviour can be toggled under preferences  
<img width="353" alt="image" src="https://user-images.githubusercontent.com/2670784/170845136-3db1a97f-25ad-4e9e-a1de-63280e569857.png">