### PR TITLE
Create a standard API for fill types

### DIFF
--- a/.github/workflows/win/file_version.txt
+++ b/.github/workflows/win/file_version.txt
@@ -6,8 +6,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(0, 8, 6, 0),
-    prodvers=(0, 8, 6, 0),
+    filevers=(0, 8, 7, 0),
+    prodvers=(0, 8, 7, 0),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'MeerK40t'),
         StringStruct(u'FileDescription', u'MeerK40t Laser Control Software'),
-        StringStruct(u'FileVersion', u'0.8.0006.0'),
+        StringStruct(u'FileVersion', u'0.8.0007.0'),
         StringStruct(u'InternalName', u'MeerK40t.exe'),
         StringStruct(u'LegalCopyright', u'MeerK40t, MIT License'),
         StringStruct(u'OriginalFilename', u'MeerK40t.exe'),
         StringStruct(u'ProductName', u'MeerK40t'),
-        StringStruct(u'ProductVersion', u'0.8.0006')])
+        StringStruct(u'ProductVersion', u'0.8.0007')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1031, 2058])])
   ]

--- a/meerk40t/balormk/BalorDriver.py
+++ b/meerk40t/balormk/BalorDriver.py
@@ -284,7 +284,9 @@ class BalorDriver:
         job.goto(0x8000, 0x8000)
         last_on = None
         self.wobble = None
-        for q in self.queue:
+        queue = self.queue
+        self.queue = list()
+        for q in queue:
             settings = q.settings
             penbox = settings.get("penbox_value")
             if penbox is not None:

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -29,7 +29,6 @@ class CutOpNode(Node, Parameters):
         Node.__init__(self, type="op cut", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
 
         if len(args) == 1:
             obj = args[0]

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -24,7 +24,6 @@ class DotsOpNode(Node, Parameters):
         Node.__init__(self, type="op dots", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
 
         if len(args) == 1:
             obj = args[0]

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -33,7 +33,6 @@ class EngraveOpNode(Node, Parameters):
         Node.__init__(self, type="op engrave", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
 
         if len(args) == 1:
             obj = args[0]

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -27,7 +27,6 @@ class HatchOpNode(Node, Parameters):
         Node.__init__(self, type="op hatch", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
         self._hatch_distance_native = None
 
         if len(args) == 1:

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -209,7 +209,7 @@ class HatchOpNode(Node, Parameters):
                         hatch_cache[key] = hatches
 
                     for polyline in HatchOpNode.split(hatches):
-                        node = PolylineNode(shape=abs(polyline))
+                        node = PolylineNode(shape=Polyline(*polyline))
                         node.settings.update(chain_settings)
                         self.add_node(node)
             return preprocess_hatch

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -221,9 +221,9 @@ class HatchOpNode(Node, Parameters):
                 path.approximate_arcs_with_cubics()
                 self.settings["line_color"] = path.stroke
                 for subpath in path.as_subpaths():
-                    sp = Path(subpath)
-                    if len(sp) == 0:
+                    if len(subpath) == 0:
                         continue
+                    sp = Path(subpath)
                     points = [sp.point(i / 100.0, error=1e-4) for i in range(101)]
                     c.append(points)
             commands.append(hatch(settings=self.settings, outlines=c))

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -218,6 +218,8 @@ class HatchOpNode(Node, Parameters):
             c = list()
             for node in self.children:
                 path = node.as_path()
+                path *= matrix
+                path = abs(path)
                 path.approximate_arcs_with_cubics()
                 self.settings["line_color"] = path.stroke
                 for subpath in path.as_subpaths():

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -26,7 +26,6 @@ class ImageOpNode(Node, Parameters):
         Node.__init__(self, type="op image", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
 
         if len(args) == 1:
             obj = args[0]

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -28,7 +28,6 @@ class RasterOpNode(Node, Parameters):
         Node.__init__(self, type="op raster", **kwargs)
         Parameters.__init__(self, None, **kwargs)
         self.settings.update(kwargs)
-        self._status_value = "Queued"
 
         if len(args) == 1:
             obj = args[0]

--- a/meerk40t/core/parameters.py
+++ b/meerk40t/core/parameters.py
@@ -9,7 +9,6 @@ INT_PARAMETERS = (
     "dot_length",
     "passes",
     "jog_distance",
-    "hatch_type",
     "raster_direction",
     "raster_preference_top",
     "raster_preference_right",
@@ -44,7 +43,7 @@ BOOL_PARAMETERS = (
     "force_twitchless",
 )
 
-STRING_PARAMETERS = ("overscan", "hatch_distance", "hatch_angle", "penbox_value", "penbox_pass")
+STRING_PARAMETERS = ("overscan", "hatch_distance", "hatch_angle", "hatch_type", "penbox_value", "penbox_pass")
 
 COLOR_PARAMETERS = ("color", "line_color")
 
@@ -332,7 +331,7 @@ class Parameters:
 
     @property
     def hatch_type(self):
-        return self.settings.get("hatch_type", 0)
+        return self.settings.get("hatch_type", "eulerian")
 
     @hatch_type.setter
     def hatch_type(self, value):

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -13,76 +13,61 @@ def split(points):
         yield points[pos : len(points)]
 
 
-def eulerian_fill(settings, outlines, matrix, penbox_pass=None):
+def eulerian_fill(settings, outlines, matrix):
     """
     Applies optimized Eulerian fill
     @return:
     """
     if matrix is None:
         matrix = Matrix()
-    passes = 1
-    pass_custom = settings.get("passes_custom", False)
-    if pass_custom:
-        passes = settings.get("passes", 1)
-    polyline_lookup = dict()
-    for p in range(passes):
-        settings = dict(settings)
-        if penbox_pass is not None:
-            try:
-                settings.update(penbox_pass[p])
-            except IndexError:
-                pass
-        h_dist = settings.get("hatch_distance", "1mm")
-        h_angle = settings.get("hatch_angle", "0deg")
-        distance_y = float(Length(h_dist))
-        if isinstance(h_angle, float):
-            angle = Angle.degrees(h_angle)
-            h_angle = str(h_angle)
-        else:
-            angle = Angle.parse(h_angle)
 
-        key = f"{h_angle},{h_dist}"
-        if key in polyline_lookup:
-            points = polyline_lookup[key]
-        else:
-            rotate = Matrix.rotate(angle)
-            counter_rotate = Matrix.rotate(-angle)
+    settings = dict(settings)
+    h_dist = settings.get("hatch_distance", "1mm")
+    h_angle = settings.get("hatch_angle", "0deg")
+    distance_y = float(Length(h_dist))
+    if isinstance(h_angle, float):
+        angle = Angle.degrees(h_angle)
+    else:
+        angle = Angle.parse(h_angle)
 
-            def mx_rotate(pt):
-                if pt is None:
-                    return None
-                return (
-                    pt[0] * rotate.a
-                    + pt[1] * rotate.c
-                    + 1 * rotate.e,
-                    pt[0] * rotate.b
-                    + pt[1] * rotate.d
-                    + 1 * rotate.f,
-                )
+    rotate = Matrix.rotate(angle)
+    counter_rotate = Matrix.rotate(-angle)
 
-            def mx_counter(pt):
-                if pt is None:
-                    return None
-                return (
-                    pt[0] * counter_rotate.a
-                    + pt[1] * counter_rotate.c
-                    + 1 * counter_rotate.e,
-                    pt[0] * counter_rotate.b
-                    + pt[1] * counter_rotate.d
-                    + 1 * counter_rotate.f,
-                )
-            transformed_vector = matrix.transform_vector([0, distance_y])
-            efill = EulerianFill(
-                abs(complex(transformed_vector[0], transformed_vector[1]))
-            )
-            for sp in outlines:
-                sp = list(map(mx_rotate, sp))
-                efill += sp
-            points = efill.get_fill()
+    def mx_rotate(pt):
+        if pt is None:
+            return None
+        return (
+            pt[0] * rotate.a
+            + pt[1] * rotate.c
+            + 1 * rotate.e,
+            pt[0] * rotate.b
+            + pt[1] * rotate.d
+            + 1 * rotate.f,
+        )
 
-            points = list(map(mx_counter, points))
-            polyline_lookup[key] = points
-        yield settings, points
+    def mx_counter(pt):
+        if pt is None:
+            return None
+        return (
+            pt[0] * counter_rotate.a
+            + pt[1] * counter_rotate.c
+            + 1 * counter_rotate.e,
+            pt[0] * counter_rotate.b
+            + pt[1] * counter_rotate.d
+            + 1 * counter_rotate.f,
+        )
+
+    transformed_vector = matrix.transform_vector([0, distance_y])
+    efill = EulerianFill(
+        abs(complex(transformed_vector[0], transformed_vector[1]))
+    )
+    for sp in outlines:
+        sp = list(map(mx_rotate, sp))
+        efill += sp
+    points = efill.get_fill()
+
+    points = list(map(mx_counter, points))
+    return points
 
 
 def plugin(kernel, lifecycle):

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -1,0 +1,86 @@
+from meerk40t.core.units import Length
+from meerk40t.svgelements import Angle, Matrix, Path, Polyline
+from meerk40t.tools.pathtools import EulerianFill
+
+
+def eulerian_fill(self, context, matrix):
+    """
+    Applies optimized Eulerian fill
+    @return:
+    """
+
+    def create_eulerian_fill():
+        c = list()
+        for node in self.children:
+            path = node.as_path()
+            path.approximate_arcs_with_cubics()
+            self.settings["line_color"] = path.stroke
+            for subpath in path.as_subpaths():
+                sp = Path(subpath)
+                if len(sp) == 0:
+                    continue
+                c.append(sp)
+        self.remove_all_children()
+
+        penbox_pass = self.settings.get("penbox_pass")
+        if penbox_pass is not None:
+            try:
+                penbox_pass = context.elements.penbox[penbox_pass]
+            except KeyError:
+                penbox_pass = None
+
+        polyline_lookup = dict()
+        for p in range(self.implicit_passes):
+            settings = dict(self.settings)
+            if penbox_pass is not None:
+                try:
+                    settings.update(penbox_pass[p])
+                except IndexError:
+                    pass
+            h_dist = settings.get("hatch_distance", "1mm")
+            h_angle = settings.get("hatch_angle", "0deg")
+            distance_y = float(Length(h_dist))
+            if isinstance(h_angle, float):
+                angle = Angle.degrees(h_angle)
+                h_angle = str(h_angle)
+            else:
+                angle = Angle.parse(h_angle)
+
+            key = f"{h_angle},{h_dist}"
+            if key in polyline_lookup:
+                polylines = polyline_lookup[key]
+            else:
+                counter_rotate = Matrix.rotate(-angle)
+                transformed_vector = matrix.transform_vector([0, distance_y])
+                efill = EulerianFill(
+                    abs(complex(transformed_vector[0], transformed_vector[1]))
+                )
+                for sp in c:
+                    sp.transform.reset()
+                    if angle is not None:
+                        sp *= Matrix.rotate(angle)
+                    sp = abs(sp)
+                    efill += [sp.point(i / 100.0, error=1e-4) for i in range(101)]
+                points = efill.get_fill()
+                polylines = list()
+                for pts in HatchOpNode.split(points):
+                    polyline = Polyline(pts, stoke=settings.get("line_color"))
+                    polyline *= counter_rotate
+                    polylines.append(abs(polyline))
+                polyline_lookup[key] = polylines
+            for polyline in polylines:
+                node = PolylineNode(shape=abs(polyline))
+                node.settings.update(settings)
+                self.add_node(node)
+        return
+
+    return create_eulerian_fill
+
+
+def plugin(kernel, lifecycle):
+    if lifecycle == "register":
+        _ = kernel.translation
+        context = kernel.root
+        context.register("hatch/eulerian", eulerian_fill)
+        context.register("hatch/scanline", eulerian_fill)
+

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -24,7 +24,7 @@ def eulerian_fill(context, settings, matrix, paths):
     if penbox_pass is not None:
         try:
             penbox_pass = context.elements.penbox[penbox_pass]
-        except KeyError:
+        except (KeyError, AttributeError):
             penbox_pass = None
 
     passes = 1

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -1,80 +1,85 @@
 from meerk40t.core.units import Length
-from meerk40t.svgelements import Angle, Matrix, Path, Polyline
+from meerk40t.svgelements import Angle, Matrix
 from meerk40t.tools.pathtools import EulerianFill
 
 
-def eulerian_fill(self, context, matrix):
+def split(points):
+    pos = 0
+    for i, pts in enumerate(points):
+        if pts is None:
+            yield points[pos : i - 1]
+            pos = i + 1
+    if pos != len(points):
+        yield points[pos : len(points)]
+
+
+def eulerian_fill(context, settings, matrix, paths):
     """
     Applies optimized Eulerian fill
     @return:
     """
+    if matrix is None:
+        matrix = Matrix()
+    penbox_pass = settings.get("penbox_pass")
+    if penbox_pass is not None:
+        try:
+            penbox_pass = context.elements.penbox[penbox_pass]
+        except KeyError:
+            penbox_pass = None
 
-    def create_eulerian_fill():
-        c = list()
-        for node in self.children:
-            path = node.as_path()
-            path.approximate_arcs_with_cubics()
-            self.settings["line_color"] = path.stroke
-            for subpath in path.as_subpaths():
-                sp = Path(subpath)
-                if len(sp) == 0:
-                    continue
-                c.append(sp)
-        self.remove_all_children()
-
-        penbox_pass = self.settings.get("penbox_pass")
+    passes = 1
+    pass_custom = settings.get("passes_custom", False)
+    if pass_custom:
+        passes = settings.get("passes", 1)
+    polyline_lookup = dict()
+    for p in range(passes):
+        settings = dict(settings)
         if penbox_pass is not None:
             try:
-                penbox_pass = context.elements.penbox[penbox_pass]
-            except KeyError:
-                penbox_pass = None
+                settings.update(penbox_pass[p])
+            except IndexError:
+                pass
+        h_dist = settings.get("hatch_distance", "1mm")
+        h_angle = settings.get("hatch_angle", "0deg")
+        distance_y = float(Length(h_dist))
+        if isinstance(h_angle, float):
+            angle = Angle.degrees(h_angle)
+            h_angle = str(h_angle)
+        else:
+            angle = Angle.parse(h_angle)
 
-        polyline_lookup = dict()
-        for p in range(self.implicit_passes):
-            settings = dict(self.settings)
-            if penbox_pass is not None:
-                try:
-                    settings.update(penbox_pass[p])
-                except IndexError:
-                    pass
-            h_dist = settings.get("hatch_distance", "1mm")
-            h_angle = settings.get("hatch_angle", "0deg")
-            distance_y = float(Length(h_dist))
-            if isinstance(h_angle, float):
-                angle = Angle.degrees(h_angle)
-                h_angle = str(h_angle)
-            else:
-                angle = Angle.parse(h_angle)
+        key = f"{h_angle},{h_dist}"
+        if key in polyline_lookup:
+            points = polyline_lookup[key]
+        else:
+            counter_rotate = Matrix.rotate(-angle)
+            transformed_vector = matrix.transform_vector([0, distance_y])
+            efill = EulerianFill(
+                abs(complex(transformed_vector[0], transformed_vector[1]))
+            )
+            for sp in paths:
+                sp.transform.reset()
+                if angle is not None:
+                    sp *= Matrix.rotate(angle)
+                sp = abs(sp)
+                efill += [sp.point(i / 100.0, error=1e-4) for i in range(101)]
+            points = efill.get_fill()
 
-            key = f"{h_angle},{h_dist}"
-            if key in polyline_lookup:
-                polylines = polyline_lookup[key]
-            else:
-                counter_rotate = Matrix.rotate(-angle)
-                transformed_vector = matrix.transform_vector([0, distance_y])
-                efill = EulerianFill(
-                    abs(complex(transformed_vector[0], transformed_vector[1]))
+            def matrix_point(pt):
+                if pt is None:
+                    return None
+                return (
+                    pt[0] * counter_rotate.a
+                    + pt[1] * counter_rotate.c
+                    + 1 * counter_rotate.e,
+                    pt[0] * counter_rotate.b
+                    + pt[1] * counter_rotate.d
+                    + 1 * counter_rotate.f,
                 )
-                for sp in c:
-                    sp.transform.reset()
-                    if angle is not None:
-                        sp *= Matrix.rotate(angle)
-                    sp = abs(sp)
-                    efill += [sp.point(i / 100.0, error=1e-4) for i in range(101)]
-                points = efill.get_fill()
-                polylines = list()
-                for pts in HatchOpNode.split(points):
-                    polyline = Polyline(pts, stoke=settings.get("line_color"))
-                    polyline *= counter_rotate
-                    polylines.append(abs(polyline))
-                polyline_lookup[key] = polylines
-            for polyline in polylines:
-                node = PolylineNode(shape=abs(polyline))
-                node.settings.update(settings)
-                self.add_node(node)
-        return
 
-    return create_eulerian_fill
+            points = list(map(matrix_point, points))
+            polyline_lookup[key] = points
+        yield points
 
 
 def plugin(kernel, lifecycle):
@@ -83,4 +88,3 @@ def plugin(kernel, lifecycle):
         context = kernel.root
         context.register("hatch/eulerian", eulerian_fill)
         context.register("hatch/scanline", eulerian_fill)
-

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -655,66 +655,66 @@ class GRBLDriver(Parameters):
         self.units_dirty = True
         return False
 
-    def plot_start2(self):
-        """
-        Called at the end of plot commands to ensure the driver can deal with them all as a group.
-
-        @return:
-        """
-        for q in self.queue:
-            self.plot_planner.push(q)
-        self.queue.clear()
-        if self.plot_data is None:
-            self.plot_data = self.plot_planner.gen()
-        self.g91_absolute()
-        self.g94_feedrate()
-        self.clean()
-        if self.service.use_m3:
-            self.grbl("M3\r")
-        else:
-            self.grbl("M4\r")
-
-        for x, y, on in self.plot_data:
-            while self.hold_work():
-                time.sleep(0.05)
-            if on > 1:
-                # Special Command.
-                if on & PLOT_FINISH:  # Plot planner is ending.
-                    break
-                elif on & PLOT_SETTING:  # Plot planner settings have changed.
-                    p_set = Parameters(self.plot_planner.settings)
-                    if p_set.power != self.power:
-                        self.set("power", p_set.power)
-                    if (
-                        p_set.speed != self.speed
-                        or p_set.raster_step != self.raster_step
-                    ):
-                        self.set("speed", p_set.speed)
-                    self.settings.update(p_set.settings)
-                elif on & (
-                    PLOT_RAPID | PLOT_JOG
-                ):  # Plot planner requests position change.
-                    self.move_mode = 0
-                    self.move(x, y)
-                continue
-            if on == 0:
-                self.move_mode = 0
-            else:
-                self.move_mode = 1
-            if self.on_value != on:
-                self.power_dirty = True
-            self.on_value = on
-            self.move(x, y)
-
-        self.plot_data = None
-        self.grbl("G1 S0\r")
-        self.grbl("M5\r")
-        self.power_dirty = True
-        self.speed_dirty = True
-        self.absolute_dirty = True
-        self.feedrate_dirty = True
-        self.units_dirty = True
-        return False
+    # def plot_start2(self):
+    #     """
+    #     Called at the end of plot commands to ensure the driver can deal with them all as a group.
+    #
+    #     @return:
+    #     """
+    #     for q in self.queue:
+    #         self.plot_planner.push(q)
+    #     self.queue.clear()
+    #     if self.plot_data is None:
+    #         self.plot_data = self.plot_planner.gen()
+    #     self.g91_absolute()
+    #     self.g94_feedrate()
+    #     self.clean()
+    #     if self.service.use_m3:
+    #         self.grbl("M3\r")
+    #     else:
+    #         self.grbl("M4\r")
+    #
+    #     for x, y, on in self.plot_data:
+    #         while self.hold_work():
+    #             time.sleep(0.05)
+    #         if on > 1:
+    #             # Special Command.
+    #             if on & PLOT_FINISH:  # Plot planner is ending.
+    #                 break
+    #             elif on & PLOT_SETTING:  # Plot planner settings have changed.
+    #                 p_set = Parameters(self.plot_planner.settings)
+    #                 if p_set.power != self.power:
+    #                     self.set("power", p_set.power)
+    #                 if (
+    #                     p_set.speed != self.speed
+    #                     or p_set.raster_step != self.raster_step
+    #                 ):
+    #                     self.set("speed", p_set.speed)
+    #                 self.settings.update(p_set.settings)
+    #             elif on & (
+    #                 PLOT_RAPID | PLOT_JOG
+    #             ):  # Plot planner requests position change.
+    #                 self.move_mode = 0
+    #                 self.move(x, y)
+    #             continue
+    #         if on == 0:
+    #             self.move_mode = 0
+    #         else:
+    #             self.move_mode = 1
+    #         if self.on_value != on:
+    #             self.power_dirty = True
+    #         self.on_value = on
+    #         self.move(x, y)
+    #
+    #     self.plot_data = None
+    #     self.grbl("G1 S0\r")
+    #     self.grbl("M5\r")
+    #     self.power_dirty = True
+    #     self.speed_dirty = True
+    #     self.absolute_dirty = True
+    #     self.feedrate_dirty = True
+    #     self.units_dirty = True
+    #     return False
 
     def blob(self, data_type, data):
         """

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -221,7 +221,7 @@ def plugin(kernel, lifecycle):
                 message = """This version of MeerK40t is unstable. It is intended primarily for testing purposes. Please report all problems, even small ones to the github issue opened for this version. Do not continue using this version if it is not the latest RC or if your work requires a more stable version.
                 
                 Open Issue Page?"""
-                caption = _("Release Candidate.")
+                caption = _("Report Candidate.")
                 import wx
 
                 style = wx.YES_NO | wx.CANCEL | wx.ICON_WARNING
@@ -233,7 +233,7 @@ def plugin(kernel, lifecycle):
                 )
                 answer = dlg.ShowModal()
                 if answer in (wx.YES, wx.ID_YES):
-                    issue_page = "https://github.com/meerk40t/meerk40t/issues/967"
+                    issue_page = "https://github.com/meerk40t/meerk40t/issues/1065"
                     import webbrowser
 
                     webbrowser.open(issue_page, new=0, autoraise=True)

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -1001,7 +1001,7 @@ class HatchSettingsPanel(wx.Panel):
                 (w * 0.25, h * 0.25),
             ),
         )
-        matrix = Matrix.scale(0.1)
+        matrix = Matrix.scale(0.05)
         hatches = list(hatch_algorithm(settings=self.operation.settings, outlines=paths, matrix=matrix, penbox_pass=None))
 
         h_start = []

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -861,8 +861,9 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_fill, 6, wx.EXPAND, 0)
 
+        self.fills = list(self.context.match("hatch", suffix=True))
         self.combo_fill_style = wx.ComboBox(
-            self, wx.ID_ANY, choices=["Euler", "Scan"], style=wx.CB_DROPDOWN
+            self, wx.ID_ANY, choices=self.fills, style=wx.CB_DROPDOWN
         )
         sizer_fill.Add(self.combo_fill_style, 0, wx.EXPAND, 0)
 
@@ -901,7 +902,14 @@ class HatchSettingsPanel(wx.Panel):
 
     def set_widgets(self, node):
         self.operation = node
-        self.combo_fill_style.SetSelection(self.operation.hatch_type)
+        i = 0
+        for ht in self.fills:
+            if ht == self.operation.hatch_type:
+                break
+            i += 1
+        if i == len(self.fills):
+            i = 0
+        self.combo_fill_style.SetSelection(i)
         self.text_angle.SetValue(self.operation.hatch_angle)
         self.text_distance.SetValue(str(self.operation.hatch_distance))
         try:
@@ -940,7 +948,8 @@ class HatchSettingsPanel(wx.Panel):
         self.refresh_display()
 
     def on_combo_fill(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
-        self.operation.hatch_type = int(self.combo_fill_style.GetSelection())
+        hatch_type = self.fills[int(self.combo_fill_style.GetSelection())]
+        self.operation.hatch_type = hatch_type
         self.hatch_lines = None
         self.travel_lines = None
         self.refresh_display()

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -987,10 +987,6 @@ class HatchSettingsPanel(wx.Panel):
     def calculate_hatch_lines(self):
         w, h = self._Buffer.Size
         hatch_type = self.operation.hatch_type
-        if hatch_type == 0:
-            hatch_type = "eulerian"
-        else:
-            hatch_type = "scanline"
         hatch_algorithm = self.context.lookup(f"hatch/{hatch_type}")
         if hatch_algorithm is None:
             return
@@ -1011,7 +1007,7 @@ class HatchSettingsPanel(wx.Panel):
             ),
         )
         matrix = Matrix.scale(0.05)
-        hatches = list(hatch_algorithm(settings=self.operation.settings, outlines=paths, matrix=matrix, penbox_pass=None))
+        hatch = list(hatch_algorithm(settings=self.operation.settings, outlines=paths, matrix=matrix))
 
         h_start = []
         h_end = []
@@ -1020,26 +1016,25 @@ class HatchSettingsPanel(wx.Panel):
         last_x = None
         last_y = None
         travel = True
-        for settings, hatch in hatches:
-            for p in hatch:
-                if p is None:
-                    travel = True
-                    continue
-                x, y = p
-                if last_x is None:
-                    last_x = x
-                    last_y = y
-                    travel = False
-                    continue
-                if travel:
-                    t_start.append((last_x, last_y))
-                    t_end.append((x, y))
-                else:
-                    h_start.append((last_x, last_y))
-                    h_end.append((x, y))
-                travel = False
+        for p in hatch:
+            if p is None:
+                travel = True
+                continue
+            x, y = p
+            if last_x is None:
                 last_x = x
                 last_y = y
+                travel = False
+                continue
+            if travel:
+                t_start.append((last_x, last_y))
+                t_end.append((x, y))
+            else:
+                h_start.append((last_x, last_y))
+                h_end.append((x, y))
+            travel = False
+            last_x = x
+            last_y = y
         self.hatch_lines = h_start, h_end
         self.travel_lines = t_start, t_end
 

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -984,7 +984,7 @@ class HatchSettingsPanel(wx.Panel):
             (w * 0.25, h * 0.75),
             (w * 0.25, h * 0.25),
         )
-        hatch = hatch_algorithm(self.context, None, paths)
+        hatch = hatch_algorithm(self.context, self.operation.settings, None, paths)
         h_start = []
         h_end = []
         t_start = []

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -915,6 +915,9 @@ class HatchSettingsPanel(wx.Panel):
             self.operation.hatch_distance = Length(
                 self.text_distance.GetValue()
             ).length_mm
+            self.hatch_lines = None
+            self.travel_lines = None
+            self.refresh_display()
         except ValueError:
             pass
 
@@ -923,15 +926,24 @@ class HatchSettingsPanel(wx.Panel):
             self.operation.hatch_angle = (
                 f"{Angle.parse(self.text_angle.GetValue()).as_degrees}deg"
             )
+            self.hatch_lines = None
+            self.travel_lines = None
+            self.refresh_display()
         except ValueError:
             return
 
     def on_slider_angle(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
         value = self.slider_angle.GetValue()
         self.text_angle.SetValue(f"{value}deg")
+        self.hatch_lines = None
+        self.travel_lines = None
+        self.refresh_display()
 
     def on_combo_fill(self, event):  # wxGlade: HatchSettingsPanel.<event_handler>
         self.operation.hatch_type = int(self.combo_fill_style.GetSelection())
+        self.hatch_lines = None
+        self.travel_lines = None
+        self.refresh_display()
 
     def on_display_paint(self, event=None):
         try:

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -162,6 +162,10 @@ def plugin(kernel, lifecycle):
 
         plugins.append(svg_io.plugin)
 
+        from .fill import fills
+
+        plugins.append(fills.plugin)
+
         from .extra import vectrace
 
         plugins.append(vectrace.plugin)

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -12,7 +12,7 @@ import sys
 from meerk40t.kernel import Kernel
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.8.0006 RC5"
+APPLICATION_VERSION = "0.8.0007 RC6"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = meerk40t
-version = 0.8.0006
+version = 0.8.0007
 description = MeerK40t LaserCutter Software
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/test/bootstrap.py
+++ b/test/bootstrap.py
@@ -32,6 +32,10 @@ def bootstrap():
 
     kernel.add_plugin(imagetools.plugin)
 
+    from meerk40t.fill import fills
+
+    kernel.add_plugin(fills.plugin)
+
     from meerk40t.device.ch341 import ch341
 
     kernel.add_plugin(ch341.plugin)

--- a/test/test_elements_penbox.py
+++ b/test/test_elements_penbox.py
@@ -14,9 +14,9 @@ class TestPenbox(unittest.TestCase):
         kernel = bootstrap.bootstrap()
         try:
             kernel_root = kernel.get_context("/")
-            kernel_root("penbox passes add 5 set 0-4 hatch_angle 0-90\n")
-            self.assertEqual(len(kernel_root.elements.penbox["passes"]), 5)
-            self.assertEqual(kernel_root.elements.penbox["passes"][-1]["hatch_angle"], 90)
+            kernel_root("penbox testpasses add 5 set 0-4 hatch_angle 0-90\n")
+            self.assertEqual(len(kernel_root.elements.penbox["testpasses"]), 5)
+            self.assertEqual(kernel_root.elements.penbox["testpasses"][-1]["hatch_angle"], 90)
 
         finally:
             kernel.shutdown()

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -1,0 +1,31 @@
+import unittest
+
+from meerk40t.fill.fills import eulerian_fill
+from meerk40t.svgelements import Path, Polyline
+
+
+class TestFill(unittest.TestCase):
+    """Tests the functionality of fills."""
+
+    def test_fill_euler(self):
+        w = 10000
+        h = 10000
+        paths = Path(Polyline(
+            (w * 0.05, h * 0.05),
+            (w * 0.95, h * 0.05),
+            (w * 0.95, h * 0.95),
+            (w * 0.05, h * 0.95),
+            (w * 0.05, h * 0.05),
+        )), Path(Polyline(
+            (w * 0.25, h * 0.25),
+            (w * 0.75, h * 0.25),
+            (w * 0.75, h * 0.75),
+            (w * 0.25, h * 0.75),
+            (w * 0.25, h * 0.25),
+        ))
+        fills = list(eulerian_fill(None, {}, None, paths))
+        self.assertEqual(len(fills), 1)
+        fill = fills[0]
+        self.assertEqual(len(fill), 13)
+        for x, y in fill:
+            self.assertIn(x, (500, 2500, 7500, 9500))

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -96,6 +96,37 @@ class TestFill(unittest.TestCase):
         finally:
             kernel.shutdown()
 
+    def test_fill_hatch2(self):
+        kernel = bootstrap.bootstrap()
+        try:
+            kernel.console("operation* delete\n")
+            kernel.console("rect 0 0 1in 1in\n")
+            kernel.console("rect 3in 0 1in 1in\n")
+            kernel.console("hatch\n")
+            hatch = list(kernel.elements.ops())[0]
+
+            rect0 = list(kernel.elements.elems())[0]
+            hatch.add_node(copy(rect0))
+            rect1 = list(kernel.elements.elems())[1]
+            hatch.add_node(copy(rect1))
+            commands = list()
+            # kernel.console("tree list\n")
+            hatch.preprocess(kernel.root, Matrix(), commands)
+            for command in commands:
+                command()
+            # kernel.console("tree list\n")
+            polyline_node0 = hatch.children[0]
+            shape0 = polyline_node0.shape
+            self.assertEqual(len(shape0), 76)
+            # print(shape0)
+
+            polyline_node1 = hatch.children[1]
+            shape1 = polyline_node1.shape
+            self.assertEqual(len(shape1), 50)
+            # print(shape1)
+        finally:
+            kernel.shutdown()
+
 
     def test_fill_kernel_registered(self):
         kernel = bootstrap.bootstrap()

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -1,7 +1,8 @@
 import unittest
+from copy import copy
 
 from meerk40t.fill.fills import eulerian_fill
-from meerk40t.svgelements import Matrix
+from meerk40t.svgelements import Matrix, Rect
 from test import bootstrap
 
 
@@ -72,6 +73,29 @@ class TestFill(unittest.TestCase):
             self.assertIn(x, (50, 250, 750, 950))
 
         # draw(fill, w, h)
+
+    def test_fill_hatch(self):
+        kernel = bootstrap.bootstrap()
+        try:
+            kernel.console("operation* delete\n")
+            kernel.console("rect 0 0 1in 1in\n")
+            kernel.console("hatch\n")
+            hatch = list(kernel.elements.ops())[0]
+            rect = list(kernel.elements.elems())[0]
+            hatch.add_node(copy(rect))
+            commands = list()
+            # kernel.console("tree list\n")
+            hatch.preprocess(kernel.root, Matrix(), commands)
+            for command in commands:
+                command()
+            # kernel.console("tree list\n")
+            polyline_node = hatch.children[0]
+            shape = polyline_node.shape
+            self.assertEqual(len(shape), 77)
+            print(shape)
+        finally:
+            kernel.shutdown()
+
 
     def test_fill_kernel_registered(self):
         kernel = bootstrap.bootstrap()

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -2,6 +2,7 @@ import unittest
 
 from meerk40t.fill.fills import eulerian_fill
 from meerk40t.svgelements import Matrix
+from test import bootstrap
 
 
 def draw(fill, w, h, filename="test.png"):
@@ -75,3 +76,11 @@ class TestFill(unittest.TestCase):
             self.assertIn(x, (50, 250, 750, 950))
 
         # draw(fill, w, h)
+
+    def test_fill_kernel_registered(self):
+        kernel = bootstrap.bootstrap()
+        try:
+            eulerian_fill_k = kernel.lookup("hatch/eulerian")
+            self.assertIs(eulerian_fill_k, eulerian_fill)
+        finally:
+            kernel.shutdown()

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -1,7 +1,6 @@
 import unittest
 
 from meerk40t.fill.fills import eulerian_fill
-from meerk40t.svgelements import Path, Polyline
 
 
 class TestFill(unittest.TestCase):
@@ -10,22 +9,26 @@ class TestFill(unittest.TestCase):
     def test_fill_euler(self):
         w = 10000
         h = 10000
-        paths = Path(Polyline(
-            (w * 0.05, h * 0.05),
-            (w * 0.95, h * 0.05),
-            (w * 0.95, h * 0.95),
-            (w * 0.05, h * 0.95),
-            (w * 0.05, h * 0.05),
-        )), Path(Polyline(
-            (w * 0.25, h * 0.25),
-            (w * 0.75, h * 0.25),
-            (w * 0.75, h * 0.75),
-            (w * 0.25, h * 0.75),
-            (w * 0.25, h * 0.25),
-        ))
-        fills = list(eulerian_fill(None, {}, None, paths))
+        paths = (
+            (
+                (w * 0.05, h * 0.05),
+                (w * 0.95, h * 0.05),
+                (w * 0.95, h * 0.95),
+                (w * 0.05, h * 0.95),
+                (w * 0.05, h * 0.05),
+            ),
+            (
+                (w * 0.25, h * 0.25),
+                (w * 0.75, h * 0.25),
+                (w * 0.75, h * 0.75),
+                (w * 0.25, h * 0.75),
+                (w * 0.25, h * 0.25),
+            ),
+        )
+
+        fills = list(eulerian_fill(settings={}, outlines=paths, matrix=None, penbox_pass=None))
         self.assertEqual(len(fills), 1)
-        fill = fills[0]
+        settings, fill = fills[0]
         self.assertEqual(len(fill), 13)
         for x, y in fill:
             self.assertIn(x, (500, 2500, 7500, 9500))

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -41,9 +41,7 @@ class TestFill(unittest.TestCase):
             ),
         )
 
-        fills = list(eulerian_fill(settings={}, outlines=paths, matrix=None, penbox_pass=None))
-        self.assertEqual(len(fills), 1)
-        settings, fill = fills[0]
+        fill = list(eulerian_fill(settings={}, outlines=paths, matrix=None))
         self.assertEqual(len(fill), 13)
         for x, y in fill:
             self.assertIn(x, (500, 2500, 7500, 9500))
@@ -68,9 +66,7 @@ class TestFill(unittest.TestCase):
             ),
         )
         matrix = Matrix.scale(0.005)
-        fills = list(eulerian_fill(settings={}, outlines=paths, matrix=matrix, penbox_pass=None))
-        self.assertEqual(len(fills), 1)
-        settings, fill = fills[0]
+        fill = list(eulerian_fill(settings={}, outlines=paths, matrix=matrix))
         self.assertEqual(len(fill), 327)
         for x, y in fill:
             self.assertIn(x, (50, 250, 750, 950))

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -1,6 +1,7 @@
 import unittest
 
 from meerk40t.fill.fills import eulerian_fill
+from meerk40t.svgelements import Matrix
 
 
 class TestFill(unittest.TestCase):
@@ -32,3 +33,41 @@ class TestFill(unittest.TestCase):
         self.assertEqual(len(fill), 13)
         for x, y in fill:
             self.assertIn(x, (500, 2500, 7500, 9500))
+
+    def test_fill_euler_scale(self):
+        w = 1000
+        h = 1000
+        paths = (
+            (
+                (w * 0.05, h * 0.05),
+                (w * 0.95, h * 0.05),
+                (w * 0.95, h * 0.95),
+                (w * 0.05, h * 0.95),
+                (w * 0.05, h * 0.05),
+            ),
+            (
+                (w * 0.25, h * 0.25),
+                (w * 0.75, h * 0.25),
+                (w * 0.75, h * 0.75),
+                (w * 0.25, h * 0.75),
+                (w * 0.25, h * 0.25),
+            ),
+        )
+        matrix = Matrix.scale(0.005)
+        fills = list(eulerian_fill(settings={}, outlines=paths, matrix=matrix, penbox_pass=None))
+        self.assertEqual(len(fills), 1)
+        settings, fill = fills[0]
+        self.assertEqual(len(fill), 327)
+        for x, y in fill:
+            self.assertIn(x, (50, 250, 750, 950))
+
+        # from PIL import Image, ImageDraw
+        # im = Image.new('RGBA', (w, h), "white")
+        # draw = ImageDraw.Draw(im)
+        # last_x = None
+        # last_y = None
+        # for x, y in fill:
+        #     if last_x is not None:
+        #         draw.line((last_x, last_y, x, y), fill="black")
+        #     last_x, last_y = x, y
+        # im.save("test.png")

--- a/test/test_fill.py
+++ b/test/test_fill.py
@@ -4,6 +4,19 @@ from meerk40t.fill.fills import eulerian_fill
 from meerk40t.svgelements import Matrix
 
 
+def draw(fill, w, h, filename="test.png"):
+    from PIL import Image, ImageDraw
+    im = Image.new('RGBA', (w, h), "white")
+    draw = ImageDraw.Draw(im)
+    last_x = None
+    last_y = None
+    for x, y in fill:
+        if last_x is not None:
+            draw.line((last_x, last_y, x, y), fill="black")
+        last_x, last_y = x, y
+    im.save(filename)
+
+
 class TestFill(unittest.TestCase):
     """Tests the functionality of fills."""
 
@@ -61,13 +74,4 @@ class TestFill(unittest.TestCase):
         for x, y in fill:
             self.assertIn(x, (50, 250, 750, 950))
 
-        # from PIL import Image, ImageDraw
-        # im = Image.new('RGBA', (w, h), "white")
-        # draw = ImageDraw.Draw(im)
-        # last_x = None
-        # last_y = None
-        # for x, y in fill:
-        #     if last_x is not None:
-        #         draw.line((last_x, last_y, x, y), fill="black")
-        #     last_x, last_y = x, y
-        # im.save("test.png")
+        # draw(fill, w, h)


### PR DESCRIPTION
Hatches use fill types and this code is needed in multiple places. For example:

* Hatch Operation
* Preview of Hatch Operation
* Potentially Hatch Elements with real time viewing

There is currently not an easy way to define these or allow plugins to extend these. This PR seeks to implement hatch fill types dynamically.
