### PR TITLE
Consistent classification, some bugfixes

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6700,8 +6700,8 @@ class Elemental(Service):
             was_classified = False
             # image_added code removed because it could never be used
             for op in operations:
-                # Are the colors identical?
-                same_color = False
+                # Are the colors identical? if the op is default then in any case
+                same_color = op.default
                 if hasattr(node, "stroke") and node.stroke is not None:
                     # print ("Color-node: %d, %d, %d, Color-op: %d, %d, %d" % (node.stroke.red, node.stroke.green, node.stroke.blue, op.color.red, op.color.green, op.color.blue))
                     # Remove opacity
@@ -6709,8 +6709,6 @@ class Elemental(Service):
                     plain_color_node = abs(node.stroke)
                     if plain_color_op==plain_color_node:
                         same_color = True
-                else:
-                    same_color = False
                 # print ("Node-stroke=%s, op.color=%s, node.type=%s, Default=%s, op-type=%s" % (node.stroke, op.color, node.type, op.default, op.type))
                 # print ("Color identical" if same_color else "Color different")
                 if op.type == "op raster":

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3316,6 +3316,7 @@ class Elemental(Service):
                             e.altered()
                 return "elements", data
 
+        @self.console_option("classify", "c", type=bool, action="store_true", help="Reclassify element")
         @self.console_option("filter", "f", type=str, help="Filter indexes")
         @self.console_argument(
             "color", type=Color, help=_("Color to color the given stroke")
@@ -3330,10 +3331,13 @@ class Elemental(Service):
             output_type="elements",
         )
         def element_stroke(
-            command, channel, _, color, data=None, filter=None, **kwargs
+            command, channel, _, color, data=None, classify=None, filter=None, **kwargs
         ):
             if data is None:
                 data = list(self.elems(emphasized=True))
+                was_emphasized = True
+            else:
+                was_emphasized = False
             apply = data
             if filter is not None:
                 apply = list()
@@ -3369,8 +3373,18 @@ class Elemental(Service):
                 for e in apply:
                     e.stroke = Color(color)
                     e.altered()
+            if classify is None:
+                classify = False
+            if classify:
+                self.remove_elements_from_operations(apply)
+                self.classify(apply)
+                if was_emphasized:
+                    for e in apply:
+                        e.emphasized = True
+                self.signal("rebuild_tree")
             return "elements", data
 
+        @self.console_option("classify", "c", type=bool, action="store_true", help="Reclassify element")
         @self.console_option("filter", "f", type=str, help="Filter indexes")
         @self.console_argument("color", type=Color, help=_("Color to set the fill to"))
         @self.console_command(
@@ -3382,9 +3396,12 @@ class Elemental(Service):
             ),
             output_type="elements",
         )
-        def element_fill(command, channel, _, color, data=None, filter=None, **kwargs):
+        def element_fill(command, channel, _, color, data=None, classify=None, filter=None, **kwargs):
             if data is None:
                 data = list(self.elems(emphasized=True))
+                was_emphasized = True
+            else:
+                was_emphasized = False
             apply = data
             if filter is not None:
                 apply = list()
@@ -3420,6 +3437,15 @@ class Elemental(Service):
                 for e in apply:
                     e.fill = Color(color)
                     e.altered()
+            if classify is None:
+                classify = False
+            if classify:
+                self.remove_elements_from_operations(apply)
+                self.classify(apply)
+                if was_emphasized:
+                    for e in apply:
+                        e.emphasized = True
+                self.signal("rebuild_tree")
             return "elements", data
 
         @self.console_argument(
@@ -4044,10 +4070,17 @@ class Elemental(Service):
         def element_classify(command, channel, _, data=None, **kwargs):
             if data is None:
                 data = list(self.elems(emphasized=True))
+                was_emphasized = True
+            else:
+                was_emphasized = False
             if len(data) == 0:
                 channel(_("No selected elements."))
                 return
             self.classify(data)
+            if was_emphasized:
+                for e in data:
+                    e.emphasized = True
+
             return "elements", data
 
         @self.console_command(
@@ -4059,10 +4092,17 @@ class Elemental(Service):
         def declassify(command, channel, _, data=None, **kwargs):
             if data is None:
                 data = list(self.elems(emphasized=True))
+                was_emphasized = True
+            else:
+                was_emphasized = False
             if len(data) == 0:
                 channel(_("No selected elements."))
                 return
             self.remove_elements_from_operations(data)
+            # restore emphasized flag as it is relevant for subsequent operations
+            if was_emphasized:
+                for e in data:
+                    e.emphasized = True
             return "elements", data
 
         # ==========
@@ -5180,7 +5220,7 @@ class Elemental(Service):
             for i in range(copies):
                 node.parent.add_reference(node.node, type="reference", pos=index)
             node.modified()
-            self.signal("rebuild_tree")
+            self.signal("tree_changed")
 
         @self.tree_conditional(lambda node: node.count_children() > 1)
         @self.tree_operation(
@@ -6660,12 +6700,21 @@ class Elemental(Service):
             was_classified = False
             # image_added code removed because it could never be used
             for op in operations:
+                # Are the colors identical?
+                same_color = False
+                if hasattr(node, "stroke") and node.stroke is not None:
+                    # print ("Color-node: %d, %d, %d, Color-op: %d, %d, %d" % (node.stroke.red, node.stroke.green, node.stroke.blue, op.color.red, op.color.green, op.color.blue))
+                    # Remove opacity
+                    plain_color_op = abs(op.color)
+                    plain_color_node = abs(node.stroke)
+                    if plain_color_op==plain_color_node:
+                        same_color = True
+                else:
+                    same_color = False
+                # print ("Node-stroke=%s, op.color=%s, node.type=%s, Default=%s, op-type=%s" % (node.stroke, op.color, node.type, op.default, op.type))
+                # print ("Color identical" if same_color else "Color different")
                 if op.type == "op raster":
-                    if (
-                        hasattr(node, "stroke")
-                        and node.stroke is not None
-                        and (op.color == node.stroke or op.default)
-                    ):
+                    if same_color:
                         op.add_reference(node)
                         was_classified = True
                     elif node.type == "elem image":
@@ -6682,11 +6731,7 @@ class Elemental(Service):
                         op.add_reference(node)
                         was_classified = True
                 elif op.type in ("op engrave", "op cut", "op hatch"):
-                    if (
-                        hasattr(node, "stroke")
-                        and node.stroke is not None
-                        and op.color == node.stroke
-                    ) or op.default:
+                    if same_color:
                         op.add_reference(node)
                         was_classified = True
                 elif op.type == "op image" and node.type == "elem image":
@@ -6699,6 +6744,7 @@ class Elemental(Service):
                     break  # May only classify in Dots.
 
             if not was_classified:
+                # print("Was not classified: add new op...")
                 op = None
                 if node.type == "elem image":
                     op = ImageOpNode(output=False)
@@ -6707,9 +6753,12 @@ class Elemental(Service):
                 elif (
                     hasattr(node, "stroke")
                     and node.stroke is not None
-                    and node.stroke.value is not None
                 ):
-                    op = EngraveOpNode(color=node.stroke, speed=35.0)
+                # If it's plain red then make a cutop...
+                    if node.stroke.red == 0xff and node.stroke.blue==0 and node.stroke.green==0:
+                        op = CutOpNode(color=node.stroke, speed=5.0)
+                    else:
+                        op = EngraveOpNode(color=node.stroke, speed=35.0)
                 if op is not None:
                     add_op_function(op)
                     op.add_reference(node)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -400,17 +400,14 @@ class CustomStatusBar(wx.StatusBar):
             button = event.EventObject
             color = button.GetBackgroundColour()
             rgb = [color.Red(), color.Green(), color.Blue()]
-            mysignal = "selstroke"
-            self.context.signal(mysignal, rgb)
+            self.context("stroke #%02x%02x%02x --classify\n" % (color.Red(), color.Green(), color.Blue()))
 
     def on_button_color_right(self, event):
         # Okay my backgroundcolor is...
         if not self.startup:
             button = event.EventObject
             color = button.GetBackgroundColour()
-            rgb = [color.Red(), color.Green(), color.Blue()]
-            mysignal = "selfill"
-            self.context.signal(mysignal, rgb)
+            self.context("fill #%02x%02x%02x --classify\n" % (color.Red(), color.Green(), color.Blue()))
 
     def on_stroke_width(self, event):
         if not self.startup:

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -553,55 +553,6 @@ class MeerK40tScenePanel(wx.Panel):
         self.scene.signal("theme", theme)
         self.request_refresh(origin)
 
-    @signal_listener("selstroke")
-    def on_selstroke(self, origin, rgb, *args):
-        # print (origin, rgb, args)
-        if rgb[0] == 255 and rgb[1] == 255 and rgb[2] == 255:
-            color = None
-        else:
-            color = Color(rgb[0], rgb[1], rgb[2])
-        self.widget_scene.default_stroke = color
-
-        for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
-            obj = e
-            try:
-                if color is None:
-                    e.stroke = Color("none")
-                else:
-                    e.stroke = color
-                e.altered()
-            except AttributeError:
-                # Ignore and carry on...
-                continue
-        # Reclassify selection...
-        self.context("declassify\nclassify\n")
-        self.context.signal("rebuild_tree")
-        self.request_refresh()
-
-    @signal_listener("selfill")
-    def on_selfill(self, origin, rgb, *args):
-        # print (origin, rgb, args)
-        if rgb[0] == 255 and rgb[1] == 255 and rgb[2] == 255:
-            color = None
-        else:
-            color = Color(rgb[0], rgb[1], rgb[2])
-        self.widget_scene.default_fill = color
-
-        for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
-            try:
-                if color is None:
-                    e.fill = Color("none")
-                else:
-                    e.fill = color
-                e.altered()
-            except AttributeError:
-                # Ignore and carry on...
-                continue
-        # Reclassify selection...
-        self.context("declassify\nclassify\n")
-        self.context.signal("rebuild_tree")
-        self.request_refresh()
-
     @signal_listener("selstrokewidth")
     def on_selstrokewidth(self, origin, stroke_width, *args):
         # Stroke_width is a text

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -504,6 +504,8 @@ class ShadowTree:
 
         @return:
         """
+        # Rebuild tree destroys the emphasis, so let's store it...
+        emphasized_list = list(self.elements.elems(emphasized=True))
         elemtree = self.elements._tree
         self.dragging_nodes = None
         self.wxtree.DeleteAllItems()
@@ -536,6 +538,9 @@ class ShadowTree:
         self.wxtree.Expand(node_operations.item)
         self.wxtree.Expand(node_elements.item)
         self.wxtree.Expand(node_registration.item)
+        # Restore emphasiss
+        for e in emphasized_list:
+            e.emphasized = True
 
     def register_children(self, node):
         """
@@ -615,6 +620,8 @@ class ShadowTree:
         """
         tree = self.wxtree
         node_item = node.item
+        if node_item is None:
+            return
         tree.SetItemBackgroundColour(node_item, None)
         try:
             if node.highlighted:


### PR DESCRIPTION
While trying to figure out while it always took two clicks on the colorbar to get a classification i did a couple of things
a) I tried to document the classify method a bit for my own benefit and (re)instated the pure red = cut op
b) I added an optional parameter to stroke and fill to allow for immediate classification of the object (imho that should be the default anyway but I left the current behaviour unchanged) 'stroke red --classify' or 'fill blue --classify'
c) I fixed the behaviour of "declassify" to swallow the emphasized flags
d) I fixed the behaviour of rebuild_tree to swallow the emphasized flags  

Before:
![classif_before](https://user-images.githubusercontent.com/2670784/171258928-0d40e2a3-6cda-431a-8786-6de91f479467.gif)

Now:
![classif_now](https://user-images.githubusercontent.com/2670784/171259108-ee4031fa-5cc0-47a4-a947-026ef0310a6e.gif)

