### PR TITLE
Deleting op will no longer delete contained elems

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5099,8 +5099,12 @@ class Elemental(Service):
                 self.flat(selected=True, cascade=False, types=non_structural_nodes)
             )
             for node in nodes:
-                if node.parent is not None:  # May have already removed.
-                    node.remove_node()
+                # If we are selecting an operation it also selects/emphasizes the
+                # contained elements - so both will be deleted...
+                # To circumvent this, we inquire once more the selected status...
+                if node.selected:
+                    if node.parent is not None:  # May have already removed.
+                        node.remove_node()
             self.set_emphasis(None)
 
         # ==========


### PR DESCRIPTION
Should fix the unwanted behaviour that if you delete an operation the contained elements are deleted as well