### PR TITLE
Improved Tree-menu-Display / Fix for default

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5073,21 +5073,45 @@ class Elemental(Service):
         # ==========
         # REMOVE MULTI (Tree Selected)
         # ==========
+        # Calculate the amount of selected nodes in the tree:
+        # If there are ops selected then they take preference
+        # and will only be counted
         @self.tree_conditional(
-            lambda cond: len(
+            lambda cond:
+            len(
                 list(
-                    self.flat(selected=True, cascade=False, types=non_structural_nodes)
+                    self.flat(selected=True, cascade=False, types=operate_nodes)
+                )
+            ) if len(
+                list(
+                    self.flat(selected=True, cascade=False, types=operate_nodes)
+                )
+            ) > 0 else
+            len(
+                list(
+                    self.flat(selected=True, cascade=False, types=elem_group_nodes)
                 )
             )
             > 1
         )
         @self.tree_calc(
             "ecount",
-            lambda i: len(
+            lambda i:
+            len(
                 list(
-                    self.flat(selected=True, cascade=False, types=non_structural_nodes)
+                    self.flat(selected=True, cascade=False, types=operate_nodes)
                 )
-            ),
+            ) if len(
+                list(
+                    self.flat(selected=True, cascade=False, types=operate_nodes)
+                )
+            ) > 0 else
+            len(
+                list(
+                    self.flat(selected=True, cascade=False, types=elem_group_nodes)
+                )
+            )
+            ,
         )
         @self.tree_operation(
             _("Remove %s selected items") % "{ecount}",
@@ -5095,8 +5119,16 @@ class Elemental(Service):
             help="",
         )
         def remove_multi_nodes(node, **kwargs):
+            if len(
+                list(
+                    self.flat(selected=True, cascade=False, types=operate_nodes)
+                )
+            ) > 0 :
+                types = operate_nodes
+            else:
+                types = elem_group_nodes
             nodes = list(
-                self.flat(selected=True, cascade=False, types=non_structural_nodes)
+                self.flat(selected=True, cascade=False, types=types)
             )
             for node in nodes:
                 # If we are selecting an operation it also selects/emphasizes the

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5074,7 +5074,7 @@ class Elemental(Service):
         # REMOVE MULTI (Tree Selected)
         # ==========
         # Calculate the amount of selected nodes in the tree:
-        # If there are ops selected then they take preference
+        # If there are ops selected then they take precedence
         # and will only be counted
         @self.tree_conditional(
             lambda cond:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -401,6 +401,8 @@ class CustomStatusBar(wx.StatusBar):
             color = button.GetBackgroundColour()
             rgb = [color.Red(), color.Green(), color.Blue()]
             self.context("stroke #%02x%02x%02x --classify\n" % (color.Red(), color.Green(), color.Blue()))
+            rgb = [color.Red(), color.Green(), color.Blue()]
+            self.context.signal("selstroke", rgb)
 
     def on_button_color_right(self, event):
         # Okay my backgroundcolor is...
@@ -408,6 +410,8 @@ class CustomStatusBar(wx.StatusBar):
             button = event.EventObject
             color = button.GetBackgroundColour()
             self.context("fill #%02x%02x%02x --classify\n" % (color.Red(), color.Green(), color.Blue()))
+            rgb = [color.Red(), color.Green(), color.Blue()]
+            self.context.signal("selfill", rgb)
 
     def on_stroke_width(self, event):
         if not self.startup:

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -553,6 +553,24 @@ class MeerK40tScenePanel(wx.Panel):
         self.scene.signal("theme", theme)
         self.request_refresh(origin)
 
+    @signal_listener("selstroke")
+    def on_selstroke(self, origin, rgb, *args):
+        # print (origin, rgb, args)
+        if rgb[0] == 255 and rgb[1] == 255 and rgb[2] == 255:
+            color = None
+        else:
+            color = Color(rgb[0], rgb[1], rgb[2])
+        self.widget_scene.default_stroke = color
+
+    @signal_listener("selfill")
+    def on_selfill(self, origin, rgb, *args):
+        # print (origin, rgb, args)
+        if rgb[0] == 255 and rgb[1] == 255 and rgb[2] == 255:
+            color = None
+        else:
+            color = Color(rgb[0], rgb[1], rgb[2])
+        self.widget_scene.default_fill = color
+
     @signal_listener("selstrokewidth")
     def on_selstrokewidth(self, origin, stroke_width, *args):
         # Stroke_width is a text


### PR DESCRIPTION
a) Amend display of affected nodes for node-deletion: If there are ops selected then they take precedence and will only be counted
b) The recent changes removed the default stroke / fill behaviour, this has been reestablished 