### PR TITLE
Identifying cameras

### DIFF
--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -319,6 +319,10 @@ class CameraPanel(wx.Panel, Job):
 
     def swap_camera(self, uri):
         def swap(event=None):
+            CAM_INDEX = "cam_%d_uri"
+            ukey = CAM_INDEX % self.index
+            context = self.context.get_context("/")
+            setattr(context, ukey, str(uri))
             self.context("camera%d --uri %s stop start\n" % (self.index, str(uri)))
             self.frame_bitmap = None
 
@@ -739,16 +743,18 @@ class CameraInterface(MWindow):
                     ukey = CAM_INDEX % index
                     testuri = getattr(kernel.root, ukey)
                     if testuri is None or testuri < 0:
-                        # Only offer it at the very first time, user might have chosen a different one...
                         foundstr = getattr(kernel.root, CAM_FOUND)
                         available_cameras = foundstr.split(";")
                         if index >= len(available_cameras):
                             # Took default
-                            testuri = 0
+                            if len(available_cameras>0):
+                                testuri = available_cameras[0]
+                            else:
+                                testuri = 0
                         else:
                             testuri = available_cameras[index]
                         setattr(kernel.root, ukey, int(testuri))
-                        kernel.console("camera%d --uri %s stop start\n" % (index, testuri))
+                    kernel.console("camera%d --uri %s stop start\n" % (index, testuri))
                     kernel.root.camera_default = index
                 v = kernel.root.camera_default
                 kernel.console("window toggle -m {v} CameraInterface {v}\n".format(v=v))

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -740,17 +740,15 @@ class CameraInterface(MWindow):
                 if index is not None:
                     ukey = CAM_INDEX % index
                     testuri = getattr(kernel.root, ukey)
-                    print("attribute for %d=%s" % (index, testuri))
                     if testuri is None or testuri < 0:
                         # Only offer it at the very first time, user might have chosen a different one...
                         foundstr = getattr(kernel.root, CAM_FOUND)
                         available_cameras = foundstr.split(";")
                         if index >= len(available_cameras):
+                            # Took default
                             testuri = 0
-                            print("Took default")
                         else:
                             testuri = available_cameras[index]
-                            print("Took camera %s" % testuri)
                         setattr(kernel.root, ukey, int(testuri))
                         kernel.console("camera%d --uri %s stop start\n" % (index, testuri))
                     kernel.root.camera_default = index

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -1,6 +1,5 @@
 import platform
 
-import cv2
 import wx
 from wx import aui
 
@@ -672,7 +671,6 @@ class CameraInterface(MWindow):
         super().__init__(640, 480, context, path, parent, **kwds)
         self.panel = CameraPanel(self, wx.ID_ANY, context=self.context, index=index)
         self.add_module_delegate(self.panel)
-        self.available_cameras = []
 
         # ==========
         # MENU BAR
@@ -767,11 +765,14 @@ class CameraInterface(MWindow):
                     ukey = CAM_INDEX % ci
                     kernel.root.setting(int, ukey, -1)
                     setattr(kernel.root, ukey, -1)
-
+                try:
+                    import cv2
+                except ImportError:
+                    return
                 MAXFIND = 5
                 found = 0
                 fstr = _("Cameras found: %d")
-                progress = wx.ProgressDialog(_("Looking for Cameras"), fstr % found, maximum=MAXFIND, parent=None, style=wx.PD_APP_MODAL)
+                progress = wx.ProgressDialog(_("Looking for Cameras"), fstr % found, maximum=MAXFIND, parent=None, style=wx.PD_APP_MODAL | wx.PD_CAN_ABORT)
                 # checks for cameras in the first 5 USB
                 index = 0
                 keepgoing = True


### PR DESCRIPTION
Try to look for cameras to assign them as default for camera0 to camera4. Needs testing on Darwin.
![camera](https://user-images.githubusercontent.com/2670784/172143742-df92f676-e43c-4046-8559-cd572dec0306.gif)

