### PR TITLE
Compare too rapid draw attempts

### DIFF
--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -55,6 +55,13 @@ class CircleTool(ToolWidget):
             self.p2 = complex(space_pos[0], space_pos[1])
             self.scene.request_refresh()
             response = RESPONSE_CONSUME
+        elif event_type == "leftclick":
+            # Dear user: that's too quick for my taste - take your time...
+            self.p1 = None
+            self.p2 = None
+            self.scene.tool_active = False
+            self.scene.request_refresh()
+            response = RESPONSE_ABORT
         elif event_type == "leftup":
             self.scene.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -49,6 +49,13 @@ class EllipseTool(ToolWidget):
             self.p2 = complex(space_pos[0], space_pos[1])
             self.scene.request_refresh()
             response = RESPONSE_CONSUME
+        elif event_type == "leftclick":
+            # Dear user: that's too quick for my taste - take your time...
+            self.p1 = None
+            self.p2 = None
+            self.scene.tool_active = False
+            self.scene.request_refresh()
+            response = RESPONSE_ABORT
         elif event_type == "leftup":
             self.scene.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -1,6 +1,6 @@
 import wx
 
-from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
+from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME, RESPONSE_ABORT
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
 from meerk40t.svgelements import Rect
 from meerk40t.gui.laserrender import swizzlecolor
@@ -46,6 +46,13 @@ class RectTool(ToolWidget):
             self.p2 = complex(space_pos[0], space_pos[1])
             self.scene.request_refresh()
             response = RESPONSE_CONSUME
+        elif event_type == "leftclick":
+            # Dear user: that's too quick for my taste - take your time...
+            self.p1 = None
+            self.p2 = None
+            self.scene.tool_active = False
+            self.scene.request_refresh()
+            response = RESPONSE_ABORT
         elif event_type == "leftup":
             self.scene.tool_active = False
             try:
@@ -72,7 +79,7 @@ class RectTool(ToolWidget):
             except IndexError:
                 pass
             self.scene.request_refresh()
-            response = RESPONSE_CONSUME
+            response = RESPONSE_ABORT
         elif event_type == "lost":
             self.scene.tool_active = False
         return response


### PR DESCRIPTION
Fix the ghost circles, ellipses, rectangles that appear if you try to rapidly try to draw something (internally considered to be a leftclick and not a sequence of leftdown leftup).