### PR TITLE
Some font tweaks

### DIFF
--- a/meerk40t/gui/fonts.py
+++ b/meerk40t/gui/fonts.py
@@ -86,7 +86,6 @@ def svgfont_to_wx(svgtextnode):
     wxfont.SetWeight(fontweight)
 
     ff = svgtextnode.text.font_family
-
     if ff == "fantasy":
         family = wx.FONTFAMILY_DECORATIVE
     elif ff == "serif":
@@ -94,17 +93,22 @@ def svgfont_to_wx(svgtextnode):
     elif ff == "cursive":
         family = wx.FONTFAMILY_SCRIPT
     elif ff == "sans-serif":
-        family = wx.FONTFAMILY_MODERN
+        family = wx.FONTFAMILY_SWISS
     elif ff == "monospace":
         family = wx.FONTFAMILY_TELETYPE
     else:
         family = wx.FONTFAMILY_SWISS
     wxfont.SetFamily(family)
-    okay = False
     if not svgtextnode.text.font_face is None:
         if svgtextnode.text.font_face[0] == "'":
             svgtextnode.text.font_face = svgtextnode.text.font_face.strip("'")
         okay = wxfont.SetFaceName(svgtextnode.text.font_face)
+    else:
+        try:
+            tst = wxfont.GetFaceName()
+            okay = True
+        except:
+            okay = False
     if not okay:
         if not svgtextnode.text.font_family is None:
             if svgtextnode.text.font_family[0] == "'":
@@ -114,7 +118,6 @@ def svgfont_to_wx(svgtextnode):
             okay = wxfont.SetFaceName(ff)
             if okay:
                 svgtextnode.text.font_face = ff
-
     ff = svgtextnode.font_style
     if ff == "normal":
         fontstyle = wx.FONTSTYLE_NORMAL


### PR DESCRIPTION
- Improved fontface selection
- Load and save text-anchor and text x and y attributes, better recognition of "class" provided font-attributes
- Some tweaks around bound-box calculation for a text

There's a fundamental flaw in wxPython to get the right fontsize.
Both GetTextExtent as well as GetFullTextextent provide the fontmetric-size as result for the font-height and dont take the real glyphs into account. That means that ".", "a", "g" and "T" all have the same height...
Consequently the size is always off... This can be somewhat compensated by taking the descent from the font-metric into account.
A 'real' height routine would most probably need to draw the string on an empty canvas and find the first and last dots on a line. I was wondering whether the imagetools provide such a functionality?!