### PR TITLE
Fix the fix

### DIFF
--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -172,7 +172,14 @@ class RectSelectWidget(Widget):
             else:
                 return RESPONSE_CHAIN
 
-        elif event_type in ("leftup", "leftclick"):
+        elif event_type == "leftclick":
+            # That's too fast
+            # still chaining though
+            self.scene.request_refresh()
+            self.start_location = None
+            self.end_location = None
+            return RESPONSE_CHAIN
+        elif event_type == "leftup":
             if self.start_location is None:
                 return RESPONSE_CHAIN
             _ = self.scene.context._


### PR DESCRIPTION
The previous PR was effectively consuming the leftclick event and not chain it to the elementswidget, preventing single click selections.