### PR TITLE
Apply optimisation to load command as well

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -277,9 +277,10 @@ class Elemental(Service):
                 channel(_("No such file."))
                 return
             try:
+                channel(_("loading..."))
                 result = self.load(new_file)
                 if result:
-                    channel(_("loading..."))
+                    channel(_("Done."))
             except AttributeError:
                 raise CommandSyntaxError(_("Loading files was not defined"))
             return "file", new_file
@@ -7912,7 +7913,9 @@ class Elemental(Service):
             for description, extensions, mimetype in loader.load_types():
                 if str(pathname).lower().endswith(extensions):
                     try:
+                        self.signal("freeze_tree", True)
                         results = loader.load(self, self, pathname, **kwargs)
+                        self.signal("freeze_tree", False)
                     except FileNotFoundError:
                         return False
                     except BadFileError as e:


### PR DESCRIPTION
Now:
![grafik](https://user-images.githubusercontent.com/2670784/176020702-26daeec4-db7f-44fc-9436-9cd5bb8dc00e.png)
About 17 sec
Before:
![grafik](https://user-images.githubusercontent.com/2670784/176023058-8e1cf82e-353a-4b95-be16-5be552a36f75.png)
About 136 sec
