### PR TITLE
Multiple fixes

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1896,13 +1896,24 @@ class Elemental(Service):
                 data = list(self.elems(emphasized=True))
 
             # Element conversion.
+            # We need to establish, if for a given node within a group all it's siblings are selected as well,
+            # if that's the case then use the parent instead
             d = list()
             elem_branch = self.elem_branch
             for node in data:
-                while node.parent and node.parent is not elem_branch:
-                    node = node.parent
-                if node not in d:
-                    d.append(node)
+                snode = node
+                if snode.parent and snode.parent is not elem_branch:
+                    # I need all other siblings
+                    singular = False
+                    for n in list(node.parent.children):
+                        if n not in data:
+                            singular = True
+                            break
+                    if not singular:
+                        while snode.parent and snode.parent is not elem_branch:
+                            snode = snode.parent
+                if snode is not None and snode not in d:
+                    d.append(snode)
             data = d
             return "align", data
 

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5241,7 +5241,16 @@ class Elemental(Service):
             _("Remove all items from operation"), node_type=op_nodes, help=""
         )
         def clear_all_op_entries(node, **kwargs):
-            node.remove_all_children()
+            data = list()
+            removed = False
+            for item in list(self.flat(selected=True, cascade=False, types=op_nodes)):
+                data.append(item)
+            for item in data:
+                removed = True
+                item.remove_all_children()
+            if removed:
+                self.signal("tree_changed")
+
 
         @self.tree_operation(_("Enable/Disable ops"), node_type=op_nodes, help="")
         def toggle_n_operations(node, **kwargs):

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6294,16 +6294,34 @@ class Elemental(Service):
         )
         def move_back(node, **kwargs):
             # Drag and Drop
+            signal_needed = False
             drop_node = self.elem_branch
-            drop_node.drop(node)
-            self.signal("tree_changed")
+            data = list()
+            for item in list(self.regmarks()):
+                if item.selected:
+                    data.append(item)
+            for item in data:
+                drop_node.drop(item)
+                signal_needed = True
+            if signal_needed:
+                self.signal("tree_changed")
 
         @self.tree_conditional(lambda node: not is_regmark(node))
         @self.tree_separator_before()
         @self.tree_operation(_("Move to regmarks"), node_type=elem_group_nodes, help="")
         def move_to_regmark(node, **kwargs):
             # Drag and Drop
+            signal_needed = False
             drop_node = self.reg_branch
+            data = list()
+            for item in list(self.elems_nodes()):
+                if item.selected:
+                    data.append(item)
+            for item in data:
+                drop_node.drop(item)
+                signal_needed = True
+            if signal_needed:
+                self.signal("tree_changed")
             drop_node.drop(node)
             self.signal("tree_changed")
 

--- a/meerk40t/core/node/filenode.py
+++ b/meerk40t/core/node/filenode.py
@@ -22,7 +22,12 @@ class FileNode(Node):
     def default_map(self, default_map=None):
         default_map = super(FileNode, self).default_map(default_map=default_map)
         default_map["element_type"] = "File"
-        default_map["filename"] = self._filepath
+        if self.filepath is None:
+            s = "None"
+        else:
+            s = os.path.basename(self._filepath)
+        default_map["full_filename"] = self._filepath
+        default_map["filename"] = s
         return default_map
 
     def drop(self, drag_node):

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -797,7 +797,7 @@ class LaserRender:
         yymin = float("inf")
         xxmax = -float("inf")
         yymax = -float("inf")
-        print ("Recursion=%d" % recursion)
+        # print ("Recursion=%d" % recursion)
         if not isinstance(nodes, (tuple, list)):
             mynodes = [nodes]
         else:
@@ -810,7 +810,7 @@ class LaserRender:
                     if item.text.width == 0 or item.text.height == 0:
                         textnodes.append(item)
             if len(textnodes)>0:
-                print ("Invalid textnodes found, call me again...")
+                # print ("Invalid textnodes found, call me again...")
                 self.make_raster(nodes=textnodes, bounds=bounds,
                     width=width, height=height, bitmap=bitmap,
                     step_x=step_x, step_y=step_y, keep_ratio=keep_ratio,
@@ -818,8 +818,8 @@ class LaserRender:
 
         for item in mynodes:
             bb = item.bounds
-            if item.type == "elem text":
-                print ("Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
+            # if item.type == "elem text":
+            #     print ("Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
             if bb[0]<xxmin:
                 xxmin = bb[0]
             if bb[1]<yymin:
@@ -837,7 +837,7 @@ class LaserRender:
         ymax = ceil(ymax)
         xmin = floor(xmin)
         ymin = floor(ymin)
-        print ("Bounds: %.1f, %.1f, %.1f, %.1f, Mine: %.1f, %.1f, %.1f, %.1f)" % (xmin, ymin, xmax, ymax, xxmin, yymin, xxmax, yymax))
+        # print ("Bounds: %.1f, %.1f, %.1f, %.1f, Mine: %.1f, %.1f, %.1f, %.1f)" % (xmin, ymin, xmax, ymax, xxmin, yymin, xxmax, yymax))
 
         image_width = int(xmax - xmin)
         if image_width == 0:
@@ -899,10 +899,10 @@ class LaserRender:
         if bitmap:
             return bmp
 
-        for item in mynodes:
-            bb = item.bounds
-            if item.type == "elem text":
-                print ("Afterwards Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
+        # for item in mynodes:
+        #     bb = item.bounds
+        #     if item.type == "elem text":
+        #         print ("Afterwards Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
 
         return image
 

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -843,7 +843,7 @@ class LaserRender:
             nodes = [nodes]
         gc.SetBrush(wx.WHITE_BRUSH)
         gc.DrawRectangle(xmin - 1, ymin - 1, xmax + 1, ymax + 1)
-        self.render(nodes, gc, draw_mode=DRAW_MODE_CACHE)
+        self.render(nodes, gc, draw_mode=DRAW_MODE_CACHE|DRAW_MODE_VARIABLES)
         img = bmp.ConvertToImage()
         buf = img.GetData()
         image = Image.frombuffer(

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -634,6 +634,9 @@ class LaserRender:
 
     def draw_text_node(self, node, gc, draw_mode=0, zoomscale=1.0, alpha=255):
         text = node.text
+        if text.text is None or text.text=="":
+            return
+
         try:
             matrix = node.matrix
             width_scale = sqrt(abs(matrix.determinant))
@@ -657,63 +660,63 @@ class LaserRender:
 
         x = text.x
         y = text.y
-        if text.text is not None:
-            textstr = text.text
-            if draw_mode & DRAW_MODE_VARIABLES:
-                # Only if flag show the translated values
-                textstr = self.context.elements.mywordlist.translate(textstr)
-            if not node.texttransform is None:
-                ttf = node.texttransform.lower()
-                if ttf == "capitalize":
-                    textstr = textstr.capitalize()
-                elif ttf == "uppercase":
-                    textstr = textstr.upper()
-                if ttf == "lowercase":
-                    textstr = textstr.lower()
-            # There's a fundamental flaw in wxPython to get the right fontsize
-            # Both GetTextExtent as well as GetFullTextextent provide the fontmetric-size
-            # as result for the font-height and dont take the real glyphs into account
-            # That means that ".", "a", "g" and "T" all have the same height...
-            # Consequently the size is always off... This can be somewhat compensated by taking
-            # the descent from the font-metric into account.
-            # A 'real' height routine would most probably need to draw the string on an
-            # empty canvas and find the first and last dots on a line...
-            f_width, f_height, f_descent, f_externalLeading = gc.GetFullTextExtent(
-                textstr
+        textstr = text.text
+        if draw_mode & DRAW_MODE_VARIABLES:
+            # Only if flag show the translated values
+            textstr = self.context.elements.mywordlist.translate(textstr)
+        if not node.texttransform is None:
+            ttf = node.texttransform.lower()
+            if ttf == "capitalize":
+                textstr = textstr.capitalize()
+            elif ttf == "uppercase":
+                textstr = textstr.upper()
+            if ttf == "lowercase":
+                textstr = textstr.lower()
+        # There's a fundamental flaw in wxPython to get the right fontsize
+        # Both GetTextExtent as well as GetFullTextextent provide the fontmetric-size
+        # as result for the font-height and dont take the real glyphs into account
+        # That means that ".", "a", "g" and "T" all have the same height...
+        # Consequently the size is always off... This can be somewhat compensated by taking
+        # the descent from the font-metric into account.
+        # A 'real' height routine would most probably need to draw the string on an
+        # empty canvas and find the first and last dots on a line...
+        f_width, f_height, f_descent, f_externalLeading = gc.GetFullTextExtent(
+            textstr
+        )
+        # print ("GetFullTextextent for %s (%s): Height=%.1f, descent=%.1f, leading=%.1f" % ( textstr, font.GetFaceName(), f_height, f_descent, f_externalLeading ))
+        # print ("Scale Width=%.1f" % width_scale)
+        # That stuff drives my crazy...
+        # If you have characters with and underline, like p, y, g, j, q the you need to subtract 1x descent otherwise 2x
+        has_underscore = any(
+            substring in textstr
+            for substring in ("g", "j", "p", "q", "y", ",", ";")
+        )
+        delta = self.fontdescent_factor * f_descent
+        if has_underscore:
+            delta -= self.fontdescent_factor / 2 * f_descent
+        delta -= f_externalLeading
+        f_height -= delta
+        text.width = f_width
+        text.height = f_height
+        # print ("Anchor= %s" % text.anchor)
+        if not hasattr(text, "anchor") or text.anchor == "start":
+            y -= (
+                text.height
+                + self.fontdescent_factor * self.fontdescent_delta * f_descent
             )
-            # print ("GetFullTextextent for %s (%s): Height=%.1f, descent=%.1f, leading=%.1f" % ( textstr, font.GetFaceName(), f_height, f_descent, f_externalLeading ))
-            # That stuff drives my crazy...
-            # If you have characters with and underline, like p, y, g, j, q the you need to subtract 1x descent otherwise 2x
-            has_underscore = any(
-                substring in textstr
-                for substring in ("g", "j", "p", "q", "y", ",", ";")
+        elif text.anchor == "middle":
+            x -= text.width / 2
+            y -= (
+                text.height
+                + self.fontdescent_factor * self.fontdescent_delta * f_descent
             )
-            delta = self.fontdescent_factor * f_descent
-            if has_underscore:
-                delta -= self.fontdescent_factor / 2 * f_descent
-            delta -= f_externalLeading
-            f_height -= delta
-            text.width = f_width
-            text.height = f_height
-            # print ("Anchor= %s" % text.anchor)
-            if not hasattr(text, "anchor") or text.anchor == "start":
-                y -= (
-                    text.height
-                    + self.fontdescent_factor * self.fontdescent_delta * f_descent
-                )
-            elif text.anchor == "middle":
-                x -= text.width / 2
-                y -= (
-                    text.height
-                    + self.fontdescent_factor * self.fontdescent_delta * f_descent
-                )
-            elif text.anchor == "end":
-                x -= text.width
-                y -= (
-                    text.height
-                    + self.fontdescent_factor * self.fontdescent_delta * f_descent
-                )
-            gc.DrawText(textstr, x, y)
+        elif text.anchor == "end":
+            x -= text.width
+            y -= (
+                text.height
+                + self.fontdescent_factor * self.fontdescent_delta * f_descent
+            )
+        gc.DrawText(textstr, x, y)
         gc.PopState()
 
     def draw_image_node(self, node, gc, draw_mode, zoomscale=1.0, alpha=255):
@@ -768,7 +771,7 @@ class LaserRender:
             gc.PopState()
 
     def make_raster(
-        self, nodes, bounds, width=None, height=None, bitmap=False, step_x=1, step_y=1, keep_ratio=False,
+        self, nodes, bounds, width=None, height=None, bitmap=False, step_x=1, step_y=1, keep_ratio=False, recursion = 0,
     ):
         """
         Make Raster turns an iterable of elements and a bounds into an image of the designated size, taking into account
@@ -790,11 +793,51 @@ class LaserRender:
         """
         if bounds is None:
             return None
-        xmin, ymin, xmax, ymax = bounds
+        xxmin = float("inf")
+        yymin = float("inf")
+        xxmax = -float("inf")
+        yymax = -float("inf")
+        print ("Recursion=%d" % recursion)
+        if not isinstance(nodes, (tuple, list)):
+            mynodes = [nodes]
+        else:
+            mynodes = nodes
+        if recursion == 0:
+            # Do it only once...
+            textnodes = []
+            for item in mynodes:
+                if item.type == "elem text":
+                    if item.text.width == 0 or item.text.height == 0:
+                        textnodes.append(item)
+            if len(textnodes)>0:
+                print ("Invalid textnodes found, call me again...")
+                self.make_raster(nodes=textnodes, bounds=bounds,
+                    width=width, height=height, bitmap=bitmap,
+                    step_x=step_x, step_y=step_y, keep_ratio=keep_ratio,
+                    recursion = 1)
+
+        for item in mynodes:
+            bb = item.bounds
+            if item.type == "elem text":
+                print ("Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
+            if bb[0]<xxmin:
+                xxmin = bb[0]
+            if bb[1]<yymin:
+                yymin = bb[1]
+            if bb[2]>xxmax:
+                xxmax = bb[2]
+            if bb[3]>yymax:
+                yymax = bb[3]
+
+        xmin = xxmin
+        ymin = yymin
+        xmax = xxmax
+        ymax = yymax
         xmax = ceil(xmax)
         ymax = ceil(ymax)
         xmin = floor(xmin)
         ymin = floor(ymin)
+        print ("Bounds: %.1f, %.1f, %.1f, %.1f, Mine: %.1f, %.1f, %.1f, %.1f)" % (xmin, ymin, xmax, ymax, xxmin, yymin, xxmax, yymax))
 
         image_width = int(xmax - xmin)
         if image_width == 0:
@@ -855,6 +898,12 @@ class LaserRender:
         del dc
         if bitmap:
             return bmp
+
+        for item in mynodes:
+            bb = item.bounds
+            if item.type == "elem text":
+                print ("Afterwards Bounds for text: %.1f, %.1f, %.1f, %.1f, w=%.1f, h=%.1f)" % (bb[0], bb[1], bb[2], bb[3], item.text.width, item.text.height))
+
         return image
 
     def make_thumbnail(

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -71,7 +71,11 @@ class GroupPropertiesPanel(wx.Panel):
         self, event=None
     ):  # wxGlade: ElementProperty.<event_handler>
         if len(self.text_label.GetValue()):
-            self.node.label = self.text_label.GetValue()
+            try:
+                self.node.label = self.text_label.GetValue()
+            except AttributeError:
+                # Can throw an error if non valid
+                pass
         else:
             self.node.label = None
         self.context.elements.signal("element_property_update", self.node)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -586,10 +586,25 @@ class MeerK40t(MWindow):
     def register_options_and_choices(self, context):
         _ = context._
         context.setting(bool, "disable_tool_tips", False)
+        context.setting(bool, "disable_auto_zoom", False)
         context.setting(bool, "enable_sel_move", True)
         context.setting(bool, "enable_sel_size", True)
         context.setting(bool, "enable_sel_rotate", True)
         context.setting(bool, "enable_sel_skew", False)
+        choices = [
+            {
+                "attr": "disable_auto_zoom",
+                "object": self.context.root,
+                "default": False,
+                "type": bool,
+                "label": _("Don't autoadjust zoom level"),
+                "tip": _(
+                    "Don't autoadjust zoom level when resizing the main window"
+                ),
+            },
+        ]
+        context.kernel.register_choices("preferences", choices)
+
         choices = [
             {
                 "attr": "select_smallest",
@@ -617,6 +632,7 @@ class MeerK40t(MWindow):
             },
         ]
         context.kernel.register_choices("preferences", choices)
+
         choices = [
             {
                 "attr": "outer_handles",
@@ -2603,6 +2619,8 @@ class MeerK40t(MWindow):
         if self.context is None:
             return
         self.Layout()
+        if not self.context.disable_auto_zoom:
+            self.context("scene focus -4% -4% 104% 104%\n")
 
     def on_focus_lost(self, event):
         self.context("-laser\nend\n")

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -224,9 +224,13 @@ class TreePanel(wx.Panel):
         self.shadow_tree.refresh_tree(source="signal_{org}".format(org=origin))
         if nodes is not None:
             if isinstance(nodes, (tuple, list)):
+                for node in nodes:
+                    self.shadow_tree.set_icon(node, force=True)
                 node = nodes[0]
             else:
                 node = nodes
+                self.shadow_tree.set_icon(node, force=True)
+
 
             self.shadow_tree.wxtree.EnsureVisible(node.item)
 
@@ -642,6 +646,8 @@ class ShadowTree:
         elemtree = self.elements._tree
         self.dragging_nodes = None
         self.wxtree.DeleteAllItems()
+        if self.tree_images is not None:
+            self.tree_images.Destroy()
 
         self.tree_images = wx.ImageList()
         self.tree_images.Create(width=20, height=20)
@@ -820,7 +826,10 @@ class ShadowTree:
 
             if node.type == "elem image":
                 image = self.renderer.make_thumbnail(node.image, width=20, height=20)
-                image_id = self.tree_images.Add(bitmap=image)
+                if image_id<0:
+                    image_id = self.tree_images.Add(bitmap=image)
+                else:
+                    self.tree_images.Replace(index=image_id, bitmap=image)
                 tree.SetItemImage(item, image=image_id)
             elif node.type == "elem point":
                 if node.stroke is not None and node.stroke.rgb is not None:
@@ -848,7 +857,10 @@ class ShadowTree:
                     node, node.bounds, width=20, height=20, bitmap=True, keep_ratio=True
                 )
                 if image is not None:
-                    image_id = self.tree_images.Add(bitmap=image)
+                    if image_id<0:
+                        image_id = self.tree_images.Add(bitmap=image)
+                    else:
+                        self.tree_images.Replace(index=image_id, bitmap=image)
                     tree.SetItemImage(item, image=image_id)
             elif node.type in ("op raster", "op image"):
                 try:
@@ -885,7 +897,15 @@ class ShadowTree:
             elif node.type == "group":
                 self.set_icon(node, icons8_group_objects_20.GetBitmap())
         else:
-            image_id = self.tree_images.Add(bitmap=icon)
+            image_id = tree.GetItemImage(item)
+            if image_id >= self.tree_images.ImageCount:
+                image_id = -1
+                # Reset Image Node in List
+            if image_id<0:
+                image_id = self.tree_images.Add(bitmap=icon)
+            else:
+                self.tree_images.Replace(index=image_id, bitmap=icon)
+
             tree.SetItemImage(item, image=image_id)
 
     def update_op_labels(self):

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -562,6 +562,9 @@ class ShadowTree:
             child, cookie = tree.GetNextChild(node, cookie)
         if level == 0:
             self.update_op_labels()
+        self.wxtree.Expand(self.elements.get(type="branch ops").item)
+        self.wxtree.Expand(self.elements.get(type="branch elems").item)
+        self.wxtree.Expand(self.elements.get(type="branch reg").item)
 
     def freeze_tree(self, status=None):
         if status is None:


### PR DESCRIPTION
Fixed:
a) Context menu "Remove all items from operations" recognises multiple ops selected
b) "Move to regmarks" touches all selected elements
c) "Move back to elements" touches all selected elements
d) MakeRaster translates variable text
e) Fix align behaviour, if you select elements in a group jointly with some outside (or just some inside a group for that matter)
![align](https://user-images.githubusercontent.com/2670784/176433497-cccadbd8-7517-4603-8068-131e389b4431.gif)
f) Adjust zoom when resizing main window (configurable in prefrerences)
g) Only display short filename for file nodes
h) Fix non-appearing textnodes in raster
<img width="820" alt="image" src="https://user-images.githubusercontent.com/2670784/176542019-7dd16655-cf11-4a37-8a78-91c4d4d59cf1.png">


Outstanding:
- ~~Text nodes icons not initially populated when loading a file~~
- ~~Text still not appearing fully in preview...~~