### PR TITLE
Upgrade Spooler

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -965,7 +965,7 @@ class BalorDevice(Service, ViewPort):
                     quantization=quantization,
                     simulate=True,
                 )
-            self.spooler.command(("light_loop", self.job.process), -1)
+            self.spooler.command("light_loop", self.job.process)
 
         @self.console_command(
             "select-light", help=_("Execute selection light idle job")
@@ -974,14 +974,14 @@ class BalorDevice(Service, ViewPort):
             if self.job is not None:
                 self.job.stop()
             self.job = LiveSelectionLightJob(self)
-            self.spooler.command(("light_loop", self.job.process), -1)
+            self.spooler.command("light_loop", self.job.process)
 
         @self.console_command("full-light", help=_("Execute full light idle job"))
         def select_light(**kwargs):
             if self.job is not None:
                 self.job.stop()
             self.job = LiveFullLightJob(self)
-            self.spooler.command(("light_loop", self.job.process), -1)
+            self.spooler.command("light_loop", self.job.process)
 
         @self.console_command(
             "stop",
@@ -1050,7 +1050,7 @@ class BalorDevice(Service, ViewPort):
                 except IndexError:
                     return
             if self.spooler.is_idle:
-                self.spooler.command(("pulse", time))
+                self.spooler.command("pulse", time)
                 channel(_("Pulse laser for %f milliseconds") % time)
             else:
                 channel(_("Pulse laser failed: Busy"))
@@ -1061,18 +1061,18 @@ class BalorDevice(Service, ViewPort):
             help=_("connect usb"),
         )
         def usb_connect(command, channel, _, data=None, remainder=None, **kwgs):
-            self.spooler.command("connect")
+            self.spooler.command("connect", priority=1)
 
         @self.console_command(
             "usb_disconnect",
             help=_("connect usb"),
         )
         def usb_connect(command, channel, _, data=None, remainder=None, **kwgs):
-            self.spooler.command("disconnect")
+            self.spooler.command("disconnect", priority=1)
 
         @self.console_command("usb_abort", help=_("Stops USB retries"))
         def usb_abort(command, channel, _, **kwargs):
-            self.spooler.command("abort_retry")
+            self.spooler.command("abort_retry", priority=1)
 
         @self.console_option(
             "default",

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -900,39 +900,6 @@ class BalorDevice(Service, ViewPort):
 
         self.viewbuffer = ""
 
-        @self.console_command(
-            "spool",
-            help=_("spool <command>"),
-            regex=True,
-            input_type=(None, "plan", "device"),
-            output_type="spooler",
-        )
-        def spool(
-            command, channel, _, data=None, data_type=None, remainder=None, **kwgs
-        ):
-            """
-            Registers the spool command for the Balor driver.
-            """
-            spooler = self.spooler
-            if data is not None:
-                # If plan data is in data, then we copy that and move on to next step.
-                spooler.laserjob(data.plan)
-                channel(_("Spooled Plan."))
-                self.signal("plan", data.name, 6)
-
-            if remainder is None:
-                channel(_("----------"))
-                channel(_("Spoolers:"))
-                for d, d_name in enumerate(self.match("device", suffix=True)):
-                    channel("%d: %s" % (d, d_name))
-                channel(_("----------"))
-                channel(_("Spooler on device %s:" % str(self.label)))
-                for s, op_name in enumerate(spooler.queue):
-                    channel("%d: %s" % (s, op_name))
-                channel(_("----------"))
-
-            return "spooler", spooler
-
         @self.console_option(
             "travel_speed", "t", type=float, help="Set the travel speed."
         )

--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -94,13 +94,6 @@ class BalorDriver:
         """
         self.laser = True
 
-    def light_loop(self, job):
-        self.connection.rapid_mode()
-        self.connection.light_mode()
-        while job(self.connection):
-            if self._shutdown:
-                break
-        self.connection.abort()
 
     def plot(self, plot):
         """

--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -65,7 +65,7 @@ class BalorDriver:
     def abort_retry(self):
         self.connection.abort_connect()
 
-    def hold_work(self):
+    def hold_work(self, priority):
         """
         This is checked by the spooler to see if we should hold any work from being processed from the work queue.
 
@@ -74,15 +74,7 @@ class BalorDriver:
 
         @return:
         """
-        return self.paused
-
-    def hold_idle(self):
-        """
-        This is checked by the spooler to see if we should abort checking if there's any idle job after the work queue
-        was found to be empty.
-        @return:
-        """
-        return False
+        return priority <= 0 and self.paused
 
     def laser_off(self, *values):
         """
@@ -174,7 +166,7 @@ class BalorDriver:
                     if con._port_bits != self._list_bits:
                         con.list_write_port()
                         self._list_bits = con._port_bits
-                    while self.hold_work():
+                    while self.paused:
                         time.sleep(0.05)
 
                     p = q.point(t)
@@ -194,7 +186,7 @@ class BalorDriver:
                     if con._port_bits != self._list_bits:
                         con.list_write_port()
                         self._list_bits = con._port_bits
-                    while self.hold_work():
+                    while self.paused:
                         time.sleep(0.05)
 
                     # q.plot can have different on values, these are parsed
@@ -253,7 +245,7 @@ class BalorDriver:
                     if con._port_bits != self._list_bits:
                         self._list_bits = con._port_bits
                         con.list_write_port()
-                    while self.hold_work():
+                    while self.paused:
                         time.sleep(0.05)
 
                     if on > 1:

--- a/meerk40t/core/drivers.py
+++ b/meerk40t/core/drivers.py
@@ -32,7 +32,7 @@ class Driver:
         self.hold = False
         self.paused = False
 
-    def hold_work(self):
+    def hold_work(self, priority):
         """
         Required.
 
@@ -41,15 +41,6 @@ class Driver:
         @return: hold?
         """
         return self.hold or self.paused
-
-    def hold_idle(self):
-        """
-        Required.
-
-        Spooler check. Should the idle job be processed or held.
-        @return:
-        """
-        return False
 
     def move_abs(self, x, y):
         """

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -83,7 +83,7 @@ def plugin(kernel, lifecycle=None):
         kernel.register("format/file", "{element_type}: {filename}")
         kernel.register("format/lasercode", "{element_type}")
         kernel.register("format/cutcode", "{element_type}")
-        kernel.register("format/branch ops", _("Operations"))
+        kernel.register("format/branch ops", _("Operations {loops}"))
         kernel.register("format/branch elems", _("Elements"))
         kernel.register("format/branch reg", _("Regmarks"))
     elif lifecycle == "register":
@@ -128,35 +128,6 @@ def plugin(kernel, lifecycle=None):
             },
         ]
         kernel.register_choices("preferences", choices)
-        choices = [
-            {
-                "attr": "loop_continuous",
-                "object": elements,
-                "default": False,
-                "type": bool,
-                "label": _("Loop Continuously"),
-                "tip": _("Operation job will run forever in a loop"),
-            },
-            {
-                "attr": "loop_enabled",
-                "object": elements,
-                "default": False,
-                "type": bool,
-                "label": _("Loop Parameter"),
-                "tip": _("Operation job should run set number of times"),
-            },
-            {
-                "attr": "loop_n",
-                "object": elements,
-                "default": 1,
-                "type": int,
-                "conditional": (elements, "loop_enabled"),
-                "label": _("Loop"),
-                "trailing": _("times"),
-                "tip": _("How many times should the operation job loop"),
-            },
-        ]
-        kernel.register_choices("loop_choice", choices)
     elif lifecycle == "prestart":
         if hasattr(kernel.args, "input") and kernel.args.input is not None:
             # Load any input file

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -128,6 +128,35 @@ def plugin(kernel, lifecycle=None):
             },
         ]
         kernel.register_choices("preferences", choices)
+        choices = [
+            {
+                "attr": "loop_continuous",
+                "object": elements,
+                "default": False,
+                "type": bool,
+                "label": _("Loop Continuously"),
+                "tip": _("Operation job will run forever in a loop"),
+            },
+            {
+                "attr": "loop_enabled",
+                "object": elements,
+                "default": False,
+                "type": bool,
+                "label": _("Loop Parameter"),
+                "tip": _("Operation job should run set number of times"),
+            },
+            {
+                "attr": "loop_n",
+                "object": elements,
+                "default": 1,
+                "type": int,
+                "conditional": (elements, "loop_enabled"),
+                "label": _("Loop"),
+                "trailing": _("times"),
+                "tip": _("How many times should the operation job loop"),
+            },
+        ]
+        kernel.register_choices("loop_choice", choices)
     elif lifecycle == "prestart":
         if hasattr(kernel.args, "input") and kernel.args.input is not None:
             # Load any input file

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5137,7 +5137,7 @@ class Elemental(Service):
                             Length(amount=p[1]).length_mm,
                         )
 
-                spooler.laserjob(trace_hull)
+                spooler.laserjob([trace_hull])
 
             run_shape(spooler, hull)
 

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5137,7 +5137,7 @@ class Elemental(Service):
                             Length(amount=p[1]).length_mm,
                         )
 
-                spooler.job(trace_hull)
+                spooler.laserjob(trace_hull)
 
             run_shape(spooler, hull)
 
@@ -5168,7 +5168,6 @@ class Elemental(Service):
                 )
                 return
 
-            spooler = self.device.spooler
             if data is None:
                 data = list(self.elems(emphasized=True))
             hull = generate_hull_shape(method, data, resolution=resolution)

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5137,7 +5137,7 @@ class Elemental(Service):
                             Length(amount=p[1]).length_mm,
                         )
 
-                spooler.laserjob([trace_hull])
+                spooler.laserjob([list(trace_hull)])
 
             run_shape(spooler, hull)
 

--- a/meerk40t/core/node/branch_ops.py
+++ b/meerk40t/core/node/branch_ops.py
@@ -9,9 +9,23 @@ class BranchOperationsNode(Node):
 
     def __init__(self, **kwargs):
         super(BranchOperationsNode, self).__init__(**kwargs)
+        self.loop_enabled = False
+        self.loop_continuous = False
+        self.loop_n = 1
 
     def __str__(self):
         return "Operations"
+
+    def default_map(self, default_map=None):
+        default_map = super(BranchOperationsNode, self).default_map(default_map=default_map)
+        if self.loop_continuous:
+            default_map["loops"] = "∞"
+        else:
+            if self.loop_enabled:
+                default_map["loops"] = str(self.loop_n)
+            else:
+                default_map["loops"] = ""
+        return default_map
 
     def drop(self, drag_node):
         if drag_node.type.startswith("op"):

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -289,13 +289,14 @@ def plugin(kernel, lifecycle=None):
 
     elif lifecycle == "poststart":
         planner = kernel.planner
-        if hasattr(kernel.args, "auto") and kernel.args.auto:
+        auto = hasattr(kernel.args, "auto") and kernel.args.auto
+        if auto:
             planner("plan copy preprocess validate blob preopt optimize\n")
-        if hasattr(kernel.args, "origin") and kernel.args.origin:
-            planner("plan append origin\n")
-        if hasattr(kernel.args, "quit") and kernel.args.quit:
-            planner("plan append shutdown\n")
-        planner("plan spool\n")
+            if hasattr(kernel.args, "origin") and kernel.args.origin:
+                planner("plan append origin\n")
+            if hasattr(kernel.args, "quit") and kernel.args.quit:
+                planner("plan append shutdown\n")
+            planner("plan spool\n")
 
 
 class Planner(Service):

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -266,6 +266,47 @@ def plugin(kernel, lifecycle):
             return "spooler", spooler
 
 
+class LaserJob:
+    def __init__(self):
+        self.label = "Job"
+        self._time_total = 0
+        self._time_started = None
+
+    def suspend(self):
+        """
+        Suspend the job currently being run.
+        @return:
+        """
+        time_ended = time.time()
+        duration = time_ended - self._time_started
+        self._time_total += duration
+
+    def resume(self):
+        """
+        Resume the currently run job.
+        @return:
+        """
+        time_ended = time.time()
+        duration = time_ended - self._time_started
+        self._time_total += duration
+
+    def estimate_time(self):
+        """
+        Give laser job time estimate.
+        @return:
+        """
+        return 0
+
+    def running_time(self):
+        return self._time_total
+
+    def stop(self):
+        """
+        Stop this current laser-job
+        @return:
+        """
+
+
 class Spooler:
     """
     Spoolers store spoolable events in a two synchronous queue, and a single idle job that

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -306,7 +306,7 @@ def plugin(kernel, lifecycle):
                 yield "home"
                 yield "wait_finish"
 
-            spooler.laserjob([list(home_dot_test)])
+            spooler.laserjob([list(home_dot_test())])
             return "spooler", spooler
 
 
@@ -317,7 +317,7 @@ class LaserJob:
         self.priority = priority
         self.time_submitted = time.time()
         self.time_started = None
-        self.time_running = 0
+        self.runtime = 0
 
         self.loops = loops
         self.loops_executed = 0
@@ -353,7 +353,7 @@ class LaserJob:
                 self.item_index = 0
                 self.loops_executed += 1
         finally:
-            self.time_running += time.time() - self.time_started
+            self.runtime += time.time() - self.time_started
         return True
 
     def execute_item(self, item):
@@ -407,9 +407,6 @@ class LaserJob:
         @return:
         """
         return 0
-
-    def running_time(self):
-        return self.time_running
 
 
 class Spooler:

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -24,7 +24,7 @@ def plugin(kernel, lifecycle):
                 # If plan data is in data, then we copy that and move on to next step.
                 spooler.laserjob(data.plan)
                 channel(_("Spooled Plan."))
-                kernel.signal("plan", data.name, 6)
+                kernel.root.signal("plan", data.name, 6)
 
             if remainder is None:
                 channel(_("----------"))

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -53,7 +53,7 @@ def plugin(kernel, lifecycle):
                 raise CommandSyntaxError
             try:
                 for plan_command, command_name, suffix in kernel.find("plan", op):
-                    spooler.command(plan_command)
+                    spooler.laserjob(plan_command)
                     return data_type, spooler
             except (KeyError, IndexError):
                 pass

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -267,7 +267,7 @@ def plugin(kernel, lifecycle):
                 yield "home"
                 yield "wait_finish"
 
-            spooler.laserjob(home_dot_test)
+            spooler.laserjob([home_dot_test])
             return "spooler", spooler
 
 

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -267,7 +267,7 @@ def plugin(kernel, lifecycle):
                 yield "home"
                 yield "wait_finish"
 
-            spooler.laserjob([home_dot_test])
+            spooler.laserjob([list(home_dot_test)])
             return "spooler", spooler
 
 

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -18,17 +18,20 @@ def plugin(kernel, lifecycle):
         )
         def spool(command, channel, _, data=None, remainder=None, **kwgs):
             device = kernel.device
-            elements = kernel.elements
+
             spooler = device.spooler
 
             if data is not None:
                 # If plan data is in data, then we copy that and move on to next step.
                 loops = 1
+                elements = kernel.elements
+                e = elements.op_branch
 
-                if elements.loop_continuous:
+                if e.loop_continuous:
                     loops = float('inf')
-                if elements.loop_enabled:
-                    loops = elements.loop_n
+                else:
+                    if e.loop_enabled:
+                        loops = e.loop_n
                 spooler.laserjob(data.plan, loops=loops)
                 channel(_("Spooled Plan."))
                 kernel.root.signal("plan", data.name, 6)

--- a/meerk40t/device/ch341/README.md
+++ b/meerk40t/device/ch341/README.md
@@ -2,7 +2,7 @@
 
 The CH341 Universal USB Interface chip is used to interface a particular board to a computer USB connection.
 These are popular in both production and hobbyist functions, and the chips are cheap and ubiquitous.
-Both the Lhystudios boards and the Moshiboards use this chip type.
+Both the Lihuiyu boards and the Moshiboards use this chip type.
 It's also possible and likely to find these in some Arduino systems and for hobbyists to use them.
 
 The purpose of this module is to provide connections to the CH341 interface objects.
@@ -11,7 +11,7 @@ This should allow multiple different connections to different CH341 connections.
 The module works like a socket handler and provides different CH341 connections on demand if there are any to provide.
 This can be requested in specific fashion based on criteria, or they can be accessed then rejected in turn after some minimum interactions.
 For example if we get a CH341 connection that has a current status of 205
-we can reject this connection in a Lhystudios driver because this code is never used there.
+we can reject this connection in a Lihuiyu driver because this code is never used there.
 However, if we are accessing this data as a Moshiboard driver, we might reject any status *other* than a 205.
 
 While it is not the goal of this subproject to fully map out all CH341 commands,

--- a/meerk40t/device/ch341/ch341.py
+++ b/meerk40t/device/ch341/ch341.py
@@ -99,7 +99,7 @@ class CH341(Module, Handler):
     """
     Generic CH341 Module performs the interactions between the requested operations and several delegated backend ch341
     drivers. This permits interfacing with LibUsb, Windll or Mock Ch341 backends. In use-agnostic fashion, this should
-    be valid and acceptable for any CH341 interactions. CH341 chip interfacing is required for Lhystudios Controllers,
+    be valid and acceptable for any CH341 interactions. CH341 chip interfacing is required for Lihuiyu Controllers,
     Moshiboard Controllers, and other interactions such as a plugin that uses addition CH341 devices.
     """
 

--- a/meerk40t/device/ch341/ch341libusbdriver.py
+++ b/meerk40t/device/ch341/ch341libusbdriver.py
@@ -36,7 +36,7 @@ def convert_to_list_bytes(data):
 class Ch341LibusbDriver:
     """
     Libusb driver for the CH341 chip. The CH341x is a USB interface chip that can emulate UART, parallel port,
-    and synchronous serial (EPP, I2C, SPI). The Lhystudios boards (M2Nano, et al.) and Moshiboards and likely others
+    and synchronous serial (EPP, I2C, SPI). The Lihuiyu boards (M2Nano, et al.) and Moshiboards and likely others
     use this in EPP 1.9 mode. This class is not and not intended to be a full driver for that chip. Rather we are
     duplicating the function calls and implementing compatible operations to permit a stand-in for the default CH341
     driver. Using libusb to do the usb connection to the chip as well as permitting easy swapping that for the default

--- a/meerk40t/device/dummydevice.py
+++ b/meerk40t/device/dummydevice.py
@@ -88,7 +88,7 @@ class DummyDevice(Service, ViewPort):
             spooler = self.spooler
             if data is not None:
                 # If plan data is in data, then we copy that and move on to next step.
-                spooler.jobs(data.plan)
+                spooler.laserjob(data.plan)
                 channel(_("Spooled Plan."))
                 self.signal("plan", data.name, 6)
 

--- a/meerk40t/grbl/README.md
+++ b/meerk40t/grbl/README.md
@@ -1,3 +1,3 @@
 # GRBL
 
-Grbl and more generic gcode devices and their interactions. Currently, this project is a stub. However, the `grblserver` previously has worked and allowed direct interactions with the GRBL Emulator and permitted the exporting of commands to the Lhystudios devices.
+Grbl and more generic gcode devices and their interactions. Currently, this project is a stub. However, the `grblserver` previously has worked and allowed direct interactions with the GRBL Emulator and permitted the exporting of commands to the Lihuiyu devices.

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -235,34 +235,6 @@ class GRBLDevice(Service, ViewPort):
 
         _ = self.kernel.translation
 
-        @self.console_command(
-            "spool",
-            help=_("spool <command>"),
-            regex=True,
-            input_type=(None, "plan", "device"),
-            output_type="spooler",
-        )
-        def spool(command, channel, _, data=None, remainder=None, **kwgs):
-            spooler = self.spooler
-            if data is not None:
-                # If plan data is in data, then we copy that and move on to next step.
-                spooler.laserjob(data.plan)
-                channel(_("Spooled Plan."))
-                self.signal("plan", data.name, 6)
-
-            if remainder is None:
-                channel(_("----------"))
-                channel(_("Spoolers:"))
-                for d, d_name in enumerate(self.match("device", suffix=True)):
-                    channel("%d: %s" % (d, d_name))
-                channel(_("----------"))
-                channel(_("Spooler on device %s:" % str(self.label)))
-                for s, op_name in enumerate(spooler.queue):
-                    channel("%d: %s" % (s, op_name))
-                channel(_("----------"))
-
-            return "spooler", spooler
-
         @self.console_argument("com")
         @self.console_option("baud", "b")
         @self.console_command(

--- a/meerk40t/gui/propertypanels/opbranchproperties.py
+++ b/meerk40t/gui/propertypanels/opbranchproperties.py
@@ -1,6 +1,7 @@
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -11,11 +12,39 @@ class OpBranchPanel(wx.Panel):
     def __init__(self, *args, context=None, node=None, **kwds):
         kwds["style"] = kwds.get("style", 0)
         wx.Panel.__init__(self, *args, **kwds)
-        root = context.root
-        self.operation = node
+        self.context = context
 
+        self.operation = node
+        choices = [
+            {
+                "attr": "loop_continuous",
+                "object": self.operation,
+                "default": False,
+                "type": bool,
+                "label": _("Loop Continuously"),
+                "tip": _("Operation job will run forever in a loop"),
+            },
+            {
+                "attr": "loop_enabled",
+                "object": self.operation,
+                "default": False,
+                "type": bool,
+                "label": _("Loop Parameter"),
+                "tip": _("Operation job should run set number of times"),
+            },
+            {
+                "attr": "loop_n",
+                "object": self.operation,
+                "default": 1,
+                "type": int,
+                "conditional": (self.operation, "loop_enabled"),
+                "label": _("Loop"),
+                "trailing": _("times"),
+                "tip": _("How many times should the operation job loop"),
+            },
+        ]
         self.panel = ChoicePropertyPanel(
-            self, wx.ID_ANY, context=root, choices="loop_choice"
+            self, wx.ID_ANY, context=context, choices=choices
         )
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -23,6 +52,12 @@ class OpBranchPanel(wx.Panel):
         self.SetSizer(main_sizer)
 
         self.Layout()
+
+    @signal_listener("loop_continuous")
+    @signal_listener("loop_n")
+    @signal_listener("loop_enabled")
+    def wait_changed(self, *args):
+        self.context.elements.signal("element_property_update", self.operation)
 
     def pane_hide(self):
         self.panel.pane_hide()

--- a/meerk40t/gui/propertypanels/opbranchproperties.py
+++ b/meerk40t/gui/propertypanels/opbranchproperties.py
@@ -1,0 +1,34 @@
+import wx
+
+from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
+
+_ = wx.GetTranslation
+
+
+class OpBranchPanel(wx.Panel):
+    name = "Loop Properties"
+
+    def __init__(self, *args, context=None, node=None, **kwds):
+        kwds["style"] = kwds.get("style", 0)
+        wx.Panel.__init__(self, *args, **kwds)
+        root = context.root
+        self.operation = node
+
+        self.panel = ChoicePropertyPanel(
+            self, wx.ID_ANY, context=root, choices="loop_choice"
+        )
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.SetSizer(main_sizer)
+
+        self.Layout()
+
+    def pane_hide(self):
+        self.panel.pane_hide()
+
+    def pane_show(self):
+        self.panel.pane_show()
+
+    def set_widgets(self, node):
+        self.operation = node

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -175,7 +175,6 @@ class SpoolerPanel(wx.Panel):
         except AttributeError:
             return str(named_obj)
 
-
     def refresh_spooler_list(self):
         if not self.update_spooler:
             return

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -196,22 +196,11 @@ class SpoolerPanel(wx.Panel):
             self.set_spool_item(m, spooler.current, status=_("running"))
             idx += 1
 
-        if len(spooler.realtime_queue) > 0:
-            for e in spooler.queue:
-                m = self.list_job_spool.InsertItem(idx, f"#{idx}")
-                self.set_spool_item(m, e, status=_("realtime"))
-                idx += 1
-
         if len(spooler.queue) > 0:
             for e in spooler.queue:
                 m = self.list_job_spool.InsertItem(idx, f"#{idx}")
                 self.set_spool_item(m, e, status=_("queued"))
                 idx += 1
-
-        if spooler.idle is not None:
-            m = self.list_job_spool.InsertItem(idx, _("Idle"))
-            self.set_spool_item(m, spooler.idle, status=_("idle"))
-            idx += 1
 
     def on_tree_popup_clear(self, element=None):
         def delete(event=None):

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -1,3 +1,5 @@
+from math import isinf
+
 import wx
 from wx import aui
 
@@ -82,7 +84,7 @@ class SpoolerPanel(wx.Panel):
         # begin wxGlade: SpoolerPanel.__set_properties
         self.combo_device.SetToolTip(_("Select the device"))
         self.list_job_spool.SetToolTip(_("List and modify the queued operations"))
-        self.list_job_spool.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=78)
+        self.list_job_spool.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=58)
         self.list_job_spool.AppendColumn(
             _("Name"), format=wx.LIST_FORMAT_LEFT, width=143
         )
@@ -93,10 +95,16 @@ class SpoolerPanel(wx.Panel):
             _("Type"), format=wx.LIST_FORMAT_LEFT, width=60
         )
         self.list_job_spool.AppendColumn(
-            _("Speed"), format=wx.LIST_FORMAT_LEFT, width=83
+            _("Passes"), format=wx.LIST_FORMAT_LEFT, width=83
         )
         self.list_job_spool.AppendColumn(
-            _("Settings"), format=wx.LIST_FORMAT_LEFT, width=223
+            _("Priority"), format=wx.LIST_FORMAT_LEFT, width=73
+        )
+        self.list_job_spool.AppendColumn(
+            _("Runtime"), format=wx.LIST_FORMAT_LEFT, width=73
+        )
+        self.list_job_spool.AppendColumn(
+            _("Estimate"), format=wx.LIST_FORMAT_LEFT, width=73
         )
         # end wxGlade
 
@@ -127,14 +135,32 @@ class SpoolerPanel(wx.Panel):
         except IndexError:
             return
         menu = wx.Menu()
-        convert = menu.Append(
+        item = menu.Append(
             wx.ID_ANY, _("Remove %s") % str(element)[:16], "", wx.ITEM_NORMAL
         )
-        self.Bind(wx.EVT_MENU, self.on_tree_popup_delete(element), convert)
-        convert = menu.Append(wx.ID_ANY, _("Clear All"), "", wx.ITEM_NORMAL)
-        self.Bind(wx.EVT_MENU, self.on_tree_popup_clear(element), convert)
+        self.Bind(wx.EVT_MENU, self.on_tree_popup_delete(element), item)
+
+        item = menu.Append(wx.ID_ANY, _("Clear All"), "", wx.ITEM_NORMAL)
+        self.Bind(wx.EVT_MENU, self.on_tree_popup_clear(element), item)
+
         self.PopupMenu(menu)
         menu.Destroy()
+
+    def on_tree_popup_clear(self, element=None):
+        def clear(event=None):
+            spooler = self.selected_device.spooler
+            spooler.clear_queue()
+            self.refresh_spooler_list()
+
+        return clear
+
+    def on_tree_popup_delete(self, element, index=None):
+        def delete(event=None):
+            spooler = self.selected_device.spooler
+            spooler.remove(element, index)
+            self.refresh_spooler_list()
+
+        return delete
 
     def pane_show(self, *args):
         self.refresh_spooler_list()
@@ -149,39 +175,10 @@ class SpoolerPanel(wx.Panel):
         except AttributeError:
             return str(named_obj)
 
-    def set_spool_item(self, list_id, spool_obj, status=None):
-        if list_id != -1:
-            self.list_job_spool.SetItem(list_id, 1, SpoolerPanel._name_str(spool_obj))
-            if status is not None:
-                self.list_job_spool.SetItem(list_id, 2, status)
-
-            try:
-                self.list_job_spool.SetItem(list_id, 3, str(spool_obj))
-            except AttributeError:
-                pass
-            try:
-                self.list_job_spool.SetItem(list_id, 4, _("%.1fmm/s") % spool_obj.speed)
-            except AttributeError:
-                pass
-            settings = list()
-            try:
-                settings.append(_("power=%g") % spool_obj.power)
-            except AttributeError:
-                pass
-            try:
-                settings.append(_("step=%d") % spool_obj.raster_step_x)
-            except AttributeError:
-                pass
-            try:
-                settings.append(_("overscan=%s") % str(spool_obj.overscan))
-            except AttributeError:
-                pass
-            self.list_job_spool.SetItem(list_id, 5, " ".join(settings))
 
     def refresh_spooler_list(self):
         if not self.update_spooler:
             return
-
         try:
             self.list_job_spool.DeleteAllItems()
         except RuntimeError:
@@ -190,33 +187,69 @@ class SpoolerPanel(wx.Panel):
         spooler = self.selected_device.spooler
         if spooler is None:
             return
-        idx = 0
-        if spooler.current is not None:
-            m = self.list_job_spool.InsertItem(idx, _("Current"))
-            self.set_spool_item(m, spooler.current, status=_("running"))
-            idx += 1
 
-        if len(spooler.queue) > 0:
-            for e in spooler.queue:
-                m = self.list_job_spool.InsertItem(idx, f"#{idx}")
-                self.set_spool_item(m, e, status=_("queued"))
-                idx += 1
+        for idx, e in enumerate(spooler.queue):
+            # Idx, Status, Type, Passes, Priority, Runtime, Estimate
+            m = self.list_job_spool.InsertItem(idx, f"#{idx}")
+            list_id = m
+            spool_obj = e
 
-    def on_tree_popup_clear(self, element=None):
-        def delete(event=None):
-            spooler = self.selected_device.spooler
-            spooler.clear_queue()
-            self.refresh_spooler_list()
+            if list_id != -1:
+                # IDX
+                try:
+                    self.list_job_spool.SetItem(list_id, 1, spool_obj.label)
+                except AttributeError:
+                    self.list_job_spool.SetItem(list_id, 1, SpoolerPanel._name_str(spool_obj))
 
-        return delete
+                # STATUS
+                try:
+                    status = spool_obj.status
+                except AttributeError:
+                    status = _("Queued")
+                self.list_job_spool.SetItem(list_id, 2, status)
 
-    def on_tree_popup_delete(self, element, index=None):
-        def delete(event=None):
-            spooler = self.selected_device.spooler
-            spooler.remove(element, index)
-            self.refresh_spooler_list()
+                # TYPE
+                try:
+                    self.list_job_spool.SetItem(list_id, 3, str(spool_obj.__class__.__name__))
+                except AttributeError:
+                    pass
 
-        return delete
+                # PASSES
+                try:
+                    loop = spool_obj.loops_executed
+                    total = spool_obj.loops
+
+                    if isinf(total):
+                        total = "∞"
+                    self.list_job_spool.SetItem(list_id, 4, f"{loop}/{total}")
+                except AttributeError:
+                    self.list_job_spool.SetItem(list_id, 4, "-")
+
+                # Priority
+                try:
+                    self.list_job_spool.SetItem(list_id, 5, f"{spool_obj.priority}")
+                except AttributeError:
+                    self.list_job_spool.SetItem(list_id, 5, "-")
+
+                # Runtime
+                try:
+                    t = spool_obj.runtime
+                    hours, remainder = divmod(t, 3600)
+                    minutes, seconds = divmod(remainder, 60)
+                    runtime = f"{int(hours)}:{str(int(minutes)).zfill(2)}:{str(int(seconds)).zfill(2)}"
+                    self.list_job_spool.SetItem(list_id, 6, runtime)
+                except AttributeError:
+                    self.list_job_spool.SetItem(list_id, 6, "-")
+
+                # Estimate Time
+                try:
+                    t = spool_obj.estimate_time()
+                    hours, remainder = divmod(t, 3600)
+                    minutes, seconds = divmod(remainder, 60)
+                    runtime = f"{int(hours)}:{str(int(minutes)).zfill(2)}:{str(int(seconds)).zfill(2)}"
+                    self.list_job_spool.SetItem(list_id, 7, runtime)
+                except AttributeError:
+                    self.list_job_spool.SetItem(list_id, 7, "-")
 
     @signal_listener("spooler;queue")
     @signal_listener("spooler;idle")

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -8,6 +8,7 @@ import wx
 from wx import aui
 
 from .propertypanels.inputproperty import InputPropertyPanel
+from .propertypanels.opbranchproperties import OpBranchPanel
 from .propertypanels.outputproperty import OutputPropertyPanel
 from .propertypanels.waitproperty import WaitPropertyPanel
 
@@ -342,6 +343,7 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("property/TextNode/TextProperty", TextPropertyPanel)
         kernel.register("property/WaitOperation/WaitProperty", WaitPropertyPanel)
         kernel.register("property/InputOperation/InputProperty", InputPropertyPanel)
+        kernel.register("property/BranchOperationsNode/LoopProperty", OpBranchPanel)
         kernel.register("property/OutputOperation/OutputProperty", OutputPropertyPanel)
         kernel.register("property/ImageNode/ImageProperty", ImagePropertyPanel)
 

--- a/meerk40t/lihuiyu/README.md
+++ b/meerk40t/lihuiyu/README.md
@@ -1,3 +1,3 @@
-# Lhystudios
+# Lihuiyu
 
-These are the stock M2 Nano boards by Lhystudios and other closely related boards. This is the primary user of CH341 interfacing drivers. And the most complete driver availible. This includes parsing of Lhymicro-GL, production of Lhymicro-GL, channels of the data being sent over the USB. As well as emulation and parsing the commands.
+These are the stock M2 Nano boards by Lihuiyu and other closely related boards. This is the primary user of CH341 interfacing drivers. And the most complete driver availible. This includes parsing of Lhymicro-GL, production of Lhymicro-GL, channels of the data being sent over the USB. As well as emulation and parsing the commands.

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -283,7 +283,7 @@ class LihuiyuDevice(Service, ViewPort):
                 yield "laser_off"
 
             if self.spooler.is_idle:
-                self.spooler.laserjob(timed_fire)
+                self.spooler.laserjob([timed_fire])
                 channel(_("Pulse laser for %f milliseconds") % time)
             else:
                 channel(_("Pulse laser failed: Busy"))
@@ -303,7 +303,7 @@ class LihuiyuDevice(Service, ViewPort):
                 yield "move_relative", dx.mil, dy.mil
                 yield "rapid_mode"
             if self.spooler.is_idle:
-                self.spooler.laserjob(move_at_speed)
+                self.spooler.laserjob([move_at_speed])
             else:
                 channel(_("Busy"))
             return
@@ -746,7 +746,7 @@ class LihuiyuDevice(Service, ViewPort):
                     yield "laser_off"
                     yield "wait_finish"
 
-            spooler.laserjob(jog_transition_test)
+            spooler.laserjob([jog_transition_test])
 
     @property
     def viewbuffer(self):

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -283,7 +283,7 @@ class LihuiyuDevice(Service, ViewPort):
                 yield "laser_off"
 
             if self.spooler.is_idle:
-                self.spooler.laserjob([timed_fire])
+                self.spooler.laserjob([list(timed_fire)])
                 channel(_("Pulse laser for %f milliseconds") % time)
             else:
                 channel(_("Pulse laser failed: Busy"))
@@ -303,7 +303,7 @@ class LihuiyuDevice(Service, ViewPort):
                 yield "move_relative", dx.mil, dy.mil
                 yield "rapid_mode"
             if self.spooler.is_idle:
-                self.spooler.laserjob([move_at_speed])
+                self.spooler.laserjob([list(move_at_speed)])
             else:
                 channel(_("Busy"))
             return
@@ -746,7 +746,7 @@ class LihuiyuDevice(Service, ViewPort):
                     yield "laser_off"
                     yield "wait_finish"
 
-            spooler.laserjob([jog_transition_test])
+            spooler.laserjob([list(jog_transition_test)])
 
     @property
     def viewbuffer(self):

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -78,7 +78,7 @@ def plugin(kernel, lifecycle=None):
     if lifecycle == "register":
         kernel.register("provider/device/lhystudios", LihuiyuDevice)
         kernel.register("load/EgvLoader", EgvLoader)
-        kernel.register("emulator/lhystudios", LihuiyuEmulator)
+        kernel.register("emulator/lihuiyu", LihuiyuEmulator)
         kernel.register("parser/egv", LihuiyuParser)
     if lifecycle == "preboot":
         suffix = "lhystudios"
@@ -92,7 +92,7 @@ def plugin(kernel, lifecycle=None):
 
 class LihuiyuDevice(Service, ViewPort):
     """
-    LihuiyuDevice is driver for the M2 Nano and other classes of Lhystudios boards.
+    LihuiyuDevice is driver for the M2 Nano and other classes of Lihuiyu boards.
     """
 
     def __init__(self, kernel, path, *args, **kwargs):
@@ -209,14 +209,14 @@ class LihuiyuDevice(Service, ViewPort):
 
         self.state = 0
 
-        self.driver = LhystudiosDriver(self)
+        self.driver = LihuiyuDriver(self)
         self.spooler = Spooler(self, driver=self.driver)
         self.add_service_delegate(self.spooler)
 
         self.tcp = TCPOutput(self)
         self.add_service_delegate(self.tcp)
 
-        self.controller = LhystudiosController(self)
+        self.controller = LihuiyuController(self)
         self.add_service_delegate(self.controller)
 
         self.driver.out_pipe = self.controller if not self.networked else self.tcp
@@ -317,7 +317,7 @@ class LihuiyuDevice(Service, ViewPort):
         )
         @self.console_argument("speed", type=str, help=_("Set the driver speed."))
         @self.console_command(
-            "speed", input_type="lhystudios", help=_("Set current speed of driver.")
+            "speed", input_type="lihuiyu", help=_("Set current speed of driver.")
         )
         def speed(
             command, channel, _, data=None, speed=None, difference=False, **kwargs
@@ -442,7 +442,7 @@ class LihuiyuDevice(Service, ViewPort):
         @self.console_command(("estop", "abort"), help=_("Abort Job"))
         def pipe_abort(channel, _, **kwargs):
             self.driver.reset()
-            channel(_("Lhystudios Channel Aborted."))
+            channel(_("Lihuiyu Channel Aborted."))
 
         @self.console_argument(
             "rapid_x", type=float, help=_("limit x speed for rapid.")
@@ -475,7 +475,7 @@ class LihuiyuDevice(Service, ViewPort):
         @self.console_argument("filename", type=str)
         @self.console_command(
             "egv_import",
-            help=_("Lhystudios Engrave Buffer Import. egv_import <egv_file>"),
+            help=_("Lihuiyu Engrave Buffer Import. egv_import <egv_file>"),
         )
         def egv_import(channel, _, filename, **kwargs):
             if filename is None:
@@ -513,7 +513,7 @@ class LihuiyuDevice(Service, ViewPort):
         @self.console_argument("filename", type=str)
         @self.console_command(
             "egv_export",
-            help=_("Lhystudios Engrave Buffer Export. egv_export <egv_file>"),
+            help=_("Lihuiyu Engrave Buffer Export. egv_export <egv_file>"),
         )
         def egv_export(channel, _, filename, **kwargs):
             if filename is None:
@@ -537,11 +537,11 @@ class LihuiyuDevice(Service, ViewPort):
 
         @self.console_command(
             "egv",
-            help=_("Lhystudios Engrave Code Sender. egv <lhymicro-gl>"),
+            help=_("Lihuiyu Engrave Code Sender. egv <lhymicro-gl>"),
         )
         def egv(command, channel, _, remainder=None, **kwargs):
             if not remainder:
-                channel("Lhystudios Engrave Code Sender. egv <lhymicro-gl>")
+                channel("Lihuiyu Engrave Code Sender. egv <lhymicro-gl>")
             else:
                 self.output.write(
                     bytes(remainder.replace("$", "\n").replace(" ", "\n"), "utf8")
@@ -565,19 +565,19 @@ class LihuiyuDevice(Service, ViewPort):
         def pipe_start(command, channel, _, **kwargs):
             self.controller.update_state(STATE_ACTIVE)
             self.controller.start()
-            channel(_("Lhystudios Channel Started."))
+            channel(_("Lihuiyu Channel Started."))
 
         @self.console_command("hold", help=_("Hold Controller"))
         def pipe_pause(command, channel, _, **kwargs):
             self.controller.update_state(STATE_PAUSE)
             self.controller.pause()
-            channel("Lhystudios Channel Paused.")
+            channel("Lihuiyu Channel Paused.")
 
         @self.console_command("resume", help=_("Resume Controller"))
         def pipe_resume(command, channel, _, **kwargs):
             self.controller.update_state(STATE_ACTIVE)
             self.controller.start()
-            channel(_("Lhystudios Channel Resumed."))
+            channel(_("Lihuiyu Channel Resumed."))
 
         @self.console_command("usb_connect", help=_("Connects USB"))
         def usb_connect(command, channel, _, **kwargs):
@@ -648,7 +648,7 @@ class LihuiyuDevice(Service, ViewPort):
                 if quit:
                     self.close(server_name)
                     return
-                channel(_("TCP Server for Lhystudios on port: %d" % port))
+                channel(_("TCP Server for lihuiyu on port: %d" % port))
                 if not silent:
                     console = kernel.channel("console")
                     server.events_channel.watch(console)
@@ -669,8 +669,8 @@ class LihuiyuDevice(Service, ViewPort):
         @self.console_command("lhyemulator", help=_("activate the lhyemulator."))
         def lhyemulator(channel, _, **kwargs):
             try:
-                self.open_as("emulator/lhystudios", "lhyemulator")
-                channel(_("Lhystudios Emulator attached to %s" % str(self)))
+                self.open_as("emulator/lihuiyu", "lhyemulator")
+                channel(_("Lihuiyu Emulator attached to %s" % str(self)))
             except KeyError:
                 channel(_("Emulator cannot be attached to any device."))
             return
@@ -771,9 +771,9 @@ class LihuiyuDevice(Service, ViewPort):
             return self.controller
 
 
-class LhystudiosDriver(Parameters):
+class LihuiyuDriver(Parameters):
     """
-    LhystudiosDriver provides Lhystudios specific coding for elements and sends it to the backend
+    LihuiyuDriver provides Lihuiyu specific coding for elements and sends it to the backend
     to write to the usb.
     """
 
@@ -848,7 +848,7 @@ class LhystudiosDriver(Parameters):
         self.step_total = 0.0
 
     def __repr__(self):
-        return "LhystudiosDriver(%s)" % self.name
+        return "LihuiyuDriver(%s)" % self.name
 
     def __call__(self, e):
         self.out_pipe.write(e)
@@ -1847,14 +1847,10 @@ class LhystudiosDriver(Parameters):
         """
         self.service.signal(signal, *args)
 
-    @property
-    def type(self):
-        return "lhystudios"
 
-
-class LhystudiosController:
+class LihuiyuController:
     """
-    K40 Controller controls the Lhystudios boards sending any queued data to the USB when the signal is not busy.
+    K40 Controller controls the Lihuiyu boards sending any queued data to the USB when the signal is not busy.
 
     Opening and closing of the pipe are dealt with internally. There are three primary monitor data channels.
     'send', 'recv' and 'usb'. They display the reading and writing of information to/from the USB and the USB connection
@@ -1930,7 +1926,7 @@ class LhystudiosController:
             self.realtime_write(b"\x18\n")
 
     def __repr__(self):
-        return "LhystudiosController(%s)" % str(self.context)
+        return f"LihuiyuController({str(self.context)})"
 
     def __len__(self):
         """Provides the length of the buffer of this device."""

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -223,34 +223,6 @@ class LihuiyuDevice(Service, ViewPort):
 
         _ = self.kernel.translation
 
-        @self.console_command(
-            "spool",
-            help=_("spool <command>"),
-            regex=True,
-            input_type=(None, "plan", "device"),
-            output_type="spooler",
-        )
-        def spool(command, channel, _, data=None, remainder=None, **kwgs):
-            spooler = self.spooler
-            if data is not None:
-                # If plan data is in data, then we copy that and move on to next step.
-                spooler.laserjob(data.plan)
-                channel(_("Spooled Plan."))
-                self.signal("plan", data.name, 6)
-
-            if remainder is None:
-                channel(_("----------"))
-                channel(_("Spoolers:"))
-                for d, d_name in enumerate(self.match("device", suffix=True)):
-                    channel("%d: %s" % (d, d_name))
-                channel(_("----------"))
-                channel(_("Spooler on device %s:" % str(self.label)))
-                for s, op_name in enumerate(spooler.queue):
-                    channel("%d: %s" % (s, op_name))
-                channel(_("----------"))
-
-            return "spooler", spooler
-
         @self.console_option(
             "idonotlovemyhouse",
             type=bool,

--- a/meerk40t/lihuiyu/gui/gui.py
+++ b/meerk40t/lihuiyu/gui/gui.py
@@ -19,14 +19,14 @@ def plugin(service, lifecycle):
             icons8_pause_50,
         )
         from meerk40t.lihuiyu.gui.lhyoperationproperties import LhyAdvancedPanel
-        from meerk40t.lihuiyu.gui.lhystudiosaccel import LhystudiosAccelerationChart
-        from meerk40t.lihuiyu.gui.lhystudioscontrollergui import LhystudiosControllerGui
-        from meerk40t.lihuiyu.gui.lhystudiosdrivergui import LhystudiosDriverGui
+        from meerk40t.lihuiyu.gui.lhyaccelgui import LihuiyuAccelerationChart
+        from meerk40t.lihuiyu.gui.lhycontrollergui import LihuiyuControllerGui
+        from meerk40t.lihuiyu.gui.lhydrivergui import LihuiyuDriverGui
         from meerk40t.lihuiyu.gui.tcpcontroller import TCPController
 
-        service.register("window/Controller", LhystudiosControllerGui)
-        service.register("window/Configuration", LhystudiosDriverGui)
-        service.register("window/AccelerationChart", LhystudiosAccelerationChart)
+        service.register("window/Controller", LihuiyuControllerGui)
+        service.register("window/Configuration", LihuiyuDriverGui)
+        service.register("window/AccelerationChart", LihuiyuAccelerationChart)
         service.register("window/Network-Controller", TCPController)
         service.register("property/RasterOpNode/Lihuiyu", LhyAdvancedPanel)
         service.register("property/CutOpNode/Lihuiyu", LhyAdvancedPanel)

--- a/meerk40t/lihuiyu/gui/lhyaccelgui.py
+++ b/meerk40t/lihuiyu/gui/lhyaccelgui.py
@@ -9,7 +9,7 @@ from meerk40t.gui.mwindow import MWindow
 _ = wx.GetTranslation
 
 
-class LhystudiosAccelerationChartPanel(ScrolledPanel):
+class LihuiyuAccelerationChartPanel(ScrolledPanel):
     def __init__(self, *args, context=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)
@@ -278,19 +278,19 @@ class LhystudiosAccelerationChartPanel(ScrolledPanel):
 
     def on_check_vector_accel_enable(
         self, event=None
-    ):  # wxGlade: LhystudiosDriver.<event_handler>
+    ):
 
         self.context.vector_accel_table = self.checkbox_vector_accel_enable.GetValue()
 
-    def on_text_vector_accel(self, event):  # wxGlade: LhystudiosDriver.<event_handler>
+    def on_text_vector_accel(self, event):
         pass
 
     def on_check_raster_accel_enable(
         self, event=None
-    ):  # wxGlade: LhystudiosDriver.<event_handler>
+    ):
         self.context.raster_accel_table = self.checkbox_raster_accel_enable.GetValue()
 
-    def on_text_raster_accel(self, event):  # wxGlade: LhystudiosDriver.<event_handler>
+    def on_text_raster_accel(self, event):
         pass
 
     def on_check_vraster_accel_enable(
@@ -302,11 +302,11 @@ class LhystudiosAccelerationChartPanel(ScrolledPanel):
         pass
 
 
-class LhystudiosAccelerationChart(MWindow):
+class LihuiyuAccelerationChart(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(551, 234, *args, **kwds)
 
-        self.panel = LhystudiosAccelerationChartPanel(
+        self.panel = LihuiyuAccelerationChartPanel(
             self, wx.ID_ANY, context=self.context
         )
         self.add_module_delegate(self.panel)

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -34,7 +34,7 @@ _advanced_width = 952
 _default_height = 584
 
 
-class LhystudiosControllerPanel(ScrolledPanel):
+class LihuiyuControllerPanel(ScrolledPanel):
     def __init__(self, *args, context=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)
@@ -132,7 +132,6 @@ class LhystudiosControllerPanel(ScrolledPanel):
         # end wxGlade
 
     def __do_layout(self):
-        # begin wxGlade: LhystudiosController.__do_layout
         sizer_24 = wx.BoxSizer(wx.HORIZONTAL)
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
         sizer_show_usb_log = wx.BoxSizer(wx.HORIZONTAL)
@@ -485,13 +484,13 @@ class LhystudiosControllerPanel(ScrolledPanel):
 
     def on_button_start_controller(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         print("Event handler 'on_button_start_controller' not implemented!")
         event.Skip()
 
     def on_check_show_usb_log(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         on = self.checkbox_show_usb_log.GetValue()
         self.text_usb_log.Show(on)
         self.context.show_usb_log = bool(on)
@@ -501,7 +500,7 @@ class LhystudiosControllerPanel(ScrolledPanel):
             self.GetParent().SetSize((_simple_width, _default_height))
 
 
-class LhystudiosControllerGui(MWindow):
+class LihuiyuControllerGui(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(_advanced_width, _default_height, *args, **kwds)
 
@@ -511,19 +510,19 @@ class LhystudiosControllerGui(MWindow):
         from platform import system as _sys
 
         if _sys() != "Darwin":
-            self.LhystudiosController_menubar = wx.MenuBar()
-            self.create_menu(self.LhystudiosController_menubar.Append)
-            self.SetMenuBar(self.LhystudiosController_menubar)
+            self.LihuiyuController_menubar = wx.MenuBar()
+            self.create_menu(self.LihuiyuController_menubar.Append)
+            self.SetMenuBar(self.LihuiyuController_menubar)
         # ==========
         # MENUBAR END
         # ==========
 
-        self.panel = LhystudiosControllerPanel(self, wx.ID_ANY, context=self.context)
+        self.panel = LihuiyuControllerPanel(self, wx.ID_ANY, context=self.context)
         self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected_50.GetBitmap())
         self.SetIcon(_icon)
-        self.SetTitle(_("Lhystudios-Controller"))
+        self.SetTitle(_("Lihuiyu-Controller"))
 
     def create_menu(self, append):
         wxglade_tmp_menu = wx.Menu()
@@ -552,7 +551,7 @@ class LhystudiosControllerGui(MWindow):
     def window_preserve(self):
         return False
 
-    def on_menu_usb_reset(self, event):  # wxGlade: LhystudiosController.<event_handler>
+    def on_menu_usb_reset(self, event):
         try:
             self.context("usb_reset\n")
         except AttributeError:
@@ -560,7 +559,7 @@ class LhystudiosControllerGui(MWindow):
 
     def on_menu_usb_release(
         self, event
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         try:
             self.context("usb_release\n")
         except AttributeError:
@@ -568,13 +567,13 @@ class LhystudiosControllerGui(MWindow):
 
     def on_menu_pause(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         try:
             self.context("pause\n")
         except AttributeError:
             pass
 
-    def on_menu_stop(self, event=None):  # wxGlade: LhystudiosController.<event_handler>
+    def on_menu_stop(self, event=None):
         try:
             self.context("estop\n")
         except AttributeError:
@@ -582,5 +581,5 @@ class LhystudiosControllerGui(MWindow):
 
     def on_menu_bufferview(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         self.context("window open BufferView\n")

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -1021,7 +1021,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
 
     def on_check_pulse_shift(
         self, event=None
-    ):  # wxGlade: LhystudiosDriver.<event_handler>
+    ):
         self.context.plot_shift = self.check_plot_shift.GetValue()
         try:
             self.context.plot_planner.force_shift = self.context.plot_shift
@@ -1030,22 +1030,22 @@ class ConfigurationSetupPanel(ScrolledPanel):
 
     def on_check_alt_raster(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         self.context.nse_raster = self.check_alternative_raster.GetValue()
 
     def on_check_twitches(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         self.context.twitches = self.check_twitches.GetValue()
 
     def on_check_rapid_between(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         self.context.opt_rapid_between = self.check_rapid_moves_between.GetValue()
 
     def on_text_min_jog_distance(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         try:
             self.context.opt_jog_minimum = int(
                 self.text_minimum_jog_distance.GetValue()
@@ -1055,17 +1055,17 @@ class ConfigurationSetupPanel(ScrolledPanel):
 
     def on_jog_method_radio(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         self.context.opt_jog_mode = self.radio_box_jog_method.GetSelection()
 
     def on_check_override_rapid(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         self.check_override_rapid.SetValue(self.context.rapid_override)
 
     def on_text_rapid_x(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         try:
             self.context.rapid_override_speed_x = float(self.text_rapid_x.GetValue())
         except ValueError:
@@ -1073,7 +1073,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
 
     def on_text_rapid_y(
         self, event
-    ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+    ):
         try:
             self.context.rapid_override_speed_y = float(self.text_rapid_y.GetValue())
         except ValueError:
@@ -1119,14 +1119,14 @@ class ConfigurationSetupPanel(ScrolledPanel):
             pass
 
 
-class LhystudiosDriverGui(MWindow):
+class LihuiyuDriverGui(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(374, 734, *args, **kwds)
         self.context = self.context.device
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_administrative_tools_50.GetBitmap())
         self.SetIcon(_icon)
-        self.SetTitle(_("Lhystudios-Configuration"))
+        self.SetTitle(_("Lihuiyu-Configuration"))
 
         # self.notebook_main = wx.Notebook(self, wx.ID_ANY)
         self.notebook_main = wx.aui.AuiNotebook(

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -216,34 +216,6 @@ class MoshiDevice(Service, ViewPort):
 
         _ = self.kernel.translation
 
-        @self.console_command(
-            "spool",
-            help=_("spool <command>"),
-            regex=True,
-            input_type=(None, "plan", "device"),
-            output_type="spooler",
-        )
-        def spool(command, channel, _, data=None, remainder=None, **kwgs):
-            spooler = self.spooler
-            if data is not None:
-                # If plan data is in data, then we copy that and move on to next step.
-                spooler.laserjob(data.plan)
-                channel(_("Spooled Plan."))
-                self.signal("plan", data.name, 6)
-
-            if remainder is None:
-                channel(_("----------"))
-                channel(_("Spoolers:"))
-                for d, d_name in enumerate(self.match("device", suffix=True)):
-                    channel("%d: %s" % (d, d_name))
-                channel(_("----------"))
-                channel(_("Spooler on device %s:" % str(self.label)))
-                for s, op_name in enumerate(spooler.queue):
-                    channel("%d: %s" % (s, op_name))
-                channel(_("----------"))
-
-            return "spooler", spooler
-
         @self.console_command("usb_connect", help=_("Connect USB"))
         def usb_connect(command, channel, _, **kwargs):
             """

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -946,7 +946,7 @@ class MoshiController:
     according to established moshi protocols.
 
     The output device is concerned with sending the moshiblobs to the control board and control events and
-    to the CH341 chip on the Moshiboard. We use the same ch341 driver as the Lhystudios boards. Giving us
+    to the CH341 chip on the Moshiboard. We use the same ch341 driver as the Lihuiyu boards. Giving us
     access to both libusb drivers and windll drivers.
 
     The protocol for sending rasters is as follows:

--- a/meerk40t/moshi/gui/moshicontrollergui.py
+++ b/meerk40t/moshi/gui/moshicontrollergui.py
@@ -382,13 +382,13 @@ class MoshiControllerPanel(wx.Panel):
 
     def on_button_start_controller(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         print("Event handler 'on_button_start_controller' not implemented!")
         event.Skip()
 
     def on_check_show_usb_log(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         on = self.checkbox_show_usb_log.GetValue()
         self.text_usb_log.Show(on)
         self.context.show_usb_log = bool(on)
@@ -461,7 +461,7 @@ class MoshiControllerGui(MWindow):
     def window_preserve(self):
         return False
 
-    def on_menu_usb_reset(self, event):  # wxGlade: LhystudiosController.<event_handler>
+    def on_menu_usb_reset(self, event):
         try:
             self.context("usb_reset\n")
         except AttributeError:
@@ -469,7 +469,7 @@ class MoshiControllerGui(MWindow):
 
     def on_menu_usb_release(
         self, event
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         try:
             self.context("usb_release\n")
         except AttributeError:
@@ -477,13 +477,13 @@ class MoshiControllerGui(MWindow):
 
     def on_menu_pause(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         try:
             self.context("pause\n")
         except AttributeError:
             pass
 
-    def on_menu_stop(self, event=None):  # wxGlade: LhystudiosController.<event_handler>
+    def on_menu_stop(self, event=None):
         try:
             self.context("estop\n")
         except AttributeError:
@@ -491,7 +491,7 @@ class MoshiControllerGui(MWindow):
 
     def on_menu_bufferview(
         self, event=None
-    ):  # wxGlade: LhystudiosController.<event_handler>
+    ):
         self.context("window open BufferView\n")
 
     def on_menu_freemotor(self, event):  # wxGlade: MoshiControllerGui.<event_handler>

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -269,7 +269,7 @@ class RuidaDevice(Service, ViewPort):
             spooler = self.spooler
             if data is not None:
                 # If plan data is in data, then we copy that and move on to next step.
-                spooler.jobs(data.plan)
+                spooler.laserjob(data.plan)
                 channel(_("Spooled Plan."))
                 self.signal("plan", data.name, 6)
 

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -258,33 +258,6 @@ class RuidaDevice(Service, ViewPort):
 
         _ = self.kernel.translation
 
-        @self.console_command(
-            "spool",
-            help=_("spool <command>"),
-            regex=True,
-            input_type=(None, "plan", "device"),
-            output_type="spooler",
-        )
-        def spool(command, channel, _, data=None, remainder=None, **kwgs):
-            spooler = self.spooler
-            if data is not None:
-                # If plan data is in data, then we copy that and move on to next step.
-                spooler.laserjob(data.plan)
-                channel(_("Spooled Plan."))
-                self.signal("plan", data.name, 6)
-
-            if remainder is None:
-                channel(_("----------"))
-                channel(_("Spoolers:"))
-                for d, d_name in enumerate(self.match("device", suffix=True)):
-                    channel("%d: %s" % (d, d_name))
-                channel(_("----------"))
-                channel(_("Spooler on device %s:" % str(self.label)))
-                for s, op_name in enumerate(spooler.queue):
-                    channel("%d: %s" % (s, op_name))
-                channel(_("----------"))
-
-            return "spooler", spooler
 
 
 class RuidaParser:


### PR DESCRIPTION
"""
Laser jobs are a generic outline for the types of jobs which can be sent to a spooler.

* Laser jobs need to provide a run-count and expected run-count this how many times it should be executed.
* Laser jobs must be able to be cancelled. Jobs running an infinite number of times must be able to be interrupted.
* Lowest priority jobs should be interrupted. They should be stopped, aborted at the earliest possibility.
* Realtime jobs should run even if the current device is paused. This is to permit resuming a backend device.
* Some, but not all, jobs should permit the serialization of the job. To permit saving the job to disk or moving it over a network.
* Dynamic laser jobs like Live-Outline mode for galvo should be a type of job, this doesn't permit saving or canceling.
* Jobs should permit interrupt and execution at the lowest level. So a lighting job can be interrupted to start a real
job with the laser. But, should be allowed to resume when the higher priority job is fully executed (or cancelled).
* Jobs should provide information for the amount of time they were executed.
* Jobs should provide an estimate for the amount of time they will take to execute.
* The execution of a laser job can vary by device. Dynamic jobs like live-outline performs several mode changes and
commands which are executed directly on the connection.
* Some jobs currently contain a sequence of steps to be called on the driver (conditionally if they exist). This divide
needs to be bridged.
* A driver is class which has a bunch of potential commands which may or may not exist, these are attempted and processed
by the spooler in order. Stalling the required amounts of time to complete each task.
* Different implementations may permit different events. Dwell may not be possible on all devices. So a dynamic jobs to
perform dwelling would work for some but not others.
* job-if-idle implemenation is basically a low priority job which allows device jogging and repositioning but only when
the job is empty.
* A network interface of job-if-idle dynamic jobs would fail to work, but the commands here are perfectly reasonable
You would issue jog commands etc. Though, if idle then you wouldn't know whether you could jog or not, so it actually
does matter.
* Jobs should provide titles, user, etc. Permit networked spoolers from executing jobs from mutliple computers.
* A spooler interface would need to provide two-way communications for job status and providing camera information etc.

"""