### PR TITLE
Use and acknowledge lock status

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1642,7 +1642,7 @@ class Elemental(Service):
 
         @self.console_command(
             "unlock",
-            help=_("Unock element (allow manipulation)"),
+            help=_("Unlock element (allow manipulation)"),
             input_type=("elements"),
             output_type=("elements"),
         )

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1625,6 +1625,36 @@ class Elemental(Service):
         # ==========
         # ELEMENT/OPERATION SUBCOMMANDS
         # ==========
+        @self.console_command(
+            "lock",
+            help=_("Lock element (protect from manipulation)"),
+            input_type=("elements"),
+            output_type=("elements"),
+        )
+        def e_lock(data=None, **kwargs):
+            if data is None:
+                data = list(self.elems(emphasized=True))
+            for e in data:
+                e.lock = True
+            self.signal("element_property_update", data)
+            self.signal("refresh_scene", "Scene")
+            return "elements", data
+
+        @self.console_command(
+            "unlock",
+            help=_("Unock element (allow manipulation)"),
+            input_type=("elements"),
+            output_type=("elements"),
+        )
+        def e_unlock(data=None, **kwargs):
+            if data is None:
+                data = list(self.elems(emphasized=True))
+            for e in data:
+                e.lock = False
+            self.signal("element_property_update", data)
+            self.signal("refresh_scene", "Scene")
+            return "elements", data
+
         @self.console_option(
             "dx", "x", help=_("copy offset x (for elems)"), type=Length, default=0
         )
@@ -3491,6 +3521,9 @@ class Elemental(Service):
                 channel(_("No selected elements."))
                 return
             for e in data:
+                if hasattr(e, "lock") and e.lock:
+                    channel(_("Can't modify a locked element: %s") % str(e))
+                    continue
                 e.stroke_width = stroke_width
                 e.altered()
             return "elements", data
@@ -3557,6 +3590,9 @@ class Elemental(Service):
                 if not capvalue is None:
                     for e in apply:
                         if hasattr(e, "linecap"):
+                            if hasattr(e, "lock") and e.lock:
+                                channel(_("Can't modify a locked element: %s") % str(e))
+                                continue
                             e.linecap = capvalue
                             e.altered()
                 return "elements", data
@@ -3633,6 +3669,9 @@ class Elemental(Service):
                 if not joinvalue is None:
                     for e in apply:
                         if hasattr(e, "linejoin"):
+                            if hasattr(e, "lock") and e.lock:
+                                channel(_("Can't modify a locked element: %s") % str(e))
+                                continue
                             e.linejoin = joinvalue
                             e.altered()
                 return "elements", data
@@ -3696,6 +3735,9 @@ class Elemental(Service):
                 if not rulevalue is None:
                     for e in apply:
                         if hasattr(e, "fillrule"):
+                            if hasattr(e, "lock") and e.lock:
+                                channel(_("Can't modify a locked element: %s") % str(e))
+                                continue
                             e.fillrule = rulevalue
                             e.altered()
                 return "elements", data
@@ -3753,10 +3795,16 @@ class Elemental(Service):
                 return
             elif color == "none":
                 for e in apply:
+                    if hasattr(e, "lock") and e.lock:
+                        channel(_("Can't modify a locked element: %s") % str(e))
+                        continue
                     e.stroke = None
                     e.altered()
             else:
                 for e in apply:
+                    if hasattr(e, "lock") and e.lock:
+                        channel(_("Can't modify a locked element: %s") % str(e))
+                        continue
                     e.stroke = Color(color)
                     e.altered()
             if classify is None:
@@ -3822,10 +3870,16 @@ class Elemental(Service):
                 return "elements", data
             elif color == "none":
                 for e in apply:
+                    if hasattr(e, "lock") and e.lock:
+                        channel(_("Can't modify a locked element: %s") % str(e))
+                        continue
                     e.fill = None
                     e.altered()
             else:
                 for e in apply:
+                    if hasattr(e, "lock") and e.lock:
+                        channel(_("Can't modify a locked element: %s") % str(e))
+                        continue
                     e.fill = Color(color)
                     e.altered()
             if classify is None:
@@ -3957,11 +4011,8 @@ class Elemental(Service):
             try:
                 if not absolute:
                     for node in data:
-                        try:
-                            if node.lock:
-                                continue
-                        except AttributeError:
-                            pass
+                        if hasattr(node, "lock") and node.lock:
+                            continue
 
                         node.matrix *= matrix
                         node.modified()
@@ -4050,22 +4101,14 @@ class Elemental(Service):
             try:
                 if not absolute:
                     for node in data:
-                        try:
-                            if node.lock:
-                                continue
-                        except AttributeError:
-                            pass
-
+                        if hasattr(node, "lock") and node.lock:
+                            continue
                         node.matrix *= matrix
                         node.modified()
                 else:
                     for node in data:
-                        try:
-                            if node.lock:
-                                continue
-                        except AttributeError:
-                            pass
-
+                        if hasattr(node, "lock") and node.lock:
+                            continue
                         osx = node.matrix.value_scale_x()
                         osy = node.matrix.value_scale_y()
                         nsx = scale_x / osx
@@ -4335,13 +4378,9 @@ class Elemental(Service):
                 if data is None:
                     data = list(self.elems(emphasized=True))
                 for node in data:
-                    try:
-                        if node.lock:
-                            channel(_("resize: cannot resize a locked image"))
-                            return
-                    except AttributeError:
-                        pass
-                for node in data:
+                    if hasattr(node, "lock") and node.lock:
+                        channel(_("resize: cannot resize a locked element"))
+                        continue
                     node.matrix *= matrix
                     node.modified()
                 return "elements", data
@@ -4393,12 +4432,8 @@ class Elemental(Service):
                     ty,
                 )
                 for node in data:
-                    try:
-                        if node.lock:
-                            continue
-                    except AttributeError:
-                        pass
-
+                    if hasattr(node, "lock") and node.lock:
+                        continue
                     node.matrix = Matrix(m)
                     node.modified()
             except ValueError:
@@ -4415,12 +4450,8 @@ class Elemental(Service):
             if data is None:
                 data = list(self.elems(emphasized=True))
             for e in data:
-                try:
-                    if e.lock:
-                        continue
-                except AttributeError:
-                    pass
-
+                if hasattr(e, "lock") and e.lock:
+                    continue
                 name = str(e)
                 if len(name) > 50:
                     name = name[:50] + "…"
@@ -4767,6 +4798,9 @@ class Elemental(Service):
                         typecount[2] += 1
                         todelete[2].append(node)
                     else:
+                        if hasattr(node, "lock") and node.lock:
+                            # Don't delete locked nodes
+                            continue
                         typecount[1] += 1
                         todelete[1].append(node)
                 else: # branches etc...
@@ -5697,6 +5731,7 @@ class Elemental(Service):
         # ==========
         # REMOVE SINGLE (Tree Selected - ELEMENT)
         # ==========
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_conditional(
             lambda cond: len(
                 list(self.flat(selected=True, cascade=False, types=elem_nodes))
@@ -5709,9 +5744,11 @@ class Elemental(Service):
             help="",
         )
         def remove_type_elem(node, **kwargs):
-
-            node.remove_node()
-            self.set_emphasis(None)
+            if hasattr(node, "lock") and node.lock:
+                pass
+            else:
+                node.remove_node()
+                self.set_emphasis(None)
 
         @self.tree_conditional(
             lambda cond: len(
@@ -5729,6 +5766,15 @@ class Elemental(Service):
             node.remove_node()
             self.set_emphasis(None)
 
+        def contains_no_locked_items():
+            nolock = True
+            for e in list(self.flat(selected=True, cascade=True)):
+                if hasattr(e, "lock") and e.lock:
+                    nolock = False
+                    break
+            return nolock
+
+        @self.tree_conditional(lambda cond: contains_no_locked_items())
         @self.tree_conditional(
             lambda cond: len(
                 list(self.flat(selected=True, cascade=False, types=("file", "group")))
@@ -5741,7 +5787,6 @@ class Elemental(Service):
             help="",
         )
         def remove_type_grp(node, **kwargs):
-
             node.remove_node()
             self.set_emphasis(None)
 
@@ -6506,6 +6551,18 @@ class Elemental(Service):
         def merge_elements(node, **kwargs):
             self("element merge\n")
 
+        @self.tree_conditional(lambda node: node.lock)
+        @self.tree_separator_before()
+        @self.tree_operation(_("Unlock Element"), node_type=elem_nodes, help="")
+        def element_unlock_manipulations(node, **kwargs):
+            self("element unlock\n")
+
+        @self.tree_conditional(lambda node: not node.lock)
+        @self.tree_separator_before()
+        @self.tree_operation(_("Lock manipulations"), node_type=elem_nodes, help="")
+        def element_lock_manipulations(node, **kwargs):
+            self("element lock\n")
+
         @self.tree_conditional(lambda node: is_regmark(node))
         @self.tree_separator_before()
         @self.tree_operation(
@@ -6537,6 +6594,11 @@ class Elemental(Service):
                 if item.selected:
                     data.append(item)
             for item in data:
+                # No usecase for having a locked regmark element
+                try:
+                    item.lock = False
+                except AttributeError:
+                    pass
                 drop_node.drop(item)
                 signal_needed = True
             if signal_needed:
@@ -6544,11 +6606,13 @@ class Elemental(Service):
             drop_node.drop(node)
             self.signal("tree_changed")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_conditional_try(lambda node: not node.lock)
         @self.tree_operation(_("Actualize pixels"), node_type="elem image", help="")
         def image_actualize_pixels(node, **kwargs):
             self("image resample\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Z-depth divide"))
         @self.tree_iterate("divide", 2, 10)
         @self.tree_operation(
@@ -6563,37 +6627,49 @@ class Elemental(Service):
                 threshold_max = threshold_min + band
                 self("image threshold %f %f\n" % (threshold_min, threshold_max))
 
-        @self.tree_conditional(lambda node: not node.lock)
+        @self.tree_conditional(lambda node: node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Unlock manipulations"), node_type="elem image", help="")
         def image_unlock_manipulations(node, **kwargs):
             self("image unlock\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
+        @self.tree_submenu(_("Image"))
+        @self.tree_operation(_("Lock manipulations"), node_type="elem image", help="")
+        def image_lock_manipulations(node, **kwargs):
+            self("image lock\n")
+
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Dither to 1 bit"), node_type="elem image", help="")
         def image_dither(node, **kwargs):
             self("image dither\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Invert image"), node_type="elem image", help="")
         def image_invert(node, **kwargs):
             self("image invert\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Mirror horizontal"), node_type="elem image", help="")
         def image_mirror(node, **kwargs):
             self("image mirror\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Flip vertical"), node_type="elem image", help="")
         def image_flip(node, **kwargs):
             self("image flip\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Rotate 90° CW"), node_type="elem image", help="")
         def image_cw(node, **kwargs):
             self("image cw\n")
 
+        @self.tree_conditional(lambda node: not node.lock)
         @self.tree_submenu(_("Image"))
         @self.tree_operation(_("Rotate 90° CCW"), node_type="elem image", help="")
         def image_ccw(node, **kwargs):
@@ -7127,6 +7203,11 @@ class Elemental(Service):
 
     def remove_elements(self, element_node_list):
         for elem in element_node_list:
+            try:
+                if hasattr(elem, "lock") and elem.lock:
+                    continue
+            except AttributeError:
+                pass
             elem.remove_node(references=True)
         self.validate_selected_area()
 

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -5,6 +5,7 @@ from ..kernel import signal_listener
 from ..svgelements import Color
 from .icons import (
     icon_meerk40t,
+    icons8_lock_50,
     icons8_direction_20,
     icons8_file_20,
     icons8_group_objects_20,
@@ -269,12 +270,19 @@ class ShadowTree:
         self.do_not_select = False
         self.was_already_expanded = []
         service.add_service_delegate(self)
+        self.setup_state_images()
 
     def service_attach(self, *args):
         self.elements.listen_tree(self)
 
     def service_detach(self, *args):
         self.elements.unlisten_tree(self)
+
+    def setup_state_images(self):
+        self.state_images = wx.ImageList()
+        self.state_images.Create(width=20, height=20)
+        image_id = self.state_images.Add(bitmap=icons8_lock_50.GetBitmap(resize=(20,20)))
+        self.wxtree.SetStateImageList(self.state_images)
 
     def node_created(self, node, **kwargs):
         """
@@ -501,8 +509,12 @@ class ShadowTree:
         @return:
         """
         element = args[0]
-        if hasattr(element, "node"):
-            self.update_decorations(element.node, force=True)
+        if isinstance(element, (tuple, list)):
+            for node in element:
+                if hasattr(node, "node"):
+                    self.update_decorations(node.node, force=True)
+                else:
+                    self.update_decorations(node, force=True)
         else:
             self.update_decorations(element, force=True)
 
@@ -513,8 +525,12 @@ class ShadowTree:
         @return:
         """
         element = args[0]
-        if hasattr(element, "node"):
-            self.update_decorations(element.node, force=True)
+        if isinstance(element, (tuple, list)):
+            for node in element:
+                if hasattr(node, "node"):
+                    self.update_decorations(node.node, force=True)
+                else:
+                    self.update_decorations(node, force=True)
         else:
             self.update_decorations(element, force=True)
 
@@ -947,6 +963,15 @@ class ShadowTree:
                 self.wxtree.SetItemTextColour(node.item, c)
         except AttributeError:
             pass
+        # Has the node a lock attribute?
+        if hasattr(node, "lock"):
+            lockit = node.lock
+        else:
+            lockit = False
+        if lockit:
+            self.wxtree.SetItemState(node.item, 0)
+        else:
+            self.wxtree.SetItemState(node.item, wx.TREE_ITEMSTATE_NONE)
 
     def on_drag_begin_handler(self, event):
         """


### PR DESCRIPTION
Consistently use and acknowledge the 'lock' status of an element.
a) new commands:
```
element lock
element unlock
```
b) Visual aknowledgement by 

1.  removing all corresponding modification actions from the context menus

<img width="217" alt="image" src="https://user-images.githubusercontent.com/2670784/178340357-6efa545e-d5e5-4f46-87fb-b964eed98f7e.png">
vs
<img width="213" alt="image" src="https://user-images.githubusercontent.com/2670784/178340402-b0e53422-8316-4852-adb6-f1576d836f93.png">

2.  displaying an appropriate icon in the element-tree
<img width="94" alt="image" src="https://user-images.githubusercontent.com/2670784/178340437-d6b55cfe-f94c-44fd-a452-8975e753426c.png">

3. removing all modification elements from the scene-item-manipulation
<img width="175" alt="image" src="https://user-images.githubusercontent.com/2670784/178340490-6d3edeb2-0b1c-43a1-beda-b01adfaeeed9.png">
vs
<img width="179" alt="image" src="https://user-images.githubusercontent.com/2670784/178340537-88177f5e-f397-427d-ae15-e2c8a7ed52e6.png">


![lock](https://user-images.githubusercontent.com/2670784/178340249-c98e7ab2-9870-4c12-a97d-32f05790abb2.gif)

