### PR TITLE
Some fixes / extending the simulation window

### DIFF
--- a/meerk40t/balormk/gui/baloroperationproperties.py
+++ b/meerk40t/balormk/gui/baloroperationproperties.py
@@ -1,5 +1,5 @@
 import wx
-
+from wx.lib.scrolledpanel import ScrolledPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 
 from ...core.units import Length
@@ -8,7 +8,7 @@ from ..balor_params import Parameters
 _ = wx.GetTranslation
 
 
-class BalorOperationPanel(wx.Panel):
+class BalorOperationPanel(ScrolledPanel):
     name = "Balor"
 
     def __init__(self, *args, context=None, node=None, **kwds):
@@ -139,10 +139,11 @@ class BalorOperationPanel(wx.Panel):
         ]
 
         self.panel = ChoicePropertyPanel(
-            self, wx.ID_ANY, context=self.context, choices=choices
+            self, wx.ID_ANY, context=self.context, choices=choices, scrolling=False
         )
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(self.panel, 1, wx.EXPAND, 0)
 
         self.SetSizer(main_sizer)
 

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -402,43 +402,59 @@ class CutCode(CutGroup):
             yield "plot", cutobject
         yield "plot_start"
 
-    def length_travel(self, include_start=False):
+    def length_travel(self, include_start=False, stop_at = -1):
         cutcode = list(self.flat())
         if len(cutcode) == 0:
             return 0
+        if stop_at < 0:
+            stop_at = len(cutcode)
+        if stop_at>len(cutcode):
+            stop_at = len(cutcode)
         distance = 0
         if include_start:
             if self.start is not None:
                 distance += abs(complex(*self.start) - complex(*cutcode[0].start))
             else:
                 distance += abs(0 - complex(*cutcode[0].start))
-        for i in range(1, len(cutcode)):
+        for i in range(1, stop_at):
             prev = cutcode[i - 1]
             curr = cutcode[i]
             delta = Point.distance(prev.end, curr.start)
             distance += delta
         return distance
 
-    def length_cut(self):
+    def length_cut(self, stop_at = -1):
         cutcode = list(self.flat())
         distance = 0
-        for i in range(0, len(cutcode)):
+        if stop_at < 0:
+            stop_at = len(cutcode)
+        if stop_at>len(cutcode):
+            stop_at = len(cutcode)
+        for i in range(0, stop_at):
             curr = cutcode[i]
             distance += curr.length()
         return distance
 
-    def extra_time(self):
+    def extra_time(self, stop_at = -1):
         cutcode = list(self.flat())
         extra = 0
-        for i in range(0, len(cutcode)):
+        if stop_at < 0:
+            stop_at = len(cutcode)
+        if stop_at>len(cutcode):
+            stop_at = len(cutcode)
+        for i in range(0, stop_at):
             curr = cutcode[i]
             extra += curr.extra()
         return extra
 
-    def duration_cut(self):
+    def duration_cut(self, stop_at = -1):
         cutcode = list(self.flat())
         distance = 0
-        for i in range(0, len(cutcode)):
+        if stop_at < 0:
+            stop_at = len(cutcode)
+        if stop_at>len(cutcode):
+            stop_at = len(cutcode)
+        for i in range(0, stop_at):
             curr = cutcode[i]
             if curr.speed != 0:
                 distance += (curr.length() / MILS_IN_MM) / curr.speed

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -34,7 +34,7 @@ def register_panel_laser(window, context):
     pane = (
         aui.AuiPaneInfo()
         .Left()
-        .MinSize(250, 210)
+        .MinSize(150, 210)
         .FloatingSize(400, 200)
         .MaxSize(500, 300)
         .Caption(_("Laser"))
@@ -42,7 +42,7 @@ def register_panel_laser(window, context):
         .Name("laser")
     )
     pane.control = notebook
-    pane.dock_proportion = 210
+    pane.dock_proportion = 150
     notebook.AddPage(laser_panel, _("Laser"))
     notebook.AddPage(optimize_panel, _("Optimize"))
 

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -1,5 +1,5 @@
 import wx
-
+from wx.lib.scrolledpanel import ScrolledPanel
 # from ...svgelements import SVG_ATTR_ID
 from ..icons import icons8_group_objects_50
 from ..mwindow import MWindow
@@ -7,7 +7,7 @@ from ..mwindow import MWindow
 _ = wx.GetTranslation
 
 
-class GroupPropertiesPanel(wx.Panel):
+class GroupPropertiesPanel(ScrolledPanel):
     def __init__(self, *args, context=None, node=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)
@@ -50,9 +50,9 @@ class GroupPropertiesPanel(wx.Panel):
         )
         sizer_1 = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Id")), wx.VERTICAL)
         sizer_1.Add(self.text_id, 0, wx.EXPAND, 0)
-        sizer_8.Add(sizer_1, 1, wx.EXPAND, 0)
+        sizer_8.Add(sizer_1, 0, wx.EXPAND, 0)
         sizer_2.Add(self.text_label, 0, wx.EXPAND, 0)
-        sizer_8.Add(sizer_2, 1, wx.EXPAND, 0)
+        sizer_8.Add(sizer_2, 0, wx.EXPAND, 0)
         sizer_8.Add((0, 0), 0, 0, 0)
         self.SetSizer(sizer_8)
         self.Layout()

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -1,12 +1,12 @@
 import wx
-
+from wx.lib.scrolledpanel import ScrolledPanel
 from ..icons import icons8_image_50
 from ..mwindow import MWindow
 
 _ = wx.GetTranslation
 
 
-class ImagePropertyPanel(wx.Panel):
+class ImagePropertyPanel(ScrolledPanel):
     def __init__(self, *args, context=None, node=None, **kwargs):
         # begin wxGlade: ConsolePanel.__init__
         kwargs["style"] = kwargs.get("style", 0) | wx.TAB_TRAVERSAL
@@ -174,33 +174,33 @@ class ImagePropertyPanel(wx.Panel):
             wx.StaticBox(self, wx.ID_ANY, _("DPI:")), wx.VERTICAL
         )
         self.text_dpi.SetToolTip(_("Dots Per Inch"))
-        sizer_dpi.Add(self.text_dpi, 5, 0, 0)
+        sizer_dpi.Add(self.text_dpi, 0, 0, 0)
 
-        sizer_main.Add(sizer_dpi, 1, wx.EXPAND, 0)
+        sizer_main.Add(sizer_dpi, 0, wx.EXPAND, 0)
         label_x = wx.StaticText(self, wx.ID_ANY, _("X:"))
         label_y = wx.StaticText(self, wx.ID_ANY, _("Y:"))
 
-        sizer_xy.Add(label_x, 1, 0, 0)
-        sizer_xy.Add(self.text_x, 5, 0, 0)
-        sizer_xy.Add(label_y, 1, 0, 0)
-        sizer_xy.Add(self.text_y, 5, 0, 0)
-        sizer_main.Add(sizer_xy, 1, wx.EXPAND, 0)
+        sizer_xy.Add(label_x, 1, wx.EXPAND, 0)
+        sizer_xy.Add(self.text_x, 3, wx.EXPAND, 0)
+        sizer_xy.Add(label_y, 1, wx.EXPAND, 0)
+        sizer_xy.Add(self.text_y, 3, wx.EXPAND, 0)
+        sizer_main.Add(sizer_xy, 0, wx.EXPAND, 0)
 
         label_w = wx.StaticText(self, wx.ID_ANY, _("Width:"))
         label_h = wx.StaticText(self, wx.ID_ANY, _("Height:"))
-        sizer_dim.Add(label_w, 1, 0, 0)
-        sizer_dim.Add(self.text_width, 5, 0, 0)
-        sizer_dim.Add(label_h, 1, 0, 0)
-        sizer_dim.Add(self.text_height, 5, 0, 0)
-        sizer_main.Add(sizer_dim, 1, wx.EXPAND, 0)
+        sizer_dim.Add(label_w, 1, wx.EXPAND, 0)
+        sizer_dim.Add(self.text_width, 3, wx.EXPAND, 0)
+        sizer_dim.Add(label_h, 1, wx.EXPAND, 0)
+        sizer_dim.Add(self.text_height, 3, wx.EXPAND, 0)
+        sizer_main.Add(sizer_dim, 0, wx.EXPAND, 0)
 
         sizer_dither = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, _("Dither")), wx.HORIZONTAL
         )
         sizer_dither.Add(self.check_enable_dither, 0, 0, 0)
-        sizer_dither.Add(self.combo_dither, 0, 0, 0)
+        sizer_dither.Add(self.combo_dither, 0, wx.EXPAND, 0)
 
-        sizer_main.Add(sizer_dither, 1, wx.EXPAND, 0)
+        sizer_main.Add(sizer_dither, 0, wx.EXPAND, 0)
 
         # -----
 
@@ -237,7 +237,7 @@ class ImagePropertyPanel(wx.Panel):
         sizer_grayscale.Add(sizer_rg, 5, wx.EXPAND, 0)
         sizer_grayscale.Add(sizer_bl, 5, wx.EXPAND, 0)
 
-        sizer_main.Add(sizer_grayscale, 1, wx.EXPAND, 0)
+        sizer_main.Add(sizer_grayscale, 0, wx.EXPAND, 0)
         self.SetSizer(sizer_main)
         self.Layout()
         self.Centre()

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -2,7 +2,7 @@ import wx
 from wx.lib.scrolledpanel import ScrolledPanel
 from ..icons import icons8_image_50
 from ..mwindow import MWindow
-
+from ...core.units import Length
 _ = wx.GetTranslation
 
 
@@ -131,10 +131,10 @@ class ImagePropertyPanel(ScrolledPanel):
         self.text_dpi.SetValue(str(node.dpi))
         try:
             bounds = node.bounds
-            self.text_x.SetValue(str(bounds[0]))
-            self.text_y.SetValue(str(bounds[1]))
-            self.text_width.SetValue(str((bounds[2] - bounds[0])))
-            self.text_height.SetValue(str((bounds[3] - bounds[1])))
+            self.text_x.SetValue("%.2fmm" % Length(amount=bounds[0], unitless=1).mm)
+            self.text_y.SetValue("%.2fmm" % Length(amount=bounds[1], unitless=1).mm)
+            self.text_width.SetValue("%.2fmm" % Length(amount=bounds[2]-bounds[0], unitless=1).mm)
+            self.text_height.SetValue("%.2fmm" % Length(amount=bounds[3]-bounds[1], unitless=1).mm)
         except AttributeError:
             pass
         self.check_enable_dither.SetValue(node.dither)

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -1,10 +1,11 @@
 import wx
-
+from wx.lib.scrolledpanel import ScrolledPanel
 from meerk40t.kernel import signal_listener
 
 from ...core.units import Length
 from ...svgelements import Angle, Color, Matrix
 from ..laserrender import swizzlecolor
+from ..wxutils import TextCtrl
 
 _ = wx.GetTranslation
 
@@ -229,7 +230,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(speed_sizer, 1, wx.EXPAND, 0)
 
-        self.text_speed = wx.TextCtrl(self, wx.ID_ANY, "20.0")
+        self.text_speed = TextCtrl(self, wx.ID_ANY, "20.0")
         self.text_speed.SetToolTip(OPERATION_SPEED_TOOLTIP)
         speed_sizer.Add(self.text_speed, 1, 0, 0)
 
@@ -238,7 +239,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(power_sizer, 1, wx.EXPAND, 0)
 
-        self.text_power = wx.TextCtrl(self, wx.ID_ANY, "1000.0")
+        self.text_power = TextCtrl(self, wx.ID_ANY, "1000.0")
         self.text_power.SetToolTip(OPERATION_POWER_TOOLTIP)
         power_sizer.Add(self.text_power, 1, 0, 0)
 
@@ -247,7 +248,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(frequency_sizer, 1, wx.EXPAND, 0)
 
-        self.text_frequency = wx.TextCtrl(self, wx.ID_ANY, "20.0")
+        self.text_frequency = TextCtrl(self, wx.ID_ANY, "20.0")
         # self.text_frequency.SetToolTip(OPERATION_SPEED_TOOLTIP)
         frequency_sizer.Add(self.text_frequency, 1, 0, 0)
 
@@ -330,11 +331,11 @@ class PassesPanel(wx.Panel):
 
         self.check_passes = wx.CheckBox(self, wx.ID_ANY, "Passes")
         self.check_passes.SetToolTip("Enable Operation Passes")
-        sizer_passes.Add(self.check_passes, 1, 0, 0)
+        sizer_passes.Add(self.check_passes, 1, wx.EXPAND, 0)
 
-        self.text_passes = wx.TextCtrl(self, wx.ID_ANY, "1")
+        self.text_passes = TextCtrl(self, wx.ID_ANY, "1")
         self.text_passes.SetToolTip(OPERATION_PASSES_TOOLTIP)
-        sizer_passes.Add(self.text_passes, 1, 0, 0)
+        sizer_passes.Add(self.text_passes, 2, wx.EXPAND, 0)
 
         self.SetSizer(sizer_passes)
 
@@ -702,7 +703,7 @@ class RasterSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_3, 0, wx.EXPAND, 0)
 
-        self.text_dpi = wx.TextCtrl(self, wx.ID_ANY, "500")
+        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500")
         self.text_dpi.SetToolTip(OPERATION_DPI_TOOLTIP)
         sizer_3.Add(self.text_dpi, 0, 0, 0)
 
@@ -711,7 +712,7 @@ class RasterSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_6, 0, wx.EXPAND, 0)
 
-        self.text_overscan = wx.TextCtrl(self, wx.ID_ANY, "1mm")
+        self.text_overscan = TextCtrl(self, wx.ID_ANY, "1mm")
         self.text_overscan.SetToolTip("Overscan amount")
         sizer_6.Add(self.text_overscan, 1, 0, 0)
 
@@ -842,7 +843,7 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_distance, 0, wx.EXPAND, 0)
 
-        self.text_distance = wx.TextCtrl(self, wx.ID_ANY, "1mm")
+        self.text_distance = TextCtrl(self, wx.ID_ANY, "1mm")
         sizer_distance.Add(self.text_distance, 0, 0, 0)
 
         sizer_angle = wx.StaticBoxSizer(
@@ -850,7 +851,7 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_angle, 1, wx.EXPAND, 0)
 
-        self.text_angle = wx.TextCtrl(self, wx.ID_ANY, "0deg")
+        self.text_angle = TextCtrl(self, wx.ID_ANY, "0deg")
         sizer_angle.Add(self.text_angle, 1, 0, 0)
 
         self.slider_angle = wx.Slider(self, wx.ID_ANY, 0, 0, 360)
@@ -1114,7 +1115,7 @@ class DwellSettingsPanel(wx.Panel):
             wx.StaticBox(self, wx.ID_ANY, "Dwell Time: (ms)"), wx.HORIZONTAL
         )
 
-        self.text_dwelltime = wx.TextCtrl(self, wx.ID_ANY, "1.0")
+        self.text_dwelltime = TextCtrl(self, wx.ID_ANY, "1.0")
         self.text_dwelltime.SetToolTip(
             _("Dwell time (ms) at each location in the sequence")
         )
@@ -1152,7 +1153,7 @@ class DwellSettingsPanel(wx.Panel):
 # end of class PassesPanel
 
 
-class ParameterPanel(wx.Panel):
+class ParameterPanel(ScrolledPanel):
     name = _("Properties")
     priority = -1
 

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -1,4 +1,5 @@
 import wx
+from wx.lib.scrolledpanel import ScrolledPanel
 
 from ...svgelements import Color
 from ..icons import icons8_vector_50
@@ -8,7 +9,7 @@ from ..mwindow import MWindow
 _ = wx.GetTranslation
 
 
-class PathPropertyPanel(wx.Panel):
+class PathPropertyPanel(ScrolledPanel):
     def __init__(self, *args, context=None, node=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -84,6 +84,10 @@ class PropertyWindow(MWindow):
             except AttributeError:
                 pass
             page_panel.Layout()
+            try:
+                page_panel.SetupScrolling()
+            except AttributeError:
+                pass
 
         self.Layout()
 

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -1,4 +1,5 @@
 import wx
+from wx.lib.scrolledpanel import ScrolledPanel
 
 from meerk40t.gui.fonts import wxfont_to_svg
 
@@ -54,7 +55,7 @@ class PromptingComboBox(wx.ComboBox):
         event.Skip()
 
 
-class TextPropertyPanel(wx.Panel):
+class TextPropertyPanel(ScrolledPanel):
     def __init__(self, *args, context=None, node=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -80,6 +80,18 @@ class SimulationPanel(wx.Panel, Job):
         self.text_time_laser = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.text_time_travel = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.text_time_total = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_distance_laser_step = wx.TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY
+        )
+        self.text_distance_travel_step = wx.TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY
+        )
+        self.text_distance_total_step = wx.TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY
+        )
+        self.text_time_laser_step = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_time_travel_step = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_time_total_step = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.button_play = wx.Button(self, wx.ID_ANY, "")
         self.slider_playbackspeed = wx.Slider(self, wx.ID_ANY, 180, 0, 310)
         self.text_playback_speed = wx.TextCtrl(
@@ -164,61 +176,89 @@ class SimulationPanel(wx.Panel, Job):
 
     def __do_layout(self):
         # begin wxGlade: Simulation.__do_layout
-        sizer_1 = wx.BoxSizer(wx.VERTICAL)
-        sizer_2 = wx.BoxSizer(wx.VERTICAL)
-        sizer_3 = wx.BoxSizer(wx.HORIZONTAL)
+        self.text_distance_laser.SetMinSize((35, -1))
+        self.text_distance_laser_step.SetMinSize((35, -1))
+        self.text_distance_total.SetMinSize((35, -1))
+        self.text_distance_total_step.SetMinSize((35, -1))
+        self.text_distance_travel.SetMinSize((35, -1))
+        self.text_distance_travel_step.SetMinSize((35, -1))
+        self.text_time_laser.SetMinSize((35, -1))
+        self.text_time_laser_step.SetMinSize((35, -1))
+        self.text_time_total.SetMinSize((35, -1))
+        self.text_time_total_step.SetMinSize((35, -1))
+        self.text_time_travel.SetMinSize((35, -1))
+        self.text_time_travel_step.SetMinSize((35, -1))
+        v_sizer_main = wx.BoxSizer(wx.VERTICAL)
+        h_sizer_scroll = wx.BoxSizer(wx.HORIZONTAL)
+        h_sizer_text_1 = wx.BoxSizer(wx.HORIZONTAL)
+        h_sizer_text_2 = wx.BoxSizer(wx.HORIZONTAL)
+        h_sizer_buttons = wx.BoxSizer(wx.HORIZONTAL)
+
         sizer_6 = wx.BoxSizer(wx.VERTICAL)
         sizer_4 = wx.BoxSizer(wx.VERTICAL)
         sizer_5 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer_time = wx.BoxSizer(wx.HORIZONTAL)
         sizer_total_time = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Total Time")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Total Time")), wx.HORIZONTAL
         )
         sizer_travel_time = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Travel Time")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Travel Time")), wx.HORIZONTAL
         )
         sizer_laser_time = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Laser Time")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Laser Time")), wx.HORIZONTAL
         )
-        sizer_distance = wx.BoxSizer(wx.HORIZONTAL)
         sizer_total_distance = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Total Distance")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Total Distance")), wx.HORIZONTAL
         )
         sizer_travel_distance = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Travel Distance")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Travel Distance")), wx.HORIZONTAL
         )
         sizer_laser_distance = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, _("Laser Distance")), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, _("Laser Distance")), wx.HORIZONTAL
         )
-        sizer_1.Add(self.view_pane, 3, wx.EXPAND, 0)
-        sizer_2.Add(self.slider_progress, 0, wx.EXPAND, 0)
-        sizer_laser_distance.Add(self.text_distance_laser, 0, wx.EXPAND, 0)
-        sizer_distance.Add(sizer_laser_distance, 1, wx.EXPAND, 0)
-        sizer_travel_distance.Add(self.text_distance_travel, 0, wx.EXPAND, 0)
-        sizer_distance.Add(sizer_travel_distance, 1, wx.EXPAND, 0)
-        sizer_total_distance.Add(self.text_distance_total, 0, wx.EXPAND, 0)
-        sizer_distance.Add(sizer_total_distance, 1, wx.EXPAND, 0)
-        sizer_2.Add(sizer_distance, 0, wx.EXPAND, 0)
-        sizer_laser_time.Add(self.text_time_laser, 0, wx.EXPAND, 0)
-        sizer_time.Add(sizer_laser_time, 1, wx.EXPAND, 0)
-        sizer_travel_time.Add(self.text_time_travel, 0, wx.EXPAND, 0)
-        sizer_time.Add(sizer_travel_time, 1, wx.EXPAND, 0)
-        sizer_total_time.Add(self.text_time_total, 0, wx.EXPAND, 0)
-        sizer_time.Add(sizer_total_time, 1, wx.EXPAND, 0)
-        sizer_2.Add(sizer_time, 0, wx.EXPAND, 0)
-        sizer_3.Add(self.button_play, 0, 0, 0)
+        v_sizer_main.Add(self.view_pane, 3, wx.EXPAND, 0)
+
+        h_sizer_scroll.Add(self.slider_progress, 1, wx.EXPAND, 0)
+        v_sizer_main.Add(h_sizer_scroll, 0, wx.EXPAND, 0)
+
+        sizer_laser_distance.Add(self.text_distance_laser_step, 1, wx.EXPAND, 0)
+        sizer_laser_distance.Add(self.text_distance_laser, 1, wx.EXPAND, 0)
+        h_sizer_text_1.Add(sizer_laser_distance, 1, wx.EXPAND, 0)
+
+        sizer_travel_distance.Add(self.text_distance_travel_step, 1, wx.EXPAND, 0)
+        sizer_travel_distance.Add(self.text_distance_travel, 1, wx.EXPAND, 0)
+        h_sizer_text_1.Add(sizer_travel_distance, 1, wx.EXPAND, 0)
+
+        sizer_total_distance.Add(self.text_distance_total_step, 1, wx.EXPAND, 0)
+        sizer_total_distance.Add(self.text_distance_total, 1, wx.EXPAND, 0)
+        h_sizer_text_1.Add(sizer_total_distance, 1, wx.EXPAND, 0)
+
+        sizer_laser_time.Add(self.text_time_laser_step, 1, wx.EXPAND, 0)
+        sizer_laser_time.Add(self.text_time_laser, 1, wx.EXPAND, 0)
+        h_sizer_text_2.Add(sizer_laser_time, 1, wx.EXPAND, 0)
+
+        sizer_travel_time.Add(self.text_time_travel_step, 1, wx.EXPAND, 0)
+        sizer_travel_time.Add(self.text_time_travel, 1, wx.EXPAND, 0)
+        h_sizer_text_2.Add(sizer_travel_time, 1, wx.EXPAND, 0)
+
+        sizer_total_time.Add(self.text_time_total_step, 1, wx.EXPAND, 0)
+        sizer_total_time.Add(self.text_time_total, 1, wx.EXPAND, 0)
+        h_sizer_text_2.Add(sizer_total_time, 1, wx.EXPAND, 0)
+
+        h_sizer_buttons.Add(self.button_play, 0, 0, 0)
         sizer_4.Add(self.slider_playbackspeed, 0, wx.EXPAND, 0)
         label_playback_speed = wx.StaticText(self, wx.ID_ANY, _("Playback Speed"))
         sizer_5.Add(label_playback_speed, 2, 0, 0)
         sizer_5.Add(self.text_playback_speed, 1, 0, 0)
         sizer_4.Add(sizer_5, 1, wx.EXPAND, 0)
-        sizer_3.Add(sizer_4, 1, wx.EXPAND, 0)
+        h_sizer_buttons.Add(sizer_4, 1, wx.EXPAND, 0)
         sizer_6.Add(self.combo_device, 0, wx.EXPAND, 0)
         sizer_6.Add(self.button_spool, 0, wx.EXPAND, 0)
-        sizer_3.Add(sizer_6, 1, wx.EXPAND, 0)
-        sizer_2.Add(sizer_3, 1, wx.EXPAND, 0)
-        sizer_1.Add(sizer_2, 1, wx.EXPAND, 0)
-        self.SetSizer(sizer_1)
+        h_sizer_buttons.Add(sizer_6, 1, wx.EXPAND, 0)
+
+        v_sizer_main.Add(h_sizer_text_1, 0, wx.EXPAND, 0)
+        v_sizer_main.Add(h_sizer_text_2, 0, wx.EXPAND, 0)
+        v_sizer_main.Add(h_sizer_buttons, 1, wx.EXPAND, 0)
+        self.SetSizer(v_sizer_main)
         self.Layout()
         # end wxGlade
 
@@ -346,13 +386,39 @@ class SimulationPanel(wx.Panel, Job):
             self.slider_progress.SetValue(self.max)
             self.request_refresh()
 
-    def pane_show(self):
-        self.context.setting(str, "units_name", "mm")
+    def update_fields(self):
+        step = self.progress
+        travel = self.cutcode.length_travel(stop_at=step)
+        cuts = self.cutcode.length_cut(stop_at=step)
+        travel /= MILS_IN_MM
+        cuts /= MILS_IN_MM
+        self.text_distance_travel_step.SetValue("%.2fmm" % travel)
+        self.text_distance_laser_step.SetValue("%.2fmm" % cuts)
+        self.text_distance_total_step.SetValue("%.2fmm" % (travel + cuts))
 
-        bbox = self.context.device.bbox()
-        self.widget_scene.widget_root.focus_viewport_scene(
-            bbox, self.view_pane.Size, 0.1
-        )
+        extra = self.cutcode.extra_time(stop_at=step)
+
+        try:
+            time_travel = travel / self.cutcode.travel_speed
+            t_hours = time_travel // 3600
+            t_mins = (time_travel % 3600) // 60
+            t_seconds = time_travel % 60
+            self.text_time_travel_step.SetValue(
+                "%d:%02d:%02d" % (t_hours, t_mins, t_seconds)
+            )
+            time_cuts = self.cutcode.duration_cut(stop_at=step)
+            t_hours = time_cuts // 3600
+            t_mins = (time_cuts % 3600) // 60
+            t_seconds = time_cuts % 60
+            self.text_time_laser_step.SetValue("%d:%02d:%02d" % (t_hours, t_mins, t_seconds))
+            time_total = time_travel + time_cuts + extra
+            t_hours = time_total // 3600
+            t_mins = (time_total % 3600) // 60
+            t_seconds = time_total % 60
+            self.text_time_total_step.SetValue("%d:%02d:%02d" % (t_hours, t_mins, t_seconds))
+        except ZeroDivisionError:
+            pass
+
         travel = self.cutcode.length_travel()
         cuts = self.cutcode.length_cut()
         travel /= MILS_IN_MM
@@ -384,6 +450,15 @@ class SimulationPanel(wx.Panel, Job):
         except ZeroDivisionError:
             pass
 
+    def pane_show(self):
+        self.context.setting(str, "units_name", "mm")
+
+        bbox = self.context.device.bbox()
+        self.widget_scene.widget_root.focus_viewport_scene(
+            bbox, self.view_pane.Size, 0.1
+        )
+        self.update_fields()
+
     def pane_hide(self):
         if self.auto_clear:
             self.context("plan%s clear\n" % self.plan_name)
@@ -408,6 +483,7 @@ class SimulationPanel(wx.Panel, Job):
 
     def on_slider_progress(self, event=None):  # wxGlade: Simulation.<event_handler>
         self.progress = min(self.slider_progress.GetValue(), self.max)
+        self.update_fields()
         self.context.signal("refresh_scene", self.widget_scene.name)
 
     def _start(self):
@@ -427,6 +503,7 @@ class SimulationPanel(wx.Panel, Job):
         if self.progress >= self.max:
             self.progress = 0
             self.slider_progress.SetValue(self.progress)
+            self.update_fields()
         self._start()
 
     def animate_sim(self, event=None):
@@ -437,6 +514,7 @@ class SimulationPanel(wx.Panel, Job):
             self._stop()
         else:
             self.slider_progress.SetValue(self.progress)
+        self.update_fields()
         self.context.signal("refresh_scene", self.widget_scene.name)
 
     def on_slider_playback(self, event=None):  # wxGlade: Simulation.<event_handler>

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -26,12 +26,12 @@ _ = wx.GetTranslation
 
 def register_panel_tree(window, context):
     wxtree = TreePanel(window, wx.ID_ANY, context=context)
-
+    minwd = 75
     pane = (
         aui.AuiPaneInfo()
         .Name("tree")
         .Left()
-        .MinSize(200, -1)
+        .MinSize(minwd, -1)
         .LeftDockable()
         .RightDockable()
         .BottomDockable(False)
@@ -39,7 +39,7 @@ def register_panel_tree(window, context):
         .CaptionVisible(not context.pane_lock)
         .TopDockable(False)
     )
-    pane.dock_proportion = 275
+    pane.dock_proportion = minwd
     pane.control = wxtree
     window.on_pane_add(pane)
     context.register("pane/tree", pane)

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -304,6 +304,12 @@ def create_menu(gui, node, elements):
         gui.PopupMenu(menu)
         menu.Destroy()
 
+class TextCtrl(wx.TextCtrl):
+# Just to add someof the more common things we need, i.e. smaller default size...
+#
+    def __init__(self, parent, id=wx.ID_ANY, value="", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0, validator=wx.DefaultValidator, name=""):
+        super().__init__(parent, id=id, value=value, pos=pos, size=size, style=style, validator=validator, name=name)
+        self.SetMinSize(wx.Size(35, -1))
 
 WX_METAKEYS = [
     wx.WXK_START,

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -1865,7 +1865,9 @@ class Kernel(Settings):
                 if signal in self.listeners:
                     listeners = self.listeners[signal]
                     removed = False
+                    ct = 0
                     for i, listen in enumerate(listeners):
+                        ct += 1
                         listen_funct, listen_lso = listen
                         if (listen_funct == remove_funct or remove_funct is None) and (
                             listen_lso is remove_lso or remove_lso is None
@@ -1873,7 +1875,7 @@ class Kernel(Settings):
                             del listeners[i]
                             removed = True
                             break
-                    if not removed:
+                    if not removed and ct>0:
                         print("Value error removing: %s  %s" % (str(listeners), signal))
 
         # Process signals.

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -1876,7 +1876,9 @@ class Kernel(Settings):
                             removed = True
                             break
                     if not removed and ct>0:
-                        print("Value error removing: %s  %s" % (str(listeners), signal))
+                        # print ("Was trying to remove: %s, %s for signal %s" % (str(remove_funct), str(remove_lso), signal))
+                        # print ("But wasn't present in : %s" % str(listeners))
+                        pass
 
         # Process signals.
         signal_channel = self.channel("signals")


### PR DESCRIPTION
Based on comments provided in discord plus some more:
a) Fix enable/disable of special ops: just fixing the error but not adding the output property or save it
b) Remove debug message from deregister listener in Kernel
c) Extend simulation window so that you can see the buildup of travel/time more clearly
![simulate](https://user-images.githubusercontent.com/2670784/178502732-e7251af5-addd-407d-b505-1624d3da2e60.gif)

d) Add scrollbars to property windows:
<img width="309" alt="image" src="https://user-images.githubusercontent.com/2670784/178512091-65156c3e-a3a5-406e-8a58-47c19c742d5d.png">
