### PR TITLE
Eliminated reDoS progress through font-list

### DIFF
--- a/meerk40t/gui/fonts.py
+++ b/meerk40t/gui/fonts.py
@@ -88,7 +88,6 @@ def wxfont_to_svg(svgtextnode):
     svgtextnode.strikethrough = wxfont.GetStrikethrough()
 
 def svgfont_to_wx(svgtextnode):
-    ###
     ### Translates all svg-text-properties to their wxfont-equivalents
     if not hasattr(svgtextnode, "wxfont"):
         svgtextnode.wxfont = wx.Font()

--- a/meerk40t/gui/fonts.py
+++ b/meerk40t/gui/fonts.py
@@ -24,6 +24,7 @@ def wxfont_to_svg(svgtextnode):
     ###
     def build_family_name(wxfont):
         fontface = wxfont.GetFaceName()
+
         if any([ char in fontface for char in [" ", ","] ]):
             fontface = "'" + fontface + "'"
         family = ""
@@ -47,7 +48,6 @@ def wxfont_to_svg(svgtextnode):
             family_name = family_name[1:].strip()
         return family_name
 
-
     if not hasattr(svgtextnode, "wxfont"):
         svgtextnode.wxfont = wx.Font()
 
@@ -56,18 +56,7 @@ def wxfont_to_svg(svgtextnode):
     factor = PX_PER_INCH / 72
     svgtextnode.text.font_size = wxfont.GetPointSize() * factor
 
-    fw = wxfont.GetWeight()
-    if fw in (wx.FONTWEIGHT_THIN, wx.FONTWEIGHT_EXTRALIGHT, wx.FONTWEIGHT_LIGHT):
-        fontweight = "lighter"
-    elif fw in (wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_MEDIUM):
-        fontweight = "normal"
-    elif fw in (wx.FONTWEIGHT_SEMIBOLD, wx.FONTWEIGHT_BOLD):
-        fontweight = "bold"
-    elif fw in (wx.FONTWEIGHT_EXTRABOLD, wx.FONTWEIGHT_HEAVY, wx.FONTWEIGHT_EXTRAHEAVY):
-        fontweight = "bolder"
-    else:
-        fontweight = "normal"
-    svgtextnode.text.font_weight = fontweight
+    svgtextnode.text.font_weight = str(wxfont.GetWeight())
 
     family = build_family_name(wxfont)
     svgtextnode.text.font_family = family
@@ -92,18 +81,7 @@ def svgfont_to_wx(svgtextnode):
     if not hasattr(svgtextnode, "wxfont"):
         svgtextnode.wxfont = wx.Font()
     wxfont = svgtextnode.wxfont
-    fw = svgtextnode.text.font_weight
-    if fw == "lighter":
-        fontweight = wx.FONTWEIGHT_THIN
-    elif fw == "normal":
-        fontweight = wx.FONTWEIGHT_NORMAL
-    elif fw == "bold":
-        fontweight = wx.FONTWEIGHT_BOLD
-    elif fw == "bolder":
-        fontweight = wx.FONTWEIGHT_EXTRABOLD
-    else:
-        fontweight = wx.FONTWEIGHT_NORMAL
-    wxfont.SetWeight(fontweight)
+    wxfont.SetWeight(svgtextnode.text.weight)
     font_list = svgtextnode.text.font_list
     for ff in font_list:
         if ff == "fantasy":

--- a/meerk40t/gui/fonts.py
+++ b/meerk40t/gui/fonts.py
@@ -1,22 +1,24 @@
-import re
 import wx
 
 from meerk40t.core.units import PX_PER_INCH
 
-# from meerk40t.core.node import node
-# from meerk40t.svgelements import Text
-# Svg-text has the following properties (and default values)
-# .anchor = "start"  # start, middle, end.
-# .font_family = "san-serif"
-# .font_size = 16.0  # 16px font 'normal' 12pt font
-# .font_weight = 400
-# NEW since svg 1.7:
-# .font_style = "normal" * DONE
-# .font_variant = "normal" * NOT SUPPORTED (ornaments, small-caps etc.)
-# .font_stretch = "normal" * NOT SUPPORTED (normal, condensed, expanded etc.)
-# .line_height = 16.0
-# Removed:
-# .font_face
+"""
+Svg-text has the following properties (and default values)
+ .anchor = "start"  # start, middle, end.
+ .font_family = "san-serif"
+ .font_size = 16.0  # 16px font 'normal' 12pt font
+ .font_weight = 400
+NEW since svg 1.7:
+ .font_style = "normal" * DONE
+ .font_variant = "normal" * NOT SUPPORTED (ornaments, small-caps etc.)
+ .font_stretch = "normal" * NOT SUPPORTED (normal, condensed, expanded etc.)
+ .line_height = 16.0
+Removed:
+ .font_face
+ 
+ The wx.FONTWEIGHT_THIN does not exist in wxPython 4.0.x and thus isn't used. 
+"""
+
 
 CONVERSION_SVG_WX = {
     "fantasy": wx.FONTFAMILY_DECORATIVE,

--- a/meerk40t/gui/fonts.py
+++ b/meerk40t/gui/fonts.py
@@ -90,20 +90,6 @@ def wxfont_to_svg(svgtextnode):
 def svgfont_to_wx(svgtextnode):
     ###
     ### Translates all svg-text-properties to their wxfont-equivalents
-    ###
-    def get_font_names(node):
-        face_family = node.text.font_family
-        fontface = ""
-        family = ""
-        if face_family is not None and face_family!="":
-            components = re.findall(r"(?:[^\s,']|'(?:\\.|[^'])*')+", face_family)
-            if len(components)>0:
-                fontface = components[0]
-                family = components[-1]
-            else:
-                family = components[0]
-        return fontface, family
-
     if not hasattr(svgtextnode, "wxfont"):
         svgtextnode.wxfont = wx.Font()
     wxfont = svgtextnode.wxfont
@@ -119,38 +105,31 @@ def svgfont_to_wx(svgtextnode):
     else:
         fontweight = wx.FONTWEIGHT_NORMAL
     wxfont.SetWeight(fontweight)
-    font_face, font_family = get_font_names(svgtextnode)
-    ff = font_family
-    if ff == "fantasy":
-        family = wx.FONTFAMILY_DECORATIVE
-    elif ff == "serif":
-        family = wx.FONTFAMILY_ROMAN
-    elif ff == "cursive":
-        family = wx.FONTFAMILY_SCRIPT
-    elif ff == "sans-serif":
-        family = wx.FONTFAMILY_SWISS
-    elif ff == "monospace":
-        family = wx.FONTFAMILY_TELETYPE
-    else:
-        family = wx.FONTFAMILY_SWISS
-    wxfont.SetFamily(family)
-    if font_face != "":
-        if font_face[0] == "'":
-            font_face = font_face.strip("'")
-        okay = wxfont.SetFaceName(font_face)
-    else:
-        try:
-            tst = wxfont.GetFaceName()
-            okay = True
-        except:
-            okay = False
-    if not okay:
-        if font_family != "":
-            if font_family[0] == "'":
-                font_family = font_family.strip("'")
-            ff = font_family
-            # Will try Family Name instead
-            okay = wxfont.SetFaceName(ff)
+    font_list = svgtextnode.text.font_list
+    for ff in font_list:
+        if ff == "fantasy":
+            family = wx.FONTFAMILY_DECORATIVE
+            wxfont.SetFamily(family)
+            break
+        elif ff == "serif":
+            family = wx.FONTFAMILY_ROMAN
+            wxfont.SetFamily(family)
+            break
+        elif ff == "cursive":
+            family = wx.FONTFAMILY_SCRIPT
+            wxfont.SetFamily(family)
+            break
+        elif ff == "sans-serif":
+            family = wx.FONTFAMILY_SWISS
+            wxfont.SetFamily(family)
+            break
+        elif ff == "monospace":
+            family = wx.FONTFAMILY_TELETYPE
+            wxfont.SetFamily(family)
+            break
+        if wxfont.SetFaceName(ff):
+            # We found a correct face name.
+            break
     ff = svgtextnode.text.font_style
     if ff == "normal":
         fontstyle = wx.FONTSTYLE_NORMAL

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -549,7 +549,7 @@ class TextPropertyPanel(ScrolledPanel):
                 self.node.fill = color
                 self.node.altered()
             else:
-                self.fill = Color("none")
+                self.node.fill = Color("none")
                 self.node.altered()
         self.update_label()
         self.refresh()

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -12,14 +12,16 @@ _ = wx.GetTranslation
 
 
 class PromptingComboBox(wx.ComboBox):
-    def __init__(self, parent, choices=[], style=0, **args):
+    def __init__(self, parent, choices=None, style=0, **kwargs):
+        if choices is None:
+            choices = []
         wx.ComboBox.__init__(
             self,
             parent,
             wx.ID_ANY,
             style=style | wx.CB_DROPDOWN,
             choices=choices,
-            **args,
+            **kwargs,
         )
         self.choices = choices
         self.Bind(wx.EVT_TEXT, self.OnText)
@@ -56,9 +58,9 @@ class PromptingComboBox(wx.ComboBox):
 
 
 class TextPropertyPanel(ScrolledPanel):
-    def __init__(self, *args, context=None, node=None, **kwds):
+    def __init__(self, parent, *args, context=None, node=None, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
-        wx.Panel.__init__(self, *args, **kwds)
+        super().__init__(parent, *args, **kwds)
         self.context = context
         self.text_id = wx.TextCtrl(self, wx.ID_ANY, "")
         self.text_label = wx.TextCtrl(self, wx.ID_ANY, "")
@@ -124,7 +126,6 @@ class TextPropertyPanel(ScrolledPanel):
         self.combo_font = PromptingComboBox(
             self, choices=elist, style=wx.TE_PROCESS_ENTER
         )
-        #        self.combo_font = wx.ComboBox(self, id=wx.ID_ANY, choices = elist, style = wx.CB_READONLY)
         self.button_attrib_larger = wx.Button(
             self, id=wx.ID_ANY, label="A", size=wx.Size(23, 23)
         )
@@ -372,7 +373,7 @@ class TextPropertyPanel(ScrolledPanel):
             pass
         self.label_fonttest.SetLabelText(self.node.text.text)
         self.label_fonttest.SetForegroundColour(wx.Colour(swizzlecolor(self.node.fill)))
-        self.button_attrib_bold.SetValue(self.node.text.font_weight != "normal")
+        self.button_attrib_bold.SetValue(self.node.text.weight > 600)
         self.button_attrib_italic.SetValue(self.node.text.font_style != "normal")
         self.button_attrib_underline.SetValue(self.node.underline)
         self.button_attrib_strikethrough.SetValue(self.node.strikethrough)
@@ -451,9 +452,9 @@ class TextPropertyPanel(ScrolledPanel):
         button = event.EventObject
         state = button.GetValue()
         if state:
-            self.node.wxfont.SetWeight(wx.FONTWEIGHT_BOLD)
+            self.node.wxfont.SetWeight(700)
         else:
-            self.node.wxfont.SetWeight(wx.FONTWEIGHT_NORMAL)
+            self.node.wxfont.SetWeight(400)
         wxfont_to_svg(self.node)
         self.update_label()
         self.refresh()

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -400,20 +400,17 @@ class TextPropertyPanel(ScrolledPanel):
     def on_button_smaller(self, event):
         try:
             size = self.node.wxfont.GetFractionalPointSize()
-            intmode = False
-        except:
+        except AttributeError:
             size = self.node.wxfont.GetPointSize()
-            intmode = True
-        if intmode:
-            size = int(size / 1.2)
-            if size < 4:
-                size = 4
-            self.node.wxfont.SetPointSize(size)
-        else:
-            size = size / 1.2
-            if size < 4:
-                size = 4.0
+
+        size = size / 1.2
+        if size < 4:
+            size = 4
+        try:
             self.node.wxfont.SetFractionalPointSize(size)
+        except AttributeError:
+            self.node.wxfont.SetPointSize(int(size))
+
         wxfont_to_svg(self.node)
         self.update_label()
         self.refresh()
@@ -422,16 +419,15 @@ class TextPropertyPanel(ScrolledPanel):
     def on_button_larger(self, event):
         try:
             size = self.node.wxfont.GetFractionalPointSize()
-            intmode = False
-        except:
+        except AttributeError:
             size = self.node.wxfont.GetPointSize()
-            intmode = True
-        if intmode:
-            size = int(size * 1.2)
-            self.node.wxfont.SetPointSize(size)
-        else:
-            size = size * 1.2
+        size *= 1.2
+
+        try:
             self.node.wxfont.SetFractionalPointSize(size)
+        except AttributeError:
+            self.node.wxfont.SetPointSize(int(size))
+
         wxfont_to_svg(self.node)
         self.update_label()
         self.refresh()
@@ -521,7 +517,7 @@ class TextPropertyPanel(ScrolledPanel):
                 self.node.wxfont = font
                 wxfont_to_svg(self.node)
                 self.node.modified()
-            except Exception:  # rgb get failed.
+            except AttributeError:  # rgb get failed.
                 pass
 
             self.update_label()

--- a/meerk40t/svgelements.py
+++ b/meerk40t/svgelements.py
@@ -242,7 +242,7 @@ REGEX_CSS_FONT = re.compile(
     r"$"
 )
 REGEX_CSS_FONT_FAMILY = re.compile(
-    r'(?:([^\s";,]+|"[^";,]+"|serif|sans-serif|cursive|fantasy|monospace)),?\s*;?'
+    r"""(?:([^\s"';,]+|"[^";,]+"|'[^';,]+'|serif|sans-serif|cursive|fantasy|monospace)),?\s*;?"""
 )
 
 svg_parse = [("COMMAND", r"[MmZzLlHhVvCcSsQqTtAa]"), ("SKIP", PATTERN_COMMAWSP)]
@@ -7961,7 +7961,7 @@ class Text(SVGElement, GraphicObject, Transformable):
     @property
     def font_list(self):
         return [
-            family[1:-1] if family.startswith('"') else family
+            family[1:-1] if family.startswith('"') or family.startswith("'") else family
             for family in REGEX_CSS_FONT_FAMILY.findall(self.font_family)
         ]
 


### PR DESCRIPTION
* Fix redos, got rid of the entire section there.
* Uses built in `.font_list` routine instead of rolling up it's own.
* Accounts for three or more potential fonts in the font-family.