### PR TITLE
Prefs reorg / simpler end of tool

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -6193,6 +6193,7 @@ class Elemental(Service):
 
             node.remove_node()
             self.set_emphasis(None)
+            self.signal("operation_removed")
 
         def contains_no_locked_items():
             nolock = True
@@ -7657,6 +7658,7 @@ class Elemental(Service):
         """
         operation_branch = self._tree.get(type="branch ops")
         operation_branch.add_node(op, pos=pos)
+        self.signal("add_operation", op)
 
     def add_ops(self, adding_ops):
         operation_branch = self._tree.get(type="branch ops")
@@ -7664,6 +7666,7 @@ class Elemental(Service):
         for op in adding_ops:
             operation_branch.add_node(op)
             items.append(op)
+        self.signal("add_operation", items)
         return items
 
     def add_elems(self, adding_elements, classify=False, branch_type="branch elems"):
@@ -7694,6 +7697,7 @@ class Elemental(Service):
     def clear_operations(self):
         operations = self._tree.get(type="branch ops")
         operations.remove_all_children()
+        self.signal("operation_removed")
 
     def clear_elements(self):
         elements = self._tree.get(type="branch elems")
@@ -7849,7 +7853,7 @@ class Elemental(Service):
             for i, o in enumerate(list(self.ops())):
                 if o is op:
                     o.remove_node()
-            self.signal("operation_removed", op)
+            self.signal("operation_removed")
 
     def remove_elements_from_operations(self, elements_list):
         for node in elements_list:

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -231,8 +231,8 @@ def plugin(kernel, lifecycle=None):
                 "tip":
                     _("Locked elements cannot be modified, but can still be moved if this option is checked.")
                 ,
-                "page": "Gui",
-                "section": "Scene",
+                "page": "Scene",
+                "section": "General",
             },
         ]
         kernel.register_choices("preferences", choices)

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -235,6 +235,31 @@ class ChoicePropertyPanel(ScrolledPanel):
                     on_button_filename(attr, control, obj, c.get("wildcard", "*")),
                 )
                 current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
+            elif data_type in (int, float) and data_style == "slider":
+                control_sizer = wx.StaticBoxSizer(
+                    wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
+                )
+                minvalue = c.get("min", 0)
+                maxvalue = c.get("max", 0)
+                if data_type == float:
+                    value = float(data)
+                elif data_type == int:
+                    value = int(data)
+                else:
+                    value = int(data)
+                control = wx.Slider(self, wx.ID_ANY, value=value, minValue=minvalue, maxValue=maxvalue, style=wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL)
+
+                def on_slider(param, ctrl, obj, dtype):
+                    def select(event=None):
+                        v = dtype(ctrl.GetValue())
+                        setattr(obj, param, v)
+                        self.context.signal(param, v)
+
+                    return select
+
+                control_sizer.Add(control)
+                control.Bind(wx.EVT_SLIDER, on_slider(attr, control, obj, data_type),)
+                current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type in (str, int, float) and data_style == "combo":
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL

--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -45,11 +45,6 @@ class OperationAssignPanel(wx.Panel):
         self.op_nodes= []
         for idx in range(self.MAXBUTTONS):
             btn = wx.Button(self, id=wx.ID_ANY, size=(self.buttonsize, self.buttonsize))
-            btn.SetToolTip(
-                _("Assign the selected elements to the operation.") +
-                "\n" +
-                _("Left click: consider stroke as main color, right click: use fill")
-            )
             self.buttons.append(btn)
             self.op_nodes.append(None)
 
@@ -66,9 +61,11 @@ class OperationAssignPanel(wx.Panel):
             _("-> OP - the assigned operation will adopt the color of the element") + "\n" +
             _("-> Elem - the elements will adopt the color of the assigned operation")
         )
-        self.chk_all_similar.SetToolTip(_("Assign as well all other elements with the same stroke-color (fill-color if right-click"))
+        self.chk_all_similar.SetToolTip(
+            _("Assign as well all other elements with the same stroke-color,") +"\n" +
+            _("respectively with the same fill-color if you right-click the button")
+        )
         self.chk_exclusive.SetToolTip(_("When assigning to an operation remove all assignments of the elements to other operations"))
-        self.lbl_nothing = wx.StaticText(self, wx.ID_ANY, _("No elements selected"))
         self.lastsize = None
         self.lastcolcount = None
         self._set_layout()
@@ -89,7 +86,6 @@ class OperationAssignPanel(wx.Panel):
         self.sizer_options.Add(self.cbo_apply_color, 1, wx.EXPAND, 0)
         self.sizer_options.Add(self.chk_all_similar, 1, wx.EXPAND, 0)
         self.sizer_options.Add(self.chk_exclusive, 1, wx.EXPAND, 0)
-        self.sizer_options.Add(self.lbl_nothing, 1, wx.EXPAND, 0)
 
         self.sizer_main.Add(self.sizer_options, 0, wx.EXPAND, 0)
         self.sizer_main.Add(self.sizer_buttons, 1, wx.EXPAND, 0)
@@ -175,7 +171,14 @@ class OperationAssignPanel(wx.Panel):
             else:
                 self.buttons[myidx].SetBitmap(image)
                 # self.buttons[myidx].SetBitmapDisabled(icons8_padlock_50.GetBitmap(color=Color("Grey"), resize=(self.iconsize, self.iconsize), noadjustment=True, keepalpha=True))
-            # self.buttons[myidx].Show(True)
+            self.buttons[myidx].SetToolTip(
+                str(node) +
+                "\n" +
+                _("Assign the selected elements to the operation.") +
+                "\n" +
+                _("Left click: consider stroke as main color, right click: use fill")
+            )
+            self.buttons[myidx].Show()
 
         lastfree = -1
         found = False
@@ -200,6 +203,9 @@ class OperationAssignPanel(wx.Panel):
                 self.op_nodes[idx] = node
                 self._set_button(node)
                 idx += 1
+                if idx>=self.MAXBUTTONS:
+                    # too many...
+                    break
         self._set_grid_layout()
         if not skip_layout:
             self.Layout()
@@ -207,15 +213,13 @@ class OperationAssignPanel(wx.Panel):
     def show_stuff(self, flag):
         if flag:
             self.set_buttons(skip_layout=True)
-        self.chk_all_similar.Show(flag)
-        self.cbo_apply_color.Show(flag)
-        self.chk_exclusive.Show(flag)
-
-        self.lbl_nothing.Show(not flag)
+        self.chk_all_similar.Enable(flag)
+        self.cbo_apply_color.Enable(flag)
+        self.chk_exclusive.Enable(flag)
 
         for idx in range(self.MAXBUTTONS):
             myflag = flag and self.op_nodes[idx] is not None
-            self.buttons[idx].Show(myflag)
+            self.buttons[idx].Enable(myflag)
             self.buttons[idx].Enable(myflag)
         if not flag:
             if self.hover>0:
@@ -223,12 +227,11 @@ class OperationAssignPanel(wx.Panel):
                 self.hover = 0
         else:
              self.chk_exclusive.SetValue(self.context.elements.classify_inherit_exclusive)
-        if flag:
-            siz = self.GetSize()
-            self._set_grid_layout(siz[0])
-            self.sizer_options.Layout()
-            self.sizer_buttons.Layout()
-            self.sizer_main.Layout()
+        siz = self.GetSize()
+        self._set_grid_layout(siz[0])
+        self.sizer_options.Layout()
+        self.sizer_buttons.Layout()
+        self.sizer_main.Layout()
         self.Layout()
 
     @signal_listener("emphasized")

--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -262,6 +262,9 @@ class OperationAssignPanel(wx.Panel):
 
     @signal_listener("rebuild_tree")
     @signal_listener("refresh_tree")
+    @signal_listener("tree_changed")
+    @signal_listener("operation_removed")
+    @signal_listener("add_operation")
     def on_rebuild(self, origin, *args):
         self.set_buttons()
 

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -82,8 +82,8 @@ def plugin(kernel, lifecycle):
                 "tip": _(
                     "Extend the Guide rulers with negative values to assist lining up objects partially outside the left/top of the bed"
                 ),
-                "page": "Gui",
-                "section": "Scene",
+                "page": "Scene",
+                "section": "General",
             },
             {
                 "attr": "windows_save",

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -229,7 +229,7 @@ class PreferencesMain(wx.Panel):
 
         self.panel_pref1 = ChoicePropertyPanel(
             self, id=wx.ID_ANY, context=context,
-            choices="preferences", constraint=("Classification", "Input/Output", "Options"),
+            choices="preferences", constraint=("-Classification", "-Gui", "-Scene"),
         )
         sizer_main.Add(self.panel_pref1, 1, wx.EXPAND, 0)
 
@@ -249,17 +249,10 @@ class PreferencesPanel(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
         self.context = context
 
-        sizer_settings = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_settings = wx.BoxSizer(wx.VERTICAL)
 
         self.panel_main = PreferencesMain(self, wx.ID_ANY, context=context)
         sizer_settings.Add(self.panel_main, 1, wx.EXPAND, 0)
-
-        self.checklist_options = ChoicePropertyPanel(
-            self, id=wx.ID_ANY, context=context,
-            choices="preferences", constraint=("-Classification", "-Input/Output", "-Options"),
-        )
-        self.checklist_options.SetupScrolling()
-        sizer_settings.Add(self.checklist_options, 2, wx.EXPAND, 0)
 
         self.SetSizer(sizer_settings)
 
@@ -280,9 +273,46 @@ class Preferences(MWindow):
             | (wx.RESIZE_BORDER if platform.system() != "Darwin" else 0),
             **kwds,
         )
+        self.notebook_main = wx.aui.AuiNotebook(
+            self,
+            -1,
+            style=wx.aui.AUI_NB_TAB_EXTERNAL_MOVE
+            | wx.aui.AUI_NB_SCROLL_BUTTONS
+            | wx.aui.AUI_NB_TAB_SPLIT
+            | wx.aui.AUI_NB_TAB_MOVE,
+        )
 
-        self.panel = PreferencesPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
+        self.panel_main = PreferencesPanel(self, wx.ID_ANY, context=self.context)
+
+        self.panel_classification = ChoicePropertyPanel(
+            self, id=wx.ID_ANY, context=self.context,
+            choices="preferences", constraint=("Classification"),
+        )
+        self.panel_classification.SetupScrolling()
+
+        self.panel_gui = ChoicePropertyPanel(
+            self, id=wx.ID_ANY, context=self.context,
+            choices="preferences", constraint=("Gui"),
+        )
+        self.panel_gui.SetupScrolling()
+
+        self.panel_scene = ChoicePropertyPanel(
+            self, id=wx.ID_ANY, context=self.context,
+            choices="preferences", constraint=("Scene"),
+        )
+        self.panel_scene.SetupScrolling()
+
+
+        self.notebook_main.AddPage(self.panel_main, _("General"))
+        self.notebook_main.AddPage(self.panel_classification, _("Classification"))
+        self.notebook_main.AddPage(self.panel_gui, _("GUI"))
+        self.notebook_main.AddPage(self.panel_scene, _("Scene"))
+        self.Layout()
+
+        self.add_module_delegate(self.panel_main)
+        self.add_module_delegate(self.panel_classification)
+        self.add_module_delegate(self.panel_gui)
+        self.add_module_delegate(self.panel_scene)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_administrative_tools_50.GetBitmap())
         self.SetIcon(_icon)

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -68,6 +68,10 @@ class ElementsWidget(Widget):
         elif event_type == "kb_ctrl_release":
             if self.key_ctrl_pressed:
                 self.key_ctrl_pressed = False
+        elif event_type == "rightdown":
+            if not self.scene.tool_active:
+                self.scene.context("tool none")
+                return RESPONSE_CONSUME
         elif event_type == "leftclick":
             elements = self.scene.context.elements
             keep_old = self.key_shift_pressed

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -433,7 +433,7 @@ class CustomStatusBar(wx.StatusBar):
                 try:
                     newval = float(self.spin_width.GetValue())
                     chg = True
-                except ValueError:                    
+                except ValueError:
                     chg = False
             if chg:
                 value = "{wd:.2f}{unit}".format(wd=newval, unit=newunit)
@@ -465,7 +465,7 @@ class CustomStatusBar(wx.StatusBar):
         rect.x += int(wd)
         self.cb_rotate.SetRect(rect)
         rect.x += int(wd)
-        self.cb_skew.SetRect(rect)        
+        self.cb_skew.SetRect(rect)
         if self.context.show_colorbar:
             rect = self.GetFieldRect(self.pos_stroke)
             ct = 3
@@ -709,8 +709,8 @@ class MeerK40t(MWindow):
                 "tip": _(
                     "Active: Single click selects the smallest element under cursor (ctrl+click selects the largest) / Inactive: Single click selects the largest element  (ctrl+click the smallest)."
                 ),
-                "page": "Gui",
-                "section": "Scene",
+                "page": "Scene",
+                "section": "General",
             },
         ]
         context.kernel.register_choices("preferences", choices)
@@ -741,8 +741,73 @@ class MeerK40t(MWindow):
                 "tip": _(
                     "Active: draw handles outside of / Inactive: Draw them on the bounding box of the selection."
                 ),
-                "page": "Gui",
-                "section": "Scene",
+                "page": "Scene",
+                "section": "General",
+            },
+        ]
+        context.kernel.register_choices("preferences", choices)
+
+        choices = [
+            {
+                "attr": "show_attract_len",
+                "object": context.root,
+                "default": 45,
+                "type": int,
+                "style": "slider",
+                "min": 1,
+                "max": 75,
+                "label": _("Distance"),
+                "tip": _("Defines until which distance snap points will be highlighted"),
+                "page": "Scene",
+                "section": "Snap-Options",
+            },
+            {
+                "attr": "snap_points",
+                "object": context.root,
+                "default": True,
+                "type": bool,
+                "label": _("Snap to element"),
+                "tip": _("Shall the cursor snap to the next element point?"),
+                "page": "Scene",
+                "section": "Snap-Options",
+            },
+            {
+                "attr": "action_attract_len",
+                "object": context.root,
+                "conditional": (context.root, "snap_points"),
+                "default": 20,
+                "type": int,
+                "style": "slider",
+                "min": 1,
+                "max": 75,
+                "label": _("Distance"),
+                "tip": _("Set the distance inside which the cursor will snap to the next element point"),
+                "page": "Scene",
+                "section": "Snap-Options",
+            },
+            {
+                "attr": "snap_grid",
+                "object": context.root,
+                "default": True,
+                "type": bool,
+                "label": _("Snap to Grid"),
+                "tip": _("Shall the cursor snap to the next grid intersection?"),
+                "page": "Scene",
+                "section": "Snap-Options",
+            },
+            {
+                "attr": "grid_attract_len",
+                "object": context.root,
+                "default": 15,
+                "conditional": (context.root, "snap_grid"),
+                "type": int,
+                "style": "slider",
+                "min": 1,
+                "max": 75,
+                "label": _("Distance"),
+                "tip": _("Set the distance inside which the cursor will snap to the next grid intersection"),
+                "page": "Scene",
+                "section": "Snap-Options",
             },
         ]
         context.kernel.register_choices("preferences", choices)

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -302,6 +302,7 @@ class ShadowTree:
             "op image": icons8_image_20,
             "op raster": icons8_direction_20,
             "op hatch": icons8_diagonal_20,
+            "op dots": icons8_scatter_plot_20,
             "elem point": icons8_scatter_plot_20,
             "file": icons8_file_20,
             "group": icons8_group_objects_20,

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2316,7 +2316,7 @@ class Kernel(Settings):
                             subfound = True
                     if subfound:
                         allparams.append(s)
-                        found = Truep
+                        found = True
                 if found:
                     if len(allcommands)>0:
                         s = "Commands:\n"

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2317,6 +2317,8 @@ class Kernel(Settings):
                     if subfound:
                         allparams.append(s)
                         found = True
+                if not found and substr in ("booze", "whisky", "gin", "alcohol", "beer"):
+                    channel (("Do you really think it's that simple and that I leave my {booze} around for you b**ards to steal it? Get a life, p*nk...").format(booze=substr))
                 if found:
                     if len(allcommands)>0:
                         s = "Commands:\n"

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2316,9 +2316,7 @@ class Kernel(Settings):
                             subfound = True
                     if subfound:
                         allparams.append(s)
-                        found = True
-                if not found and substr in ("booze", "whisky", "gin", "alcohol", "beer"):
-                    channel (("Do you really think it's that simple and that I leave my {booze} around for you b**ards to steal it? Get a life, p*nk...").format(booze=substr))
+                        found = Truep
                 if found:
                     if len(allcommands)>0:
                         s = "Commands:\n"


### PR DESCRIPTION
a) Fix missing icon for op dots in tree
b) Reorganise Preferences (and add snap-options to it, which were only accessible via Pane)
![prefs](https://user-images.githubusercontent.com/2670784/180641483-ce9e2b5d-6d35-4666-9026-7f4f314373e5.gif)

c) Allow quick tool reset: just press right-click on scene
![rclick](https://user-images.githubusercontent.com/2670784/180641492-843ab4a5-f254-4bc1-abb9-e633bb86de34.gif)

d) Make opassign panel less annoying by remaining visible and become aware of additions / removal of operations