### PR TITLE
More panel actions

### DIFF
--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -192,7 +192,7 @@ class CustomStatusBar(wx.StatusBar):
         self.activesizer = [None] * self.panelct
         self.nextbuttons = []
         for idx in range(self.panelct):
-            btn = wx.Button(self, id=wx.ID_ANY, label="", size=wx.Size(20,-1))
+            btn = wx.Button(self, id=wx.ID_ANY, label="", size=wx.Size(20, -1))
             btn.SetBitmap(icons8_next_page_20.GetBitmap(noadjustment=True))
             btn.Show(False)
             btn.Bind(wx.EVT_BUTTON, self.on_button_next)
@@ -213,8 +213,8 @@ class CustomStatusBar(wx.StatusBar):
             return
         super().SetStatusText(message, panel)
 
-    def AddPanel(self, panel_idx, wx_boxsizer, identifier, visible=True, callback = None):
-        if panel_idx<0 or panel_idx>= self.panelct:
+    def add_sizer_panel(self, panel_idx, wx_boxsizer, identifier, visible=True, callback=None):
+        if panel_idx < 0 or panel_idx >= self.panelct:
             return
         # Mke sure they belong to me, else the wx.Boxsizer
         # will have wrong information to work with
@@ -223,10 +223,10 @@ class CustomStatusBar(wx.StatusBar):
             if wind is not None:
                 wind.Reparent(self)
 
-        storage = [wx_boxsizer, panel_idx, visible, callback] # Visible by default
+        storage = [wx_boxsizer, panel_idx, visible, callback]  # Visible by default
         self.box_id_visible[identifier] = storage
 
-    def ActivatePanel(self, identifier, newflag):
+    def activate_panel(self, identifier, newflag):
         # Activate Panel will make the indicated panel become choosable
         try:
             oldflag = self.box_id_visible[identifier][2]
@@ -249,8 +249,8 @@ class CustomStatusBar(wx.StatusBar):
                         break
             self.Reposition(panelidx=panelidx)
 
-    def ForcePanel(self, identifier):
-        # ForcePanel will make the indicated panel choosable and visible
+    def force_panel(self, identifier):
+        # force_panel will make the indicated panel choosable and visible
         try:
             oldflag = self.box_id_visible[identifier][2]
         except (IndexError, KeyError):
@@ -262,8 +262,8 @@ class CustomStatusBar(wx.StatusBar):
         self.activesizer[panelidx] = identifier
         self.Reposition(panelidx=panelidx)
 
-    def NextEntryInPanel(self, panelidx):
-        if panelidx<0 or panelidx>=self.panelct:
+    def next_entry_in_panel(self, panelidx):
+        if panelidx < 0 or panelidx >= self.panelct:
             return
         first_entry = None
         next_entry = None
@@ -271,7 +271,7 @@ class CustomStatusBar(wx.StatusBar):
         for key in self.box_id_visible:
             entry = self.box_id_visible[key]
             if entry[1] == panelidx and entry[2]:
-                if key == self.activesizer[panelidx]: # Visible
+                if key == self.activesizer[panelidx]:  # Visible
                     visible_seen = True
                 else:
                     if visible_seen and next_entry is None:
@@ -283,12 +283,12 @@ class CustomStatusBar(wx.StatusBar):
         if next_entry is None:
             next_entry = first_entry
         if next_entry is not None:
-            self.ForcePanel(next_entry)
+            self.force_panel(next_entry)
         else:
             self.activesizer[panelidx] = None
 
-    def PreviousEntryInPanel(self, panelidx):
-        if panelidx<0 or panelidx>=self.panelct:
+    def prev_entry_in_panel(self, panelidx):
+        if panelidx < 0 or panelidx >= self.panelct:
             return
         last_entry = None
         prev_entry = None
@@ -296,7 +296,7 @@ class CustomStatusBar(wx.StatusBar):
         for key in self.box_id_visible:
             entry = self.box_id_visible[key]
             if entry[1] == panelidx and entry[2]:
-                if key == self.activesizer[panelidx]: # Visible
+                if key == self.activesizer[panelidx]:  # Visible
                     visible_seen = True
                 elif visible_seen:
                     last_entry = key
@@ -305,7 +305,7 @@ class CustomStatusBar(wx.StatusBar):
         if prev_entry is None:
             prev_entry = last_entry
         if prev_entry is not None:
-            self.ForcePanel(prev_entry)
+            self.force_panel(prev_entry)
         else:
             self.activesizer[panelidx] = None
 
@@ -313,29 +313,29 @@ class CustomStatusBar(wx.StatusBar):
         button = event.GetEventObject()
         for idx in range(self.panelct):
             if self.nextbuttons[idx] == button:
-                self.NextEntryInPanel(idx)
+                self.next_entry_in_panel(idx)
                 break
-#        self.Reposition()
+        #        self.Reposition()
         event.Skip()
 
     def on_button_prev(self, event):
         button = event.GetEventObject()
         for idx in range(self.panelct):
             if self.nextbuttons[idx] == button:
-                self.PreviousEntryInPanel(idx)
+                self.prev_entry_in_panel(idx)
                 break
-#        self.Reposition()
+        #        self.Reposition()
         event.Skip()
 
     # Draw the panels
-    def Reposition(self, panelidx = None):
-        def debug_me():
-            for key in self.box_id_visible:
-                siz = self.box_id_visible[key][0]
-                items = siz.GetItemCount()
-                print ("Sizer '%s', children=%s" % (key, items))
-                for idx in range(items):
-                    print("   Item #%d - shown=%s" % (idx, siz.IsShown(idx)))
+    def Reposition(self, panelidx=None):
+        # def debug_me():
+        #     for key in self.box_id_visible:
+        #         siz = self.box_id_visible[key][0]
+        #         items = siz.GetItemCount()
+        #         print("Sizer '%s', children=%s" % (key, items))
+        #         for idx in range(items):
+        #             print("   Item #%d - shown=%s" % (idx, siz.IsShown(idx)))
 
         def deep_show_hide(sizerbox, key, showit, callback):
             # print ("Showit: key=%s, flag=%s, idx=%d, default=%s" % (key, showit, debugidx, debugdefault))
@@ -357,7 +357,7 @@ class CustomStatusBar(wx.StatusBar):
             #         wind.Show(showit)
             sizerbox.Layout()
 
-        selfrect = self.GetRect()
+        # selfrect = self.GetRect()
         if panelidx is None:
             targets = range(self.panelct)
         else:
@@ -372,13 +372,15 @@ class CustomStatusBar(wx.StatusBar):
                 entry = self.box_id_visible[key]
                 # print ("%s = %s" %(key, entry) )
                 if entry[1] == pidx:
-                    if entry[2]: # The right one and choosable...
+                    if entry[2]:  # The right one and choosable...
                         ct += 1
                         if self.activesizer[pidx] is None:
                             self.activesizer[pidx] = key
-                        if self.activesizer[pidx] != key: # its not the default, so hide
+                        if (
+                            self.activesizer[pidx] != key
+                        ):  # its not the default, so hide
                             deep_show_hide(entry[0], key, False, entry[3])
-                    else: # not choosable --> hide:
+                    else:  # not choosable --> hide:
                         deep_show_hide(entry[0], key, False, entry[3])
             if ct > 1:
                 # Show Button and reduce available width for sizer
@@ -395,7 +397,9 @@ class CustomStatusBar(wx.StatusBar):
                 callback = self.box_id_visible[self.activesizer[pidx]][3]
                 # print ("Panel %s='%s' - %s" % (pidx, self.activesizer[pidx], panelrect))
                 # print ("Entries: %s" % sizer.GetItemCount())
-                sizer.SetDimension(panelrect.x, panelrect.y, panelrect.width, panelrect.height)
+                sizer.SetDimension(
+                    panelrect.x, panelrect.y, panelrect.width, panelrect.height
+                )
                 deep_show_hide(sizer, self.activesizer[pidx], True, callback)
                 text = self.status_text[pidx]
                 if text != "":
@@ -405,7 +409,6 @@ class CustomStatusBar(wx.StatusBar):
                 self.SetStatusText(self.previous_text[pidx], pidx)
         # debug_me()
         self.sizeChanged = False
-
 
     def OnSize(self, evt):
         evt.Skip()
@@ -595,7 +598,9 @@ class MeerK40t(MWindow):
             )
             self.button_color = []
             for idx in range(len(colors)):
-                wx_button = wx.Button(self.main_statusbar, id=wx.ID_ANY, size=wx.Size(20,-1), label="")
+                wx_button = wx.Button(
+                    self.main_statusbar, id=wx.ID_ANY, size=wx.Size(20, -1), label=""
+                )
                 wx_button.SetBackgroundColour(wx.Colour(colors[idx]))
                 wx_button.SetMinSize(wx.Size(10, -1))
                 wx_button.SetToolTip(_("Set stroke-color (right click set fill color)"))
@@ -618,7 +623,9 @@ class MeerK40t(MWindow):
                     wx.FONTWEIGHT_NORMAL,
                 )
             )
-            self.spin_width = wx.TextCtrl(self, id=wx.ID_ANY, value="0.10", style=wx.TE_PROCESS_ENTER)
+            self.spin_width = wx.TextCtrl(
+                self, id=wx.ID_ANY, value="0.10", style=wx.TE_PROCESS_ENTER
+            )
             self.spin_width.SetFont(
                 wx.Font(
                     FONT_SIZE,
@@ -667,13 +674,17 @@ class MeerK40t(MWindow):
             self.btn_cap_round = wx.Button(self, id=wx.ID_ANY, size=wx.Size(30, -1))
             self.btn_cap_round.SetBitmap(cap_round_20.GetBitmap(noadjustment=True))
             self.btn_cap_round.SetMaxSize(wx.Size(50, -1))
-            self.btn_cap_round.SetToolTip(_("Set the end of the lines to a round-shape"))
+            self.btn_cap_round.SetToolTip(
+                _("Set the end of the lines to a round-shape")
+            )
             self.btn_cap_round.Bind(wx.EVT_BUTTON, self.on_cap_round)
 
             self.btn_cap_square = wx.Button(self, id=wx.ID_ANY, size=wx.Size(30, -1))
             self.btn_cap_square.SetBitmap(cap_square_20.GetBitmap(noadjustment=True))
             self.btn_cap_square.SetMaxSize(wx.Size(50, -1))
-            self.btn_cap_square.SetToolTip(_("Set the end of the lines to a square-shape"))
+            self.btn_cap_square.SetToolTip(
+                _("Set the end of the lines to a square-shape")
+            )
             self.btn_cap_square.Bind(wx.EVT_BUTTON, self.on_cap_square)
 
             self.linecap_sizer.Add(self.cap_lbl, 0, wx.EXPAND, 0)
@@ -687,7 +698,9 @@ class MeerK40t(MWindow):
 
             self.btn_join_bevel = wx.Button(self, id=wx.ID_ANY, size=wx.Size(25, -1))
             self.btn_join_bevel.SetBitmap(join_bevel.GetBitmap(noadjustment=True))
-            self.btn_join_bevel.SetToolTip(_("Set the join of the lines to a bevel-shape"))
+            self.btn_join_bevel.SetToolTip(
+                _("Set the join of the lines to a bevel-shape")
+            )
             self.btn_join_bevel.Bind(wx.EVT_BUTTON, self.on_join_bevel)
 
             self.btn_join_round = wx.Button(self, id=wx.ID_ANY, size=wx.Size(25, -1))
@@ -724,13 +737,17 @@ class MeerK40t(MWindow):
             self.btn_fill_nonzero = wx.Button(self, id=wx.ID_ANY, size=wx.Size(30, -1))
             self.btn_fill_nonzero.SetMaxSize(wx.Size(50, -1))
             self.btn_fill_nonzero.SetBitmap(fill_nonzero.GetBitmap(noadjustment=True))
-            self.btn_fill_nonzero.SetToolTip(_("Set the fillstyle to non-zero (regular)"))
+            self.btn_fill_nonzero.SetToolTip(
+                _("Set the fillstyle to non-zero (regular)")
+            )
             self.btn_fill_nonzero.Bind(wx.EVT_BUTTON, self.on_fill_nonzero)
 
             self.btn_fill_evenodd = wx.Button(self, id=wx.ID_ANY, size=wx.Size(30, -1))
             self.btn_fill_evenodd.SetBitmap(fill_evenodd.GetBitmap(noadjustment=True))
             self.btn_fill_evenodd.SetMaxSize(wx.Size(50, -1))
-            self.btn_fill_evenodd.SetToolTip(_("Set the fillstyle to even-odd (alternating areas)"))
+            self.btn_fill_evenodd.SetToolTip(
+                _("Set the fillstyle to even-odd (alternating areas)")
+            )
             self.btn_fill_evenodd.Bind(wx.EVT_BUTTON, self.on_fill_evenodd)
             self.fill_sizer.Add(self.fill_lbl, 0, wx.EXPAND, 0)
             self.fill_sizer.Add(self.btn_fill_nonzero, 1, wx.EXPAND, 0)
@@ -743,16 +760,38 @@ class MeerK40t(MWindow):
                 _("-> OP"),
                 _("-> Elem"),
             ]
-            self.cbo_apply_color = wx.ComboBox(self, wx.ID_ANY, choices=choices, value=choices[0], style=wx.CB_READONLY | wx.CB_DROPDOWN)
+            self.cbo_apply_color = wx.ComboBox(
+                self,
+                wx.ID_ANY,
+                choices=choices,
+                value=choices[0],
+                style=wx.CB_READONLY | wx.CB_DROPDOWN,
+            )
             self.chk_all_similar = wx.CheckBox(self, wx.ID_ANY, _("Similar"))
             self.chk_exclusive = wx.CheckBox(self, wx.ID_ANY, _("Exclusive"))
             self.cbo_apply_color.SetToolTip(
-                _("Leave - neither the color of the operation nor of the elements will be changed") + "\n" +
-                _("-> OP - the assigned operation will adopt the color of the element") + "\n" +
-                _("-> Elem - the elements will adopt the color of the assigned operation")
+                _(
+                    "Leave - neither the color of the operation nor of the elements will be changed"
+                )
+                + "\n"
+                + _(
+                    "-> OP - the assigned operation will adopt the color of the element"
+                )
+                + "\n"
+                + _(
+                    "-> Elem - the elements will adopt the color of the assigned operation"
+                )
             )
-            self.chk_all_similar.SetToolTip(_("Assign as well all other elements with the same stroke-color (fill-color if right-click"))
-            self.chk_exclusive.SetToolTip(_("When assigning to an operation remove all assignments of the elements to other operations"))
+            self.chk_all_similar.SetToolTip(
+                _(
+                    "Assign as well all other elements with the same stroke-color (fill-color if right-click"
+                )
+            )
+            self.chk_exclusive.SetToolTip(
+                _(
+                    "When assigning to an operation remove all assignments of the elements to other operations"
+                )
+            )
             self.assign_option_sizer.Add(self.cbo_apply_color, 1, wx.EXPAND, 0)
             self.assign_option_sizer.Add(self.chk_all_similar, 1, wx.EXPAND, 0)
             self.assign_option_sizer.Add(self.chk_exclusive, 1, wx.EXPAND, 0)
@@ -764,10 +803,12 @@ class MeerK40t(MWindow):
             self.MAXBUTTONS = 24
             self.assign_hover = 0
             self.assign_buttons = []
-            self.op_nodes= []
+            self.op_nodes = []
             self.assign_sizer = wx.BoxSizer(wx.HORIZONTAL)
             for idx in range(self.MAXBUTTONS):
-                btn = wx.Button(self, id=wx.ID_ANY, size=(self.buttonsize, self.buttonsize))
+                btn = wx.Button(
+                    self, id=wx.ID_ANY, size=(self.buttonsize, self.buttonsize)
+                )
                 self.assign_buttons.append(btn)
                 self.op_nodes.append(None)
                 self.assign_sizer.Add(btn, 1, wx.EXPAND, 0)
@@ -776,49 +817,68 @@ class MeerK40t(MWindow):
                 btn.Bind(wx.EVT_BUTTON, self.on_assign_button_left)
                 btn.Bind(wx.EVT_RIGHT_DOWN, self.on_assign_button_right)
 
-
         FONT_SIZE = 7
         self.idx_selection = self.main_statusbar.panelct - 1
         self.idx_colors = self.main_statusbar.panelct - 2
         self.idx_assign = self.main_statusbar.panelct - 3
 
         define_selection()
-        self.main_statusbar.AddPanel(self.idx_selection, self.handle_sizer, "selection", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_selection, self.handle_sizer, "selection", False
+        )
 
         define_info()
-        self.main_statusbar.AddPanel(self.idx_selection, self.info_sizer, "infos", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_selection, self.info_sizer, "infos", False
+        )
 
         # ----- Color buttons and stroke
         define_color()
-        self.main_statusbar.AddPanel(self.idx_colors, self.stroke_sizer, "color", True)
+        self.main_statusbar.add_sizer_panel(self.idx_colors, self.stroke_sizer, "color", True)
 
         define_stroke()
-        self.main_statusbar.AddPanel(self.idx_colors, self.stroke_options_sizer, "stroke", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_colors, self.stroke_options_sizer, "stroke", False
+        )
 
         define_linecap()
-        self.main_statusbar.AddPanel(self.idx_colors, self.linecap_sizer, "linecap", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_colors, self.linecap_sizer, "linecap", False
+        )
 
         define_linejoin()
-        self.main_statusbar.AddPanel(self.idx_colors, self.linejoin_sizer, "linejoin", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_colors, self.linejoin_sizer, "linejoin", False
+        )
 
         define_fill()
-        self.main_statusbar.AddPanel(self.idx_colors, self.fill_sizer, "fillrule", False)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_colors, self.fill_sizer, "fillrule", False
+        )
 
         define_assign_buttons()
-        self.main_statusbar.AddPanel(self.idx_assign, self.assign_sizer, "assign", True, callback = self.callback_show_assign_buttons)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_assign,
+            self.assign_sizer,
+            "assign",
+            True,
+            callback=self.callback_show_assign_buttons,
+        )
 
         define_assign_options()
-        self.main_statusbar.AddPanel(self.idx_assign, self.assign_option_sizer, "assign-options", True)
+        self.main_statusbar.add_sizer_panel(
+            self.idx_assign, self.assign_option_sizer, "assign-options", True
+        )
         # Setup assign buttons
         self.assign_show_stuff(False)
 
-# --------- Logic for operation assignment
+    # --------- Logic for operation assignment
     def assign_clear_old(self):
         for idx in range(self.MAXBUTTONS):
             self.op_nodes[idx] = None
             self.assign_buttons[idx].SetBitmap(wx.NullBitmap)
             self.assign_buttons[idx].Show(False)
-        if self.assign_hover>0:
+        if self.assign_hover > 0:
             self.main_statusbar.SetStatusText("", 0)
             self.assign_hover = 0
 
@@ -830,7 +890,7 @@ class MeerK40t(MWindow):
                 if background is not None:
                     c1 = Color("Black")
                     c2 = Color("White")
-                    if Color.distance(background, c1)> Color.distance(background, c2):
+                    if Color.distance(background, c1) > Color.distance(background, c2):
                         iconcolor = c1
                     else:
                         iconcolor = c2
@@ -841,22 +901,52 @@ class MeerK40t(MWindow):
             d = None
             if node.type == "op raster":
                 c, d = get_color()
-                result = icons8_direction_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_direction_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             elif node.type == "op image":
                 c, d = get_color()
-                result = icons8_image_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_image_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             elif node.type == "op engrave":
                 c, d = get_color()
-                result = icons8_small_beam_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_small_beam_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             elif node.type == "op cut":
                 c, d = get_color()
-                result = icons8_laser_beam_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_laser_beam_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             elif node.type == "op hatch":
                 c, d = get_color()
-                result = icons8_diagonal_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_diagonal_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             elif node.type == "op dots":
                 c, d = get_color()
-                result = icons8_scatter_plot_20.GetBitmap(color=c, resize=(iconsize, iconsize), noadjustment=True, keepalpha=True)
+                result = icons8_scatter_plot_20.GetBitmap(
+                    color=c,
+                    resize=(iconsize, iconsize),
+                    noadjustment=True,
+                    keepalpha=True,
+                )
             return d, result
 
         def process_button(myidx):
@@ -864,7 +954,9 @@ class MeerK40t(MWindow):
             if image is None:
                 return
             if col is not None:
-                self.assign_buttons[myidx].SetBackgroundColour(wx.Colour(swizzlecolor(col)))
+                self.assign_buttons[myidx].SetBackgroundColour(
+                    wx.Colour(swizzlecolor(col))
+                )
             else:
                 self.assign_buttons[myidx].SetBackgroundColour(wx.LIGHT_GREY)
             if image is None:
@@ -873,11 +965,11 @@ class MeerK40t(MWindow):
                 self.assign_buttons[myidx].SetBitmap(image)
                 # self.assign_buttons[myidx].SetBitmapDisabled(icons8_padlock_50.GetBitmap(color=Color("Grey"), resize=(self.iconsize, self.iconsize), noadjustment=True, keepalpha=True))
             self.assign_buttons[myidx].SetToolTip(
-                str(node) +
-                "\n" +
-                _("Assign the selected elements to the operation.") +
-                "\n" +
-                _("Left click: consider stroke as main color, right click: use fill")
+                str(node)
+                + "\n"
+                + _("Assign the selected elements to the operation.")
+                + "\n"
+                + _("Left click: consider stroke as main color, right click: use fill")
             )
             self.assign_buttons[myidx].Show()
 
@@ -889,10 +981,10 @@ class MeerK40t(MWindow):
                 found = True
                 break
             else:
-                if lastfree<0 and self.op_nodes[idx] is None:
+                if lastfree < 0 and self.op_nodes[idx] is None:
                     lastfree = idx
         if not found:
-            if lastfree>=0:
+            if lastfree >= 0:
                 self.op_nodes[lastfree] = node
                 process_button(lastfree)
 
@@ -904,7 +996,7 @@ class MeerK40t(MWindow):
                 self.op_nodes[idx] = node
                 self.assign_set_single_button(node)
                 idx += 1
-                if idx>=self.MAXBUTTONS:
+                if idx >= self.MAXBUTTONS:
                     # too many...
                     break
         # We need to call reposition for the updates to be seen
@@ -922,11 +1014,13 @@ class MeerK40t(MWindow):
             self.assign_buttons[idx].Enable(myflag)
             self.assign_buttons[idx].Enable(myflag)
         if not flag:
-            if self.assign_hover>0:
+            if self.assign_hover > 0:
                 self.main_statusbar.SetStatusText("", 0)
                 self.assign_hover = 0
         else:
-             self.chk_exclusive.SetValue(self.context.elements.classify_inherit_exclusive)
+            self.chk_exclusive.SetValue(
+                self.context.elements.classify_inherit_exclusive
+            )
         self.main_statusbar.Reposition(self.idx_assign)
 
     # --- Listen to external events to update the bar
@@ -974,7 +1068,7 @@ class MeerK40t(MWindow):
     def on_assign_mouse_leave(self, event):
         # Leave events of one tool may come later than the enter events of the next
         self.assign_hover -= 1
-        if self.assign_hover<0:
+        if self.assign_hover < 0:
             self.assign_hover = 0
         if self.assign_hover == 0:
             self.main_statusbar.SetStatusText("", 0)
@@ -991,11 +1085,11 @@ class MeerK40t(MWindow):
         event.Skip()
 
     def execute_on(self, targetop, attrib):
-        data = list(self.context.elements.flat(emphasized = True))
+        data = list(self.context.elements.flat(emphasized=True))
         idx = self.cbo_apply_color.GetCurrentSelection()
-        if idx==1:
+        if idx == 1:
             impose = "to_op"
-        elif idx==2:
+        elif idx == 2:
             impose = "to_elem"
         else:
             impose = None
@@ -1004,8 +1098,13 @@ class MeerK40t(MWindow):
         if len(data) == 0:
             return
         self.context.elements.assign_operation(
-            op_assign=targetop, data=data, impose=impose,
-            attrib = attrib, similar=similar, exclusive = exclusive)
+            op_assign=targetop,
+            data=data,
+            impose=impose,
+            attrib=attrib,
+            similar=similar,
+            exclusive=exclusive,
+        )
 
     def on_assign_button_left(self, event):
         button = event.GetEventObject()
@@ -1029,7 +1128,7 @@ class MeerK40t(MWindow):
         newval = self.chk_exclusive.GetValue()
         self.context.elements.classify_inherit_exclusive = newval
 
-# --------- Events for status bar
+    # --------- Events for status bar
 
     def assign_fill(self, filltype):
         self.context("fillrule {fill}".format(fill=filltype))
@@ -1146,7 +1245,7 @@ class MeerK40t(MWindow):
         _mm = float(Length("1{unit}".format(unit="mm")))
         for e in elements.flat(types=elem_nodes, emphasized=True):
             ct += 1
-            this_area, this_length = elements.get_information(e, fine = False)
+            this_area, this_length = elements.get_information(e, fine=False)
             total_area += this_area
             total_length += this_length
 
@@ -1158,13 +1257,14 @@ class MeerK40t(MWindow):
         self.info_text3.SetLabel("D = %.1f mm" % total_length)
 
         self.assign_show_stuff(value)
-        self.main_statusbar.ActivatePanel("selection", value)
-        self.main_statusbar.ActivatePanel("infos", value)
-        self.main_statusbar.ActivatePanel("fillrule", value)
-        self.main_statusbar.ActivatePanel("linejoin", value)
-        self.main_statusbar.ActivatePanel("linecap", value)
-        self.main_statusbar.ActivatePanel("stroke", value)
+        self.main_statusbar.activate_panel("selection", value)
+        self.main_statusbar.activate_panel("infos", value)
+        self.main_statusbar.activate_panel("fillrule", value)
+        self.main_statusbar.activate_panel("linejoin", value)
+        self.main_statusbar.activate_panel("linecap", value)
+        self.main_statusbar.activate_panel("stroke", value)
         self.main_statusbar.Reposition()
+
     #         if self.context.show_colorbar:
     #             if self._cb_enabled != cb_enabled:
     #                 # Keep old values...
@@ -1188,8 +1288,7 @@ class MeerK40t(MWindow):
     #                 self.combo_units.SetSelection(self.choices.index("mm"))
     #                 self.startup = False
 
-
-# ------------ Setup
+    # ------------ Setup
     def register_options_and_choices(self, context):
         _ = context._
         context.setting(bool, "disable_tool_tips", False)
@@ -1198,7 +1297,7 @@ class MeerK40t(MWindow):
         context.setting(bool, "enable_sel_size", True)
         context.setting(bool, "enable_sel_rotate", True)
         context.setting(bool, "enable_sel_skew", False)
-        context.setting(int, "zoom_level", 4) # 4%
+        context.setting(int, "zoom_level", 4)  # 4%
         # Standard-Icon-Sizes
         # default, factor 1 - leave as is
         # small = factor 2/3, min_size = 32
@@ -1216,13 +1315,11 @@ class MeerK40t(MWindow):
                 "default": "default",
                 "type": str,
                 "style": "combosmall",
-                "choices": [
-                    "default",
-                    "small",
-                    "tiny"
-                ],
+                "choices": ["default", "small", "tiny"],
                 "label": _("Ribbon-Size:"),
-                "tip": _("Appearance of ribbon at the top (requires a restart to take effect))"),
+                "tip": _(
+                    "Appearance of ribbon at the top (requires a restart to take effect))"
+                ),
                 "page": "Gui",
                 "section": "Appearance",
             },
@@ -1235,15 +1332,11 @@ class MeerK40t(MWindow):
                 "default": "default",
                 "type": str,
                 "style": "combosmall",
-                "choices": [
-                    "large",
-                    "big",
-                    "default",
-                    "small",
-                    "tiny"
-                ],
+                "choices": ["large", "big", "default", "small", "tiny"],
                 "label": _("Icon size:"),
-                "tip": _("Appearance of all icons in the GUI (requires a restart to take effect))"),
+                "tip": _(
+                    "Appearance of all icons in the GUI (requires a restart to take effect))"
+                ),
                 "page": "Gui",
                 "section": "Appearance",
             },
@@ -1274,7 +1367,9 @@ class MeerK40t(MWindow):
                     25,
                 ],
                 "label": _("Default zoom level:"),
-                "tip": _("Default zoom level when changing zoom (automatically or via Ctrl-B)"),
+                "tip": _(
+                    "Default zoom level when changing zoom (automatically or via Ctrl-B)"
+                ),
                 "page": "Gui",
                 "section": "Zoom",
             },
@@ -1352,7 +1447,9 @@ class MeerK40t(MWindow):
                 "min": 1,
                 "max": 75,
                 "label": _("Distance"),
-                "tip": _("Defines until which distance snap points will be highlighted"),
+                "tip": _(
+                    "Defines until which distance snap points will be highlighted"
+                ),
                 "page": "Scene",
                 "section": "Snap-Options",
             },
@@ -1376,7 +1473,9 @@ class MeerK40t(MWindow):
                 "min": 1,
                 "max": 75,
                 "label": _("Distance"),
-                "tip": _("Set the distance inside which the cursor will snap to the next element point"),
+                "tip": _(
+                    "Set the distance inside which the cursor will snap to the next element point"
+                ),
                 "page": "Scene",
                 "section": "Snap-Options",
             },
@@ -1400,7 +1499,9 @@ class MeerK40t(MWindow):
                 "min": 1,
                 "max": 75,
                 "label": _("Distance"),
-                "tip": _("Set the distance inside which the cursor will snap to the next grid intersection"),
+                "tip": _(
+                    "Set the distance inside which the cursor will snap to the next grid intersection"
+                ),
                 "page": "Scene",
                 "section": "Snap-Options",
             },
@@ -1428,7 +1529,7 @@ class MeerK40t(MWindow):
         if context.icon_size == "tiny":
             set_icon_appearance(0.5, int(0.5 * STD_ICON_SIZE))
         elif context.icon_size == "small":
-            set_icon_appearance(2/3, int(2/3 * STD_ICON_SIZE))
+            set_icon_appearance(2 / 3, int(2 / 3 * STD_ICON_SIZE))
         elif context.icon_size == "big":
             set_icon_appearance(1.5, 0)
         elif context.icon_size == "large":
@@ -1650,7 +1751,10 @@ class MeerK40t(MWindow):
                 "tip": _("Flip the selected element vertically"),
                 "action": lambda v: kernel.elements("scale 1 -1\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1661,7 +1765,10 @@ class MeerK40t(MWindow):
                 "tip": _("Mirror the selected element horizontally"),
                 "action": lambda v: kernel.elements("scale -1 1\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1672,7 +1779,10 @@ class MeerK40t(MWindow):
                 "tip": _("Rotate the selected element clockwise by 90 deg"),
                 "action": lambda v: kernel.elements("rotate 90deg\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1683,7 +1793,10 @@ class MeerK40t(MWindow):
                 "tip": _("Rotate the selected element counterclockwise by 90 deg"),
                 "action": lambda v: kernel.elements("rotate -90deg\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1694,7 +1807,10 @@ class MeerK40t(MWindow):
                 "tip": _("Create a union of the selected elements"),
                 "action": lambda v: kernel.elements("element union\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 1,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 1,
             },
         )
         kernel.register(
@@ -1705,7 +1821,10 @@ class MeerK40t(MWindow):
                 "tip": _("Create a difference of the selected elements"),
                 "action": lambda v: kernel.elements("element difference\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 1,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 1,
             },
         )
         kernel.register(
@@ -1716,7 +1835,10 @@ class MeerK40t(MWindow):
                 "tip": _("Create a xor of the selected elements"),
                 "action": lambda v: kernel.elements("element xor\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 1,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 1,
             },
         )
         kernel.register(
@@ -1727,7 +1849,10 @@ class MeerK40t(MWindow):
                 "tip": _("Create a intersection of the selected elements"),
                 "action": lambda v: kernel.elements("element intersection\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 1,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 1,
             },
         )
 
@@ -1776,7 +1901,10 @@ class MeerK40t(MWindow):
                 "tip": _("Group elements together"),
                 "action": lambda v: group_selection(),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 1,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 1,
             },
         )
 
@@ -1785,6 +1913,7 @@ class MeerK40t(MWindow):
                 for n in list(node.children):
                     node.insert_sibling(n)
                 node.remove_node()  # Removing group/file node.
+
             found_some = False
             for node in list(kernel.elements.elems(emphasized=True)):
                 if not node is None:
@@ -1831,7 +1960,10 @@ class MeerK40t(MWindow):
                 "action": lambda v: kernel.elements("align left\n"),
                 "right": lambda v: kernel.elements("align bedleft\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1845,7 +1977,10 @@ class MeerK40t(MWindow):
                 "action": lambda v: kernel.elements("align right\n"),
                 "right": lambda v: kernel.elements("align bedright\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1859,7 +1994,10 @@ class MeerK40t(MWindow):
                 "action": lambda v: kernel.elements("align top\n"),
                 "right": lambda v: kernel.elements("align bedtop\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1873,7 +2011,10 @@ class MeerK40t(MWindow):
                 "action": lambda v: kernel.elements("align bottom\n"),
                 "right": lambda v: kernel.elements("align bedbottom\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1887,7 +2028,10 @@ class MeerK40t(MWindow):
                 "action": lambda v: kernel.elements("align center\n"),
                 "right": lambda v: kernel.elements("align bedcenter\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 0,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 0,
             },
         )
         kernel.register(
@@ -1898,7 +2042,10 @@ class MeerK40t(MWindow):
                 "tip": _("Distribute Space Horizontally"),
                 "action": lambda v: kernel.elements("align spaceh\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 2,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 2,
             },
         )
         kernel.register(
@@ -1909,7 +2056,10 @@ class MeerK40t(MWindow):
                 "tip": _("Distribute Space Vertically"),
                 "action": lambda v: kernel.elements("align spacev\n"),
                 "size": buttonsize,
-                "rule_enabled": lambda cond: len(list(kernel.elements.elems(emphasized=True))) > 2,
+                "rule_enabled": lambda cond: len(
+                    list(kernel.elements.elems(emphasized=True))
+                )
+                > 2,
             },
         )
 
@@ -3292,7 +3442,6 @@ class MeerK40t(MWindow):
     def on_update_statusmsg(self, origin, value):
         self.main_statusbar.SetStatusText(value, 0)
 
-
     def __set_titlebar(self):
         device_name = ""
         device_version = ""
@@ -3479,7 +3628,12 @@ class MeerK40t(MWindow):
             return False
         else:
             if results:
-                self.context("scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level))
+                self.context(
+                    "scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(
+                        zoom=self.context.zoom_level,
+                        zoom100=100 + self.context.zoom_level,
+                    )
+                )
 
                 self.set_file_as_recently_used(pathname)
                 if n != self.context.elements.note and self.context.elements.auto_note:
@@ -3516,7 +3670,11 @@ class MeerK40t(MWindow):
             return
         self.Layout()
         if not self.context.disable_auto_zoom:
-            self.context("scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level))
+            self.context(
+                "scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(
+                    zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level
+                )
+            )
 
     def on_focus_lost(self, event):
         self.context("-laser\nend\n")
@@ -3598,13 +3756,21 @@ class MeerK40t(MWindow):
 
     def on_click_toggle_ui(self, event=None):
         self.context("pane toggleui\n")
-        self.context("scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level))
+        self.context(
+            "scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(
+                zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level
+            )
+        )
 
     def on_click_zoom_bed(self, event=None):  # wxGlade: MeerK40t.<event_handler>
         """
         Zoom scene to bed size.
         """
-        self.context("scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level))
+        self.context(
+            "scene focus -{zoom}% -{zoom}% {zoom100}% {zoom100}%\n".format(
+                zoom=self.context.zoom_level, zoom100=100 + self.context.zoom_level
+            )
+        )
 
     def toggle_draw_mode(self, bits):
         """

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -179,14 +179,8 @@ class CustomStatusBar(wx.StatusBar):
         self.SetMinHeight(25)
         self.SetFieldsCount(self.panelct)
         self.SetStatusStyles([wx.SB_SUNKEN] * self.panelct)
-        sizes = [-2] * self.panelct
-        # Make the first Panel large
-        sizes[0] = -4
         self.status_text = [""] * self.panelct
         self.previous_text = [""] * self.panelct
-        # The most intelligent way would be to calculate the needed size...
-        sizes[self.panelct - 1] =  -1
-        self.SetStatusWidths(sizes)
         self.sizeChanged = False
         self.box_id_visible = {}
         self.activesizer = [None] * self.panelct
@@ -466,7 +460,15 @@ class MeerK40t(MWindow):
         self.main_statusbar.SetStatusStyles(
             [wx.SB_SUNKEN] * self.main_statusbar.GetFieldsCount()
         )
-        self.main_statusbar.SetStatusWidths([-1] * self.main_statusbar.GetFieldsCount())
+        # Set the panel sizes
+        sizes = [-3] * self.main_statusbar.GetFieldsCount()
+        # Make the first Panel large
+        sizes[0] = -4
+        # And the last one smaller
+        sizes[self.main_statusbar.GetFieldsCount() - 1] = -2
+        self.SetStatusWidths(sizes)
+
+        # self.main_statusbar.SetStatusWidths([-1] * self.main_statusbar.GetFieldsCount())
         self.SetStatusBarPane(0)
         self.main_statusbar.SetStatusText("", 0)
         self.startup = False


### PR DESCRIPTION
a) Append operation assignments to status-bar
b) Make panel sizes more fit for purpose

Open: need to show the status-text for panel 2 + 3 differently (as two will always be concealed by the ops buttons) 