### PR TITLE
Improve/harmonize textentry behaviour across the board

### DIFF
--- a/meerk40t/grbl/gui/tcpcontroller.py
+++ b/meerk40t/grbl/gui/tcpcontroller.py
@@ -13,8 +13,8 @@ class TCPController(MWindow):
         self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
         self.service = self.context.device
         self.text_status = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_ip_host = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_port = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_ip_host = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_port = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.gauge_buffer = wx.Gauge(self, wx.ID_ANY, 10)
         self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "")
         self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "")
@@ -25,8 +25,10 @@ class TCPController(MWindow):
         self.Bind(
             wx.EVT_BUTTON, self.on_button_start_connection, self.button_device_connect
         )
-        self.Bind(wx.EVT_TEXT, self.on_port_change, self.text_port)
-        self.Bind(wx.EVT_TEXT, self.on_address_change, self.text_ip_host)
+        self.text_port.Bind(wx.EVT_TEXT_ENTER, self.on_port_change)
+        self.text_port.Bind(wx.EVT_KILL_FOCUS, self.on_port_change)
+        self.text_ip_host.Bind(wx.EVT_TEXT_ENTER, self.on_address_change)
+        self.text_ip_host.Bind(wx.EVT_KILL_FOCUS, self.on_address_change)
         # end wxGlade
         self.max = 0
         self.state = None

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -412,7 +412,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, -1)
+                control = wx.TextCtrl(self, wx.ID_ANY, style = wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
@@ -430,7 +430,10 @@ class ChoicePropertyPanel(ScrolledPanel):
                     return text
 
                 control.Bind(
-                    wx.EVT_TEXT, on_textbox_text(attr, control, obj, data_type)
+                    wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
+                )
+                control.Bind(
+                    wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type)
                 )
                 current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type == Length:
@@ -438,11 +441,11 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, -1)
+                control = wx.TextCtrl(self, wx.ID_ANY, style = wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
-                def on_textbox_text(param, ctrl, obj, dtype):
+                def on_textbox_check(param, ctrl):
                     def text(event=None):
                         try:
                             v = Length(ctrl.GetValue())
@@ -452,7 +455,12 @@ class ChoicePropertyPanel(ScrolledPanel):
                             ctrl.SetBackgroundColour(wx.RED)
                             ctrl.Refresh()
                             return
+                    return text
+
+                def on_textbox_text(param, ctrl, obj, dtype):
+                    def text(event=None):
                         try:
+                            v = Length(ctrl.GetValue())
                             data_v = v.preferred_length
                             setattr(obj, param, data_v)
                             self.context.signal(param, data_v)
@@ -463,7 +471,13 @@ class ChoicePropertyPanel(ScrolledPanel):
                     return text
 
                 control.Bind(
-                    wx.EVT_TEXT, on_textbox_text(attr, control, obj, data_type)
+                    wx.EVT_TEXT, on_textbox_check(attr, control)
+                )
+                control.Bind(
+                    wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
+                )
+                control.Bind(
+                    wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type)
                 )
                 current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type == Angle:
@@ -471,11 +485,11 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, -1)
+                control = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
-                def on_textbox_text(param, ctrl, obj, dtype):
+                def on_textbox_check(param, ctrl):
                     def text(event=None):
                         try:
                             v = Angle(ctrl.GetValue(), digits=5)
@@ -485,7 +499,13 @@ class ChoicePropertyPanel(ScrolledPanel):
                             ctrl.SetBackgroundColour(wx.RED)
                             ctrl.Refresh()
                             return
+
+                    return text
+
+                def on_textbox_text(param, ctrl, obj, dtype):
+                    def text(event=None):
                         try:
+                            v = Angle(ctrl.GetValue(), digits=5)
                             data_v = str(v)
                             setattr(obj, param, data_v)
                             self.context.signal(param, data_v)
@@ -496,7 +516,13 @@ class ChoicePropertyPanel(ScrolledPanel):
                     return text
 
                 control.Bind(
-                    wx.EVT_TEXT, on_textbox_text(attr, control, obj, data_type)
+                    wx.EVT_TEXT, on_textbox_check(attr, control)
+                )
+                control.Bind(
+                    wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
+                )
+                control.Bind(
+                    wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type)
                 )
                 current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type == Color:

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -16,7 +16,15 @@ class ChoicePropertyPanel(ScrolledPanel):
     and display the given properties, automatically generating an appropriate changer for that property.
     """
 
-    def __init__(self, *args, context: Context = None, choices=None, scrolling = True, constraint=None, **kwds):
+    def __init__(
+        self,
+        *args,
+        context: Context = None,
+        choices=None,
+        scrolling=True,
+        constraint=None,
+        **kwds,
+    ):
         # constraints is either
         # - None (default) - all choices will be display
         # - a pair of integers (start, end), from where to where (index) to display
@@ -48,15 +56,17 @@ class ChoicePropertyPanel(ScrolledPanel):
             except KeyError:
                 c["page"] = ""
         # print ("Choices: " , choices)
-        prechoices = sorted(sorted(choices, key=lambda d: d["section"]), key=lambda d: d["page"])
+        prechoices = sorted(
+            sorted(choices, key=lambda d: d["section"]), key=lambda d: d["page"]
+        )
         self.choices = list()
         dealt_with = False
         if not constraint is None:
             if isinstance(constraint, (tuple, list, str)):
                 if isinstance(constraint, str):
                     # make it a tuple
-                    constraint=(constraint,)
-                if len(constraint)>0:
+                    constraint = (constraint,)
+                if len(constraint) > 0:
                     if isinstance(constraint[0], str):
                         dealt_with = True
                         # Section list
@@ -73,15 +83,15 @@ class ChoicePropertyPanel(ScrolledPanel):
                                 this_page = c["page"].lower()
                             except KeyError:
                                 this_page = ""
-                            if len(negative)>0 and len(positive)>0:
+                            if len(negative) > 0 and len(positive) > 0:
                                 # Negative takes precedence:
                                 if not this_page in negative and this_page in positive:
                                     self.choices.append(c)
-                            elif len(negative)>0:
+                            elif len(negative) > 0:
                                 # only negative....
                                 if not this_page in negative:
                                     self.choices.append(c)
-                            elif len(positive)>0:
+                            elif len(positive) > 0:
                                 # only positive....
                                 if this_page in positive:
                                     self.choices.append(c)
@@ -90,18 +100,18 @@ class ChoicePropertyPanel(ScrolledPanel):
                         # Section list
                         startfrom = 0
                         endat = len(prechoices)
-                        if constraint[0]>=0:
+                        if constraint[0] >= 0:
                             startfrom = constraint[0]
-                        if len(constraint)>1 and constraint[1]>=0:
+                        if len(constraint) > 1 and constraint[1] >= 0:
                             endat = constraint[1]
                         if startfrom < 0:
                             startfrom = 0
-                        if endat>len(prechoices):
+                        if endat > len(prechoices):
                             endat = len(prechoices)
-                        if endat<startfrom:
+                        if endat < startfrom:
                             endat = len(prechoices)
                         for i, c in enumerate(prechoices):
-                            if i>=startfrom and i<endat:
+                            if i >= startfrom and i < endat:
                                 self.choices.append(c)
         else:
             # Empty constraint
@@ -109,7 +119,7 @@ class ChoicePropertyPanel(ScrolledPanel):
         if not dealt_with:
             # no valid constraints
             self.choices = prechoices
-        if len(self.choices)==0:
+        if len(self.choices) == 0:
             return
         sizer_main = wx.BoxSizer(wx.VERTICAL)
         last_page = ""
@@ -170,14 +180,18 @@ class ChoicePropertyPanel(ScrolledPanel):
             if last_page != this_page:
                 last_section = ""
                 # We could do a notebook, but let's choose a simple StaticBoxSizer instead...
-                last_box = wx.StaticBoxSizer(wx.StaticBox(self, id=wx.ID_ANY, label=_(this_page)), wx.VERTICAL)
-                sizer_main.Add(last_box, 0, wx.EXPAND, 0 )
+                last_box = wx.StaticBoxSizer(
+                    wx.StaticBox(self, id=wx.ID_ANY, label=_(this_page)), wx.VERTICAL
+                )
+                sizer_main.Add(last_box, 0, wx.EXPAND, 0)
                 current_main_sizer = last_box
                 current_sizer = last_box
 
             if last_section != this_section:
-                last_box = wx.StaticBoxSizer(wx.StaticBox(self, id=wx.ID_ANY, label=_(this_section)), wx.VERTICAL)
-                current_main_sizer.Add(last_box, 0, wx.EXPAND, 0 )
+                last_box = wx.StaticBoxSizer(
+                    wx.StaticBox(self, id=wx.ID_ANY, label=_(this_section)), wx.VERTICAL
+                )
+                current_main_sizer.Add(last_box, 0, wx.EXPAND, 0)
                 current_sizer = last_box
 
             if data_type == bool:
@@ -247,7 +261,14 @@ class ChoicePropertyPanel(ScrolledPanel):
                     value = int(data)
                 else:
                     value = int(data)
-                control = wx.Slider(self, wx.ID_ANY, value=value, minValue=minvalue, maxValue=maxvalue, style=wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL)
+                control = wx.Slider(
+                    self,
+                    wx.ID_ANY,
+                    value=value,
+                    minValue=minvalue,
+                    maxValue=maxvalue,
+                    style=wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL,
+                )
 
                 def on_slider(param, ctrl, obj, dtype):
                     def select(event=None):
@@ -258,7 +279,10 @@ class ChoicePropertyPanel(ScrolledPanel):
                     return select
 
                 control_sizer.Add(control)
-                control.Bind(wx.EVT_SLIDER, on_slider(attr, control, obj, data_type),)
+                control.Bind(
+                    wx.EVT_SLIDER,
+                    on_slider(attr, control, obj, data_type),
+                )
                 current_sizer.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type in (str, int, float) and data_style == "combo":
                 control_sizer = wx.StaticBoxSizer(
@@ -280,7 +304,9 @@ class ChoicePropertyPanel(ScrolledPanel):
                             if least is None:
                                 least = entry
                             else:
-                                if abs(data_type(entry) - data) < abs(data_type(least) - data):
+                                if abs(data_type(entry) - data) < abs(
+                                    data_type(least) - data
+                                ):
                                     least = entry
                         if least is not None:
                             control.SetValue(least)
@@ -320,7 +346,9 @@ class ChoicePropertyPanel(ScrolledPanel):
                             if least is None:
                                 least = entry
                             else:
-                                if abs(data_type(entry) - data) < abs(data_type(least) - data):
+                                if abs(data_type(entry) - data) < abs(
+                                    data_type(least) - data
+                                ):
                                     least = entry
                         if least is not None:
                             control.SetValue(least)
@@ -373,12 +401,21 @@ class ChoicePropertyPanel(ScrolledPanel):
                     return check
 
                 bit_sizer = wx.BoxSizer(wx.VERTICAL)
-                label_text = wx.StaticText(self, wx.ID_ANY, "", style=wx.ALIGN_CENTRE_HORIZONTAL)
+                label_text = wx.StaticText(
+                    self, wx.ID_ANY, "", style=wx.ALIGN_CENTRE_HORIZONTAL
+                )
                 bit_sizer.Add(label_text, 0, wx.EXPAND, 0)
                 if mask is not None:
-                    label_text = wx.StaticText(self, wx.ID_ANY, _("mask") + " ", style=wx.ALIGN_CENTRE_HORIZONTAL)
+                    label_text = wx.StaticText(
+                        self,
+                        wx.ID_ANY,
+                        _("mask") + " ",
+                        style=wx.ALIGN_CENTRE_HORIZONTAL,
+                    )
                     bit_sizer.Add(label_text, 0, wx.EXPAND, 0)
-                label_text = wx.StaticText(self, wx.ID_ANY, _("value") + " ", style=wx.ALIGN_CENTRE_HORIZONTAL)
+                label_text = wx.StaticText(
+                    self, wx.ID_ANY, _("value") + " ", style=wx.ALIGN_CENTRE_HORIZONTAL
+                )
                 bit_sizer.Add(label_text, 0, wx.EXPAND, 0)
                 control_sizer.Add(bit_sizer, 0, wx.EXPAND, 0)
 
@@ -386,7 +423,9 @@ class ChoicePropertyPanel(ScrolledPanel):
                 for b in range(bits):
                     # Label
                     bit_sizer = wx.BoxSizer(wx.VERTICAL)
-                    label_text = wx.StaticText(self, wx.ID_ANY, str(b), style=wx.ALIGN_CENTRE_HORIZONTAL)
+                    label_text = wx.StaticText(
+                        self, wx.ID_ANY, str(b), style=wx.ALIGN_CENTRE_HORIZONTAL
+                    )
                     bit_sizer.Add(label_text, 0, wx.EXPAND, 0)
 
                     # value bit
@@ -394,13 +433,20 @@ class ChoicePropertyPanel(ScrolledPanel):
                     control.SetValue(bool((data >> b) & 1))
                     if mask:
                         control.Enable(bool((mask_bits >> b) & 1))
-                    control.Bind(wx.EVT_CHECKBOX, on_checkbox_check(attr, control, obj, b))
+                    control.Bind(
+                        wx.EVT_CHECKBOX, on_checkbox_check(attr, control, obj, b)
+                    )
 
                     # mask bit
                     if mask:
                         mask_ctrl = wx.CheckBox(self)
                         mask_ctrl.SetValue(bool((mask_bits >> b) & 1))
-                        mask_ctrl.Bind(wx.EVT_CHECKBOX, on_checkbox_check(mask, mask_ctrl, obj, b, enable_ctrl=control))
+                        mask_ctrl.Bind(
+                            wx.EVT_CHECKBOX,
+                            on_checkbox_check(
+                                mask, mask_ctrl, obj, b, enable_ctrl=control
+                            ),
+                        )
                         bit_sizer.Add(mask_ctrl, 0, wx.EXPAND, 0)
 
                     bit_sizer.Add(control, 0, wx.EXPAND, 0)
@@ -412,7 +458,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, wx.ID_ANY, style = wx.TE_PROCESS_ENTER)
+                control = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
@@ -441,7 +487,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, wx.ID_ANY, style = wx.TE_PROCESS_ENTER)
+                control = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
@@ -455,6 +501,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                             ctrl.SetBackgroundColour(wx.RED)
                             ctrl.Refresh()
                             return
+
                     return text
 
                 def on_textbox_text(param, ctrl, obj, dtype):
@@ -470,9 +517,7 @@ class ChoicePropertyPanel(ScrolledPanel):
 
                     return text
 
-                control.Bind(
-                    wx.EVT_TEXT, on_textbox_check(attr, control)
-                )
+                control.Bind(wx.EVT_TEXT, on_textbox_check(attr, control))
                 control.Bind(
                     wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
                 )
@@ -515,9 +560,7 @@ class ChoicePropertyPanel(ScrolledPanel):
 
                     return text
 
-                control.Bind(
-                    wx.EVT_TEXT, on_textbox_check(attr, control)
-                )
+                control.Bind(wx.EVT_TEXT, on_textbox_check(attr, control))
                 control.Bind(
                     wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
                 )

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -161,15 +161,15 @@ def register_panel_navigation(window, context):
     pane = (
         aui.AuiPaneInfo()
         .Right()
-        .MinSize(max(3*iconsize, 3*57), 3*iconsize + dy)
-        .FloatingSize(max(3*iconsize, 3*57), 3*iconsize + dy)
+        .MinSize(max(3 * iconsize, 3 * 57), 3 * iconsize + dy)
+        .FloatingSize(max(3 * iconsize, 3 * 57), 3 * iconsize + dy)
         .MaxSize(300, 300)
         .Caption(_("Transform"))
         .Name("transform")
         .CaptionVisible(not context.pane_lock)
         .Hide()
     )
-    pane.dock_proportion = max(3*iconsize, 3*57)
+    pane.dock_proportion = max(3 * iconsize, 3 * 57)
     pane.control = panel
     pane.submenu = _("Editing")
 
@@ -931,8 +931,22 @@ class MovePanel(wx.Panel):
         )
         units = self.context.units_name
         default_pos = f"0{units}"
-        self.text_position_x = TextCtrl(self, wx.ID_ANY, default_pos, limited=True, check="length", style=wx.TE_PROCESS_ENTER)
-        self.text_position_y = TextCtrl(self, wx.ID_ANY, default_pos, limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_position_x = TextCtrl(
+            self,
+            wx.ID_ANY,
+            default_pos,
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
+        self.text_position_y = TextCtrl(
+            self,
+            wx.ID_ANY,
+            default_pos,
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
 
         self.__set_properties()
         self.__do_layout()
@@ -981,7 +995,6 @@ class MovePanel(wx.Panel):
         main_sizer.Fit(self)
         self.Layout()
         # end wxGlade
-
 
     def on_button_navigate_move_to(
         self, event=None
@@ -1281,6 +1294,7 @@ class SizePanel(wx.Panel):
             return
         event.Skip()
 
+
 class Transform(wx.Panel):
     def __init__(self, *args, context=None, **kwds):
         # begin wxGlade: Transform.__init__
@@ -1315,22 +1329,52 @@ class Transform(wx.Panel):
             self, wx.ID_ANY, icons8_rotate_right_50.GetBitmap()
         )
         self.text_a = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="1.000000", check="percent", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="1.000000",
+            check="percent",
+            limited=True,
         )
         self.text_d = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="1.000000", check="percent", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="1.000000",
+            check="percent",
+            limited=True,
         )
         self.text_c = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="0.000000", check="angle", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="0.000000",
+            check="angle",
+            limited=True,
         )
         self.text_b = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="0.000000", check="angle", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="0.000000",
+            check="angle",
+            limited=True,
         )
         self.text_e = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="0.0", check="float", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="0.0",
+            check="float",
+            limited=True,
         )
         self.text_f = TextCtrl(
-            self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER, value="0.0", check="float", limited=True
+            self,
+            wx.ID_ANY,
+            style=wx.TE_PROCESS_ENTER,
+            value="0.0",
+            check="float",
+            limited=True,
         )
 
         self.__set_properties()
@@ -1756,7 +1800,6 @@ class NavigationPanel(wx.Panel):
         self.context = context
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
-
 
         pulse_and_move_sizer = wx.BoxSizer(wx.HORIZONTAL)
         main_panels_sizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -9,6 +9,7 @@ import wx
 from .choicepropertypanel import ChoicePropertyPanel
 from .icons import icons8_administrative_tools_50
 from .mwindow import MWindow
+from .wxutils import TextCtrl
 
 _ = wx.GetTranslation
 
@@ -154,7 +155,7 @@ class PreferencesPixelsPerInchPanel(wx.Panel):
 
         sizer_3.Add((20, 20), 0, 0, 0)
 
-        self.text_svg_ppi = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_svg_ppi = TextCtrl(self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER)
         self.text_svg_ppi.SetMinSize((60, 23))
         self.text_svg_ppi.SetToolTip(
             _("Custom Pixels Per Inch to use when loading an SVG file")
@@ -166,7 +167,8 @@ class PreferencesPixelsPerInchPanel(wx.Panel):
         self.Layout()
 
         self.Bind(wx.EVT_COMBOBOX, self.on_combo_svg_ppi, self.combo_svg_ppi)
-        self.Bind(wx.EVT_TEXT, self.on_text_svg_ppi, self.text_svg_ppi)
+        self.text_svg_ppi.Bind(wx.EVT_TEXT_ENTER, self.on_text_svg_ppi)
+        self.text_svg_ppi.Bind(wx.EVT_KILL_FOCUS, self.on_text_svg_ppi)
         # end wxGlade
 
         context.elements.setting(float, "svg_ppi", 96.0)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -104,7 +104,9 @@ class PreferencesLanguagePanel(wx.Panel):
         self.combo_language = wx.ComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_READONLY
         )
-        self.combo_language.SetToolTip(_("Select the desired language to use (requires a restart to take effect)."))
+        self.combo_language.SetToolTip(
+            _("Select the desired language to use (requires a restart to take effect).")
+        )
         sizer_2.Add(self.combo_language, 0, 0, 0)
 
         self.SetSizer(sizer_2)
@@ -155,7 +157,9 @@ class PreferencesPixelsPerInchPanel(wx.Panel):
 
         sizer_3.Add((20, 20), 0, 0, 0)
 
-        self.text_svg_ppi = TextCtrl(self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_svg_ppi = TextCtrl(
+            self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER
+        )
         self.text_svg_ppi.SetMinSize((60, 23))
         self.text_svg_ppi.SetToolTip(
             _("Custom Pixels Per Inch to use when loading an SVG file")
@@ -230,8 +234,11 @@ class PreferencesMain(wx.Panel):
         sizer_main.Add(self.panel_ppi, 0, wx.EXPAND, 0)
 
         self.panel_pref1 = ChoicePropertyPanel(
-            self, id=wx.ID_ANY, context=context,
-            choices="preferences", constraint=("-Classification", "-Gui", "-Scene"),
+            self,
+            id=wx.ID_ANY,
+            context=context,
+            choices="preferences",
+            constraint=("-Classification", "-Gui", "-Scene"),
         )
         sizer_main.Add(self.panel_pref1, 1, wx.EXPAND, 0)
 
@@ -287,23 +294,31 @@ class Preferences(MWindow):
         self.panel_main = PreferencesPanel(self, wx.ID_ANY, context=self.context)
 
         self.panel_classification = ChoicePropertyPanel(
-            self, id=wx.ID_ANY, context=self.context,
-            choices="preferences", constraint=("Classification"),
+            self,
+            id=wx.ID_ANY,
+            context=self.context,
+            choices="preferences",
+            constraint=("Classification"),
         )
         self.panel_classification.SetupScrolling()
 
         self.panel_gui = ChoicePropertyPanel(
-            self, id=wx.ID_ANY, context=self.context,
-            choices="preferences", constraint=("Gui"),
+            self,
+            id=wx.ID_ANY,
+            context=self.context,
+            choices="preferences",
+            constraint=("Gui"),
         )
         self.panel_gui.SetupScrolling()
 
         self.panel_scene = ChoicePropertyPanel(
-            self, id=wx.ID_ANY, context=self.context,
-            choices="preferences", constraint=("Scene"),
+            self,
+            id=wx.ID_ANY,
+            context=self.context,
+            choices="preferences",
+            constraint=("Scene"),
         )
         self.panel_scene.SetupScrolling()
-
 
         self.notebook_main.AddPage(self.panel_main, _("General"))
         self.notebook_main.AddPage(self.panel_classification, _("Classification"))

--- a/meerk40t/gui/propertypanels/consoleproperty.py
+++ b/meerk40t/gui/propertypanels/consoleproperty.py
@@ -38,7 +38,7 @@ class ConsolePropertiesPanel(wx.Panel):
             self,
             wx.ID_ANY,
             "Command text",
-            style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP ,
+            style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP,
         )
 
         self.__do_layout()

--- a/meerk40t/gui/propertypanels/consoleproperty.py
+++ b/meerk40t/gui/propertypanels/consoleproperty.py
@@ -38,7 +38,7 @@ class ConsolePropertiesPanel(wx.Panel):
             self,
             wx.ID_ANY,
             "Command text",
-            style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP,
+            style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_WORDWRAP ,
         )
 
         self.__do_layout()

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -15,8 +15,8 @@ class GroupPropertiesPanel(ScrolledPanel):
 
         self.node = node
 
-        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
 
         self.__set_properties()
         self.__do_layout()
@@ -33,10 +33,10 @@ class GroupPropertiesPanel(ScrolledPanel):
         except AttributeError:
             pass
 
-        self.Bind(wx.EVT_TEXT, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT, self.on_text_label_change, self.text_label)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change, self.text_label)
+        self.text_id.Bind(wx.EVT_KILL_FOCUS, self.on_text_id_change)
+        self.text_id.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change)
+        self.text_label.Bind(wx.EVT_KILL_FOCUS, self.on_text_label_change)
+        self.text_label.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change)
         # end wxGlade
 
     def __set_properties(self):

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -1,5 +1,6 @@
 import wx
 from wx.lib.scrolledpanel import ScrolledPanel
+
 # from ...svgelements import SVG_ATTR_ID
 from ..icons import icons8_group_objects_50
 from ..mwindow import MWindow

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -2,6 +2,7 @@ import wx
 from wx.lib.scrolledpanel import ScrolledPanel
 from ..icons import icons8_image_50
 from ..mwindow import MWindow
+from ..wxutils import TextCtrl
 from ...core.units import Length
 _ = wx.GetTranslation
 
@@ -13,14 +14,14 @@ class ImagePropertyPanel(ScrolledPanel):
         wx.Panel.__init__(self, *args, **kwargs)
         self.context = context
         self.node = node
-        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
 
-        self.text_dpi = wx.TextCtrl(self, wx.ID_ANY, "500")
-        self.text_x = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_y = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_width = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_height = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500", style=wx.TE_PROCESS_ENTER, check="float")
+        self.text_x = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
+        self.text_y = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
+        self.text_width = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
+        self.text_height = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
 
         self.check_enable_dither = wx.CheckBox(self, wx.ID_ANY, _("Dither"))
         self.choices = [
@@ -67,26 +68,19 @@ class ImagePropertyPanel(ScrolledPanel):
         self.__set_properties()
         self.__do_layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT, self.on_text_label_change, self.text_label)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change, self.text_label)
+        self.text_id.Bind(wx.EVT_KILL_FOCUS, self.on_text_id_change)
+        self.text_id.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change)
+        self.text_label.Bind(wx.EVT_KILL_FOCUS, self.on_text_label_change)
+        self.text_label.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_enable_dither, self.check_enable_dither
         )
         self.Bind(wx.EVT_COMBOBOX, self.on_combo_dither_type, self.combo_dither)
         self.Bind(wx.EVT_TEXT_ENTER, self.on_combo_dither_type, self.combo_dither)
 
-        self.Bind(wx.EVT_TEXT, self.on_text_dpi, self.text_dpi)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_dpi, self.text_dpi)
-        self.Bind(wx.EVT_TEXT, self.on_text_x, self.text_x)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_x, self.text_x)
-        self.Bind(wx.EVT_TEXT, self.on_text_y, self.text_y)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_y, self.text_y)
-        self.Bind(wx.EVT_TEXT, self.on_text_width, self.text_width)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_width, self.text_width)
-        self.Bind(wx.EVT_TEXT, self.on_text_height, self.text_height)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_height, self.text_height)
+        self.text_dpi.Bind(wx.EVT_KILL_FOCUS, self.on_text_dpi)
+        self.text_dpi.Bind(wx.EVT_TEXT_ENTER, self.on_text_dpi)
+
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_invert_grayscale, self.check_invert_grayscale
         )
@@ -160,13 +154,9 @@ class ImagePropertyPanel(ScrolledPanel):
 
     def __set_properties(self):
         self.text_x.SetToolTip(_("X property of image"))
-        self.text_x.Enable(False)
         self.text_y.SetToolTip(_("Y property of image"))
-        self.text_y.Enable(False)
         self.text_width.SetToolTip(_("Width property of image"))
-        self.text_width.Enable(False)
         self.text_height.SetToolTip(_("Height property of image"))
-        self.text_height.Enable(False)
         self.check_enable_dither.SetToolTip(_("Enable Dither"))
         self.check_enable_dither.SetValue(1)
         self.combo_dither.SetToolTip(_("Select dither algorithm to use"))
@@ -267,6 +257,11 @@ class ImagePropertyPanel(ScrolledPanel):
         sizer_grayscale.Add(sizer_rg, 5, wx.EXPAND, 0)
         sizer_grayscale.Add(sizer_bl, 5, wx.EXPAND, 0)
 
+        self.text_grayscale_red.SetMaxSize(wx.Size(70, -1))
+        self.text_grayscale_green.SetMaxSize(wx.Size(70, -1))
+        self.text_grayscale_blue.SetMaxSize(wx.Size(70, -1))
+        self.text_grayscale_lightness.SetMaxSize(wx.Size(70, -1))
+
         sizer_main.Add(sizer_grayscale, 0, wx.EXPAND, 0)
         self.SetSizer(sizer_main)
         self.Layout()
@@ -290,18 +285,6 @@ class ImagePropertyPanel(ScrolledPanel):
     def on_text_dpi(self, event=None):  # wxGlade: ImageProperty.<event_handler>
         new_step = float(self.text_dpi.GetValue())
         self.node.dpi = new_step
-
-    def on_text_x(self, event):  # wxGlade: ImageProperty.<event_handler>
-        event.Skip()
-
-    def on_text_y(self, event):  # wxGlade: ImageProperty.<event_handler>
-        event.Skip()
-
-    def on_text_width(self, event):  # wxGlade: ImageProperty.<event_handler>
-        event.Skip()
-
-    def on_text_height(self, event):  # wxGlade: ImageProperty.<event_handler>
-        event.Skip()
 
     def on_check_enable_dither(
         self, event=None

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -4,6 +4,7 @@ from ..icons import icons8_image_50
 from ..mwindow import MWindow
 from ..wxutils import TextCtrl
 from ...core.units import Length
+
 _ = wx.GetTranslation
 
 
@@ -17,11 +18,17 @@ class ImagePropertyPanel(ScrolledPanel):
         self.text_id = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_label = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
 
-        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500", style=wx.TE_PROCESS_ENTER, check="float")
+        self.text_dpi = TextCtrl(
+            self, wx.ID_ANY, "500", style=wx.TE_PROCESS_ENTER, check="float"
+        )
         self.text_x = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
         self.text_y = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
-        self.text_width = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
-        self.text_height = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
+        self.text_width = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True
+        )
+        self.text_height = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True
+        )
 
         self.check_enable_dither = wx.CheckBox(self, wx.ID_ANY, _("Dither"))
         self.choices = [
@@ -143,10 +150,18 @@ class ImagePropertyPanel(ScrolledPanel):
         self.text_dpi.SetValue(str(node.dpi))
         try:
             bounds = node.bounds
-            self.text_x.SetValue(Length(amount=bounds[0], unitless=1, digits=2).length_mm)
-            self.text_y.SetValue(Length(amount=bounds[1], unitless=1, digits=2).length_mm)
-            self.text_width.SetValue(Length(amount=bounds[2]-bounds[0], unitless=1, digits=2).length_mm)
-            self.text_height.SetValue(Length(amount=bounds[3]-bounds[1], unitless=1, digits=2).length_mm)
+            self.text_x.SetValue(
+                Length(amount=bounds[0], unitless=1, digits=2).length_mm
+            )
+            self.text_y.SetValue(
+                Length(amount=bounds[1], unitless=1, digits=2).length_mm
+            )
+            self.text_width.SetValue(
+                Length(amount=bounds[2] - bounds[0], unitless=1, digits=2).length_mm
+            )
+            self.text_height.SetValue(
+                Length(amount=bounds[3] - bounds[1], unitless=1, digits=2).length_mm
+            )
         except AttributeError:
             pass
         self.check_enable_dither.SetValue(node.dither)

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -310,7 +310,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(speed_sizer, 1, wx.EXPAND, 0)
 
-        self.text_speed = TextCtrl(self, wx.ID_ANY, "20.0", limited=True)
+        self.text_speed = TextCtrl(self, wx.ID_ANY, "20.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_speed.SetToolTip(OPERATION_SPEED_TOOLTIP)
         speed_sizer.Add(self.text_speed, 1, wx.EXPAND, 0)
 
@@ -319,7 +319,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(power_sizer, 1, wx.EXPAND, 0)
 
-        self.text_power = TextCtrl(self, wx.ID_ANY, "1000.0", limited=True)
+        self.text_power = TextCtrl(self, wx.ID_ANY, "1000.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_power.SetToolTip(OPERATION_POWER_TOOLTIP)
         power_sizer.Add(self.text_power, 1, wx.EXPAND, 0)
 
@@ -328,7 +328,7 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(frequency_sizer, 1, wx.EXPAND, 0)
 
-        self.text_frequency = TextCtrl(self, wx.ID_ANY, "20.0", limited=True)
+        self.text_frequency = TextCtrl(self, wx.ID_ANY, "20.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         # self.text_frequency.SetToolTip(OPERATION_SPEED_TOOLTIP)
         frequency_sizer.Add(self.text_frequency, 1, wx.EXPAND, 0)
 
@@ -336,13 +336,13 @@ class SpeedPpiPanel(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_speed, self.text_speed)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed, self.text_speed)
-        self.Bind(wx.EVT_TEXT, self.on_text_power, self.text_power)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_power, self.text_power)
+        self.text_speed.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed)
+        self.text_speed.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed)
+        self.text_power.Bind(wx.EVT_KILL_FOCUS, self.on_text_power)
+        self.text_power.Bind(wx.EVT_TEXT_ENTER, self.on_text_power)
 
-        self.Bind(wx.EVT_TEXT, self.on_text_frequency, self.text_frequency)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_frequency, self.text_frequency)
+        self.text_frequency.Bind(wx.EVT_KILL_FOCUS, self.on_text_frequency)
+        self.text_frequency.Bind(wx.EVT_TEXT_ENTER, self.on_text_frequency)
 
         # end wxGlade
 
@@ -422,7 +422,7 @@ class PassesPanel(wx.Panel):
         self.check_passes.SetToolTip(_("Enable Operation Passes"))
         sizer_passes.Add(self.check_passes, 0, wx.EXPAND, 0)
 
-        self.text_passes = TextCtrl(self, wx.ID_ANY, "1", limited=True)
+        self.text_passes = TextCtrl(self, wx.ID_ANY, "1", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_passes.SetToolTip(OPERATION_PASSES_TOOLTIP)
         sizer_passes.Add(self.text_passes, 1, wx.EXPAND, 0)
 
@@ -431,7 +431,9 @@ class PassesPanel(wx.Panel):
         self.Layout()
 
         self.Bind(wx.EVT_CHECKBOX, self.on_check_passes, self.check_passes)
-        self.Bind(wx.EVT_TEXT, self.on_text_passes, self.text_passes)
+
+        self.text_passes.Bind(wx.EVT_KILL_FOCUS, self.on_text_passes)
+        self.text_passes.Bind(wx.EVT_TEXT_ENTER, self.on_text_passes)
         # end wxGlade
 
     def pane_hide(self):
@@ -862,7 +864,7 @@ class RasterSettingsPanel(wx.Panel):
         )
         param_sizer.Add(sizer_3, 1, wx.EXPAND, 0)
 
-        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500", limited=True)
+        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_dpi.SetToolTip(OPERATION_DPI_TOOLTIP)
         sizer_3.Add(self.text_dpi, 1, wx.EXPAND, 0)
 
@@ -873,7 +875,7 @@ class RasterSettingsPanel(wx.Panel):
 
         raster_sizer.Add(param_sizer, 0, wx.EXPAND, 0)
 
-        self.text_overscan = TextCtrl(self, wx.ID_ANY, "1mm", limited=True)
+        self.text_overscan = TextCtrl(self, wx.ID_ANY, "1mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         self.text_overscan.SetToolTip(_("Overscan amount"))
         sizer_6.Add(self.text_overscan, 1, wx.EXPAND, 0)
 
@@ -919,10 +921,11 @@ class RasterSettingsPanel(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_dpi, self.text_dpi)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_dpi, self.text_dpi)
-        self.Bind(wx.EVT_TEXT, self.on_text_overscan, self.text_overscan)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_overscan, self.text_overscan)
+        self.text_dpi.Bind(wx.EVT_KILL_FOCUS, self.on_text_dpi)
+        self.text_dpi.Bind(wx.EVT_TEXT_ENTER, self.on_text_dpi)
+        self.text_overscan.Bind(wx.EVT_KILL_FOCUS, self.on_text_overscan)
+        self.text_overscan.Bind(wx.EVT_TEXT_ENTER, self.on_text_overscan)
+
         self.Bind(
             wx.EVT_COMBOBOX, self.on_combo_raster_direction, self.combo_raster_direction
         )
@@ -967,11 +970,7 @@ class RasterSettingsPanel(wx.Panel):
         ctrl = self.text_overscan
         try:
             v = Length(ctrl.GetValue(), unitless=UNITS_PER_MM, preferred_units="mm", digits=4)
-            ctrl.SetBackgroundColour(None)
-            ctrl.Refresh()
         except ValueError:
-            ctrl.SetBackgroundColour(wx.RED)
-            ctrl.Refresh()
             return
         # print ("Start overscan=%s - target=%s" % (start_text, str(v.preferred_length)))
         value = v.preferred_length
@@ -1016,7 +1015,7 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_distance, 0, wx.EXPAND, 0)
 
-        self.text_distance = TextCtrl(self, wx.ID_ANY, "1mm", limited=True)
+        self.text_distance = TextCtrl(self, wx.ID_ANY, "1mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         sizer_distance.Add(self.text_distance, 1, wx.EXPAND, 0)
 
         sizer_angle = wx.StaticBoxSizer(
@@ -1024,7 +1023,7 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_angle, 1, wx.EXPAND, 0)
 
-        self.text_angle = TextCtrl(self, wx.ID_ANY, "0deg", limited=True)
+        self.text_angle = TextCtrl(self, wx.ID_ANY, "0deg", limited=True, check="angle", style=wx.TE_PROCESS_ENTER)
         sizer_angle.Add(self.text_angle, 1, wx.EXPAND, 0)
 
         self.slider_angle = wx.Slider(self, wx.ID_ANY, 0, 0, 360)
@@ -1048,8 +1047,10 @@ class HatchSettingsPanel(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_distance, self.text_distance)
-        self.Bind(wx.EVT_TEXT, self.on_text_angle, self.text_angle)
+        self.text_distance.Bind(wx.EVT_TEXT_ENTER, self.on_text_distance)
+        self.text_distance.Bind(wx.EVT_KILL_FOCUS, self.on_text_distance)
+        self.text_angle.Bind(wx.EVT_TEXT_ENTER, self.on_text_angle)
+        self.text_angle.Bind(wx.EVT_KILL_FOCUS, self.on_text_angle)
         self.Bind(wx.EVT_COMMAND_SCROLL, self.on_slider_angle, self.slider_angle)
         self.Bind(wx.EVT_COMBOBOX, self.on_combo_fill, self.combo_fill_style)
         # end wxGlade
@@ -1288,7 +1289,7 @@ class DwellSettingsPanel(wx.Panel):
             wx.StaticBox(self, wx.ID_ANY, _("Dwell Time: (ms)")), wx.HORIZONTAL
         )
 
-        self.text_dwelltime = TextCtrl(self, wx.ID_ANY, "1.0", limited=True)
+        self.text_dwelltime = TextCtrl(self, wx.ID_ANY, "1.0", limited=True, style=wx.TE_PROCESS_ENTER, check="float")
         self.text_dwelltime.SetToolTip(
             _("Dwell time (ms) at each location in the sequence")
         )
@@ -1298,7 +1299,8 @@ class DwellSettingsPanel(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_dwelltime, self.text_dwelltime)
+        self.text_dwelltime.Bind(wx.EVT_TEXT_ENTER, self.on_text_dwelltime)
+        self.text_dwelltime.Bind(wx.EVT_KILL_FOCUS, self.on_text_dwelltime)
         # end wxGlade
 
     def pane_hide(self):
@@ -1316,12 +1318,11 @@ class DwellSettingsPanel(wx.Panel):
     ):  # wxGlade: OperationProperty.<event_handler>
         try:
             value = float(self.text_dwelltime.GetValue())
-            self.text_dwelltime.SetBackgroundColour(None)
             if self.operation.dwell_time != value:
                 self.operation.dwell_time = value
                 self.context.elements.signal("element_property_reload", self.operation, "text_dwell")
         except ValueError:
-            self.text_dwelltime.SetBackgroundColour(wx.RED)
+            pass
         event.Skip()
 
 # end of class PassesPanel

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -5,7 +5,7 @@ from meerk40t.kernel import signal_listener
 from ...core.units import Length, UNITS_PER_MM
 from ...svgelements import Angle, Color, Matrix
 from ..laserrender import swizzlecolor
-from ..wxutils import TextCtrl
+from ..wxutils import TextCtrl, set_ctrl_value
 
 _ = wx.GetTranslation
 
@@ -355,12 +355,12 @@ class SpeedPpiPanel(wx.Panel):
     def set_widgets(self, node):
         self.operation = node
         if self.operation.speed is not None:
-            self.text_speed.SetValue(str(self.operation.speed))
+            set_ctrl_value(self.text_speed, str(self.operation.speed))
         if self.operation.power is not None:
             self.update_power_label()
-            self.text_power.SetValue(str(self.operation.power))
+            set_ctrl_value(self.text_power, str(self.operation.power))
         if self.operation.frequency is not None:
-            self.text_frequency.SetValue(str(self.operation.frequency))
+            set_ctrl_value(self.text_frequency, str(self.operation.frequency))
 
     def on_text_speed(self, event=None):  # wxGlade: OperationProperty.<event_handler>
         try:
@@ -445,7 +445,7 @@ class PassesPanel(wx.Panel):
         if self.operation.passes_custom is not None:
             self.check_passes.SetValue(self.operation.passes_custom)
         if self.operation.passes is not None:
-            self.text_passes.SetValue(str(self.operation.passes))
+            set_ctrl_value(self.text_passes, str(self.operation.passes))
         on = self.check_passes.GetValue()
         self.text_passes.Enable(on)
 
@@ -944,9 +944,9 @@ class RasterSettingsPanel(wx.Panel):
     def set_widgets(self, node):
         self.operation = node
         if self.operation.dpi is not None:
-            self.text_dpi.SetValue(str(self.operation.dpi))
+            set_ctrl_value(self.text_dpi, str(self.operation.dpi))
         if self.operation.overscan is not None:
-            self.text_overscan.SetValue(str(self.operation.overscan))
+            set_ctrl_value(self.text_overscan, str(self.operation.overscan))
         if self.operation.raster_direction is not None:
             self.combo_raster_direction.SetSelection(self.operation.raster_direction)
         if self.operation.raster_swing is not None:
@@ -1089,8 +1089,8 @@ class HatchSettingsPanel(wx.Panel):
         if i == len(self.fills):
             i = 0
         self.combo_fill_style.SetSelection(i)
-        self.text_angle.SetValue(self.operation.hatch_angle)
-        self.text_distance.SetValue(str(self.operation.hatch_distance))
+        set_ctrl_value(self.text_angle, self.operation.hatch_angle)
+        set_ctrl_value(self.text_distance, str(self.operation.hatch_distance))
         try:
             h_angle = float(Angle.parse(self.operation.hatch_angle).as_degrees)
             self.slider_angle.SetValue(int(h_angle))
@@ -1309,7 +1309,7 @@ class DwellSettingsPanel(wx.Panel):
 
     def set_widgets(self, node):
         self.operation = node
-        self.text_dwelltime.SetValue(str(self.operation.dwell_time))
+        set_ctrl_value(self.text_dwelltime, str(self.operation.dwell_time))
 
     def on_text_dwelltime(
         self, event=None

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -100,8 +100,12 @@ class LayerSettingPanel(wx.Panel):
         self.button_layer_color.SetBackgroundColour(wx.Colour(0, 0, 0))
         self.button_layer_color.SetToolTip(COLOR_TOOLTIP)
         layer_sizer.Add(self.button_layer_color, 0, wx.EXPAND, 0)
-        h_classify_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Classification")), wx.HORIZONTAL)
-        h_property_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Properties")), wx.HORIZONTAL)
+        h_classify_sizer = wx.StaticBoxSizer(
+            wx.StaticBox(self, wx.ID_ANY, _("Classification")), wx.HORIZONTAL
+        )
+        h_property_sizer = wx.StaticBoxSizer(
+            wx.StaticBox(self, wx.ID_ANY, _("Properties")), wx.HORIZONTAL
+        )
 
         try:
             self.has_stroke = self.operation.has_color_attribute("stroke")
@@ -127,8 +131,9 @@ class LayerSettingPanel(wx.Panel):
             self.has_stop = self.operation.has_color_attribute("stopop")
             self.checkbox_stop = wx.CheckBox(self, wx.ID_ANY, _("Stop"))
             self.checkbox_stop.SetToolTip(
-                _("If active, then this op will prevent further classification") + "\n" +
-                _("from other ops if it could classify an element by itself.")
+                _("If active, then this op will prevent further classification")
+                + "\n"
+                + _("from other ops if it could classify an element by itself.")
             )
             self.checkbox_stop.SetValue(1 if self.has_stop else 0)
             h_classify_sizer.Add(self.checkbox_stop, 1, 0, 0)
@@ -136,7 +141,11 @@ class LayerSettingPanel(wx.Panel):
         except AttributeError:
             self.has_stop = None
 
-        if self.has_fill is not None or self.has_stroke is not None or self.has_stop is not None:
+        if (
+            self.has_fill is not None
+            or self.has_stroke is not None
+            or self.has_stop is not None
+        ):
             layer_sizer.Add(h_classify_sizer, 1, wx.EXPAND, 0)
 
         # self.combo_type = wx.ComboBox(
@@ -208,12 +217,16 @@ class LayerSettingPanel(wx.Panel):
             self.checkbox_default.SetValue(self.operation.default)
         try:
             if self.has_fill:
-                self.checkbox_fill.SetValue(1 if self.operation.has_color_attribute("fill") else 0)
+                self.checkbox_fill.SetValue(
+                    1 if self.operation.has_color_attribute("fill") else 0
+                )
         except AttributeError:
             pass
         try:
             if self.has_stroke:
-                self.checkbox_stroke.SetValue(1 if self.operation.has_color_attribute("stroke") else 0)
+                self.checkbox_stroke.SetValue(
+                    1 if self.operation.has_color_attribute("stroke") else 0
+                )
         except AttributeError:
             pass
         try:
@@ -237,7 +250,9 @@ class LayerSettingPanel(wx.Panel):
             self.button_layer_color.SetBackgroundColour(
                 wx.Colour(swizzlecolor(self.operation.color))
             )
-        self.context.elements.signal("element_property_reload", self.operation, "button_layer")
+        self.context.elements.signal(
+            "element_property_reload", self.operation, "button_layer"
+        )
 
     # def on_combo_operation(
     #     self, event=None
@@ -261,19 +276,25 @@ class LayerSettingPanel(wx.Panel):
     def on_check_output(self, event=None):  # wxGlade: OperationProperty.<event_handler>
         if self.operation.output != bool(self.checkbox_output.GetValue()):
             self.operation.output = bool(self.checkbox_output.GetValue())
-            self.context.elements.signal("element_property_reload", self.operation, "check_output")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "check_output"
+            )
 
     def on_check_default(self, event=None):
         if self.operation.default != bool(self.checkbox_default.GetValue()):
             self.operation.default = bool(self.checkbox_default.GetValue())
-            self.context.elements.signal("element_property_reload", self.operation, "check_default")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "check_default"
+            )
 
     def on_check_fill(self, event=None):
         if self.checkbox_fill.GetValue():
             self.operation.add_color_attribute("fill")
         else:
             self.operation.remove_color_attribute("fill")
-        self.context.elements.signal("element_property_reload", self.operation, "check_fill")
+        self.context.elements.signal(
+            "element_property_reload", self.operation, "check_fill"
+        )
         event.Skip()
 
     def on_check_stroke(self, event=None):
@@ -281,7 +302,9 @@ class LayerSettingPanel(wx.Panel):
             self.operation.add_color_attribute("stroke")
         else:
             self.operation.remove_color_attribute("stroke")
-        self.context.elements.signal("element_property_reload", self.operation, "check_stroke")
+        self.context.elements.signal(
+            "element_property_reload", self.operation, "check_stroke"
+        )
         event.Skip()
 
     def on_check_stop(self, event=None):
@@ -289,8 +312,11 @@ class LayerSettingPanel(wx.Panel):
             self.operation.stopop = True
         else:
             self.operation.stopop = False
-        self.context.elements.signal("element_property_reload", self.operation, "check_stopop")
+        self.context.elements.signal(
+            "element_property_reload", self.operation, "check_stopop"
+        )
         event.Skip()
+
 
 # end of class LayerSettingPanel
 
@@ -310,7 +336,14 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(speed_sizer, 1, wx.EXPAND, 0)
 
-        self.text_speed = TextCtrl(self, wx.ID_ANY, "20.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_speed = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "20.0",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_speed.SetToolTip(OPERATION_SPEED_TOOLTIP)
         speed_sizer.Add(self.text_speed, 1, wx.EXPAND, 0)
 
@@ -319,7 +352,14 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(power_sizer, 1, wx.EXPAND, 0)
 
-        self.text_power = TextCtrl(self, wx.ID_ANY, "1000.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_power = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1000.0",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_power.SetToolTip(OPERATION_POWER_TOOLTIP)
         power_sizer.Add(self.text_power, 1, wx.EXPAND, 0)
 
@@ -328,7 +368,14 @@ class SpeedPpiPanel(wx.Panel):
         )
         speed_power_sizer.Add(frequency_sizer, 1, wx.EXPAND, 0)
 
-        self.text_frequency = TextCtrl(self, wx.ID_ANY, "20.0", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_frequency = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "20.0",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         # self.text_frequency.SetToolTip(OPERATION_SPEED_TOOLTIP)
         frequency_sizer.Add(self.text_frequency, 1, wx.EXPAND, 0)
 
@@ -367,7 +414,9 @@ class SpeedPpiPanel(wx.Panel):
             value = float(self.text_speed.GetValue())
             if self.operation.speed != value:
                 self.operation.speed = value
-                self.context.elements.signal("element_property_reload", self.operation, "text_speed")
+                self.context.elements.signal(
+                    "element_property_reload", self.operation, "text_speed"
+                )
         except ValueError:
             pass
         event.Skip()
@@ -379,7 +428,9 @@ class SpeedPpiPanel(wx.Panel):
             value = float(self.text_frequency.GetValue())
             if self.operation.frequency != value:
                 self.operation.frequency = value
-                self.context.elements.signal("element_property_reload", self.operation, "text_frquency")
+                self.context.elements.signal(
+                    "element_property_reload", self.operation, "text_frquency"
+                )
         except ValueError:
             pass
         event.Skip()
@@ -397,7 +448,9 @@ class SpeedPpiPanel(wx.Panel):
             if self.operation.power != value:
                 self.operation.power = value
                 self.update_power_label()
-                self.context.elements.signal("element_property_reload", self.operation, "text_power")
+                self.context.elements.signal(
+                    "element_property_reload", self.operation, "text_power"
+                )
         except ValueError:
             return
         event.Skip()
@@ -422,7 +475,9 @@ class PassesPanel(wx.Panel):
         self.check_passes.SetToolTip(_("Enable Operation Passes"))
         sizer_passes.Add(self.check_passes, 0, wx.EXPAND, 0)
 
-        self.text_passes = TextCtrl(self, wx.ID_ANY, "1", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_passes = TextCtrl(
+            self, wx.ID_ANY, "1", limited=True, check="float", style=wx.TE_PROCESS_ENTER
+        )
         self.text_passes.SetToolTip(OPERATION_PASSES_TOOLTIP)
         sizer_passes.Add(self.text_passes, 1, wx.EXPAND, 0)
 
@@ -455,7 +510,9 @@ class PassesPanel(wx.Panel):
         on = self.check_passes.GetValue()
         self.text_passes.Enable(on)
         self.operation.passes_custom = bool(on)
-        self.context.elements.signal("element_property_reload", self.operation, "check_passes")
+        self.context.elements.signal(
+            "element_property_reload", self.operation, "check_passes"
+        )
         event.Skip()
 
     def on_text_passes(self, event=None):  # wxGlade: OperationProperty.<event_handler>
@@ -463,12 +520,16 @@ class PassesPanel(wx.Panel):
             value = int(self.text_passes.GetValue())
             if self.operation.passes != value:
                 self.operation.passes = value
-                self.context.elements.signal("element_property_reload", self.operation, "text_Passes")
+                self.context.elements.signal(
+                    "element_property_reload", self.operation, "text_Passes"
+                )
         except ValueError:
             pass
         event.Skip()
 
+
 # end of class PassesPanel
+
 
 class InfoPanel(wx.Panel):
     def __init__(self, *args, context=None, node=None, **kwds):
@@ -495,7 +556,9 @@ class InfoPanel(wx.Panel):
         self.text_time = wx.TextCtrl(self, wx.ID_ANY, "---", style=wx.TE_READONLY)
         self.text_time.SetMinSize((55, -1))
         self.text_time.SetMaxSize((100, -1))
-        self.text_children.SetToolTip(_("How many elements does this operation contain"))
+        self.text_children.SetToolTip(
+            _("How many elements does this operation contain")
+        )
         self.text_time.SetToolTip(_("Estimated time for execution (hh:mm:ss)"))
 
         sizer_children.Add(self.text_children, 1, wx.EXPAND, 0)
@@ -532,6 +595,7 @@ class InfoPanel(wx.Panel):
 
 
 # end of class InfoPanel
+
 
 class PanelStartPreference(wx.Panel):
     def __init__(self, *args, context=None, node=None, **kwds):
@@ -825,24 +889,33 @@ class PanelStartPreference(wx.Panel):
     def on_slider_top(self, event=None):  # wxGlade: OperationProperty.<event_handler>
         if self.operation.raster_preference_top != self.slider_top.GetValue() - 1:
             self.operation.raster_preference_top = self.slider_top.GetValue() - 1
-            self.context.elements.signal("element_property_reload", self.operation, "slider_top")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "slider_top"
+            )
 
     def on_slider_left(self, event=None):  # wxGlade: OperationProperty.<event_handler>
         if self.operation.raster_preference_left != self.slider_left.GetValue() - 1:
             self.operation.raster_preference_left = self.slider_left.GetValue() - 1
-            self.context.elements.signal("element_property_reload", self.operation, "slider_left")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "slider_left"
+            )
 
     def on_slider_right(self, event=None):  # wxGlade: OperationProperty.<event_handler>
         if self.operation.raster_preference_right != self.slider_right.GetValue() - 1:
             self.operation.raster_preference_right = self.slider_right.GetValue() - 1
-            self.context.elements.signal("element_property_reload", self.operation, "slider_right")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "slider_right"
+            )
 
     def on_slider_bottom(
         self, event=None
     ):  # wxGlade: OperationProperty.<event_handler>
         if self.operation.raster_preference_bottom != self.slider_bottom.GetValue() - 1:
             self.operation.raster_preference_bottom = self.slider_bottom.GetValue() - 1
-            self.context.elements.signal("element_property_reload", self.operation, "slider_bottom")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "slider_bottom"
+            )
+
 
 # end of class PanelStartPreference
 
@@ -864,7 +937,14 @@ class RasterSettingsPanel(wx.Panel):
         )
         param_sizer.Add(sizer_3, 1, wx.EXPAND, 0)
 
-        self.text_dpi = TextCtrl(self, wx.ID_ANY, "500", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_dpi = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "500",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_dpi.SetToolTip(OPERATION_DPI_TOOLTIP)
         sizer_3.Add(self.text_dpi, 1, wx.EXPAND, 0)
 
@@ -875,7 +955,14 @@ class RasterSettingsPanel(wx.Panel):
 
         raster_sizer.Add(param_sizer, 0, wx.EXPAND, 0)
 
-        self.text_overscan = TextCtrl(self, wx.ID_ANY, "1mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_overscan = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_overscan.SetToolTip(_("Overscan amount"))
         sizer_6.Add(self.text_overscan, 1, wx.EXPAND, 0)
 
@@ -960,7 +1047,9 @@ class RasterSettingsPanel(wx.Panel):
             value = int(self.text_dpi.GetValue())
             if self.operation.dpi != value:
                 self.operation.dpi = value
-                self.context.signal("element_property_reload", self.operation, "text_dpi")
+                self.context.signal(
+                    "element_property_reload", self.operation, "text_dpi"
+                )
         except ValueError:
             pass
         event.Skip()
@@ -969,7 +1058,9 @@ class RasterSettingsPanel(wx.Panel):
         start_text = self.text_overscan.GetValue()
         ctrl = self.text_overscan
         try:
-            v = Length(ctrl.GetValue(), unitless=UNITS_PER_MM, preferred_units="mm", digits=4)
+            v = Length(
+                ctrl.GetValue(), unitless=UNITS_PER_MM, preferred_units="mm", digits=4
+            )
         except ValueError:
             return
         # print ("Start overscan=%s - target=%s" % (start_text, str(v.preferred_length)))
@@ -978,20 +1069,29 @@ class RasterSettingsPanel(wx.Panel):
             value = 0
         if self.operation.overscan != value:
             self.operation.overscan = value
-            self.context.elements.signal("element_property_reload", self.operation, "text_overscan")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "text_overscan"
+            )
         event.Skip()
 
     def on_combo_raster_direction(self, event=None):
-        if self.operation.raster_direction != self.combo_raster_direction.GetSelection():
+        if (
+            self.operation.raster_direction
+            != self.combo_raster_direction.GetSelection()
+        ):
             self.operation.raster_direction = self.combo_raster_direction.GetSelection()
             self.context.raster_direction = self.operation.raster_direction
-            self.context.elements.signal("element_property_reload", self.operation, "combo_raster")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "combo_raster"
+            )
         event.Skip()
 
     def on_radio_directional(self, event=None):
         if self.operation.raster_swing != self.radio_directional_raster.GetSelection():
             self.operation.raster_swing = self.radio_directional_raster.GetSelection()
-            self.context.elements.signal("element_property_reload", self.operation, "radio_direct")
+            self.context.elements.signal(
+                "element_property_reload", self.operation, "radio_direct"
+            )
         event.Skip()
 
 
@@ -1015,7 +1115,14 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_distance, 0, wx.EXPAND, 0)
 
-        self.text_distance = TextCtrl(self, wx.ID_ANY, "1mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_distance = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         sizer_distance.Add(self.text_distance, 1, wx.EXPAND, 0)
 
         sizer_angle = wx.StaticBoxSizer(
@@ -1023,7 +1130,14 @@ class HatchSettingsPanel(wx.Panel):
         )
         raster_sizer.Add(sizer_angle, 1, wx.EXPAND, 0)
 
-        self.text_angle = TextCtrl(self, wx.ID_ANY, "0deg", limited=True, check="angle", style=wx.TE_PROCESS_ENTER)
+        self.text_angle = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "0deg",
+            limited=True,
+            check="angle",
+            style=wx.TE_PROCESS_ENTER,
+        )
         sizer_angle.Add(self.text_angle, 1, wx.EXPAND, 0)
 
         self.slider_angle = wx.Slider(self, wx.ID_ANY, 0, 0, 360)
@@ -1289,7 +1403,14 @@ class DwellSettingsPanel(wx.Panel):
             wx.StaticBox(self, wx.ID_ANY, _("Dwell Time: (ms)")), wx.HORIZONTAL
         )
 
-        self.text_dwelltime = TextCtrl(self, wx.ID_ANY, "1.0", limited=True, style=wx.TE_PROCESS_ENTER, check="float")
+        self.text_dwelltime = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1.0",
+            limited=True,
+            style=wx.TE_PROCESS_ENTER,
+            check="float",
+        )
         self.text_dwelltime.SetToolTip(
             _("Dwell time (ms) at each location in the sequence")
         )
@@ -1320,10 +1441,13 @@ class DwellSettingsPanel(wx.Panel):
             value = float(self.text_dwelltime.GetValue())
             if self.operation.dwell_time != value:
                 self.operation.dwell_time = value
-                self.context.elements.signal("element_property_reload", self.operation, "text_dwell")
+                self.context.elements.signal(
+                    "element_property_reload", self.operation, "text_dwell"
+                )
         except ValueError:
             pass
         event.Skip()
+
 
 # end of class PassesPanel
 
@@ -1434,5 +1558,6 @@ class ParameterPanel(ScrolledPanel):
         self.hatch_panel.pane_show()
         self.dwell_panel.pane_show()
         self.info_panel.pane_show()
+
 
 # end of class ParameterPanel

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -17,8 +17,8 @@ class PathPropertyPanel(ScrolledPanel):
 
         self.node = node
 
-        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.button_stroke_none = wx.Button(self, wx.ID_ANY, _("None"))
         self.button_stroke_none.name = "stroke none"
         self.button_stroke_F00 = wx.Button(self, wx.ID_ANY, "")
@@ -58,10 +58,10 @@ class PathPropertyPanel(ScrolledPanel):
         self.__set_properties()
         self.__do_layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT, self.on_text_label_change, self.text_label)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change, self.text_label)
+        self.text_id.Bind(wx.EVT_KILL_FOCUS, self.on_text_id_change)
+        self.text_id.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change)
+        self.text_label.Bind(wx.EVT_KILL_FOCUS, self.on_text_label_change)
+        self.text_label.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_none)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_F00)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_0F0)

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -62,8 +62,8 @@ class TextPropertyPanel(ScrolledPanel):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         super().__init__(parent, *args, **kwds)
         self.context = context
-        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_id = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_label = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
 
         self.text_text = wx.TextCtrl(self, wx.ID_ANY, "")
         self.node = node
@@ -148,12 +148,13 @@ class TextPropertyPanel(ScrolledPanel):
         self.__set_properties()
         self.__do_layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change, self.text_id)
-        self.Bind(wx.EVT_TEXT, self.on_text_label_change, self.text_label)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change, self.text_label)
+        self.text_id.Bind(wx.EVT_KILL_FOCUS, self.on_text_id_change)
+        self.text_id.Bind(wx.EVT_TEXT_ENTER, self.on_text_id_change)
+        self.text_label.Bind(wx.EVT_KILL_FOCUS, self.on_text_label_change)
+        self.text_label.Bind(wx.EVT_TEXT_ENTER, self.on_text_label_change)
+
         self.Bind(wx.EVT_TEXT, self.on_text_name_change, self.text_text)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_name_change, self.text_text)
+
         self.Bind(wx.EVT_BUTTON, self.on_button_choose_font, self.button_choose_font)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_none)
         self.Bind(wx.EVT_BUTTON, self.on_button_color, self.button_stroke_F00)
@@ -174,7 +175,7 @@ class TextPropertyPanel(ScrolledPanel):
 
         self.Bind(wx.EVT_COMBOBOX, self.on_font_choice, self.combo_font)
         self.Bind(wx.EVT_TEXT_ENTER, self.on_font_choice, self.combo_font)
-        self.Bind(wx.EVT_KILL_FOCUS, self.on_font_choice, self.combo_font)
+        self.combo_font.Bind(wx.EVT_KILL_FOCUS, self.on_font_choice)
 
         self.Bind(wx.EVT_BUTTON, self.on_button_larger, self.button_attrib_larger)
         self.Bind(wx.EVT_BUTTON, self.on_button_smaller, self.button_attrib_smaller)

--- a/meerk40t/gui/wizardpanel.py
+++ b/meerk40t/gui/wizardpanel.py
@@ -96,8 +96,12 @@ class WizardPanel(wx.Panel):
 
                     return text
 
-                control.Bind(wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type))
-                control.Bind(wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type))
+                control.Bind(
+                    wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type)
+                )
+                control.Bind(
+                    wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type)
+                )
                 sizer_main.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type == Color:
                 control_sizer = wx.StaticBoxSizer(
@@ -150,9 +154,7 @@ class TreeSelectionPanel(wx.Panel):
         kwds["style"] = kwds.get("style", 0)
         wx.Panel.__init__(self, *args, **kwds)
 
-        main_sizer = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, ""), wx.VERTICAL
-        )
+        main_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, ""), wx.VERTICAL)
 
         self.selected_tree = wx.TreeCtrl(self, wx.ID_ANY)
         main_sizer.Add(self.controller_tree, 7, wx.EXPAND, 0)

--- a/meerk40t/gui/wizardpanel.py
+++ b/meerk40t/gui/wizardpanel.py
@@ -81,22 +81,23 @@ class WizardPanel(wx.Panel):
                 control_sizer = wx.StaticBoxSizer(
                     wx.StaticBox(self, wx.ID_ANY, label), wx.HORIZONTAL
                 )
-                control = wx.TextCtrl(self, -1)
+                control = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
                 control.SetValue(str(data))
                 control_sizer.Add(control)
 
-                def on_textbox_text(param, ctrl, obj):
+                def on_textbox_text(param, ctrl, obj, dtype):
                     def text(event=None):
                         v = ctrl.GetValue()
                         try:
-                            setattr(obj, param, data_type(v))
+                            setattr(obj, param, dtype(v))
                         except ValueError:
                             # cannot cast to data_type, pass
                             pass
 
                     return text
 
-                control.Bind(wx.EVT_TEXT, on_textbox_text(attr, control, obj))
+                control.Bind(wx.EVT_KILL_FOCUS, on_textbox_text(attr, control, obj, data_type))
+                control.Bind(wx.EVT_TEXT_ENTER, on_textbox_text(attr, control, obj, data_type))
                 sizer_main.Add(control_sizer, 0, wx.EXPAND, 0)
             elif data_type == Color:
                 control_sizer = wx.StaticBoxSizer(
@@ -150,7 +151,7 @@ class TreeSelectionPanel(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
 
         main_sizer = wx.StaticBoxSizer(
-            wx.StaticBox(self, wx.ID_ANY, selection_text), wx.VERTICAL
+            wx.StaticBox(self, wx.ID_ANY, ""), wx.VERTICAL
         )
 
         self.selected_tree = wx.TreeCtrl(self, wx.ID_ANY)

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -6,6 +6,8 @@ from typing import List
 
 import wx
 
+from meerk40t.core.units import Angle, Length
+
 _ = wx.GetTranslation
 
 
@@ -323,11 +325,41 @@ def create_menu(gui, node, elements):
 class TextCtrl(wx.TextCtrl):
 # Just to add someof the more common things we need, i.e. smaller default size...
 #
-    def __init__(self, parent, id=wx.ID_ANY, value="", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0, validator=wx.DefaultValidator, name="", limited=False):
+    def __init__(self, parent, id=wx.ID_ANY, value="", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0, validator=wx.DefaultValidator, name="", check="", limited=False):
         super().__init__(parent, id=id, value=value, pos=pos, size=size, style=style, validator=validator, name=name)
         self.SetMinSize(wx.Size(35, -1))
         if limited:
             self.SetMaxSize(wx.Size(100, -1))
+        self._check = check
+        if self._check is not None and self._check != "":
+            self.Bind(wx.EVT_TEXT, self.on_check)
+
+    def on_check(self, event):
+        event.Skip()
+        try:
+            txt = self.GetValue()
+            if self._check == "float":
+                __ = float(txt)
+            elif self._check == "percent":
+                if txt.endswith("%"):
+                    __ = float(txt[:-1]) / 100.0
+                else:
+                    __ = float(txt)
+            elif self._check == "int":
+                __ = int(txt)
+            elif self._check == "empty":
+                if len(txt) == 0:
+                    raise ValueError
+            elif self._check == "length":
+                __ = Length(txt)
+            elif self._check == "angle":
+                __ = Angle(txt)
+
+            self.SetBackgroundColour(None)
+            self.Refresh()
+        except ValueError:
+            self.SetBackgroundColour(wx.RED)
+            self.Refresh()
 
 WX_METAKEYS = [
     wx.WXK_START,

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -205,9 +205,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
                 else:
                     kind = wx.ITEM_NORMAL
                     check = None
-                item = menu_context.Append(
-                    wx.ID_ANY, func.real_name, func.help, kind
-                )
+                item = menu_context.Append(wx.ID_ANY, func.real_name, func.help, kind)
                 if check is not None:
                     item.Check(check)
                 if func.enabled:
@@ -270,9 +268,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
             else:
                 kind = wx.ITEM_NORMAL
                 check = None
-            item = menu_context.Append(
-                wx.ID_ANY, func.real_name, func.help, kind
-            )
+            item = menu_context.Append(wx.ID_ANY, func.real_name, func.help, kind)
             if check is not None:
                 item.Check(check)
             if func.enabled:
@@ -322,11 +318,33 @@ def create_menu(gui, node, elements):
         gui.PopupMenu(menu)
         menu.Destroy()
 
+
 class TextCtrl(wx.TextCtrl):
-# Just to add someof the more common things we need, i.e. smaller default size...
-#
-    def __init__(self, parent, id=wx.ID_ANY, value="", pos=wx.DefaultPosition, size=wx.DefaultSize, style=0, validator=wx.DefaultValidator, name="", check="", limited=False):
-        super().__init__(parent, id=id, value=value, pos=pos, size=size, style=style, validator=validator, name=name)
+    # Just to add someof the more common things we need, i.e. smaller default size...
+    #
+    def __init__(
+        self,
+        parent,
+        id=wx.ID_ANY,
+        value="",
+        pos=wx.DefaultPosition,
+        size=wx.DefaultSize,
+        style=0,
+        validator=wx.DefaultValidator,
+        name="",
+        check="",
+        limited=False,
+    ):
+        super().__init__(
+            parent,
+            id=id,
+            value=value,
+            pos=pos,
+            size=size,
+            style=style,
+            validator=validator,
+            name=name,
+        )
         self.SetMinSize(wx.Size(35, -1))
         if limited:
             self.SetMaxSize(wx.Size(100, -1))
@@ -360,6 +378,7 @@ class TextCtrl(wx.TextCtrl):
         except ValueError:
             self.SetBackgroundColour(wx.RED)
             self.Refresh()
+
 
 WX_METAKEYS = [
     wx.WXK_START,
@@ -507,6 +526,7 @@ def disable_window(window):
             m.Disable()
         if hasattr(m, "Children"):
             disable_window(m)
+
 
 def set_ctrl_value(ctrl, value):
     # Lets try to save the caret position

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -475,3 +475,10 @@ def disable_window(window):
             m.Disable()
         if hasattr(m, "Children"):
             disable_window(m)
+
+def set_ctrl_value(ctrl, value):
+    # Lets try to save the caret position
+    cursor = ctrl.GetLastPosition()
+    if ctrl.GetValue() != value:
+        ctrl.SetValue(value)
+        ctrl.SetInsertionPoint(min(len(value), cursor))

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -7,6 +7,7 @@ from meerk40t.gui.icons import icons8_administrative_tools_50
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.kernel import signal_listener
 from meerk40t.gui.wxutils import TextCtrl
+
 _ = wx.GetTranslation
 
 FIX_SPEEDS_RATIO = 0.9195
@@ -37,9 +38,7 @@ class ConfigurationUsb(wx.Panel):
         )
         sizer_criteria.Add(sizer_chip_version, 0, wx.EXPAND, 0)
 
-        self.text_device_version = TextCtrl(
-            self, wx.ID_ANY, "", style=wx.TE_READONLY
-        )
+        self.text_device_version = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         sizer_chip_version.Add(self.text_device_version, 1, wx.EXPAND, 0)
 
         self.spin_device_version = wx.SpinCtrl(self, wx.ID_ANY, "-1", min=-1, max=25)
@@ -79,7 +78,9 @@ class ConfigurationUsb(wx.Panel):
         )
         sizer_serial.Add(self.check_serial_number, 0, wx.EXPAND, 0)
 
-        self.text_serial_number = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_serial_number = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
+        )
         self.text_serial_number.SetMinSize((50, -1))
         self.text_serial_number.SetToolTip(
             _(
@@ -104,7 +105,9 @@ class ConfigurationUsb(wx.Panel):
         self.checkbox_limit_buffer.SetValue(1)
         sizer_buffer.Add(self.checkbox_limit_buffer, 0, 0, 0)
 
-        self.text_buffer_length = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True)
+        self.text_buffer_length = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_READONLY, limited=True
+        )
         self.text_buffer_length.SetToolTip(
             _("Current number of bytes in the write buffer.")
         )
@@ -240,7 +243,9 @@ class ConfigurationTcp(wx.Panel):
         )
         sizer_13.Add(sizer_port, 1, wx.EXPAND, 0)
 
-        self.text_port = TextCtrl(self, wx.ID_ANY, "", limited=True, check="int", style=wx.TE_PROCESS_ENTER)
+        self.text_port = TextCtrl(
+            self, wx.ID_ANY, "", limited=True, check="int", style=wx.TE_PROCESS_ENTER
+        )
         self.text_port.SetToolTip(_("Port for tcp connection on the server computer"))
         sizer_port.Add(self.text_port, 1, wx.EXPAND, 0)
 
@@ -295,7 +300,14 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_home.Add(h_sizer_x, 1, wx.EXPAND, 0)
 
-        self.text_home_x = TextCtrl(self, wx.ID_ANY, "0mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_home_x = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "0mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_home_x.SetToolTip(_("Translate Home X"))
         h_sizer_x.Add(self.text_home_x, 1, wx.EXPAND, 0)
 
@@ -304,7 +316,14 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_home.Add(h_sizer_y, 1, wx.EXPAND, 0)
 
-        self.text_home_y = TextCtrl(self, wx.ID_ANY, "0mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_home_y = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "0mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_home_y.SetToolTip(_("Translate Home Y"))
         h_sizer_y.Add(self.text_home_y, 1, wx.EXPAND, 0)
 
@@ -313,7 +332,6 @@ class ConfigurationLaserPanel(wx.Panel):
             _("Set Home Position based on the current position")
         )
         sizer_home.Add(self.button_home_by_current, 1, wx.EXPAND, 0)
-
 
         sizer_bed = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, _("Bed Dimensions")), wx.HORIZONTAL
@@ -325,7 +343,14 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_bed.Add(h_sizer_wd, 1, wx.EXPAND, 0)
 
-        self.text_bedwidth = TextCtrl(self, wx.ID_ANY, "310mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_bedwidth = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "310mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_bedwidth.SetToolTip(_("Width of the laser bed."))
         h_sizer_wd.Add(self.text_bedwidth, 1, wx.EXPAND, 0)
 
@@ -337,7 +362,14 @@ class ConfigurationLaserPanel(wx.Panel):
         label_3 = wx.StaticText(self, wx.ID_ANY, "")
         h_sizer_ht.Add(label_3, 0, wx.EXPAND, 0)
 
-        self.text_bedheight = TextCtrl(self, wx.ID_ANY, "210mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_bedheight = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "210mm",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_bedheight.SetToolTip(_("Height of the laser bed."))
         h_sizer_ht.Add(self.text_bedheight, 1, wx.EXPAND, 0)
 
@@ -351,7 +383,14 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_scale_factors.Add(h_sizer_x_2, 1, wx.EXPAND, 0)
 
-        self.text_scale_x = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_scale_x = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1.000",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_scale_x.SetToolTip(
             _("Scale factor for the X-axis. Board units to actual physical units.")
         )
@@ -362,7 +401,14 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_scale_factors.Add(h_sizer_y_2, 1, wx.EXPAND, 0)
 
-        self.text_scale_y = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_scale_y = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1.000",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_scale_y.SetToolTip(
             _("Scale factor for the Y-axis. Board units to actual physical units.")
         )
@@ -496,7 +542,9 @@ class ConfigurationInterfacePanel(ScrolledPanel):
         sizer_name = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, _("Device Name")), wx.HORIZONTAL
         )
-        self.text_device_label = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_device_label = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
+        )
         self.text_device_label.SetToolTip(
             _("The internal label to be used for this device")
         )
@@ -790,7 +838,9 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         h_sizer_y3.Add(h_sizer_y5, 0, wx.EXPAND, 0)
 
-        self.text_minimum_jog_distance = TextCtrl(self, wx.ID_ANY, "", limited=True, style=wx.TE_PROCESS_ENTER)
+        self.text_minimum_jog_distance = TextCtrl(
+            self, wx.ID_ANY, "", limited=True, style=wx.TE_PROCESS_ENTER
+        )
         h_sizer_y5.Add(self.text_minimum_jog_distance, 1, wx.EXPAND, 0)
 
         self.radio_box_jog_method = wx.RadioBox(
@@ -824,7 +874,9 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_rapid_override.Add(sizer_36, 0, wx.EXPAND, 0)
 
-        self.text_rapid_x = TextCtrl(self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_rapid_x = TextCtrl(
+            self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER
+        )
         sizer_36.Add(self.text_rapid_x, 1, wx.EXPAND, 0)
 
         label_2 = wx.StaticText(self, wx.ID_ANY, _("mm/s"))
@@ -835,7 +887,9 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_rapid_override.Add(sizer_35, 0, wx.EXPAND, 0)
 
-        self.text_rapid_y = TextCtrl(self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_rapid_y = TextCtrl(
+            self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER
+        )
         sizer_35.Add(self.text_rapid_y, 1, wx.EXPAND, 0)
 
         label_4 = wx.StaticText(self, wx.ID_ANY, _("mm/s"))
@@ -875,7 +929,14 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         h_sizer_y9.Add(self.check_scale_speed, 1, wx.EXPAND, 0)
 
-        self.text_speed_scale_amount = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_speed_scale_amount = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "1.000",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_speed_scale_amount.SetToolTip(
             _(
                 "Scales the machine's speed ratio so that rated speeds speeds multiplied by this ratio."
@@ -894,7 +955,14 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_30.Add(self.check_max_speed_vector, 1, wx.EXPAND, 0)
 
-        self.text_max_speed_vector = TextCtrl(self, wx.ID_ANY, "100", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_max_speed_vector = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "100",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_max_speed_vector.SetToolTip(
             _("maximum speed at which all greater speeds are limited")
         )
@@ -911,7 +979,14 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_31.Add(self.check_max_speed_raster, 1, wx.EXPAND, 0)
 
-        self.text_max_speed_raster = TextCtrl(self, wx.ID_ANY, "750", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_max_speed_raster = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "750",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_max_speed_raster.SetToolTip(
             _("maximum speed at which all greater speeds are limited")
         )
@@ -931,8 +1006,12 @@ class ConfigurationSetupPanel(ScrolledPanel):
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_rapid_between, self.check_rapid_moves_between
         )
-        self.text_minimum_jog_distance.Bind(wx.EVT_TEXT_ENTER, self.on_text_min_jog_distance)
-        self.text_minimum_jog_distance.Bind(wx.EVT_KILL_FOCUS, self.on_text_min_jog_distance)
+        self.text_minimum_jog_distance.Bind(
+            wx.EVT_TEXT_ENTER, self.on_text_min_jog_distance
+        )
+        self.text_minimum_jog_distance.Bind(
+            wx.EVT_KILL_FOCUS, self.on_text_min_jog_distance
+        )
         self.Bind(wx.EVT_RADIOBOX, self.on_jog_method_radio, self.radio_box_jog_method)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_override_rapid, self.check_override_rapid
@@ -948,13 +1027,21 @@ class ConfigurationSetupPanel(ScrolledPanel):
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_max_speed_vector, self.check_max_speed_vector
         )
-        self.text_max_speed_vector.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed_max_vector)
-        self.text_max_speed_vector.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed_max_vector)
+        self.text_max_speed_vector.Bind(
+            wx.EVT_TEXT_ENTER, self.on_text_speed_max_vector
+        )
+        self.text_max_speed_vector.Bind(
+            wx.EVT_KILL_FOCUS, self.on_text_speed_max_vector
+        )
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_max_speed_raster, self.check_max_speed_raster
         )
-        self.text_max_speed_raster.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed_max_raster)
-        self.text_max_speed_raster.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed_max_raster)
+        self.text_max_speed_raster.Bind(
+            wx.EVT_TEXT_ENTER, self.on_text_speed_max_raster
+        )
+        self.text_max_speed_raster.Bind(
+            wx.EVT_KILL_FOCUS, self.on_text_speed_max_raster
+        )
         # end wxGlade
 
         self.check_autolock.SetValue(self.context.autolock)
@@ -1003,33 +1090,23 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_check_autolock(self, event=None):
         self.context.autolock = self.check_autolock.GetValue()
 
-    def on_check_pulse_shift(
-        self, event=None
-    ):
+    def on_check_pulse_shift(self, event=None):
         self.context.plot_shift = self.check_plot_shift.GetValue()
         try:
             self.context.plot_planner.force_shift = self.context.plot_shift
         except (AttributeError, TypeError):
             pass
 
-    def on_check_alt_raster(
-        self, event
-    ):
+    def on_check_alt_raster(self, event):
         self.context.nse_raster = self.check_alternative_raster.GetValue()
 
-    def on_check_twitches(
-        self, event
-    ):
+    def on_check_twitches(self, event):
         self.context.twitches = self.check_twitches.GetValue()
 
-    def on_check_rapid_between(
-        self, event
-    ):
+    def on_check_rapid_between(self, event):
         self.context.opt_rapid_between = self.check_rapid_moves_between.GetValue()
 
-    def on_text_min_jog_distance(
-        self, event
-    ):
+    def on_text_min_jog_distance(self, event):
         try:
             self.context.opt_jog_minimum = int(
                 self.text_minimum_jog_distance.GetValue()
@@ -1037,28 +1114,20 @@ class ConfigurationSetupPanel(ScrolledPanel):
         except ValueError:
             pass
 
-    def on_jog_method_radio(
-        self, event
-    ):
+    def on_jog_method_radio(self, event):
         self.context.opt_jog_mode = self.radio_box_jog_method.GetSelection()
 
-    def on_check_override_rapid(
-        self, event
-    ):
+    def on_check_override_rapid(self, event):
         self.check_override_rapid.SetValue(self.context.rapid_override)
 
-    def on_text_rapid_x(
-        self, event
-    ):
+    def on_text_rapid_x(self, event):
         event.Skip()
         try:
             self.context.rapid_override_speed_x = float(self.text_rapid_x.GetValue())
         except ValueError:
             pass
 
-    def on_text_rapid_y(
-        self, event
-    ):
+    def on_text_rapid_y(self, event):
         event.Skip()
         try:
             self.context.rapid_override_speed_y = float(self.text_rapid_y.GetValue())

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -79,7 +79,7 @@ class ConfigurationUsb(wx.Panel):
         )
         sizer_serial.Add(self.check_serial_number, 0, wx.EXPAND, 0)
 
-        self.text_serial_number = TextCtrl(self, wx.ID_ANY, "")
+        self.text_serial_number = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_serial_number.SetMinSize((50, -1))
         self.text_serial_number.SetToolTip(
             _(
@@ -135,7 +135,8 @@ class ConfigurationUsb(wx.Panel):
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_serial_number, self.check_serial_number
         )
-        self.Bind(wx.EVT_TEXT, self.on_text_serial_number, self.text_serial_number)
+        self.text_serial_number.Bind(wx.EVT_TEXT_ENTER, self.on_text_serial_number)
+        self.text_serial_number.Bind(wx.EVT_KILL_FOCUS, self.on_text_serial_number)
         self.Bind(
             wx.EVT_CHECKBOX,
             self.on_check_limit_packet_buffer,
@@ -209,6 +210,7 @@ class ConfigurationUsb(wx.Panel):
         self.context.serial_enable = self.check_serial_number.GetValue()
 
     def on_text_serial_number(self, event):  # wxGlade: ConfigurationUsb.<event_handler>
+        event.Skip()
         self.context.serial = self.text_serial_number.GetValue()
 
 
@@ -228,7 +230,7 @@ class ConfigurationTcp(wx.Panel):
         )
         sizer_13.Add(h_sizer_y1, 3, wx.EXPAND, 0)
 
-        self.text_address = TextCtrl(self, wx.ID_ANY, "")
+        self.text_address = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_address.SetMinSize((75, -1))
         self.text_address.SetToolTip(_("IP/Host if the server computer"))
         h_sizer_y1.Add(self.text_address, 1, wx.EXPAND, 0)
@@ -238,7 +240,7 @@ class ConfigurationTcp(wx.Panel):
         )
         sizer_13.Add(sizer_port, 1, wx.EXPAND, 0)
 
-        self.text_port = TextCtrl(self, wx.ID_ANY, "", limited=True)
+        self.text_port = TextCtrl(self, wx.ID_ANY, "", limited=True, check="int", style=wx.TE_PROCESS_ENTER)
         self.text_port.SetToolTip(_("Port for tcp connection on the server computer"))
         sizer_port.Add(self.text_port, 1, wx.EXPAND, 0)
 
@@ -246,10 +248,10 @@ class ConfigurationTcp(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_address, self.text_address)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_address, self.text_address)
-        self.Bind(wx.EVT_TEXT, self.on_text_port, self.text_port)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_port, self.text_port)
+        self.text_address.Bind(wx.EVT_KILL_FOCUS, self.on_text_address)
+        self.text_address.Bind(wx.EVT_TEXT_ENTER, self.on_text_address)
+        self.text_port.Bind(wx.EVT_KILL_FOCUS, self.on_text_port)
+        self.text_port.Bind(wx.EVT_TEXT_ENTER, self.on_text_port)
         # end wxGlade
         self.text_port.SetValue(str(self.context.port))
         self.text_address.SetValue(self.context.address)
@@ -261,9 +263,11 @@ class ConfigurationTcp(wx.Panel):
         pass
 
     def on_text_address(self, event):  # wxGlade: ConfigurationTcp.<event_handler>
+        event.Skip()
         self.context.address = self.text_address.GetValue()
 
     def on_text_port(self, event):  # wxGlade: ConfigurationTcp.<event_handler>
+        event.Skip()
         try:
             self.context.port = int(self.text_port.GetValue())
         except ValueError:
@@ -291,7 +295,7 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_home.Add(h_sizer_x, 1, wx.EXPAND, 0)
 
-        self.text_home_x = TextCtrl(self, wx.ID_ANY, "0mm", limited=True)
+        self.text_home_x = TextCtrl(self, wx.ID_ANY, "0mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         self.text_home_x.SetToolTip(_("Translate Home X"))
         h_sizer_x.Add(self.text_home_x, 1, wx.EXPAND, 0)
 
@@ -300,7 +304,7 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_home.Add(h_sizer_y, 1, wx.EXPAND, 0)
 
-        self.text_home_y = TextCtrl(self, wx.ID_ANY, "0mm", limited=True)
+        self.text_home_y = TextCtrl(self, wx.ID_ANY, "0mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         self.text_home_y.SetToolTip(_("Translate Home Y"))
         h_sizer_y.Add(self.text_home_y, 1, wx.EXPAND, 0)
 
@@ -321,7 +325,7 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_bed.Add(h_sizer_wd, 1, wx.EXPAND, 0)
 
-        self.text_bedwidth = TextCtrl(self, wx.ID_ANY, "310mm", limited=True)
+        self.text_bedwidth = TextCtrl(self, wx.ID_ANY, "310mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         self.text_bedwidth.SetToolTip(_("Width of the laser bed."))
         h_sizer_wd.Add(self.text_bedwidth, 1, wx.EXPAND, 0)
 
@@ -333,7 +337,7 @@ class ConfigurationLaserPanel(wx.Panel):
         label_3 = wx.StaticText(self, wx.ID_ANY, "")
         h_sizer_ht.Add(label_3, 0, wx.EXPAND, 0)
 
-        self.text_bedheight = TextCtrl(self, wx.ID_ANY, "210mm", limited=True)
+        self.text_bedheight = TextCtrl(self, wx.ID_ANY, "210mm", limited=True, check="length", style=wx.TE_PROCESS_ENTER)
         self.text_bedheight.SetToolTip(_("Height of the laser bed."))
         h_sizer_ht.Add(self.text_bedheight, 1, wx.EXPAND, 0)
 
@@ -347,7 +351,7 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_scale_factors.Add(h_sizer_x_2, 1, wx.EXPAND, 0)
 
-        self.text_scale_x = TextCtrl(self, wx.ID_ANY, "1.000", limited=True)
+        self.text_scale_x = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_scale_x.SetToolTip(
             _("Scale factor for the X-axis. Board units to actual physical units.")
         )
@@ -358,7 +362,7 @@ class ConfigurationLaserPanel(wx.Panel):
         )
         sizer_scale_factors.Add(h_sizer_y_2, 1, wx.EXPAND, 0)
 
-        self.text_scale_y = TextCtrl(self, wx.ID_ANY, "1.000", limited=True)
+        self.text_scale_y = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_scale_y.SetToolTip(
             _("Scale factor for the Y-axis. Board units to actual physical units.")
         )
@@ -375,15 +379,21 @@ class ConfigurationLaserPanel(wx.Panel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_text_home_x, self.text_home_x)
-        self.Bind(wx.EVT_TEXT, self.on_text_home_y, self.text_home_y)
+        self.text_home_x.Bind(wx.EVT_TEXT_ENTER, self.on_text_home_x)
+        self.text_home_x.Bind(wx.EVT_KILL_FOCUS, self.on_text_home_x)
+        self.text_home_y.Bind(wx.EVT_TEXT_ENTER, self.on_text_home_y)
+        self.text_home_y.Bind(wx.EVT_KILL_FOCUS, self.on_text_home_y)
         self.Bind(
             wx.EVT_BUTTON, self.on_button_set_home_current, self.button_home_by_current
         )
-        self.Bind(wx.EVT_TEXT, self.on_text_bedwidth, self.text_bedwidth)
-        self.Bind(wx.EVT_TEXT, self.on_text_bedheight, self.text_bedheight)
-        self.Bind(wx.EVT_TEXT, self.on_text_x_scale, self.text_scale_x)
-        self.Bind(wx.EVT_TEXT, self.on_text_y_scale, self.text_scale_y)
+        self.text_bedwidth.Bind(wx.EVT_TEXT_ENTER, self.on_text_bedwidth)
+        self.text_bedwidth.Bind(wx.EVT_KILL_FOCUS, self.on_text_bedwidth)
+        self.text_bedheight.Bind(wx.EVT_TEXT_ENTER, self.on_text_bedheight)
+        self.text_bedheight.Bind(wx.EVT_KILL_FOCUS, self.on_text_bedheight)
+        self.text_scale_x.Bind(wx.EVT_TEXT_ENTER, self.on_text_x_scale)
+        self.text_scale_x.Bind(wx.EVT_KILL_FOCUS, self.on_text_x_scale)
+        self.text_scale_y.Bind(wx.EVT_TEXT_ENTER, self.on_text_y_scale)
+        self.text_scale_y.Bind(wx.EVT_KILL_FOCUS, self.on_text_y_scale)
 
     def pane_show(self):
         pass
@@ -392,28 +402,20 @@ class ConfigurationLaserPanel(wx.Panel):
         pass
 
     def on_text_home_x(self, event=None):
-        ctrl = self.text_home_x
+        event.Skip()
         try:
-            length = Length(ctrl.GetValue())
-            ctrl.SetBackgroundColour(None)
-            ctrl.Refresh()
+            length = Length(self.text_home_x.GetValue())
+            self.context.home_x = length.preferred_length
         except ValueError:
-            ctrl.SetBackgroundColour(wx.RED)
-            ctrl.Refresh()
             return
-        self.context.home_x = length.preferred_length
 
     def on_text_home_y(self, event=None):
-        ctrl = self.text_home_y
+        event.Skip()
         try:
-            length = Length(ctrl.GetValue())
-            ctrl.SetBackgroundColour(None)
-            ctrl.Refresh()
+            length = Length(self.text_home_y.GetValue())
+            self.context.home_y = length.preferred_length
         except ValueError:
-            ctrl.SetBackgroundColour(wx.RED)
-            ctrl.Refresh()
             return
-        self.context.home_y = length.preferred_length
 
     def on_button_set_home_current(self, event=None):
         current_x, current_y = self.context.device.current
@@ -423,14 +425,11 @@ class ConfigurationLaserPanel(wx.Panel):
         self.text_home_y.SetValue(self.context.home_y)
 
     def on_text_bedwidth(self, event=None):
+        event.Skip()
         ctrl = self.text_bedwidth
         try:
             bedwidth = Length(ctrl.GetValue())
-            ctrl.SetBackgroundColour(None)
-            ctrl.Refresh()
         except ValueError:
-            ctrl.SetBackgroundColour(wx.RED)
-            ctrl.Refresh()
             return
 
         self.context.device.width = bedwidth.preferred_length
@@ -442,14 +441,11 @@ class ConfigurationLaserPanel(wx.Panel):
         self.context("viewport_update\n")
 
     def on_text_bedheight(self, event=None):
+        event.Skip()
         ctrl = self.text_bedheight
         try:
             bedheight = Length(ctrl.GetValue())
-            ctrl.SetBackgroundColour(None)
-            ctrl.Refresh()
         except ValueError:
-            ctrl.SetBackgroundColour(wx.RED)
-            ctrl.Refresh()
             return
         self.context.device.height = bedheight.preferred_length
         self.context.device.bedheight = bedheight.preferred_length
@@ -460,36 +456,32 @@ class ConfigurationLaserPanel(wx.Panel):
         self.context("viewport_update\n")
 
     def on_text_x_scale(self, event=None):
+        event.Skip()
         try:
             self.context.device.user_scale_x = float(self.text_scale_x.GetValue())
             self.context.device.user_scale_y = float(self.text_scale_y.GetValue())
-            self.text_scale_x.SetBackgroundColour(None)
-            self.text_scale_x.Refresh()
             self.context.signal(
                 "scale_step", (self.context.device.scale_x, self.context.device.scale_y)
             )
             self.context.device.realize()
             self.context("viewport_update\n")
         except ValueError:
-            self.text_scale_x.SetBackgroundColour(wx.RED)
-            self.text_scale_x.Refresh()
+            pass
 
     def on_text_y_scale(self, event=None):
+        event.Skip()
         try:
             self.context.device.user_scale_x = float(self.text_scale_x.GetValue())
             self.context.device.user_scale_y = float(self.text_scale_y.GetValue())
             self.context.device.scale_x = self.context.device.user_scale_x
             self.context.device.scale_y = self.context.device.user_scale_y
-            self.text_scale_y.SetBackgroundColour(None)
-            self.text_scale_y.Refresh()
             self.context.signal(
                 "scale_step", (self.context.device.scale_x, self.context.device.scale_y)
             )
             self.context.device.realize()
             self.context("viewport_update\n")
         except ValueError:
-            self.text_scale_y.SetBackgroundColour(wx.RED)
-            self.text_scale_y.Refresh()
+            pass
 
 
 class ConfigurationInterfacePanel(ScrolledPanel):
@@ -504,7 +496,7 @@ class ConfigurationInterfacePanel(ScrolledPanel):
         sizer_name = wx.StaticBoxSizer(
             wx.StaticBox(self, wx.ID_ANY, _("Device Name")), wx.HORIZONTAL
         )
-        self.text_device_label = TextCtrl(self, wx.ID_ANY, "")
+        self.text_device_label = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_device_label.SetToolTip(
             _("The internal label to be used for this device")
         )
@@ -622,7 +614,8 @@ class ConfigurationInterfacePanel(ScrolledPanel):
 
         self.Layout()
 
-        self.Bind(wx.EVT_TEXT, self.on_device_label, self.text_device_label)
+        self.text_device_label.Bind(wx.EVT_TEXT_ENTER, self.on_device_label)
+        self.text_device_label.Bind(wx.EVT_KILL_FOCUS, self.on_device_label)
         self.Bind(wx.EVT_COMBOBOX, self.on_combobox_boardtype, self.combobox_board)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_flip_x, self.checkbox_flip_x)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_home_right, self.checkbox_home_right)
@@ -797,7 +790,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         h_sizer_y3.Add(h_sizer_y5, 0, wx.EXPAND, 0)
 
-        self.text_minimum_jog_distance = TextCtrl(self, wx.ID_ANY, "", limited=True)
+        self.text_minimum_jog_distance = TextCtrl(self, wx.ID_ANY, "", limited=True, style=wx.TE_PROCESS_ENTER)
         h_sizer_y5.Add(self.text_minimum_jog_distance, 1, wx.EXPAND, 0)
 
         self.radio_box_jog_method = wx.RadioBox(
@@ -831,7 +824,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_rapid_override.Add(sizer_36, 0, wx.EXPAND, 0)
 
-        self.text_rapid_x = TextCtrl(self, wx.ID_ANY, "", limited=True)
+        self.text_rapid_x = TextCtrl(self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         sizer_36.Add(self.text_rapid_x, 1, wx.EXPAND, 0)
 
         label_2 = wx.StaticText(self, wx.ID_ANY, _("mm/s"))
@@ -842,7 +835,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_rapid_override.Add(sizer_35, 0, wx.EXPAND, 0)
 
-        self.text_rapid_y = TextCtrl(self, wx.ID_ANY, "", limited=True)
+        self.text_rapid_y = TextCtrl(self, wx.ID_ANY, "", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         sizer_35.Add(self.text_rapid_y, 1, wx.EXPAND, 0)
 
         label_4 = wx.StaticText(self, wx.ID_ANY, _("mm/s"))
@@ -882,7 +875,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         h_sizer_y9.Add(self.check_scale_speed, 1, wx.EXPAND, 0)
 
-        self.text_speed_scale_amount = TextCtrl(self, wx.ID_ANY, "1.000", limited=True)
+        self.text_speed_scale_amount = TextCtrl(self, wx.ID_ANY, "1.000", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_speed_scale_amount.SetToolTip(
             _(
                 "Scales the machine's speed ratio so that rated speeds speeds multiplied by this ratio."
@@ -901,7 +894,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_30.Add(self.check_max_speed_vector, 1, wx.EXPAND, 0)
 
-        self.text_max_speed_vector = TextCtrl(self, wx.ID_ANY, "100", limited=True)
+        self.text_max_speed_vector = TextCtrl(self, wx.ID_ANY, "100", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_max_speed_vector.SetToolTip(
             _("maximum speed at which all greater speeds are limited")
         )
@@ -918,7 +911,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
         )
         sizer_31.Add(self.check_max_speed_raster, 1, wx.EXPAND, 0)
 
-        self.text_max_speed_raster = TextCtrl(self, wx.ID_ANY, "750", limited=True)
+        self.text_max_speed_raster = TextCtrl(self, wx.ID_ANY, "750", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_max_speed_raster.SetToolTip(
             _("maximum speed at which all greater speeds are limited")
         )
@@ -938,30 +931,30 @@ class ConfigurationSetupPanel(ScrolledPanel):
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_rapid_between, self.check_rapid_moves_between
         )
-        self.Bind(
-            wx.EVT_TEXT, self.on_text_min_jog_distance, self.text_minimum_jog_distance
-        )
+        self.text_minimum_jog_distance.Bind(wx.EVT_TEXT_ENTER, self.on_text_min_jog_distance)
+        self.text_minimum_jog_distance.Bind(wx.EVT_KILL_FOCUS, self.on_text_min_jog_distance)
         self.Bind(wx.EVT_RADIOBOX, self.on_jog_method_radio, self.radio_box_jog_method)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_override_rapid, self.check_override_rapid
         )
-        self.Bind(wx.EVT_TEXT, self.on_text_rapid_x, self.text_rapid_x)
-        self.Bind(wx.EVT_TEXT, self.on_text_rapid_y, self.text_rapid_y)
+        self.text_rapid_x.Bind(wx.EVT_TEXT_ENTER, self.on_text_rapid_x)
+        self.text_rapid_x.Bind(wx.EVT_KILL_FOCUS, self.on_text_rapid_x)
+        self.text_rapid_y.Bind(wx.EVT_TEXT_ENTER, self.on_text_rapid_y)
+        self.text_rapid_y.Bind(wx.EVT_KILL_FOCUS, self.on_text_rapid_y)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_fix_speeds, self.check_fix_speeds)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_scale_speed, self.check_scale_speed)
-        self.Bind(wx.EVT_TEXT, self.on_text_speed_scale, self.text_speed_scale_amount)
+        self.text_speed_scale_amount.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed_scale)
+        self.text_speed_scale_amount.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed_scale)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_max_speed_vector, self.check_max_speed_vector
         )
-        self.Bind(
-            wx.EVT_TEXT, self.on_text_speed_max_vector, self.text_max_speed_vector
-        )
+        self.text_max_speed_vector.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed_max_vector)
+        self.text_max_speed_vector.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed_max_vector)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_max_speed_raster, self.check_max_speed_raster
         )
-        self.Bind(
-            wx.EVT_TEXT, self.on_text_speed_max_raster, self.text_max_speed_raster
-        )
+        self.text_max_speed_raster.Bind(wx.EVT_TEXT_ENTER, self.on_text_speed_max_raster)
+        self.text_max_speed_raster.Bind(wx.EVT_KILL_FOCUS, self.on_text_speed_max_raster)
         # end wxGlade
 
         self.check_autolock.SetValue(self.context.autolock)
@@ -1057,6 +1050,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_text_rapid_x(
         self, event
     ):
+        event.Skip()
         try:
             self.context.rapid_override_speed_x = float(self.text_rapid_x.GetValue())
         except ValueError:
@@ -1065,6 +1059,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_text_rapid_y(
         self, event
     ):
+        event.Skip()
         try:
             self.context.rapid_override_speed_y = float(self.text_rapid_y.GetValue())
         except ValueError:
@@ -1078,6 +1073,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_text_speed_scale(
         self, event
     ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+        event.Skip()
         try:
             self.context.scale_speed = float(self.text_speed_scale_amount.GetValue())
         except ValueError:
@@ -1091,6 +1087,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_text_speed_max_vector(
         self, event
     ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+        event.Skip()
         try:
             self.context.max_speed_vector = float(self.text_max_speed_vector.GetValue())
         except ValueError:
@@ -1104,6 +1101,7 @@ class ConfigurationSetupPanel(ScrolledPanel):
     def on_text_speed_max_raster(
         self, event
     ):  # wxGlade: ConfigurationSetupPanel.<event_handler>
+        event.Skip()
         try:
             self.context.max_speed_raster = float(self.text_max_speed_raster.GetValue())
         except ValueError:

--- a/meerk40t/lihuiyu/gui/lhyoperationproperties.py
+++ b/meerk40t/lihuiyu/gui/lhyoperationproperties.py
@@ -59,7 +59,7 @@ class LhyAdvancedPanel(wx.Panel):
         )
         sizer_11.Add(self.check_dratio_custom, 1, 0, 0)
 
-        self.text_dratio = TextCtrl(self, wx.ID_ANY, "0.261", limited=True)
+        self.text_dratio = TextCtrl(self, wx.ID_ANY, "0.261", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
         self.text_dratio.SetToolTip(OPERATION_DRATIO_TOOLTIP)
         sizer_11.Add(self.text_dratio, 1, 0, 0)
 
@@ -90,7 +90,7 @@ class LhyAdvancedPanel(wx.Panel):
         self.check_dot_length_custom = wx.CheckBox(self, wx.ID_ANY, "Dot Length")
         self.check_dot_length_custom.SetToolTip("Enable Dot Length")
         sizer_20.Add(self.check_dot_length_custom, 1, 0, 0)
-        self.text_dot_length = TextCtrl(self, wx.ID_ANY, "1", limited=True)
+        self.text_dot_length = TextCtrl(self, wx.ID_ANY, "1", limited=True, check="int", style=wx.TE_PROCESS_ENTER)
         self.text_dot_length.SetToolTip(OPERATION_DOTLENGTH_TOOLTIP)
         sizer_20.Add(self.text_dot_length, 1, 0, 0)
 
@@ -112,8 +112,8 @@ class LhyAdvancedPanel(wx.Panel):
         self.Layout()
 
         self.Bind(wx.EVT_CHECKBOX, self.on_check_dratio, self.check_dratio_custom)
-        self.Bind(wx.EVT_TEXT, self.on_text_dratio, self.text_dratio)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_dratio, self.text_dratio)
+        self.text_dratio.Bind(wx.EVT_TEXT_ENTER, self.on_text_dratio)
+        self.text_dratio.Bind(wx.EVT_KILL_FOCUS, self.on_text_dratio)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_acceleration, self.checkbox_custom_accel
         )
@@ -121,8 +121,8 @@ class LhyAdvancedPanel(wx.Panel):
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_dot_length, self.check_dot_length_custom
         )
-        self.Bind(wx.EVT_TEXT, self.on_text_dot_length, self.text_dot_length)
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_text_dot_length, self.text_dot_length)
+        self.text_dot_length.Bind(wx.EVT_TEXT_ENTER, self.on_text_dot_length)
+        self.text_dot_length.Bind(wx.EVT_KILL_FOCUS, self.on_text_dot_length)
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_shift_enabled, self.check_shift_enabled
         )

--- a/meerk40t/lihuiyu/gui/lhyoperationproperties.py
+++ b/meerk40t/lihuiyu/gui/lhyoperationproperties.py
@@ -1,5 +1,6 @@
 import wx
 from meerk40t.gui.wxutils import TextCtrl
+
 _ = wx.GetTranslation
 
 OPERATION_ACCEL_TOOLTIP = _(
@@ -59,7 +60,14 @@ class LhyAdvancedPanel(wx.Panel):
         )
         sizer_11.Add(self.check_dratio_custom, 1, 0, 0)
 
-        self.text_dratio = TextCtrl(self, wx.ID_ANY, "0.261", limited=True, check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_dratio = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "0.261",
+            limited=True,
+            check="float",
+            style=wx.TE_PROCESS_ENTER,
+        )
         self.text_dratio.SetToolTip(OPERATION_DRATIO_TOOLTIP)
         sizer_11.Add(self.text_dratio, 1, 0, 0)
 
@@ -90,7 +98,9 @@ class LhyAdvancedPanel(wx.Panel):
         self.check_dot_length_custom = wx.CheckBox(self, wx.ID_ANY, "Dot Length")
         self.check_dot_length_custom.SetToolTip("Enable Dot Length")
         sizer_20.Add(self.check_dot_length_custom, 1, 0, 0)
-        self.text_dot_length = TextCtrl(self, wx.ID_ANY, "1", limited=True, check="int", style=wx.TE_PROCESS_ENTER)
+        self.text_dot_length = TextCtrl(
+            self, wx.ID_ANY, "1", limited=True, check="int", style=wx.TE_PROCESS_ENTER
+        )
         self.text_dot_length.SetToolTip(OPERATION_DOTLENGTH_TOOLTIP)
         sizer_20.Add(self.text_dot_length, 1, 0, 0)
 

--- a/meerk40t/lihuiyu/gui/tcpcontroller.py
+++ b/meerk40t/lihuiyu/gui/tcpcontroller.py
@@ -14,8 +14,12 @@ class TCPController(MWindow):
         self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
         self.service = self.context.device
         self.text_status = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
-        self.text_ip_host = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER, check="empty")
-        self.text_port = TextCtrl(self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_ip_host = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER, check="empty"
+        )
+        self.text_port = TextCtrl(
+            self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER
+        )
         self.gauge_buffer = wx.Gauge(self, wx.ID_ANY, 10)
         self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "")
         self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "")

--- a/meerk40t/lihuiyu/gui/tcpcontroller.py
+++ b/meerk40t/lihuiyu/gui/tcpcontroller.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected_50, icons8_disconnected_50
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.kernel import signal_listener
+from meerk40t.gui.wxutils import TextCtrl
 
 _ = wx.GetTranslation
 
@@ -12,9 +13,9 @@ class TCPController(MWindow):
         super().__init__(499, 170, *args, **kwds)
         self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
         self.service = self.context.device
-        self.text_status = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_ip_host = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_port = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_status = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_ip_host = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER, check="empty")
+        self.text_port = TextCtrl(self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER)
         self.gauge_buffer = wx.Gauge(self, wx.ID_ANY, 10)
         self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "")
         self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "")
@@ -25,8 +26,10 @@ class TCPController(MWindow):
         self.Bind(
             wx.EVT_BUTTON, self.on_button_start_connection, self.button_device_connect
         )
-        self.Bind(wx.EVT_TEXT, self.on_port_change, self.text_port)
-        self.Bind(wx.EVT_TEXT, self.on_address_change, self.text_ip_host)
+        self.text_port.Bind(wx.EVT_TEXT_ENTER, self.on_port_change)
+        self.text_port.Bind(wx.EVT_KILL_FOCUS, self.on_port_change)
+        self.text_ip_host.Bind(wx.EVT_TEXT_ENTER, self.on_address_change)
+        self.text_ip_host.Bind(wx.EVT_KILL_FOCUS, self.on_address_change)
         # end wxGlade
         self.max = 0
         self.state = None

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -19,8 +19,12 @@ class MoshiConfigurationPanel(ScrolledPanel):
 
         self.checkbox_home_right = wx.CheckBox(self, wx.ID_ANY, _("Home Right"))
         self.checkbox_home_bottom = wx.CheckBox(self, wx.ID_ANY, _("Home Bottom"))
-        self.text_home_x = TextCtrl(self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER)
-        self.text_home_y = TextCtrl(self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_home_x = TextCtrl(
+            self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER
+        )
+        self.text_home_y = TextCtrl(
+            self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER
+        )
         self.button_home_by_current = wx.Button(self, wx.ID_ANY, _("Set Current"))
         # self.checkbox_random_ppi = wx.CheckBox(self, wx.ID_ANY, _("Randomize PPI"))
 

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -6,6 +6,7 @@ from wx.lib.scrolledpanel import ScrolledPanel
 from meerk40t.core.units import Length
 from meerk40t.gui.icons import icons8_administrative_tools_50
 from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import TextCtrl
 
 _ = wx.GetTranslation
 
@@ -18,8 +19,8 @@ class MoshiConfigurationPanel(ScrolledPanel):
 
         self.checkbox_home_right = wx.CheckBox(self, wx.ID_ANY, _("Home Right"))
         self.checkbox_home_bottom = wx.CheckBox(self, wx.ID_ANY, _("Home Bottom"))
-        self.text_home_x = wx.TextCtrl(self, wx.ID_ANY, "0mm")
-        self.text_home_y = wx.TextCtrl(self, wx.ID_ANY, "0mm")
+        self.text_home_x = TextCtrl(self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER)
+        self.text_home_y = TextCtrl(self, wx.ID_ANY, "0mm", check="length", style=wx.TE_PROCESS_ENTER)
         self.button_home_by_current = wx.Button(self, wx.ID_ANY, _("Set Current"))
         # self.checkbox_random_ppi = wx.CheckBox(self, wx.ID_ANY, _("Randomize PPI"))
 
@@ -28,8 +29,10 @@ class MoshiConfigurationPanel(ScrolledPanel):
 
         self.Bind(wx.EVT_CHECKBOX, self.on_check_home_right, self.checkbox_home_right)
         self.Bind(wx.EVT_CHECKBOX, self.on_check_home_bottom, self.checkbox_home_bottom)
-        self.Bind(wx.EVT_TEXT, self.on_text_home_x, self.text_home_x)
-        self.Bind(wx.EVT_TEXT, self.on_text_home_y, self.text_home_y)
+        self.text_home_x.Bind(wx.EVT_TEXT_ENTER, self.on_text_home_x)
+        self.text_home_x.Bind(wx.EVT_KILL_FOCUS, self.on_text_home_x)
+        self.text_home_y.Bind(wx.EVT_TEXT_ENTER, self.on_text_home_y)
+        self.text_home_y.Bind(wx.EVT_KILL_FOCUS, self.on_text_home_y)
         self.Bind(
             wx.EVT_BUTTON, self.on_button_set_home_current, self.button_home_by_current
         )
@@ -113,9 +116,11 @@ class MoshiConfigurationPanel(ScrolledPanel):
         self.context.home_bottom = self.checkbox_home_bottom.GetValue()
 
     def on_text_home_x(self, event):  # wxGlade: MoshiDriverGui.<event_handler>
+        event.Skip()
         self.context.home_x = self.text_home_x.GetValue()
 
     def on_text_home_y(self, event):  # wxGlade: MoshiDriverGui.<event_handler>
+        event.Skip()
         self.context.home_y = self.text_home_y.GetValue()
 
     def on_button_set_home_current(

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -22,8 +22,12 @@ class RotarySettingsPanel(ScrolledPanel):
 
         self.checkbox_rotary = wx.CheckBox(self, wx.ID_ANY, _("Enable Rotary"))
         self.Children[0].SetFocus()
-        self.text_rotary_scaley = TextCtrl(self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER)
-        self.text_rotary_scalex = TextCtrl(self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_rotary_scaley = TextCtrl(
+            self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER
+        )
+        self.text_rotary_scalex = TextCtrl(
+            self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER
+        )
         # self.checkbox_rotary_loop = wx.CheckBox(self, wx.ID_ANY, _("Field Loop"))
         # self.text_rotary_rotation = wx.TextCtrl(self, wx.ID_ANY, "360.0")
         # self.checkbox_rotary_roller = wx.CheckBox(self, wx.ID_ANY, _("Uses Roller"))

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -9,6 +9,7 @@ from wx.lib.scrolledpanel import ScrolledPanel
 
 from meerk40t.gui.icons import icons8_roll_50
 from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import TextCtrl
 
 _ = wx.GetTranslation
 
@@ -21,8 +22,8 @@ class RotarySettingsPanel(ScrolledPanel):
 
         self.checkbox_rotary = wx.CheckBox(self, wx.ID_ANY, _("Enable Rotary"))
         self.Children[0].SetFocus()
-        self.text_rotary_scaley = wx.TextCtrl(self, wx.ID_ANY, "1.0")
-        self.text_rotary_scalex = wx.TextCtrl(self, wx.ID_ANY, "1.0")
+        self.text_rotary_scaley = TextCtrl(self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER)
+        self.text_rotary_scalex = TextCtrl(self, wx.ID_ANY, "1.0", check="float", style=wx.TE_PROCESS_ENTER)
         # self.checkbox_rotary_loop = wx.CheckBox(self, wx.ID_ANY, _("Field Loop"))
         # self.text_rotary_rotation = wx.TextCtrl(self, wx.ID_ANY, "360.0")
         # self.checkbox_rotary_roller = wx.CheckBox(self, wx.ID_ANY, _("Uses Roller"))
@@ -33,10 +34,12 @@ class RotarySettingsPanel(ScrolledPanel):
         self.__do_layout()
 
         self.Bind(wx.EVT_CHECKBOX, self.on_check_rotary, self.checkbox_rotary)
-        self.Bind(wx.EVT_TEXT, self.on_text_rotary_scale_y, self.text_rotary_scaley)
-        self.Bind(wx.EVT_TEXT, self.on_text_rotary_scale_x, self.text_rotary_scalex)
+        self.text_rotary_scalex.Bind(wx.EVT_TEXT_ENTER, self.on_text_rotary_scale_x)
+        self.text_rotary_scalex.Bind(wx.EVT_KILL_FOCUS, self.on_text_rotary_scale_x)
+        self.text_rotary_scaley.Bind(wx.EVT_TEXT_ENTER, self.on_text_rotary_scale_y)
+        self.text_rotary_scaley.Bind(wx.EVT_KILL_FOCUS, self.on_text_rotary_scale_y)
         # self.Bind(wx.EVT_CHECKBOX, self.on_check_rotary_loop, self.checkbox_rotary_loop)
-        # self.Bind(wx.EVT_TEXT, self.on_text_rotation, self.text_rotary_rotation)
+        # self.text_rotary_rotation.Bind(wx.EVT_TEXT, self.on_text_rotation)
         # self.Bind(
         #     wx.EVT_CHECKBOX, self.on_check_rotary_roller, self.checkbox_rotary_roller
         # )


### PR DESCRIPTION
Make textinput behaviour consistent across MK:
- changes during textentry are no longer immediately assigned to underlying properties per keystroke. Some of wrong input was caught, some not, but mostly you propagated unwanted changes during textentry (ie change bedwidth from "310mm" to "240mm" created confusing UI behaviour and quite a lot of unnecessary updates in-between before you had your desired value)
- changes are acknowledged after leaving the field (EVT_KILL_FOCUS) or after pressing the enter-key

- Plus visual feedback if invalid data has been entered in more fields