### PR TITLE
Two minor fixes

### DIFF
--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -204,7 +204,8 @@ class InformationPanel(wx.Panel):
         if git and branch and branch not in ("main", "legacy6", "legacy7"):
             info = info + " - " + branch
         self.mk_version.SetValue(info)
-        info = self.context.kernel.current_directory
+        info = os.path.dirname(self.context.elements.op_data._config_file)
+        # info = self.context.kernel.current_directory
         self.config_path.SetValue(info)
 
     def __do_layout(self):

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1094,6 +1094,16 @@ class ShadowTree:
         @param event:
         @return:
         """
+        def typefamily(typename):
+            # Combine similar nodetypes
+            if typename.startswith("op "):
+                result = "op"
+            elif typename.startswith("elem "):
+                result = "elem"
+            else:
+                result = typename
+            return result
+
         self.dragging_nodes = None
 
         pt = event.GetPoint()
@@ -1110,9 +1120,11 @@ class ShadowTree:
             event.Skip()
             return
 
-        t = self.dragging_nodes[0].type
+        t = typefamily(self.dragging_nodes[0].type)
         for n in self.dragging_nodes:
-            if t != n.type:
+            tt = typefamily(n.type)
+            if t != tt:
+                # Different typefamilies
                 event.Skip()
                 return
             if not n.is_movable():


### PR DESCRIPTION
a) Show 'real' configpath in about
b) Allow drag and drop of node of simlar types (right now you can only drag two or more rectangles but not a rectangle and a circle, ie allowed only identical node types)