### PR TITLE
Lifecycle Delegation Loop

### DIFF
--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -4,6 +4,7 @@ from meerk40t.device.gui.warningpanel import WarningPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools_50
 from meerk40t.gui.mwindow import MWindow
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -60,26 +61,8 @@ class BalorConfiguration(MWindow):
         yield self.panel_extra
         yield self.panel_warn
 
-    def window_close(self):
-        self.context.unlisten("flip_x", self.on_viewport_update)
-        self.context.unlisten("flip_y", self.on_viewport_update)
-        self.panel_main.pane_hide()
-        self.panel_red.pane_hide()
-        self.panel_global.pane_hide()
-        self.panel_timing.pane_hide()
-        self.panel_extra.pane_hide()
-        self.panel_warn.pane_hide()
-
-    def window_open(self):
-        self.context.listen("flip_x", self.on_viewport_update)
-        self.context.listen("flip_y", self.on_viewport_update)
-        self.panel_main.pane_show()
-        self.panel_red.pane_show()
-        self.panel_global.pane_show()
-        self.panel_timing.pane_show()
-        self.panel_extra.pane_show()
-        self.panel_warn.pane_show()
-
+    @signal_listener("flip_x")
+    @signal_listener("flip_y")
     def on_viewport_update(self, origin, *args):
         self.context("viewport_update\n")
 

--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -52,12 +52,13 @@ class BalorConfiguration(MWindow):
 
         self.Layout()
 
-        self.add_module_delegate(self.panel_main)
-        self.add_module_delegate(self.panel_red)
-        self.add_module_delegate(self.panel_global)
-        self.add_module_delegate(self.panel_timing)
-        self.add_module_delegate(self.panel_extra)
-        self.add_module_delegate(self.panel_warn)
+    def delegates(self):
+        yield self.panel_main
+        yield self.panel_red
+        yield self.panel_global
+        yield self.panel_timing
+        yield self.panel_extra
+        yield self.panel_warn
 
     def window_close(self):
         self.context.unlisten("flip_x", self.on_viewport_update)

--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -43,8 +43,8 @@ class BalorConfiguration(MWindow):
                 newpanel = ChoicePropertyPanel(
                     self, wx.ID_ANY, context=self.context, choices=section
                 )
-            self.panels.append(newpanel)
-            self.notebook_main.AddPage(newpanel, pagetitle)
+                self.panels.append(newpanel)
+                self.notebook_main.AddPage(newpanel, pagetitle)
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
         self.notebook_main.AddPage(newpanel, _("Warning"))

--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -130,11 +130,11 @@ class BalorControllerPanel(wx.ScrolledWindow):
         else:
             self.context("usb_connect\n")
 
-    def pane_show(self):
+    def module_open(self):
         name = self.service.label
         self.context.channel(f"{name}/usb").watch(self.update_text)
 
-    def pane_hide(self):
+    def module_close(self):
         name = self.service.label
         self.context.channel(f"{name}/usb").unwatch(self.update_text)
 
@@ -143,15 +143,11 @@ class BalorController(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(499, 170, *args, **kwds)
         self.panel = BalorControllerPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         self.SetTitle(_("Balor-Controller"))
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected_50.GetBitmap())
         self.SetIcon(_icon)
         self.Layout()
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegates(self):
+        yield self.panel

--- a/meerk40t/balormk/gui/baloroperationproperties.py
+++ b/meerk40t/balormk/gui/baloroperationproperties.py
@@ -150,11 +150,8 @@ class BalorOperationPanel(ScrolledPanel):
 
         self.Layout()
 
-    def pane_hide(self):
-        self.panel.pane_hide()
-
-    def pane_show(self):
-        self.panel.pane_show()
+    def delegate(self):
+        yield self.panel
 
     def set_widgets(self, node):
         self.operation = node

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -167,7 +167,7 @@ class CameraPanel(wx.Panel, Job):
             CamInterfaceWidget(self.widget_scene, self)
         )
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         if platform.system() == "Darwin" and not hasattr(self.camera, "_first"):
             self.camera(f"camera{self.index} start -t 1\n")
             self.camera._first = False
@@ -177,7 +177,7 @@ class CameraPanel(wx.Panel, Job):
         self.camera.listen("camera;fps", self.on_fps_change)
         self.camera.listen("camera;stopped", self.on_camera_stop)
 
-    def pane_hide(self, *args):
+    def module_close(self, *args):
         self.camera(f"camera{self.index} stop\n")
         self.camera.unschedule(self)
         if not self.pane:
@@ -687,7 +687,6 @@ class CameraInterface(MWindow):
         super().__init__(640, 480, context, path, parent, **kwds)
         self.camera = self.context.get_context(f"camera/{index}")
         self.panel = CameraPanel(self, wx.ID_ANY, context=self.camera, index=index)
-        self.add_module_delegate(self.panel)
 
         # ==========
         # MENU BAR
@@ -746,11 +745,8 @@ class CameraInterface(MWindow):
 
         append(wxglade_tmp_menu, _("Camera"))
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegates(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -933,7 +933,7 @@ class CameraURIPanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
-    def pane_show(self):
+    def module_open(self):
         camera_root_context = self.context.get_context("camera")
         keylist = camera_root_context.kernel.read_persistent_string_dict(
             camera_root_context.path, suffix=True
@@ -944,7 +944,7 @@ class CameraURIPanel(wx.Panel):
             self.uri_list = [keylist[k] for k in keys]
             self.on_list_refresh()
 
-    def pane_hide(self):
+    def module_close(self):
         self.commit()
 
     def commit(self):
@@ -1066,8 +1066,5 @@ class CameraURI(MWindow):
         # begin wxGlade: CameraURI.__set_properties
         self.SetTitle(_("Camera URI"))
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegates(self):
+        yield self.panel

--- a/meerk40t/device/gui/warningpanel.py
+++ b/meerk40t/device/gui/warningpanel.py
@@ -258,9 +258,8 @@ class WarningPanel(wx.Panel):
             except KeyError:
                 pass
 
-    def pane_hide(self):
+    def module_close(self):
         pass
 
-    def pane_show(self):
+    def module_open(self):
         self.update_widgets()
-        pass

--- a/meerk40t/grbl/gui/grblconfiguration.py
+++ b/meerk40t/grbl/gui/grblconfiguration.py
@@ -41,22 +41,12 @@ class GRBLConfiguration(MWindow):
         self.notebook_main.AddPage(self.panel_global, _("Global Settings"))
         self.notebook_main.AddPage(self.panel_warn, _("Warning"))
         self.Layout()
-        self.add_module_delegate(self.panel_main)
-        self.add_module_delegate(self.panel_global)
-        self.add_module_delegate(self.panel_dim)
-        self.add_module_delegate(self.panel_warn)
 
-    def window_open(self):
-        self.panel_main.pane_show()
-        self.panel_global.pane_show()
-        self.panel_dim.pane_show()
-        self.panel_warn.pane_show()
-
-    def window_close(self):
-        self.panel_main.pane_hide()
-        self.panel_global.pane_hide()
-        self.panel_dim.pane_hide()
-        self.panel_warn.pane_hide()
+    def delegates(self):
+        yield self.panel_main
+        yield self.panel_global
+        yield self.panel_dim
+        yield self.panel_warn
 
     def window_preserve(self):
         return False

--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -291,8 +291,6 @@ class About(MWindow):
         self.notebook_main.AddPage(self.panel_about, _("About"))
         self.notebook_main.AddPage(self.panel_info, _("System-Information"))
 
-        self.add_module_delegate(self.panel_about)
-        self.add_module_delegate(self.panel_info)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_about_50.GetBitmap())
         self.SetIcon(_icon)
@@ -301,3 +299,7 @@ class About(MWindow):
         name = self.context.kernel.name
         version = self.context.kernel.version
         self.SetTitle(_("About {name} v{version}").format(name=name, version=version))
+
+    def delegate(self):
+        yield self.panel_about
+        yield self.panel_info

--- a/meerk40t/gui/bufferview.py
+++ b/meerk40t/gui/bufferview.py
@@ -19,7 +19,7 @@ class BufferViewPanel(wx.Panel):
         self.__set_properties()
         self.__do_layout()
 
-    def pane_show(self):
+    def module_open(self):
         buffer = self.context.device.viewbuffer
         if buffer is None:
             buffer = _("Could not find buffer.\n")
@@ -58,9 +58,11 @@ class BufferView(MWindow):
         # begin wxGlade: BufferView.__set_properties
         self.SetTitle(_("BufferView"))
 
+    def delegate(self):
+        yield self.panel
+
     def window_preserve(self):
         return False
 
     def window_open(self):
         self.context.close(self.name)
-        self.panel.pane_show()

--- a/meerk40t/gui/bufferview.py
+++ b/meerk40t/gui/bufferview.py
@@ -51,7 +51,6 @@ class BufferView(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(697, 586, *args, **kwds)
         self.panel = BufferViewPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_comments_50.GetBitmap())
         self.SetIcon(_icon)

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -854,6 +854,12 @@ class ChoicePropertyPanel(ScrolledPanel):
                 result = result[idx + 1 :]
         return result
 
+    def module_open(self):
+        self.pane_show()
+
+    def module_close(self):
+        self.pane_hide()
+
     def pane_hide(self):
         for attr, listener in self.listeners:
             self.context.unlisten(attr, listener)

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -855,14 +855,8 @@ class ChoicePropertyPanel(ScrolledPanel):
         return result
 
     def module_open(self):
-        self.pane_show()
+        pass
 
     def module_close(self):
-        self.pane_hide()
-
-    def pane_hide(self):
         for attr, listener in self.listeners:
             self.context.unlisten(attr, listener)
-
-    def pane_show(self):
-        pass

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -184,7 +184,8 @@ class ChoicePropertyPanel(ScrolledPanel):
             weight = int(c.get("weight", 1))
             if weight < 0:
                 weight = 0
-            if not self.context.root.developer_mode and hidden:
+            developer_mode = self.context.root.setting(bool, "developer_mode", False)
+            if not developer_mode and hidden:
                 continue
             # get default value
             if hasattr(obj, attr):

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -403,9 +403,3 @@ class Console(MWindow):
                 "size": STD_ICON_SIZE,
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -227,10 +227,10 @@ class ConsolePanel(wx.ScrolledWindow):
         self.Layout()
         # end wxGlade
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         self.context.channel("console").watch(self.update_text)
 
-    def pane_hide(self, *args):
+    def module_close(self, *args):
         self.context.channel("console").unwatch(self.update_text)
 
     def clear(self):
@@ -381,12 +381,14 @@ class Console(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(581, 410, *args, **kwds)
         self.panel = ConsolePanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_console_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Console"))
         self.Layout()
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -105,7 +105,7 @@ class DevicePanel(wx.Panel):
         self.Parent.Bind(wx.EVT_SIZE, self.on_resize)
         # end wxGlade
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         self.refresh_device_tree()
         if len(self.devices) > 0:
             self.devices_list.Select(0, 1)
@@ -114,7 +114,7 @@ class DevicePanel(wx.Panel):
         self.on_resize(None)
         self.enable_controls()
 
-    def pane_hide(self, *args):
+    def module_close(self, *args):
         pass
 
     def on_resize(self, event):
@@ -361,11 +361,13 @@ class DeviceManager(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(653, 332, *args, **kwds)
         self.panel = DevicePanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_manager_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Devices"))
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -382,9 +382,3 @@ class DeviceManager(MWindow):
                 "action": lambda v: kernel.console("window toggle DeviceManager\n"),
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -325,7 +325,7 @@ class PlannerPanel(wx.Panel):
                     pass
         self.update_gui()
 
-    def pane_show(self):
+    def module_open(self):
         # self.context.setting(bool, "opt_rasters_split", True)
         # TODO: OPT_RASTER_SPLIT
         cutplan = self.context.planner.default_plan
@@ -335,7 +335,7 @@ class PlannerPanel(wx.Panel):
 
         self.update_gui()
 
-    def pane_hide(self):
+    def module_close(self):
         self.context(f"plan{self.plan_name} clear\n")
 
     @signal_listener("plan")
@@ -412,7 +412,6 @@ class ExecuteJob(MWindow):
         self.panel = PlannerPanel(
             self, wx.ID_ANY, context=self.context, plan_name=plan_name
         )
-        self.add_module_delegate(self.panel)
         self.panel.Bind(wx.EVT_RIGHT_DOWN, self.on_menu, self.panel)
         self.panel.list_operations.Bind(
             wx.EVT_RIGHT_DOWN, self.on_menu, self.panel.list_operations
@@ -501,6 +500,9 @@ class ExecuteJob(MWindow):
             self.panel.jobchange_step_repeat,
             wx_menu.Append(wx.ID_ANY, _("Step Repeat"), _("Execute Step Repeat")),
         )
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -516,9 +516,3 @@ class ExecuteJob(MWindow):
                 "size": STD_ICON_SIZE,
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/keymap.py
+++ b/meerk40t/gui/keymap.py
@@ -48,9 +48,6 @@ class KeymapPanel(wx.Panel):
         self.reload_keymap()
         self.Children[0].SetFocus()
 
-    def module_close(self):
-        pass
-
     def __set_properties(self):
         self.list_keymap.SetToolTip(_("What keys are bound to which actions?"))
         self.list_keymap.AppendColumn(_("Key"), format=wx.LIST_FORMAT_LEFT, width=140)
@@ -333,9 +330,3 @@ class Keymap(MWindow):
                 "action": lambda v: kernel.console("window toggle Keymap\n"),
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/keymap.py
+++ b/meerk40t/gui/keymap.py
@@ -44,11 +44,11 @@ class KeymapPanel(wx.Panel):
         self.text_key_name.Bind(wx.EVT_KEY_UP, self.on_key_up)
         self.key_pressed = False
 
-    def pane_show(self):
+    def module_open(self):
         self.reload_keymap()
         self.Children[0].SetFocus()
 
-    def pane_hide(self):
+    def module_close(self):
         pass
 
     def __set_properties(self):
@@ -313,12 +313,14 @@ class Keymap(MWindow):
         super().__init__(500, 530, *args, **kwds)
 
         self.panel = KeymapPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_keyboard_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: Keymap.__set_properties
         self.SetTitle(_("Keymap Settings"))
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/lasertoolpanel.py
+++ b/meerk40t/gui/lasertoolpanel.py
@@ -9,6 +9,7 @@ from meerk40t.gui.icons import (
     instruction_frame,
     instruction_rectangle,
 )
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -708,13 +709,7 @@ class LaserToolPanel(wx.Panel):
                 self.context("reference\n")
         event.Skip()
 
-    def pane_show(self, *args):
-        self.context.listen("driver;position", self.on_update_laser)
-        self.context.listen("emulator;position", self.on_update_laser)
-
-    def pane_hide(self, *args):
-        self.context.unlisten("driver;position", self.on_update_laser)
-        self.context.unlisten("emulator;position", self.on_update_laser)
-
+    @signal_listener("driver;position")
+    @signal_listener("emulator;position")
     def on_update_laser(self, origin, pos):
         self.laserposition = (pos[2], pos[3])

--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -4,6 +4,7 @@ from wx import aui
 from meerk40t.core.element_types import elem_nodes
 from meerk40t.core.units import Length
 from meerk40t.gui.icons import icons8_lock_50, icons8_padlock_50
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -42,14 +43,6 @@ class DebugTreePanel(wx.Panel):
 
         self._update_position()
 
-    def pane_show(self, *args):
-        self.context.listen("emphasized", self._update_position)
-        self.context.listen("selected", self._update_position)
-
-    def pane_hide(self, *args):
-        self.context.unlisten("emphasized", self._update_position)
-        self.context.unlisten("selected", self._update_position)
-
     def __set_properties(self):
         # begin wxGlade: PositionPanel.__set_properties
         self.lb_emphasized.SetToolTip(_("Emphasized nodes"))
@@ -76,6 +69,8 @@ class DebugTreePanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
+    @signal_listener("emphasized")
+    @signal_listener("selected")
     def _update_position(self, *args):
         self.update_position(True)
 

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -1829,9 +1829,3 @@ class Navigation(MWindow):
                 "action": lambda v: kernel.console("window toggle Navigation\n"),
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/notes.py
+++ b/meerk40t/gui/notes.py
@@ -127,10 +127,3 @@ class Notes(MWindow):
                 "size": STD_ICON_SIZE,
             },
         )
-
-    def window_open(self):
-        self.context.close(self.name)
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/notes.py
+++ b/meerk40t/gui/notes.py
@@ -70,14 +70,14 @@ class NotePanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         self.context.setting(bool, "auto_note", True)
         self.check_auto_open_notes.SetValue(self.context.elements.auto_note)
         if self.context.elements.note is not None:
             self.text_notes.SetValue(self.context.elements.note)
         self.context.listen("note", self.on_note_listen)
 
-    def pane_hide(self):
+    def module_close(self):
         self.context.unlisten("note", self.on_note_listen)
 
     def on_check_auto_note_open(self, event=None):  # wxGlade: Notes.<event_handler>
@@ -105,12 +105,14 @@ class Notes(MWindow):
         super().__init__(730, 621, *args, **kwds)
 
         self.panel = NotePanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_comments_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Notes"))
         self.Children[0].SetFocus()
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -322,14 +322,6 @@ class OperationAssignPanel(wx.Panel):
     def on_rebuild(self, origin, *args):
         self.set_buttons()
 
-    def pane_show(self, *args):
-        # nothing yet
-        return
-
-    def pane_hide(self, *args):
-        # nothing yet
-        return
-
     def on_resize(self, event):
         if self.lastsize != event.Size:
             self.lastsize = event.Size

--- a/meerk40t/gui/position.py
+++ b/meerk40t/gui/position.py
@@ -4,6 +4,7 @@ from wx import aui
 from meerk40t.core.element_types import elem_nodes
 from meerk40t.core.units import Length
 from meerk40t.gui.icons import icons8_up_left_50
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -84,18 +85,6 @@ class PositionPanel(wx.Panel):
         self.position_units = self.context.units_name
         self._update_position()
 
-    def pane_show(self, *args):
-        self.context.listen("units", self.space_changed)
-        self.context.listen("emphasized", self._update_position)
-        self.context.listen("modified", self._update_position)
-        self.context.listen("altered", self._update_position)
-
-    def pane_hide(self, *args):
-        self.context.unlisten("units", self.space_changed)
-        self.context.unlisten("emphasized", self._update_position)
-        self.context.unlisten("modified", self._update_position)
-        self.context.unlisten("altered", self._update_position)
-
     def __set_properties(self):
         # begin wxGlade: PositionPanel.__set_properties
         self.text_h.SetToolTip(_("New height (enter to apply)"))
@@ -166,6 +155,9 @@ class PositionPanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
+    @signal_listener("emphasized")
+    @signal_listener("modified")
+    @signal_listener("altered")
     def _update_position(self, *args):
         self.update_position(True)
 
@@ -232,6 +224,7 @@ class PositionPanel(wx.Panel):
             self.text_h.SetValue(f"{self.position_h:.2f}")
         self.combo_box_units.SetSelection(self.choices.index(self.position_units))
 
+    @signal_listener("units")
     def space_changed(self, origin, *args):
         self.position_units = self.context.units_name
         self.update_position(True)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -252,7 +252,12 @@ class PreferencesMain(wx.Panel):
         self.SetSizer(sizer_main)
 
         self.Layout()
-        # end wxGlade
+
+    def delegates(self):
+        yield self.panel_units
+        yield self.panel_language
+        yield self.panel_ppi
+        yield self.panel_pref1
 
 
 # end of class PreferencesMain
@@ -273,7 +278,9 @@ class PreferencesPanel(wx.Panel):
         self.SetSizer(sizer_settings)
 
         self.Layout()
-        # end wxGlade
+
+    def delegates(self):
+        yield self.panel_main
 
 
 class Preferences(MWindow):
@@ -333,14 +340,16 @@ class Preferences(MWindow):
         self.notebook_main.AddPage(self.panel_scene, _("Scene"))
         self.Layout()
 
-        self.add_module_delegate(self.panel_main)
-        self.add_module_delegate(self.panel_classification)
-        self.add_module_delegate(self.panel_gui)
-        self.add_module_delegate(self.panel_scene)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_administrative_tools_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Preferences"))
+
+    def delegates(self):
+        yield self.panel_main
+        yield self.panel_classification
+        yield self.panel_gui
+        yield self.panel_scene
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/propertypanels/attrib_stroke.py
+++ b/meerk40t/gui/propertypanels/attrib_stroke.py
@@ -4,6 +4,7 @@ from wx import aui
 from meerk40t.core.element_types import elem_nodes
 from meerk40t.core.units import Length
 from meerk40t.gui.icons import icons8_lock_50, icons8_padlock_50
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -76,19 +77,12 @@ class ElementpropertyPanel(wx.Panel):
         self.panel_cap.fill_widgets(selection)
         self.panel_text.fill_widgets(selection)
 
-    def _update_position(self):
+    @signal_listener("emphasized")
+    @signal_listener("modified")
+    @signal_listener("altered")
+    def _update_position(self, *args):
         elems = list(self.context.elements.flat(types=elem_nodes, emphasized=True))
         self.fill_widgets(elems)
-
-    def pane_show(self, *args):
-        self.context.listen("emphasized", self._update_position)
-        self.context.listen("modified", self._update_position)
-        self.context.listen("altered", self._update_position)
-
-    def pane_hide(self, *args):
-        self.context.unlisten("emphasized", self._update_position)
-        self.context.unlisten("modified", self._update_position)
-        self.context.unlisten("altered", self._update_position)
 
     def __set_properties(self):
         # begin wxGlade: PositionPanel.__set_properties

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -90,11 +90,13 @@ class GroupProperty(MWindow):
         self.panel = GroupPropertiesPanel(
             self, wx.ID_ANY, context=self.context, node=node
         )
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_group_objects_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Group Properties"))
+
+    def delegate(self):
+        yield self.panel
 
     def window_preserve(self):
         return False

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -344,12 +344,13 @@ class ImageProperty(MWindow):
         self.panel = ImagePropertyPanel(
             self, wx.ID_ANY, context=self.context, node=node
         )
-        self.add_module_delegate(self.panel)
-        # begin wxGlade: ImageProperty.__set_properties
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_image_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Image Properties"))
+
+    def delegate(self):
+        yield self.panel
 
     def restore(self, *args, node=None, **kwds):
         self.panel.set_widgets(node)

--- a/meerk40t/gui/propertypanels/inputproperty.py
+++ b/meerk40t/gui/propertypanels/inputproperty.py
@@ -35,16 +35,13 @@ class InputPropertyPanel(wx.Panel):
         self.SetSizer(main_sizer)
         self.Layout()
 
+    def delegate(self):
+        yield self.panel
+
     @signal_listener("mask")
     @signal_listener("value")
     def wait_changed(self, *args):
         self.context.elements.signal("element_property_update", self.operation)
-
-    def pane_hide(self):
-        self.panel.pane_hide()
-
-    def pane_show(self):
-        self.panel.pane_show()
 
     def set_widgets(self, node):
         self.operation = node

--- a/meerk40t/gui/propertypanels/opbranchproperties.py
+++ b/meerk40t/gui/propertypanels/opbranchproperties.py
@@ -53,17 +53,14 @@ class OpBranchPanel(wx.Panel):
 
         self.Layout()
 
+    def delegate(self):
+        yield self.panel
+
     @signal_listener("loop_continuous")
     @signal_listener("loop_n")
     @signal_listener("loop_enabled")
     def wait_changed(self, *args):
         self.context.elements.signal("element_property_update", self.operation)
-
-    def pane_hide(self):
-        self.panel.pane_hide()
-
-    def pane_show(self):
-        self.panel.pane_show()
 
     def set_widgets(self, node):
         self.operation = node

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -183,12 +183,6 @@ class LayerSettingPanel(wx.Panel):
         self.Bind(wx.EVT_CHECKBOX, self.on_check_default, self.checkbox_default)
         # end wxGlade
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
     def accepts(self, node):
         return node.type in (
             "op cut",
@@ -405,14 +399,6 @@ class SpeedPpiPanel(wx.Panel):
         self.text_frequency.Bind(wx.EVT_KILL_FOCUS, self.on_text_frequency)
         self.text_frequency.Bind(wx.EVT_TEXT_ENTER, self.on_text_frequency)
 
-        # end wxGlade
-
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
     def accepts(self, node):
         return node.type in (
             "op cut",
@@ -519,12 +505,6 @@ class PassesPanel(wx.Panel):
         self.text_passes.Bind(wx.EVT_TEXT_ENTER, self.on_text_passes)
         # end wxGlade
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
     def accepts(self, node):
         return node.type in (
             "op cut",
@@ -615,14 +595,6 @@ class InfoPanel(wx.Panel):
         self.SetSizer(sizer_info)
 
         self.Layout()
-
-        # end wxGlade
-
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
 
     def on_button_calculate(self, event):
         try:
@@ -733,13 +705,7 @@ class PanelStartPreference(wx.Panel):
             self.toggle_sliders = True
             self._toggle_sliders()
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
-    # @signal_listener("element_property_reload")
+    @signal_listener("element_property_reload")
     def on_element_property_reload(self, *args):
         self._toggle_sliders()
         self.raster_lines = None
@@ -1098,12 +1064,6 @@ class RasterSettingsPanel(wx.Panel):
         if not self.context.developer_mode:
             self.radio_directional_raster.Enable(False)
 
-    def pane_hide(self):
-        self.panel_start.pane_hide()
-
-    def pane_show(self):
-        self.panel_start.pane_show()
-
     def accepts(self, node):
         return node.type in (
             "op raster",
@@ -1272,11 +1232,6 @@ class HatchSettingsPanel(wx.Panel):
         self.travel_lines = None
         self.outline_lines = None
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
 
     def accepts(self, node):
         return node.type in ("op hatch",)
@@ -1519,12 +1474,6 @@ class DwellSettingsPanel(wx.Panel):
         self.text_dwelltime.Bind(wx.EVT_KILL_FOCUS, self.on_text_dwelltime)
         # end wxGlade
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
     def accepts(self, node):
         return node.type in ("op dots",)
 
@@ -1601,36 +1550,14 @@ class ParameterPanel(ScrolledPanel):
         self.Layout()
         # end wxGlade
 
-    @signal_listener("element_property_reload")
-    def on_element_property_reload(self, origin=None, *args):
-        # if origin is None:
-        #     print ("EPR called with no origin")
-        # else:
-        #     print ("EPR called from:", args)
-        try:
-            self.raster_panel.panel_start.on_element_property_reload(*args)
-        except AttributeError:
-            pass
-        # if self.operation.type != "op hatch":
-        #     if self.hatch_panel.Shown:
-        #         self.hatch_panel.Hide()
-        # else:
-        #     if not self.hatch_panel.Shown:
-        #         self.hatch_panel.Show()
-        # if self.operation.type not in ("op raster", "op image"):
-        #     if self.raster_panel.Shown:
-        #         self.raster_panel.Hide()
-        # else:
-        #     if not self.raster_panel.Shown:
-        #         self.raster_panel.Show()
-        # if self.operation.type != "op dots":
-        #     if self.dwell_panel.Shown:
-        #         self.dwell_panel.Hide()
-        # else:
-        #     if not self.dwell_panel.Shown:
-        #         self.dwell_panel.Show()
-        self.set_widgets(self.operation)
-        self.Layout()
+    def delegate(self):
+        yield self.layer_panel
+        yield self.speedppi_panel
+        yield self.passes_panel
+        yield self.raster_panel
+        yield self.hatch_panel
+        yield self.dwell_panel
+        yield self.info_panel
 
     def set_widgets(self, node):
         self.operation = node
@@ -1641,24 +1568,3 @@ class ParameterPanel(ScrolledPanel):
         self.hatch_panel.set_widgets(node)
         self.dwell_panel.set_widgets(node)
         self.info_panel.set_widgets(node)
-
-    def pane_hide(self):
-        self.layer_panel.pane_hide()
-        self.speedppi_panel.pane_hide()
-        self.passes_panel.pane_hide()
-        self.raster_panel.pane_hide()
-        self.hatch_panel.pane_hide()
-        self.dwell_panel.pane_hide()
-        self.info_panel.pane_hide()
-
-    def pane_show(self):
-        self.layer_panel.pane_show()
-        self.speedppi_panel.pane_show()
-        self.passes_panel.pane_show()
-        self.raster_panel.pane_show()
-        self.hatch_panel.pane_show()
-        self.dwell_panel.pane_show()
-        self.info_panel.pane_show()
-
-
-# end of class ParameterPanel

--- a/meerk40t/gui/propertypanels/outputproperty.py
+++ b/meerk40t/gui/propertypanels/outputproperty.py
@@ -35,16 +35,13 @@ class OutputPropertyPanel(wx.Panel):
         self.SetSizer(main_sizer)
         self.Layout()
 
+    def delegate(self):
+        yield self.panel
+
     @signal_listener("mask")
     @signal_listener("value")
     def wait_changed(self, *args):
         self.context.elements.signal("element_property_update", self.operation)
-
-    def pane_hide(self):
-        self.panel.pane_hide()
-
-    def pane_show(self):
-        self.panel.pane_show()
 
     def set_widgets(self, node):
         self.operation = node

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -340,12 +340,14 @@ class PathProperty(MWindow):
         super().__init__(288, 303, *args, **kwds)
 
         self.panel = PathPropertyPanel(self, wx.ID_ANY, context=self.context, node=node)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_vector_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: PathProperty.__set_properties
         self.SetTitle(_("Path Properties"))
+
+    def delegate(self):
+        yield self.panel
 
     def restore(self, *args, node=None, **kwds):
         self.panel.set_widgets(node)

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -27,6 +27,7 @@ class PropertyWindow(MWindow):
             | wx.aui.AUI_NB_TAB_SPLIT
             | wx.aui.AUI_NB_TAB_MOVE,
         )
+        self.page_panel = None
         self.Layout()
 
     @signal_listener("selected")
@@ -65,8 +66,9 @@ class PropertyWindow(MWindow):
         self.window_close()
         # self.panel_instances.clear()
         self.notebook_main.DeleteAllPages()
+        self.page_panel = None
         for prop_sheet, instance in pages_to_instance:
-            page_panel = prop_sheet(
+            self.page_panel = prop_sheet(
                 self.notebook_main, wx.ID_ANY, context=self.context, node=instance
             )
             try:
@@ -74,24 +76,26 @@ class PropertyWindow(MWindow):
             except AttributeError:
                 name = instance.__class__.__name__
 
-            self.notebook_main.AddPage(page_panel, name)
+            self.notebook_main.AddPage(self.page_panel, name)
             try:
-                page_panel.set_widgets(instance)
+                self.page_panel.set_widgets(instance)
             except AttributeError:
                 pass
-            self.add_module_delegate(page_panel)
-            self.panel_instances.append(page_panel)
+            self.panel_instances.append(self.page_panel)
             try:
-                page_panel.pane_show()
+                self.page_panel.pane_show()
             except AttributeError:
                 pass
-            page_panel.Layout()
+            self.page_panel.Layout()
             try:
-                page_panel.SetupScrolling()
+                self.page_panel.SetupScrolling()
             except AttributeError:
                 pass
 
         self.Layout()
+
+    def delegate(self):
+        yield self.page_panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -640,12 +640,6 @@ class TextProperty(MWindow):
     def restore(self, *args, node=None, **kwds):
         self.panel.set_widgets(node)
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
-
     def window_preserve(self):
         return False
 

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -208,11 +208,8 @@ class TextPropertyPanel(ScrolledPanel):
             return True
         return False
 
-    def pane_show(self):
+    def module_open(self):
         self.set_widgets(self.node)
-
-    def pane_hide(self):
-        pass
 
     def set_widgets(self, node):
         if node is not None:
@@ -631,12 +628,14 @@ class TextProperty(MWindow):
         super().__init__(317, 360, *args, **kwds)
 
         self.panel = TextPropertyPanel(self, wx.ID_ANY, context=self.context, node=node)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_text_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: TextProperty.__set_properties
         self.SetTitle(_("Text Properties"))
+
+    def delegate(self):
+        yield self.panel
 
     def restore(self, *args, node=None, **kwds):
         self.panel.set_widgets(node)

--- a/meerk40t/gui/propertypanels/waitproperty.py
+++ b/meerk40t/gui/propertypanels/waitproperty.py
@@ -32,15 +32,12 @@ class WaitPropertyPanel(wx.Panel):
         self.SetSizer(main_sizer)
         self.Layout()
 
+    def delegate(self):
+        yield self.panel
+
     @signal_listener("wait")
     def wait_changed(self, *args):
         self.context.elements.signal("element_property_update", self.operation)
-
-    def pane_hide(self):
-        self.panel.pane_hide()
-
-    def pane_show(self):
-        self.panel.pane_show()
 
     def set_widgets(self, node):
         self.operation = node

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -15,7 +15,7 @@ from .icons import (
     icons8_play_50,
     icons8_route_50,
 )
-from .laserrender import DRAW_MODE_BACKGROUND, DRAW_MODE_GUIDES, LaserRender
+from .laserrender import DRAW_MODE_BACKGROUND, LaserRender
 from .mwindow import MWindow
 from .scene.scenepanel import ScenePanel
 from .scene.widget import Widget
@@ -328,6 +328,9 @@ class SimulationPanel(wx.Panel, Job):
             self.hscene_sizer.Layout()
             self.Layout()
 
+    def delegates(self):
+        yield self.panel_optimize
+
     def toggle_background(self, event):
         """
         Toggle the draw mode for the background
@@ -561,7 +564,6 @@ class SimulationPanel(wx.Panel, Job):
             bbox, self.view_pane.Size, 0.1
         )
         self.update_fields()
-        self.panel_optimize.pane_show()
 
     def pane_hide(self):
         if self.auto_clear:
@@ -569,7 +571,6 @@ class SimulationPanel(wx.Panel, Job):
         self.context.close("SimScene")
         self.context.unschedule(self)
         self.running = False
-        self.panel_optimize.pane_hide()
 
     @signal_listener("refresh_scene")
     def on_refresh_scene(self, origin, scene_name=None, *args):
@@ -790,11 +791,14 @@ class Simulation(MWindow):
             plan_name=plan_name,
             auto_clear=auto_clear,
         )
-        self.add_module_delegate(self.panel)
+        self.module_delegate()
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_laser_beam_hazard2_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Simulation"))
+
+    def delegates(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -561,6 +561,7 @@ class SimulationPanel(wx.Panel, Job):
             bbox, self.view_pane.Size, 0.1
         )
         self.update_fields()
+        self.panel_optimize.pane_show()
 
     def pane_hide(self):
         if self.auto_clear:
@@ -568,6 +569,7 @@ class SimulationPanel(wx.Panel, Job):
         self.context.close("SimScene")
         self.context.unschedule(self)
         self.running = False
+        self.panel_optimize.pane_hide()
 
     @signal_listener("refresh_scene")
     def on_refresh_scene(self, origin, scene_name=None, *args):

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -791,7 +791,6 @@ class Simulation(MWindow):
             plan_name=plan_name,
             auto_clear=auto_clear,
         )
-        self.module_delegate()
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_laser_beam_hazard2_50.GetBitmap())
         self.SetIcon(_icon)

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -556,7 +556,7 @@ class SimulationPanel(wx.Panel, Job):
             )
         self.refresh_my_plan()
 
-    def pane_show(self):
+    def module_open(self):
         self.context.setting(str, "units_name", "mm")
 
         bbox = self.context.device.bbox()
@@ -565,7 +565,7 @@ class SimulationPanel(wx.Panel, Job):
         )
         self.update_fields()
 
-    def pane_hide(self):
+    def module_close(self):
         if self.auto_clear:
             self.context(f"plan{self.plan_name} clear\n")
         self.context.close("SimScene")
@@ -817,12 +817,6 @@ class Simulation(MWindow):
                 "size": STD_ICON_SIZE,
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
 
     @signal_listener("background")
     def on_background_signal(self, origin, background):

--- a/meerk40t/gui/snapoptions.py
+++ b/meerk40t/gui/snapoptions.py
@@ -157,8 +157,5 @@ class SnapOptionPanel(wx.Panel):
         self.slider_distance_points.SetValue(self.context.action_attract_len)
         self.slider_visibility.SetValue(self.context.show_attract_len)
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         self.update_values()
-
-    def pane_hide(self, *args):
-        pass

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -226,11 +226,8 @@ class SpoolerPanel(wx.Panel):
 
         return delete
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         self.refresh_spooler_list()
-
-    def pane_hide(self, *args):
-        pass
 
     @staticmethod
     def _name_str(named_obj):
@@ -427,9 +424,3 @@ class JobSpooler(MWindow):
                 "action": lambda v: kernel.console("window toggle JobSpooler\n"),
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -406,12 +406,14 @@ class JobSpooler(MWindow):
         self.panel = SpoolerPanel(
             self, wx.ID_ANY, context=self.context, selected_device=selected_device
         )
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_route_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Job Spooler"))
         self.Layout()
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):

--- a/meerk40t/gui/toolwidgets/textentry.py
+++ b/meerk40t/gui/toolwidgets/textentry.py
@@ -140,12 +140,6 @@ class TextEntryPanel(wx.Panel):
         self.setLogic()
         self.result = 0
 
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
-
     def setLayout(self):
         sizer_v_main = wx.BoxSizer(wx.VERTICAL)
 
@@ -473,11 +467,13 @@ class TextEntry(MWindow):
         y = 0 if len(args) <= 4 else float(args[4])
         default_string = "" if len(args) <= 5 else " ".join(args[5:])
         self.panel = TextEntryPanel(self, wx.ID_ANY, context=self.context, x=x, y=y, default_string=default_string)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_type_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Add a Text-element"))
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):
@@ -492,11 +488,7 @@ class TextEntry(MWindow):
         # )
         pass
 
-    def window_open(self):
-        self.panel.pane_show()
-
     def window_close(self):
-        self.panel.pane_hide()
         if self.panel.result == 1:
             text = self.panel.result_text
             elements = self.context.elements

--- a/meerk40t/gui/usbconnect.py
+++ b/meerk40t/gui/usbconnect.py
@@ -27,12 +27,12 @@ class UsbConnectPanel(wx.Panel):
         self.pipe = None
         self._active_when_loaded = None
 
-    def pane_show(self):
+    def module_open(self):
         active = self.context.device.active
         self._active_when_loaded = active
         self.context.channel(f"{active}/usb", buffer_size=500).watch(self.update_text)
 
-    def pane_hide(self):
+    def module_close(self):
         active = self._active_when_loaded
         self.context.channel(f"{active}/usb").unwatch(self.update_text)
 
@@ -73,15 +73,11 @@ class UsbConnect(MWindow):
         super().__init__(915, 424, *args, **kwds)
 
         self.panel = UsbConnectPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_usb_connector_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: Terminal.__set_properties
         self.SetTitle(_("UsbConnect"))
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegate(self):
+        yield self.panel

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -129,12 +129,9 @@ class WordlistPanel(wx.Panel):
         self.btn_import.Enable(False)
         self.populate_gui()
 
-    def pane_show(self):
+    def module_open(self):
         self.populate_gui()
         self.grid_wordlist.SetFocus()
-
-    def pane_hide(self):
-        pass
 
     def refresh_grid_wordlist(self):
         self.grid_wordlist.ClearAll()
@@ -316,12 +313,14 @@ class WordlistEditor(MWindow):
         super().__init__(500, 530, *args, **kwds)
 
         self.panel = WordlistPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_curly_brackets_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: Keymap.__set_properties
         self.SetTitle(_("Wordlist Editor"))
+
+    def delegate(self):
+        yield self.panel
 
     @staticmethod
     def sub_register(kernel):
@@ -334,9 +333,3 @@ class WordlistEditor(MWindow):
                 "action": lambda v: kernel.console("window toggle Wordlist\n"),
             },
         )
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1498,7 +1498,6 @@ class MeerK40t(MWindow):
         def unlock_pane(command, _, channel, **kwargs):
             self.on_pane_lock(None, lock=False)
 
-
     def on_pane_reset(self, event=None):
         self.on_panes_closed()
         self._mgr.LoadPerspective(self.default_perspective, update=True)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1498,44 +1498,6 @@ class MeerK40t(MWindow):
         def unlock_pane(command, _, channel, **kwargs):
             self.on_pane_lock(None, lock=False)
 
-        @context.console_argument("pane", help=_("pane to create"))
-        @context.console_command(
-            "create",
-            input_type="panes",
-            help=_("create a floating about pane"),
-        )
-        def create_pane(command, _, channel, pane=None, **kwargs):
-            if pane == "about":
-                from .about import AboutPanel as CreatePanel
-
-                caption = _("About")
-                width = 646
-                height = 519
-            elif pane == "preferences":
-                from .preferences import PreferencesPanel as CreatePanel
-
-                caption = _("Preferences")
-                width = 565
-                height = 327
-            else:
-                channel(_("Pane not found."))
-                return
-            panel = CreatePanel(self, context=context)
-            _pane = (
-                aui.AuiPaneInfo()
-                .Dockable(False)
-                .Float()
-                .Caption(caption)
-                .FloatingSize(width, height)
-                .Name(pane)
-                .CaptionVisible(True)
-            )
-            _pane.control = panel
-            self.on_pane_add(_pane)
-            if hasattr(panel, "pane_show"):
-                panel.pane_show()
-            self.context.register("pane/about", _pane)
-            self._mgr.Update()
 
     def on_pane_reset(self, event=None):
         self.on_panes_closed()

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1548,11 +1548,11 @@ class MeerK40t(MWindow):
                 window = pane.window
                 if hasattr(window, "pane_hide"):
                     window.pane_hide()
-                if isinstance(window, wx.aui.AuiNotebook):
-                    for i in range(window.GetPageCount()):
-                        page = window.GetPage(i)
-                        if hasattr(page, "pane_hide"):
-                            page.pane_hide()
+                # if isinstance(window, wx.aui.AuiNotebook):
+                #     for i in range(window.GetPageCount()):
+                #         page = window.GetPage(i)
+                #         if hasattr(page, "pane_hide"):
+                #             page.pane_hide()
 
     def on_panes_opened(self):
         for pane in self._mgr.GetAllPanes():

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -857,11 +857,6 @@ class RibbonPanel(wx.Panel):
 
         self.ensure_realize()
 
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
 
     # def on_page_changing(self, event):
     #     page = event.GetPage()

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -599,12 +599,9 @@ class MeerK40tScenePanel(wx.Panel):
             strength = 0
         self.scene.scene.magnet_attraction = strength
 
-    def pane_show(self, *args):
+    def module_open(self, *args):
         zl = self.context.zoom_level
         self.context(f"scene focus -{zl}% -{zl}% {100 + zl}% {100 + zl}%\n")
-
-    def pane_hide(self, *args):
-        pass
 
     @signal_listener("activate;device")
     def on_activate_device(self, origin, device):
@@ -722,15 +719,11 @@ class SceneWindow(MWindow):
     def __init__(self, *args, **kwds):
         super().__init__(1280, 800, *args, **kwds)
         self.panel = MeerK40tScenePanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icon_meerk40t.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Scene"))
         self.Layout()
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegate(self):
+        yield self.panel

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -119,12 +119,6 @@ class TreePanel(wx.Panel):
             # Make sure the treectl can work on standard keys...
             event.Skip()
 
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
-
     @signal_listener("select_emphasized_tree")
     def on_shadow_select_emphasized_tree(self, origin, *args):
         self.shadow_tree.select_in_tree_by_emphasis(origin, *args)
@@ -248,24 +242,13 @@ class ElementsTree(MWindow):
         super().__init__(423, 131, *args, **kwds)
 
         self.panel = TreePanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_smartphone_ram_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Tree"))
 
-    def window_open(self):
-        try:
-            self.panel.pane_show()
-        except AttributeError:
-            pass
-
-    def window_close(self):
-        try:
-            self.panel.pane_hide()
-        except AttributeError:
-            pass
-
+    def delegate(self):
+        yield self.panel
 
 class ShadowTree:
     """

--- a/meerk40t/kernel/context.py
+++ b/meerk40t/kernel/context.py
@@ -427,11 +427,36 @@ class Context:
 
         instance = open_object(self, instance_path, *args, **kwargs)
         instance.registered_path = registered_path
+        self._module_delegate(instance)
 
         # Call module_open lifecycle event.
         self.kernel.set_module_lifecycle(instance, LIFECYCLE_MODULE_OPENED)
-
         return instance
+
+    def _module_delegate(self, module, model=None, add=True):
+        """
+        Recursively find any delegates for a module yielded under `.delegate()`
+
+        @param module:
+        @param model:
+        @param add:
+        @return:
+        """
+        kernel = self.kernel
+        if model is None:
+            model = module
+
+        try:
+            if model is not module:
+                # We are the model we don't delegate to it.
+                if add:
+                    kernel.add_delegate(model, module)
+                else:
+                    kernel.remove_delegate(model, module)
+            for delegate in model.delegates():
+                self._module_delegate(module=module, model=delegate, add=add)
+        except AttributeError:
+            pass
 
     def close(self, instance_path: str, *args, **kwargs) -> None:
         """

--- a/meerk40t/kernel/module.py
+++ b/meerk40t/kernel/module.py
@@ -45,23 +45,6 @@ class Module:
         shutdown or if this individual module is being closed on its own."""
         pass
 
-    def module_delegate(self, model=None, add=True, kernel=None):
-        if kernel is None:
-            kernel = self.context.kernel
-        if model is None:
-            model = self
-
-        try:
-            if model is not self:
-                if add:
-                    kernel.add_delegate(model, self)
-                else:
-                    kernel.remove_delegate(model, self)
-            for delegate in model.delegates():
-                self.module_delegate(model=delegate, add=add, kernel=kernel)
-        except AttributeError:
-            pass
-
     def add_module_delegate(self, delegate):
         self.context.kernel.add_delegate(delegate, self)
 

--- a/meerk40t/kernel/module.py
+++ b/meerk40t/kernel/module.py
@@ -45,6 +45,23 @@ class Module:
         shutdown or if this individual module is being closed on its own."""
         pass
 
+    def module_delegate(self, model=None, add=True, kernel=None):
+        if kernel is None:
+            kernel = self.context.kernel
+        if model is None:
+            model = self
+
+        try:
+            if model is not self:
+                if add:
+                    kernel.add_delegate(model, self)
+                else:
+                    kernel.remove_delegate(model, self)
+            for delegate in model.delegates():
+                self.module_delegate(model=delegate, add=add, kernel=kernel)
+        except AttributeError:
+            pass
+
     def add_module_delegate(self, delegate):
         self.context.kernel.add_delegate(delegate, self)
 

--- a/meerk40t/lihuiyu/gui/lhyaccelgui.py
+++ b/meerk40t/lihuiyu/gui/lhyaccelgui.py
@@ -5,6 +5,7 @@ import wx
 from meerk40t.gui.icons import icons8_administrative_tools_50
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -310,14 +311,7 @@ class LihuiyuAccelerationChartPanel(ScrolledPanel):
         self.checkbox_raster_accel_enable.SetValue(context.raster_accel_table)
         self.checkbox_vector_accel_enable.SetValue(context.vector_accel_table)
 
-    def pane_show(self):
-        # self.context.listen("pipe;buffer", self.on_buffer_update)
-        self.context.listen("active", self.on_active_change)
-
-    def pane_hide(self):
-        # self.context.unlisten("pipe;buffer", self.on_buffer_update)
-        self.context.unlisten("active", self.on_active_change)
-
+    @signal_listener("active")
     def on_active_change(self, origin, active):
         # self.Close()
         pass
@@ -351,14 +345,10 @@ class LihuiyuAccelerationChart(MWindow):
         self.panel = LihuiyuAccelerationChartPanel(
             self, wx.ID_ANY, context=self.context
         )
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_administrative_tools_50.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Acceleration Chart"))
 
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegate(self):
+        yield self.panel

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -253,18 +253,12 @@ class LihuiyuControllerPanel(ScrolledPanel):
         # end wxGlade
 
     def module_open(self, *args, **kwargs):
-        self.pane_show()
-
-    def module_close(self, *args, **kwargs):
-        self.pane_hide()
-
-    def pane_show(self):
         self.context.channel(f"{self.context.label}/usb", buffer_size=500).watch(
             self.update_text
         )
         self.on_network_update()
 
-    def pane_hide(self):
+    def module_close(self, *args, **kwargs):
         self.context.channel(f"{self.context.label}/usb").unwatch(self.update_text)
 
     @signal_listener("network_update")
@@ -535,7 +529,6 @@ class LihuiyuControllerGui(MWindow):
         # ==========
 
         self.panel = LihuiyuControllerPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected_50.GetBitmap())
         self.SetIcon(_icon)
@@ -564,6 +557,9 @@ class LihuiyuControllerGui(MWindow):
         )
         self.Bind(wx.EVT_MENU, self.on_menu_bufferview, id=item.GetId())
         append(wxglade_tmp_menu, _("Views"))
+
+    def delegate(self):
+        yield self.panel
 
     def window_preserve(self):
         return False

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -169,14 +169,6 @@ class ConfigurationUsb(wx.Panel):
         self.check_serial_number.Enable(False)
         self.text_serial_number.Enable(False)
 
-    def pane_show(self):
-        # self.context.listen("pipe;buffer", self.on_buffer_update)
-        pass
-
-    def pane_hide(self):
-        # self.context.unlisten("pipe;buffer", self.on_buffer_update)
-        pass
-
     @signal_listener("pipe;buffer")
     def on_buffer_update(self, origin, value, *args):
         self.text_buffer_length.SetValue(str(value))
@@ -260,12 +252,6 @@ class ConfigurationTcp(wx.Panel):
         # end wxGlade
         self.text_port.SetValue(str(self.context.port))
         self.text_address.SetValue(self.context.address)
-
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
 
     def on_text_address(self, event):  # wxGlade: ConfigurationTcp.<event_handler>
         event.Skip()
@@ -440,12 +426,6 @@ class ConfigurationLaserPanel(wx.Panel):
         self.text_scale_x.Bind(wx.EVT_KILL_FOCUS, self.on_text_x_scale)
         self.text_scale_y.Bind(wx.EVT_TEXT_ENTER, self.on_text_y_scale)
         self.text_scale_y.Bind(wx.EVT_KILL_FOCUS, self.on_text_y_scale)
-
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
 
     def on_text_home_x(self, event=None):
         event.Skip()
@@ -693,10 +673,10 @@ class ConfigurationInterfacePanel(ScrolledPanel):
             self.panel_tcp_config.Hide()
         self.SetupScrolling()
 
-    def pane_show(self):
-        self.ConfigurationLaserPanel.pane_show()
-        self.panel_usb_settings.pane_show()
-        self.panel_tcp_config.pane_show()
+    def delegate(self):
+        yield self.ConfigurationLaserPanel
+        yield self.panel_usb_settings
+        yield self.panel_tcp_config
 
     def pane_hide(self):
         self.ConfigurationLaserPanel.pane_hide()
@@ -1077,12 +1057,6 @@ class ConfigurationSetupPanel(ScrolledPanel):
         self.check_scale_speed.Enable(False)
         self.SetupScrolling()
 
-    def pane_show(self):
-        pass
-
-    def pane_hide(self):
-        pass
-
     def on_check_fix_speeds(self, event=None):
         self.context.fix_speeds = self.check_fix_speeds.GetValue()
         self.text_fix_rated_speed.SetValue(
@@ -1216,19 +1190,10 @@ class LihuiyuDriverGui(MWindow):
 
         self.Layout()
 
-        self.add_module_delegate(self.ConfigurationPanel)
-        self.add_module_delegate(self.SetupPanel)
-        self.add_module_delegate(self.panel_warn)
-
-    def window_open(self):
-        self.SetupPanel.pane_show()
-        self.ConfigurationPanel.pane_show()
-        self.panel_warn.pane_show()
-
-    def window_close(self):
-        self.SetupPanel.pane_hide()
-        self.ConfigurationPanel.pane_hide()
-        self.panel_warn.pane_hide()
+    def delegate(self):
+        yield self.ConfigurationPanel
+        yield self.SetupPanel
+        yield self.panel_warn
 
     def window_preserve(self):
         return False

--- a/meerk40t/lihuiyu/gui/lhyoperationproperties.py
+++ b/meerk40t/lihuiyu/gui/lhyoperationproperties.py
@@ -139,12 +139,6 @@ class LhyAdvancedPanel(wx.Panel):
         )
         # end wxGlade
 
-    def pane_hide(self):
-        pass
-
-    def pane_show(self):
-        pass
-
     def set_widgets(self, node):
         self.operation = node
         if self.operation.dratio is not None:

--- a/meerk40t/moshi/gui/moshicontrollergui.py
+++ b/meerk40t/moshi/gui/moshicontrollergui.py
@@ -243,7 +243,7 @@ class MoshiControllerPanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
-    def pane_show(self):
+    def module_open(self):
         active = self.context.path.split("/")[-1]
         self.context.channel(f"{active}/usb", buffer_size=500).watch(self.update_text)
         self.context.listen("pipe;status", self.update_status)
@@ -251,7 +251,7 @@ class MoshiControllerPanel(wx.Panel):
         self.context.listen("pipe;state", self.on_connection_state_change)
         self.context.listen("active", self.on_active_change)
 
-    def pane_hide(self):
+    def module_close(self):
         active = self.context.path.split("/")[-1]
         self.context.channel(f"{active}/usb").unwatch(self.update_text)
         self.context.unlisten("pipe;status", self.update_status)
@@ -428,7 +428,6 @@ class MoshiControllerGui(MWindow):
         # ==========
 
         self.panel = MoshiControllerPanel(self, wx.ID_ANY, context=self.context)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected_50.GetBitmap())
         self.SetIcon(_icon)
@@ -461,14 +460,11 @@ class MoshiControllerGui(MWindow):
         append(wxglade_tmp_menu, _("Views"))
         self.SetMenuBar(self.MoshiController_menubar)
 
+    def delegate(self):
+        yield self.panel
+
     def restore(self, *args, **kwargs):
         self.panel.set_widgets()
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
 
     def window_preserve(self):
         return False

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -100,14 +100,7 @@ class MoshiConfigurationPanel(ScrolledPanel):
         self.Layout()
         # end wxGlade
 
-    def pane_show(self):
-        # self.context.listen("pipe;buffer", self.on_buffer_update)
-        self.context.listen("active", self.on_active_change)
-
-    def pane_hide(self):
-        # self.context.unlisten("pipe;buffer", self.on_buffer_update)
-        self.context.unlisten("active", self.on_active_change)
-
+    @signal_listener("active")
     def on_active_change(self, origin, active):
         # self.Close()
         pass
@@ -168,16 +161,9 @@ class MoshiDriverGui(MWindow):
 
         self.Layout()
 
-        self.add_module_delegate(self.ConfigurationPanel)
-        self.add_module_delegate(self.panel_warn)
-
-    def window_open(self):
-        self.ConfigurationPanel.pane_show()
-        self.panel_warn.pane_show()
-
-    def window_close(self):
-        self.ConfigurationPanel.pane_hide()
-        self.panel_warn.pane_hide()
+    def delegate(self):
+        yield self.ConfigurationPanel
+        yield self.panel_warn
 
     def window_preserve(self):
         return False

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -58,14 +58,11 @@ class RotarySettingsPanel(ScrolledPanel):
         # )
         self.SetupScrolling()
 
-    def pane_show(self):
+    def module_open(self):
         self.text_rotary_scalex.SetValue(str(self.rotary.scale_x))
         self.text_rotary_scaley.SetValue(str(self.rotary.scale_y))
         self.checkbox_rotary.SetValue(self.rotary.rotary_enabled)
         self.on_check_rotary(None)
-
-    def pane_hide(self):
-        pass
 
     def __set_properties(self):
         self.checkbox_rotary.SetFont(
@@ -197,15 +194,10 @@ class RotarySettings(MWindow):
         super().__init__(200, 125, *args, **kwds)
 
         self.panel = RotarySettingsPanel(self, wx.ID_ANY, context=self.context.rotary)
-        self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_roll_50.GetBitmap())
         self.SetIcon(_icon)
         # begin wxGlade: RotarySettings.__set_properties
         self.SetTitle(_("RotarySettings"))
-
-    def window_open(self):
-        self.panel.pane_show()
-
-    def window_close(self):
-        self.panel.pane_hide()
+    def delegate(self):
+        yield self.panel


### PR DESCRIPTION
Modules typically have a sort of weird hamstring structure to provide delegates. This modifies that structure to permit anything within the module to yield `delegates()` these in turn can also yield their own `delegate()` values providing a tree of delegated objects more easily than being forced to call `add_module_delegate()` at the delegate level itself.