### PR TITLE
Remove Fractional Point Sizes

### DIFF
--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -109,15 +109,7 @@ def svgfont_to_wx(textnode):
     # A point is 1/72 of an inch
     factor = 72 / PX_PER_INCH
     font_size = textnode.font_size * factor
-    if font_size < 1:
-        if font_size > 0:
-            textnode.matrix.pre_scale(font_size, font_size)
-            font_size = 1
-            textnode.font_size = font_size  # No zero sized fonts.
-    try:
-        wxfont.SetFractionalPointSize(font_size)
-    except AttributeError:
-        wxfont.SetPointSize(int(font_size))
+    wxfont.SetPointSize(int(round(font_size)) if font_size > 1 else 1)
     wxfont.SetUnderlined(textnode.underline)
     wxfont.SetStrikethrough(textnode.strikethrough)
 

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -106,9 +106,7 @@ def svgfont_to_wx(textnode):
     svg_to_wx_family(textnode, wxfont)
     svg_to_wx_fontstyle(textnode, wxfont)
 
-    # A point is 1/72 of an inch
-    factor = 72 / PX_PER_INCH
-    font_size = textnode.font_size * factor
+    font_size = textnode.font_size
     wxfont.SetPointSize(int(round(font_size)) if font_size > 1 else 1)
     wxfont.SetUnderlined(textnode.underline)
     wxfont.SetStrikethrough(textnode.strikethrough)

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -456,18 +456,12 @@ class TextPropertyPanel(ScrolledPanel):
             pass
 
     def on_button_smaller(self, event):
-        try:
-            size = self.node.wxfont.GetFractionalPointSize()
-        except AttributeError:
-            size = self.node.wxfont.GetPointSize()
+        size = self.node.wxfont.GetPointSize()
 
         size = size / 1.2
         if size < 4:
             size = 4
-        try:
-            self.node.wxfont.SetFractionalPointSize(size)
-        except AttributeError:
-            self.node.wxfont.SetPointSize(int(size))
+        self.node.wxfont.SetPointSize(int(round(size)) if size > 1 else 1)
 
         wxfont_to_svg(self.node)
         self.update_label()
@@ -475,17 +469,9 @@ class TextPropertyPanel(ScrolledPanel):
         event.Skip()
 
     def on_button_larger(self, event):
-        try:
-            size = self.node.wxfont.GetFractionalPointSize()
-        except AttributeError:
-            size = self.node.wxfont.GetPointSize()
+        size = self.node.wxfont.GetPointSize()
         size *= 1.2
-
-        try:
-            self.node.wxfont.SetFractionalPointSize(size)
-        except AttributeError:
-            self.node.wxfont.SetPointSize(int(size))
-
+        self.node.wxfont.SetPointSize(int(round(size)) if size > 1 else 1)
         wxfont_to_svg(self.node)
         self.update_label()
         self.refresh()

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -109,10 +109,7 @@ class SceneToast:
         while self.text_height > height or self.text_width > width:
             # If we do not fit in the box, decrease size
             text_size *= 0.9
-            try:
-                self.font.SetFractionalPointSize(text_size)
-            except AttributeError:
-                self.font.SetPointSize(int(text_size))
+            self.font.SetPointSize(int(round(text_size)) if text_size > 1 else 1)
             gc.SetFont(self.font, self.font_color)
             self.text_width, self.text_height = gc.GetTextExtent(self.message)
         if text_size == height:

--- a/meerk40t/gui/toolwidgets/textentry.py
+++ b/meerk40t/gui/toolwidgets/textentry.py
@@ -367,34 +367,20 @@ class TextEntryPanel(wx.Panel):
             self.last_font[i].SetFont(font)
 
     def on_button_smaller(self, event):
-        try:
-            size = self.result_font.GetFractionalPointSize()
-        except AttributeError:
-            size = self.result_font.GetPointSize()
-
+        size = self.result_font.GetPointSize()
         size = size / 1.2
         if size < 4:
             size = 4
-        try:
-            self.result_font.SetFractionalPointSize(size)
-        except AttributeError:
-            self.result_font.SetPointSize(int(size))
+        self.result_font.SetPointSize(int(round(size)) if size > 1 else 1)
 
         self.preview.Font = self.result_font
         self.preview.Refresh()
         event.Skip()
 
     def on_button_larger(self, event):
-        try:
-            size = self.result_font.GetFractionalPointSize()
-        except AttributeError:
-            size = self.result_font.GetPointSize()
+        size = self.result_font.GetPointSize()
         size *= 1.2
-
-        try:
-            self.result_font.SetFractionalPointSize(size)
-        except AttributeError:
-            self.result_font.SetPointSize(int(size))
+        self.result_font.SetPointSize(int(round(size)) if size > 1 else 1)
 
         self.preview.Font = self.result_font
         self.preview.Refresh()

--- a/meerk40t/gui/utilitywidgets/checkboxwidget.py
+++ b/meerk40t/gui/utilitywidgets/checkboxwidget.py
@@ -70,10 +70,7 @@ class CheckboxWidget(Widget):
             height = self.bottom - self.top
             width = self.right - self.left
             text_size = height * 3.0 / 4.0  # px to pt conversion
-            try:
-                self.font.SetFractionalPointSize(text_size)
-            except AttributeError:
-                self.font.SetPointSize(int(text_size))
+            self.font.SetPointSize(int(round(text_size)) if text_size > 1 else 1)
             gc.SetFont(self.font, self.font_color)
             gc.DrawText(self.text, self.right + width * self._text_gap, self.top)
 


### PR DESCRIPTION
Fractional point sizes are inconsistent across platforms making them unacceptable for use. Linux could change size when the matrix changed and it would result in inconsistent font calculations between scene and raster-image.

@tiger12506 I might need you to check if this actually fixes the critical bug.