### PR TITLE
Add paint bounds rather than pure geometric bounds for nodes

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -3762,7 +3762,7 @@ class Elemental(Service):
                 channel(_("No renderer is registered to perform render."))
                 return
 
-            bounds = Node.union_bounds(data)
+            bounds = Node.union_bounds(data, attr="paint_bounds")
             if bounds is None:
                 return
             xmin, ymin, xmax, ymax = bounds
@@ -7119,7 +7119,7 @@ class Elemental(Service):
             if len(data) == 0:
                 return
             try:
-                bounds = Node.union_bounds(data)
+                bounds = Node.union_bounds(data, attr="paint_bounds")
                 width = bounds[2] - bounds[0]
                 height = bounds[3] - bounds[1]
             except TypeError:

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -62,13 +62,9 @@ class EllipseNode(Node):
             setting=self.settings,
         )
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._sync_svg()
-            self._bounds = self.shape.bbox(with_stroke=True)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        self._sync_svg()
+        return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     @property
     def stroke_scaled(self):

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -94,6 +94,7 @@ class EllipseNode(Node):
         self.matrix *= matrix
         self.stroke_scaled = False
         self._sync_svg()
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(EllipseNode, self).default_map(default_map=default_map)
@@ -151,7 +152,7 @@ class EllipseNode(Node):
         )
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -152,7 +152,6 @@ class EllipseNode(Node):
         )
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
-        self.set_dirty_bounds()
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -140,26 +140,23 @@ class ImageNode(Node):
         """
         self.step_x, self.step_y = context.device.dpi_to_steps(self.dpi)
         self.matrix *= matrix
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
         self.process_image()
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            image_width, image_height = self.active_image.size
-            matrix = self.active_matrix
-            x0, y0 = matrix.point_in_matrix_space((0, 0))
-            x1, y1 = matrix.point_in_matrix_space((image_width, image_height))
-            x2, y2 = matrix.point_in_matrix_space((0, image_height))
-            x3, y3 = matrix.point_in_matrix_space((image_width, 0))
-            self._bounds_dirty = False
-            self._bounds = (
-                min(x0, x1, x2, x3),
-                min(y0, y1, y2, y3),
-                max(x0, x1, x2, x3),
-                max(y0, y1, y2, y3),
-            )
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        image_width, image_height = self.active_image.size
+        matrix = self.active_matrix
+        x0, y0 = matrix.point_in_matrix_space((0, 0))
+        x1, y1 = matrix.point_in_matrix_space((image_width, image_height))
+        x2, y2 = matrix.point_in_matrix_space((0, image_height))
+        x3, y3 = matrix.point_in_matrix_space((image_width, 0))
+        self._bounds_dirty = False
+        self._bounds = (
+            min(x0, x1, x2, x3),
+            min(y0, y1, y2, y3),
+            max(x0, x1, x2, x3),
+            max(y0, y1, y2, y3),
+        )
 
     def default_map(self, default_map=None):
         default_map = super(ImageNode, self).default_map(default_map=default_map)

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -150,8 +150,7 @@ class ImageNode(Node):
         x1, y1 = matrix.point_in_matrix_space((image_width, image_height))
         x2, y2 = matrix.point_in_matrix_space((0, image_height))
         x3, y3 = matrix.point_in_matrix_space((image_width, 0))
-        self._bounds_dirty = False
-        self._bounds = (
+        return (
             min(x0, x1, x2, x3),
             min(y0, y1, y2, y3),
             max(x0, x1, x2, x3),

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -93,13 +93,9 @@ class LineNode(Node):
             sw = limit
         return sw
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._sync_svg()
-            self._bounds = self.shape.bbox(with_stroke=True)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        self._sync_svg()
+        return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, commands):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -102,6 +102,7 @@ class LineNode(Node):
         self.matrix *= matrix
         self.stroke_scaled = False
         self._sync_svg()
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(LineNode, self).default_map(default_map=default_map)
@@ -160,7 +161,6 @@ class LineNode(Node):
         self.shape.stroke = self.stroke
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
-        self._bounds_dirty = True
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_numpath.py
+++ b/meerk40t/core/node/elem_numpath.py
@@ -65,7 +65,7 @@ class NumpathNode(Node, Parameters):
     def preprocess(self, context, matrix, commands):
         self.path.transform(self.matrix)
         self.path.transform(matrix)
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(NumpathNode, self).default_map(default_map=default_map)

--- a/meerk40t/core/node/elem_numpath.py
+++ b/meerk40t/core/node/elem_numpath.py
@@ -59,12 +59,8 @@ class NumpathNode(Node, Parameters):
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(len(self.path))}, {str(self._parent)})"
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = self.path.bbox(self.matrix)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        return self.path.bbox(self.matrix)
 
     def preprocess(self, context, matrix, commands):
         self.path.transform(self.matrix)

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -89,13 +89,9 @@ class PathNode(Node):
             sw = limit
         return sw
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._sync_svg()
-            self._bounds = self.path.bbox(with_stroke=True)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        self._sync_svg()
+        return self.path.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, commands):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -98,6 +98,7 @@ class PathNode(Node):
         self.matrix *= matrix
         self.stroke_scaled = False
         self._sync_svg()
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(PathNode, self).default_map(default_map=default_map)
@@ -155,7 +156,6 @@ class PathNode(Node):
         )
         self.path.transform = self.matrix
         self.path.stroke_width = self.stroke_width
-        self._bounds_dirty = True
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -57,18 +57,9 @@ class PointNode(Node):
         self.matrix *= matrix
         self._bounds_dirty = True
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            p = self.matrix.transform_point(self.point)
-            self._bounds = (
-                p[0],
-                p[1],
-                p[0],
-                p[1],
-            )
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        p = self.matrix.transform_point(self.point)
+        return (p[0], p[1], p[0], p[1])
 
     def default_map(self, default_map=None):
         default_map = super(PointNode, self).default_map(default_map=default_map)

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -55,7 +55,7 @@ class PointNode(Node):
 
     def preprocess(self, context, matrix, commands):
         self.matrix *= matrix
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
 
     def bbox(self, transformed=True, with_stroke=False):
         p = self.matrix.transform_point(self.point)

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -93,13 +93,9 @@ class PolylineNode(Node):
             sw = limit
         return sw
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._sync_svg()
-            self._bounds = self.shape.bbox(with_stroke=True)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        self._sync_svg()
+        return self.shape.bbox(transformed=True, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, commands):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -102,6 +102,7 @@ class PolylineNode(Node):
         self.matrix *= matrix
         self.stroke_scaled = False
         self._sync_svg()
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(PolylineNode, self).default_map(default_map=default_map)
@@ -159,7 +160,6 @@ class PolylineNode(Node):
         )
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
-        self._bounds_dirty = True
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -90,13 +90,9 @@ class RectNode(Node):
             sw = limit
         return sw
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._sync_svg()
-            self._bounds = self.shape.bbox(with_stroke=True)
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        self._sync_svg()
+        return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, commands):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -99,6 +99,7 @@ class RectNode(Node):
         self.matrix *= matrix
         self.stroke_scaled = False
         self._sync_svg()
+        self.set_dirty_bounds()
 
     def default_map(self, default_map=None):
         default_map = super(RectNode, self).default_map(default_map=default_map)
@@ -156,7 +157,6 @@ class RectNode(Node):
         )
         self.shape.transform = self.matrix
         self.shape.stroke_width = self.stroke_width
-        self._bounds_dirty = True
 
     def as_path(self):
         self._sync_svg()

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -183,7 +183,7 @@ class TextNode(Node):
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
 
     def remove_text(self):
         self.remove_node()

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -168,13 +168,6 @@ class TextNode(Node):
             sw = limit
         return sw
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds_dirty = False
-            self._bounds = self.bbox(with_stroke=True)
-        return self._bounds
-
     def preprocess(self, context, matrix, commands):
         if self.parent.type != "op raster":
             commands.append(self.remove_text)

--- a/meerk40t/core/node/filenode.py
+++ b/meerk40t/core/node/filenode.py
@@ -33,13 +33,6 @@ class FileNode(Node):
         return False
 
     @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
-    @property
     def filepath(self):
         return self._filepath
 

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -15,21 +15,18 @@ class GroupNode(Node):
     def __repr__(self):
         return f"GroupNode('{self.type}', {str(self._parent)})"
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            if len(self.children) == 0:
-                # empty, otherwise will recurse forever...
-                self._bounds = (
-                    float("inf"),
-                    float("inf"),
-                    -float("inf"),
-                    -float("inf"),
-                )
-            else:
-                self._bounds = Node.union_bounds(self._flatten_children(self))
-            self._bounds_dirty = False
-        return self._bounds
+    def bbox(self, transformed=True, with_stroke=False):
+        """
+        Group default bbox is empty. If childless there are no bounds.
+
+        empty, otherwise will recurse forever...
+
+        @param transformed:
+        @param with_stroke:
+        @return:
+        """
+
+        return float("inf"), float("inf"), -float("inf"), -float("inf"),
 
     def default_map(self, default_map=None):
         default_map = super(GroupNode, self).default_map(default_map=default_map)

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -26,7 +26,12 @@ class GroupNode(Node):
         @return:
         """
 
-        return float("inf"), float("inf"), -float("inf"), -float("inf"),
+        return (
+            float("inf"),
+            float("inf"),
+            -float("inf"),
+            -float("inf"),
+        )
 
     def default_map(self, default_map=None):
         default_map = super(GroupNode, self).default_map(default_map=default_map)

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -199,7 +199,6 @@ class Node:
         self._paint_bounds_dirty = True
         self._bounds_dirty = True
 
-
     @property
     def formatter(self):
         return self._formatter
@@ -741,16 +740,19 @@ class Node:
         dest.insert_node(self, pos=pos)
 
     @staticmethod
-    def union_bounds(nodes):
+    def union_bounds(nodes, bounds=None):
         """
-        Returns the union of the node list given.
+        Returns the union of the node list given, optionally unioned the given bounds value
 
         @return: union of all bounds within the iterable.
         """
-        xmin = float("inf")
-        ymin = float("inf")
-        xmax = -xmin
-        ymax = -ymin
+        if bounds is None:
+            xmin = float("inf")
+            ymin = float("inf")
+            xmax = -xmin
+            ymax = -ymin
+        else:
+            xmin, ymin, xmax, ymax = bounds
         for e in nodes:
             box = e.bounds
             if box is None:

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -79,6 +79,9 @@ class Node:
         self._bounds = None
         self._bounds_dirty = True
 
+        self._paint_bounds = None
+        self._paint_bounds_dirty = True
+
         self.item = None
         self.icon = None
         self.cache = None
@@ -187,6 +190,15 @@ class Node:
     @property
     def bounds(self):
         return None
+
+    @property
+    def paint_bounds(self):
+        return None
+
+    def set_dirty_bounds(self):
+        self._paint_bounds_dirty = True
+        self._bounds_dirty = True
+
 
     @property
     def formatter(self):
@@ -435,8 +447,9 @@ class Node:
         Invalidation of the individual node.
         """
         self._points_dirty = True
-        self._bounds_dirty = True
+        self.set_dirty_bounds()
         self._bounds = None
+        self._paint_bounds = None
 
     def invalidated(self):
         """

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -213,7 +213,9 @@ class Node:
             self._paint_bounds = None
 
         if self._children:
-            self._paint_bounds = Node.union_bounds(self._children, bounds=self._paint_bounds, attr="paint_bounds")
+            self._paint_bounds = Node.union_bounds(
+                self._children, bounds=self._paint_bounds, attr="paint_bounds"
+            )
         self._paint_bounds_dirty = False
         return self._paint_bounds
 

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -191,7 +191,6 @@ class Node:
     def bounds(self):
         if not self._bounds_dirty:
             return self._bounds
-        self._bounds_dirty = False
 
         try:
             self._bounds = self.bbox(with_stroke=False)
@@ -200,22 +199,23 @@ class Node:
 
         if self._children:
             self._bounds = Node.union_bounds(self._children, bounds=self._bounds)
+        self._bounds_dirty = False
         return self._bounds
 
     @property
     def paint_bounds(self):
-        if not self._bounds_dirty:
-            return self._bounds
-        self._bounds_dirty = False
+        if not self._paint_bounds_dirty:
+            return self._paint_bounds
 
         try:
-            self._bounds = self.bbox(with_stroke=True)
+            self._paint_bounds = self.bbox(with_stroke=True)
         except AttributeError:
-            self._bounds = None
+            self._paint_bounds = None
 
         if self._children:
-            self._bounds = Node.union_bounds(self._children, bounds=self._bounds, attr="paint_bounds")
-        return self._bounds
+            self._paint_bounds = Node.union_bounds(self._children, bounds=self._paint_bounds, attr="paint_bounds")
+        self._paint_bounds_dirty = False
+        return self._paint_bounds
 
     def set_dirty_bounds(self):
         self._paint_bounds_dirty = True

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -740,7 +740,7 @@ class Node:
         dest.insert_node(self, pos=pos)
 
     @staticmethod
-    def union_bounds(nodes, bounds=None):
+    def union_bounds(nodes, bounds=None, attr="bounds"):
         """
         Returns the union of the node list given, optionally unioned the given bounds value
 
@@ -754,7 +754,7 @@ class Node:
         else:
             xmin, ymin, xmax, ymax = bounds
         for e in nodes:
-            box = e.bounds
+            box = getattr(e, attr)
             if box is None:
                 continue
             if box[0] < xmin:

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -189,11 +189,33 @@ class Node:
 
     @property
     def bounds(self):
-        return None
+        if not self._bounds_dirty:
+            return self._bounds
+        self._bounds_dirty = False
+
+        try:
+            self._bounds = self.bbox(with_stroke=False)
+        except AttributeError:
+            self._bounds = None
+
+        if self._children:
+            self._bounds = Node.union_bounds(self._children, bounds=self._bounds)
+        return self._bounds
 
     @property
     def paint_bounds(self):
-        return None
+        if not self._bounds_dirty:
+            return self._bounds
+        self._bounds_dirty = False
+
+        try:
+            self._bounds = self.bbox(with_stroke=True)
+        except AttributeError:
+            self._bounds = None
+
+        if self._children:
+            self._bounds = Node.union_bounds(self._children, bounds=self._bounds, attr="paint_bounds")
+        return self._bounds
 
     def set_dirty_bounds(self):
         self._paint_bounds_dirty = True

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -67,13 +67,6 @@ class CutOpNode(Node, Parameters):
     def __copy__(self):
         return CutOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -45,13 +45,6 @@ class DotsOpNode(Node, Parameters):
     def __copy__(self):
         return DotsOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -73,12 +73,6 @@ class EngraveOpNode(Node, Parameters):
     def __copy__(self):
         return EngraveOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -65,13 +65,6 @@ class HatchOpNode(Node, Parameters):
     def __copy__(self):
         return HatchOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -48,13 +48,6 @@ class ImageOpNode(Node, Parameters):
     def __copy__(self):
         return ImageOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -71,13 +71,6 @@ class RasterOpNode(Node, Parameters):
     def __copy__(self):
         return RasterOpNode(self)
 
-    @property
-    def bounds(self):
-        if self._bounds_dirty:
-            self._bounds = Node.union_bounds(self.flat(types=elem_ref_nodes))
-            self._bounds_dirty = False
-        return self._bounds
-
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False
     #     if maxspeed is not None and self.speed > maxspeed:
@@ -279,6 +272,7 @@ class RasterOpNode(Node, Parameters):
     def time_estimate(self):
         estimate = 0
         dpi = self.dpi
+        # Get fresh union bounds, may not have been marked dirty on additions or removals.
         min_x, min_y, max_x, max_y = Node.union_bounds(self.flat(types=elem_ref_nodes))
         width_in_inches = (max_x - min_x) / UNITS_PER_INCH
         height_in_inches = (max_y - min_y) / UNITS_PER_INCH

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -341,7 +341,7 @@ class RasterOpNode(Node, Parameters):
         def make_image():
             step_x = self.raster_step_x
             step_y = self.raster_step_y
-            bounds = self.bounds
+            bounds = self.paint_bounds
             img_mx = Matrix.scale(step_x, step_y)
             data = list(self.flat())
             reverse = context.elements.classify_reverse

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -703,7 +703,7 @@ class LaserRender:
             node.height = f_height
             node.descent = f_descent
             node.leading = f_external_leading
-            node._bounds_dirty = True
+            node.set_dirty_bounds()
         # No offset. Text draw positions should match svg. Draw box over text. Must obscure.
         dy = f_descent - f_height  # wx=0, convert baseline to correct position.
         dx = 0
@@ -860,7 +860,7 @@ class LaserRender:
             # image.save(f"dbg_{text}.png")
 
         if node.width != f_width or node.height != f_height:
-            node._bounds_dirty = True
+            node.set_dirty_bounds()
         node.width = f_width
         node.height = f_height
         node.descent = f_descent
@@ -882,7 +882,7 @@ class LaserRender:
             ):
                 # We never drew this cleanly; our initial bounds calculations will be off if we don't premeasure
                 self.measure_text(item)
-                item._bounds_dirty = True
+                item.set_dirty_bounds()
 
     def make_raster(
         self,

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -931,7 +931,7 @@ class LaserRender:
         self.validate_text_nodes(nodecopy, variable_translation)
 
         for item in _nodes:
-            bb = item.bounds
+            bb = item.paint_bounds
             if bb[0] < x_min:
                 x_min = bb[0]
             if bb[1] < y_min:

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -969,7 +969,7 @@ class ShadowTree:
             if node.type.startswith("elem ") and node.type != "elem point":
                 image = self.renderer.make_raster(
                     node,
-                    node.bounds,
+                    node.paint_bounds,
                     width=self.iconsize,
                     height=self.iconsize,
                     bitmap=True,

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -294,7 +294,9 @@ class LihuiyuDevice(Service, ViewPort):
                 yield "rapid_mode"
 
             if self.spooler.is_idle:
-                self.spooler.laserjob(list(move_at_speed()), label=f"move {dx} {dy} at {speed}")
+                self.spooler.laserjob(
+                    list(move_at_speed()), label=f"move {dx} {dy} at {speed}"
+                )
             else:
                 channel(_("Busy"))
             return


### PR DESCRIPTION
* Set bounds to pure geometric bounds.
* Add paint_bounds() for the paint bounds.

I guess switch everything to using no-stroke width for the nodes but also include a paint_bounds() which gives the area the node paints in. I'm thinking that could also be useful if we want to cache the display buffer or whatever.