### PR TITLE
Correct Image Matrix Bug, Improve Readability

### DIFF
--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -13,7 +13,7 @@ class ImageNode(Node):
     ImageNode is the bootstrapped node type for the 'elem image' type.
 
     ImageNode contains a main matrix, main image. A processed image and a processed matrix.
-    The processed matrix must be concated with the main matrix to be accurate.
+    The processed matrix must be concatenated with the main matrix to be accurate.
     """
 
     def __init__(
@@ -290,7 +290,7 @@ class ImageNode(Node):
         except ZeroDivisionError:
             pass
 
-        transform = (
+        transform_is_needed = (
             main_matrix.a != step_x
             or main_matrix.b != 0.0
             or main_matrix.c != 0.0
@@ -372,7 +372,7 @@ class ImageNode(Node):
             matrix.post_scale(step_scale_x, step_scale_y)
 
         # Perform image transform if needed.
-        if transform:
+        if transform_is_needed:
             if image_height <= 0:
                 image_height = 1
             if image_width <= 0:

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -205,6 +205,15 @@ class ImageNode(Node):
         return False
 
     def update(self, context):
+        """
+        Update kicks off the image processing thread, which performs RasterWizard script operations on the image node.
+
+        The text should be displayed in the scene by the renderer. And any additional changes will be processed
+        until the new processed image is completed.
+
+        @param context:
+        @return:
+        """
         self._needs_update = True
         self.text = "Processing..."
         context.signal("refresh_scene", "Scene")
@@ -223,10 +232,15 @@ class ImageNode(Node):
             self.processed_image = None
             # self.processed_matrix = None
             self._update_thread = context.threaded(
-                self.process_image_thread, result=clear, daemon=True
+                self._process_image_thread, result=clear, daemon=True
             )
 
-    def process_image_thread(self):
+    def _process_image_thread(self):
+        """
+        The function deletes the caches and processes the image until it no longer needs updating.
+
+        @return:
+        """
         while self._needs_update:
             self._needs_update = False
             self.process_image()
@@ -260,6 +274,15 @@ class ImageNode(Node):
         self.altered()
 
     def _process_image(self, crop=True):
+        """
+        This core code replaces the older actualize and rasterwizard functionalities. It should convert the image to
+        a post-processed form with resulting post-process matrix. Which should be combined with the main matrix to get
+        the relevant combined matrix values.
+
+        @param crop: Should the unneeded edges be cropped as part of this process. The need for the edge is determined
+            by the color and the state of the self.invert attribute.
+        @return:
+        """
         from PIL import Image, ImageEnhance, ImageFilter, ImageOps
 
         from meerk40t.image.imagetools import dither

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -615,7 +615,9 @@ class ImageNode(Node):
 
         image = self._process_script(image)
 
-        image = self._apply_mask(image, reject_mask, reject_color="white")
+        background = Image.new("L", image.size, "white")
+        background.paste(image, mask=reject_mask)
+        image = background
 
         image = self._apply_dither(image)
         return actualized_matrix, image

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -332,6 +332,7 @@ class ImageNode(Node):
         if reject_color is None:
             reject_color = "black" if self.invert else "white"
         from PIL import Image
+
         background = image.copy()
         reject = Image.new("L", image.size, reject_color)
         background.paste(reject, mask=mask)
@@ -361,6 +362,7 @@ class ImageNode(Node):
         @return: processed image
         """
         from PIL import ImageEnhance, ImageFilter, ImageOps
+
         for op in self.operations:
             name = op["name"]
             if name == "crop":
@@ -489,6 +491,7 @@ class ImageNode(Node):
         @return: 1 bit dithered image
         """
         from meerk40t.image.imagetools import dither
+
         if self.dither and self.dither_type is not None:
             if self.dither_type != "Floyd-Steinberg":
                 image = dither(image, self.dither_type)

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -592,7 +592,7 @@ class ImageNode(Node):
             if box is not None:
                 width = box[2] - box[0]
                 height = box[3] - box[1]
-                if width != image_width or height != image_height:
+                if width != image.width or height != image.height:
                     image = image.crop(box)
                     actualized_matrix.post_translate(box[0], box[1])
 

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -504,9 +504,7 @@ class ImageNode(Node):
             by the color and the state of the self.invert attribute.
         @return:
         """
-        from PIL import Image, ImageEnhance, ImageFilter, ImageOps
-
-        from meerk40t.image.imagetools import dither
+        from PIL import Image, ImageOps
 
         image = self.image
 
@@ -612,15 +610,12 @@ class ImageNode(Node):
         if self.invert:
             image = ImageOps.invert(image)
 
-        # Find rejection mask of white pixels.
+        # Find rejection mask of white pixels. (already inverted)
         reject_mask = image.point(lambda e: 0 if e == 255 else 255)
 
         image = self._process_script(image)
 
-        # Remask image removing pixels that were white before operations were processed.
-        background = Image.new("L", image.size, "white")
-        background.paste(image, mask=reject_mask)
-        image = background
+        image = self._apply_mask(image, reject_mask, reject_color="white")
 
         image = self._apply_dither(image)
         return actualized_matrix, image

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -318,20 +318,22 @@ class ImageNode(Node):
         except ValueError:
             return None
 
-    def _apply_mask(self, image, mask):
+    def _apply_mask(self, image, mask, reject_color=None):
         """
         Fill in original image with reject pixels.
 
         @param image: Image to be masked off.
         @param mask: Mask to apply to image
-        @return: image with mask pixels filled in with reject pixels (reject pixels colors depend on self.invert).
+        @param reject_color: Optional specified reject color override. Reject is usually "white" or black if inverted.
+        @return: image with mask pixels filled in with reject pixels
         """
         if not mask:
             return image
-
+        if reject_color is None:
+            reject_color = "black" if self.invert else "white"
         from PIL import Image
         background = image.copy()
-        reject = Image.new("L", image.size, "black" if self.invert else "white")
+        reject = Image.new("L", image.size, reject_color)
         background.paste(reject, mask=mask)
         return background
 

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -622,12 +622,7 @@ class ImageNode(Node):
         background.paste(image, mask=reject_mask)
         image = background
 
-        # Dither image to 1 bit.
-        if self.dither and self.dither_type is not None:
-            if self.dither_type != "Floyd-Steinberg":
-                image = dither(image, self.dither_type)
-            image = image.convert("1")
-
+        image = self._apply_dither(image)
         return actualized_matrix, image
 
     @staticmethod

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -498,8 +498,7 @@ class ImageNode(Node):
     def _process_image(self, step_x, step_y, crop=True):
         """
         This core code replaces the older actualize and rasterwizard functionalities. It should convert the image to
-        a post-processed form with resulting post-process matrix. Which should be combined with the main matrix to get
-        the relevant combined matrix values.
+        a post-processed form with resulting post-process matrix.
 
         @param crop: Should the unneeded edges be cropped as part of this process. The need for the edge is determined
             by the color and the state of the self.invert attribute.


### PR DESCRIPTION
The DPI change triggered a bug by actually matching the values required to trigger the use of passthrough and avoid modifications of the image. This gave it a wrong matrix which moved it wronlgly. This set of code changes fixes that error and divides up the `ImageNode` process_image into different functions that serves to assist readability greatly.