### PR TITLE
Grbl Realtime

### DIFF
--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -1300,6 +1300,7 @@ class MockConnection:
         if self.just_connected:
             self.just_connected = False
             return "grbl version fake"
+        time.sleep(0.05)  # takes some time
         if self.write_lines:
             self.write_lines -= 1
             return "ok"

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -1221,6 +1221,9 @@ class GrblController:
                 read += 1
             if read == 0 and write == 0:
                 time.sleep(0.05)
+                self.service.signal("pipe;running", False)
+            else:
+                self.service.signal("pipe;running", True)
 
     def __repr__(self):
         return f"GRBLSerial('{self.service.com_port}:{str(self.service.serial_baud_rate)}')"

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -932,7 +932,10 @@ class GRBLDriver(Parameters):
         @param args:
         @return:
         """
+        self.service.spooler.clear_queue()
+        self.plot_planner.clear()
         self.grbl_realtime("\x18")
+        self.paused = False
 
     def status(self):
         """
@@ -1302,8 +1305,8 @@ class MockConnection:
         if self.just_connected:
             self.just_connected = False
             return "grbl version fake"
-        time.sleep(0.2)  # takes some time
         if self.write_lines:
+            time.sleep(0.2)  # takes some time
             self.write_lines -= 1
             return "ok"
         else:

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -1151,6 +1151,8 @@ class GrblController:
         self.service.signal("serial;write", data)
         with self.lock_realtime_queue:
             self.realtime_queue.append(data)
+            if "\x18" in data:
+                self.sending_queue.clear()
             self.service.signal("serial;buffer", len(self.sending_queue) + len(self.realtime_queue))
 
     def start(self):

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -1300,7 +1300,7 @@ class MockConnection:
         if self.just_connected:
             self.just_connected = False
             return "grbl version fake"
-        time.sleep(0.05)  # takes some time
+        time.sleep(0.2)  # takes some time
         if self.write_lines:
             self.write_lines -= 1
             return "ok"

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -109,7 +109,7 @@ class MeerK40t(MWindow):
             pass
 
         self.context.gui = self
-        self.usb_running = False
+        self._usb_running = dict()
         context = self.context
         self.register_options_and_choices(context)
 
@@ -2606,7 +2606,7 @@ class MeerK40t(MWindow):
         self.__set_titlebar()
 
     def window_close_veto(self):
-        if self.usb_running:
+        if self.any_device_running:
             message = _("The device is actively sending data. Really quit?")
             answer = wx.MessageBox(
                 message, _("Currently Sending Data..."), wx.YES_NO | wx.CANCEL, None
@@ -2700,9 +2700,18 @@ class MeerK40t(MWindow):
         dlg.ShowModal()
         dlg.Destroy()
 
+    @property
+    def any_device_running(self):
+        running = self._usb_running
+        for v in running:
+            q = running[v]
+            if q:
+                return True
+        return False
+
     @signal_listener("pipe;running")
     def on_usb_running(self, origin, value):
-        self.usb_running = value
+        self._usb_running[origin] = value
 
     @signal_listener("pipe;usb_status")
     def on_usb_state_text(self, origin, value):


### PR DESCRIPTION
Corrects a few issues in GRBL with regards to realtime commands. This also corrects multiple devices having different running states and the main quit message needing all of them to to be False. We correct the device purging within grbl when you call abort and ensure that realtime pause and resume are sent outside the regular channel.