### PR TITLE
Less Lossy Save

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4078,7 +4078,7 @@ class Elemental(Service):
             all_arguments_required=True,
         )
         def element_circle_r(channel, _, r_pos, data=None, **kwargs):
-            circ = Circle(r=float(r_pos))
+            circ = Ellipse(r=float(r_pos))
             if circ.is_degenerate():
                 channel(_("Shape is degenerate."))
                 return "elements", data

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -4052,7 +4052,7 @@ class Elemental(Service):
             all_arguments_required=True,
         )
         def element_circle(channel, _, x_pos, y_pos, r_pos, data=None, **kwargs):
-            circ = Circle(cx=float(x_pos), cy=float(y_pos), r=float(r_pos))
+            circ = Ellipse(cx=float(x_pos), cy=float(y_pos), r=float(r_pos))
             if circ.is_degenerate():
                 channel(_("Shape is degenerate."))
                 return "elements", data

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -5024,7 +5024,7 @@ class Elemental(Service):
             height += y_offset * 2
 
             _element = Path(Rect(x=x_pos, y=y_pos, width=width, height=height))
-            node = self.elem_branch.add(shape=_element, type="elem ellipse")
+            node = self.elem_branch.add(shape=_element, type="elem path")
             node.stroke = Color("red")
             self.set_emphasis([node])
             node.focus()

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -5,7 +5,7 @@ from meerk40t.core.node.node import Fillrule, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path, Ellipse,
+    Path, Ellipse, Circle,
 )
 
 
@@ -35,7 +35,7 @@ class EllipseNode(Node):
             del settings["type"]
         super(EllipseNode, self).__init__(type="elem ellipse", **settings)
         self.__formatter = "{element_type} {id} {stroke}"
-        assert(isinstance(shape, Ellipse))
+        assert(isinstance(shape, (Ellipse, Circle)))
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -88,12 +88,13 @@ class EllipseNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke, and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -5,7 +5,7 @@ from meerk40t.core.node.node import Fillrule, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path,
+    Path, Ellipse,
 )
 
 
@@ -35,6 +35,7 @@ class EllipseNode(Node):
             del settings["type"]
         super(EllipseNode, self).__init__(type="elem ellipse", **settings)
         self.__formatter = "{element_type} {id} {stroke}"
+        assert(isinstance(shape, Ellipse))
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -92,12 +92,13 @@ class LineNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -5,7 +5,7 @@ from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path,
+    Path, SimpleLine,
 )
 
 
@@ -37,6 +37,7 @@ class LineNode(Node):
             del settings["type"]
         super(LineNode, self).__init__(type="elem line", **settings)
         self._formatter = "{element_type} {id} {stroke}"
+        assert (isinstance(shape, SimpleLine))
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -87,12 +87,13 @@ class PathNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke, and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -92,12 +92,13 @@ class PolylineNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke, and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -5,7 +5,7 @@ from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path,
+    Path, Polyline, Polygon,
 )
 
 
@@ -37,6 +37,7 @@ class PolylineNode(Node):
             del settings["type"]
         super(PolylineNode, self).__init__(type="elem polyline", **settings)
         self._formatter = "{element_type} {id} {stroke}"
+        assert (isinstance(shape, (Polyline, Polygon)))
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -37,7 +37,7 @@ class RectNode(Node):
             del settings["type"]
         super(RectNode, self).__init__(type="elem rect", **settings)
         self._formatter = "{element_type} {id} {stroke}"
-        assert (isinstance(shape, Rect))
+        assert isinstance(shape, Rect)
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -6,6 +6,7 @@ from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
+    Rect,
 )
 
 
@@ -36,6 +37,7 @@ class RectNode(Node):
             del settings["type"]
         super(RectNode, self).__init__(type="elem rect", **settings)
         self._formatter = "{element_type} {id} {stroke}"
+        assert (isinstance(shape, Rect))
         self.shape = shape
         self.settings = settings
         self.matrix = shape.transform if matrix is None else matrix

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -90,12 +90,13 @@ class RectNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke, and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -191,12 +191,13 @@ class TextNode(Node):
         """If the stroke is not scaled, the matrix scale will scale the stroke, and we
         need to countermand that scaling by dividing by the square root of the absolute
         value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = 1.0 if self._stroke_scaled else sqrt(abs(self.matrix.determinant))
-        sw = self.stroke_width / scalefactor
-        limit = 25 * sqrt(zoomscale) / scalefactor
-        if sw < limit:
-            sw = limit
-        return sw
+        scalefactor = sqrt(abs(self.matrix.determinant))
+        if self.stroke_scaled:
+            # Our implied stroke-width is prescaled.
+            return self.stroke_width
+        else:
+            sw = self.stroke_width / scalefactor
+            return sw
 
     def preprocess(self, context, matrix, plan):
         commands = plan.commands

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -427,15 +427,16 @@ class SVGWriter:
                         math.sqrt(c.matrix.determinant) if c.stroke_scaled else 1.0
                     )
                     # Note this is the reversed scaling in `implied_stroke_width`
-                    stroke_width = (
-                        Length(
-                            amount=c.stroke_width * stroke_scale,
-                            digits=6,
-                            preferred_units="px",
-                        ).preferred_length
-                        if c.stroke_width is not None
-                        else SVG_VALUE_NONE
-                    )
+                    stroke_width = str(c.stroke_width * stroke_scale)
+                    # stroke_width = (
+                    #     Length(
+                    #         amount=c.stroke_width * stroke_scale,
+                    #         digits=6,
+                    #         preferred_units="px",
+                    #     ).preferred_length
+                    #     if c.stroke_width is not None
+                    #     else SVG_VALUE_NONE
+                    # )
                     subelement.set(SVG_ATTR_STROKE_WIDTH, stroke_width)
                 except AttributeError as Err:
                     # print (f"Shit happened when trying to set stroke_width: {Err}")

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -297,7 +297,7 @@ class SVGWriter:
                 element = c.shape
                 copy_attributes(c, element)
                 subelement = SubElement(xml_tree, SVG_TAG_POLYLINE)
-                subelement.set(SVG_ATTR_POINTS, element.points)
+                subelement.set(SVG_ATTR_POINTS, " ".join([f"{e[0]} {e[1]}" for e in element.points]))
                 t = c.matrix
                 subelement.set(
                     "transform",

--- a/meerk40t/dxf/dxf_io.py
+++ b/meerk40t/dxf/dxf_io.py
@@ -153,7 +153,7 @@ class DXFProcessor:
         except AttributeError:
             pass
         if entity.dxftype() == "CIRCLE":
-            element = Circle(center=entity.dxf.center, r=entity.dxf.radius)
+            element = Ellipse(center=entity.dxf.center, r=entity.dxf.radius)
             element.values[SVG_ATTR_VECTOR_EFFECT] = SVG_VALUE_NON_SCALING_STROKE
             element.transform.post_scale(self.scale, -self.scale)
             element.transform.post_translate_y(self.elements.device.unit_height)
@@ -162,7 +162,7 @@ class DXFProcessor:
             e_list.append(node)
             return
         elif entity.dxftype() == "ARC":
-            circ = Circle(center=entity.dxf.center, r=entity.dxf.radius)
+            circ = Ellipse(center=entity.dxf.center, r=entity.dxf.radius)
             start_angle = Angle.degrees(entity.dxf.start_angle)
             end_angle = Angle.degrees(entity.dxf.end_angle)
             if end_angle < start_angle:

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -884,7 +884,7 @@ class TemplatePanel(wx.Panel):
                             stroke=set_color,
                             fill=fill_color,
                         )
-                        elem_type = "elem rect"
+                        elem_type = "elem ellipse"
                         elemnode = self.context.elements.elem_branch.add(
                             shape=pattern, type=elem_type
                         )

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -1,3 +1,5 @@
+from math import sqrt
+
 from meerk40t.gui.laserrender import DRAW_MODE_REGMARKS
 from meerk40t.gui.scene.sceneconst import (
     HITCHAIN_HIT,
@@ -24,7 +26,7 @@ class ElementsWidget(Widget):
     def process_draw(self, gc):
         context = self.scene.context
         matrix = self.scene.widget_root.scene_widget.matrix
-        scale_x = matrix.value_scale_x()
+        scale_x = sqrt(abs(matrix.determinant))
         try:
             zoom_scale = 1 / scale_x
         except ZeroDivisionError:

--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -10,7 +10,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.svgelements import Circle, Path
+from meerk40t.svgelements import Ellipse
 
 
 class CircleTool(ToolWidget):
@@ -58,13 +58,12 @@ class CircleTool(ToolWidget):
                     )
                 )
             if self.creation_mode == 1:
-                ellipse = Circle(cx, cy, radius)
+                ellipse = Ellipse(cx=cx, cy=cy, r=radius)
             else:
-                ellipse = Circle(
-                    (x1 + x0) / 2.0, (y1 + y0) / 2.0, abs(self.p1 - self.p2) / 2
+                ellipse = Ellipse(
+                    cx=(x1 + x0) / 2.0, cy=(y1 + y0) / 2.0, r=abs(self.p1 - self.p2) / 2
                 )
-            t = Path(ellipse)
-            bbox = t.bbox()
+            bbox = ellipse.bbox()
             if bbox is not None:
                 gc.DrawEllipse(bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1])
                 units = self.scene.context.units_name
@@ -130,16 +129,16 @@ class CircleTool(ToolWidget):
                 x1 = max(self.p1.real, self.p2.real)
                 y1 = max(self.p1.imag, self.p2.imag)
                 if self.creation_mode == 1:
-                    ellipse = Circle(
-                        cx,
-                        cy,
-                        radius,
+                    ellipse = Ellipse(
+                        cx=cx,
+                        cy=cy,
+                        r=radius,
                     )
                 else:
-                    ellipse = Circle(
-                        (x1 + x0) / 2.0,
-                        (y1 + y0) / 2.0,
-                        abs(self.p1 - self.p2) / 2,
+                    ellipse = Ellipse(
+                        cx=(x1 + x0) / 2.0,
+                        cy=(y1 + y0) / 2.0,
+                        r=abs(self.p1 - self.p2) / 2,
                     )
 
                 if not ellipse.is_degenerate():


### PR DESCRIPTION
The core idea behind this is to fix the vector text object jump on recreation. The nodes can store offset in either the actual points or matrix. This PR intends to preserve the difference. The actual parameters used here are given overtly, and the matrix it creates is preserved. So that if we create a vector text object the movement/rotation matrix gets preserved independently. So rebuilding the object with the same properties maintains the position.

Typically loading and saving causes a few lossy issues. First, the ellipse, rect, line, and polyline objects get reified, and lose their matrix. This means resetting them restores them to their initial load position. These objects also get saved as `<path>` type objects rather than their valid native forms.

The lack of native form loading lead to interpreting these objects based on their `type` parameter. This lead to objects being of a `Path` type and occupying a `RectNode` or `EllipseNode`. This is not currently problematic but if we engineered a tool to, for example, adjust the rounded corners of a Rectangle or the radius of a Ellipse we'd end up being unable to do that, since we would have lost that information.

* Save will use the svg types for a particular svg node.
* Ellipse saves as an `<ellipse>`. 
* Rect saves as an `<rect>`.
* Line saves as a `<line>`
* Polyline saves as a `<polyline>` or `<polygon>`
* SVG saves in native units. Sets the Viewport size such that no scaling is required.
* Reverts `isinstance(element, Path) and element.values.get("type") == "elem ellipse"` code.
* Disallows EllipseNode, LineNode, RectNode, PolylineNode from containing paths. They must contain the explicitly stated shape.
* Loading svg does not reify.
* Loading svg does not convert to path.
* Loading svg does not convert arcs to beziers (except in Path).

---

- [x] Some stroke loading for Archimedean_spiral is screwy.

![Archimedean_spiral](https://user-images.githubusercontent.com/3302478/196830681-70ff1d46-6eb3-429e-b4bf-2e2413232325.svg)
