### PR TITLE
Remove Dummy PlotPlanners

### DIFF
--- a/meerk40t/gui/statusbarwidgets/infowidget.py
+++ b/meerk40t/gui/statusbarwidgets/infowidget.py
@@ -319,12 +319,8 @@ class BurnProgressPanel(SimpleInfoWidget):
                 self._job_active = True
                 self._job_loops = spool_obj.loops
                 self._loops_executed = spool_obj.loops_executed
-                if hasattr(self._driver, "total_steps"):
-                    self._job_len = self._driver.total_steps
-                    self._job_pos = self._driver.current_steps
-                else:
-                    self._job_len = len(spool_obj.items)
-                    self._job_pos = spool_obj.item_index
+                self._job_len = len(spool_obj.items)
+                self._job_pos = spool_obj.item_index
                 self.inspect_job_details(spool_obj)
                 self._job_elapsed = time.time() - spool_obj.time_started
                 self._job_estimate = spool_obj.estimate_time()

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -1447,7 +1447,6 @@ class LihuiyuDriver(Parameters):
         if self.plot_data is None:
             return False
         for x, y, on in self.plot_data:
-            self.current_steps += 1
             while self.hold_work(0):
                 time.sleep(0.05)
             sx = self.native_x

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -809,10 +809,6 @@ class LihuiyuDriver(Parameters):
         self.plot_planner.force_shift = service.plot_shift
         self.plot_data = None
 
-        self.current_steps = 0
-        self.total_steps = 0
-        self.dummy_planner = PlotPlanner(self.settings)
-
         self.state = DRIVER_STATE_RAPID
         self.properties = 0
         self.is_relative = False
@@ -1269,8 +1265,6 @@ class LihuiyuDriver(Parameters):
             self.set_origin(x, y)
         else:
             self.plot_planner.push(plot)
-            # Mirror the stuff
-            self.dummy_planner.push(plot)
 
     def plot_start(self):
         """
@@ -1279,18 +1273,8 @@ class LihuiyuDriver(Parameters):
 
         @return:
         """
-        self.total_steps = 0
-        self.current_steps = 0
         if self.plot_data is None:
             self.plot_data = self.plot_planner.gen()
-            skip_calc = True
-            if not skip_calc:
-                assessment_start = time.time()
-                dummy_data = list(self.dummy_planner.gen())
-                self.total_steps += len(dummy_data)
-                self.dummy_planner.clear()
-                # print ("m2nano-Assessment done, Steps=%d - did take %.1f sec" % (self.total_steps, time.time()-assessment_start))
-
         self._plotplanner_process()
 
     def set(self, key, value):


### PR DESCRIPTION
* The PlotPlanners were not useful since they had to compute everything ahead of time and cause massive delays causing the project to start running suddenly without the user knowing which was a safety hazard.
* This was to accurately solve for the time estimate; It did not provide very successful time estimates. 
* The PlotPlanner code also confused the driver, where there was mostly repeated code in order to count the number of cuts in a strange fashion.