### PR TITLE
outline --outer can deal now with more topologies

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -3250,7 +3250,7 @@ def init_commands(kernel):
         help=_("Only outer line"),
     )
     @self.console_option(
-        "times",
+        "steps",
         "x",
         type=int,
         default=1,
@@ -3278,7 +3278,7 @@ def init_commands(kernel):
         invert=None,
         blacklevel=None,
         outer=None,
-        times=None,
+        steps=None,
         data=None,
         **kwargs,
     ):
@@ -3353,8 +3353,8 @@ def init_commands(kernel):
             offset = self.length("5mm")
         else:
             offset = self.length(offset)
-        if times is None or times < 1:
-            times = 1
+        if steps is None or steps < 1:
+            steps = 1
         if outer is None:
             outer = False
         outputdata = []
@@ -3442,7 +3442,7 @@ def init_commands(kernel):
         ################################################################
         # Phase 2: change outline witdh and render and vectorize again
         ################################################################
-        for numidx in range(times):
+        for numidx in range(steps):
             data_node.stroke_width += 2 * offset
             data_node.set_dirty_bounds()
             pb = data_node.paint_bounds

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -782,13 +782,15 @@ class LaserRender:
         @param node:
         @return:
         """
-
-        bmp = wx.Bitmap(1000, 500, 32)
+        dimension_x = 1000
+        dimension_y = 500
+        bmp = wx.Bitmap(dimension_x, dimension_y, 32)
         dc = wx.MemoryDC()
         dc.SelectObject(bmp)
         dc.SetBackground(wx.BLACK_BRUSH)
         dc.Clear()
         gc = wx.GraphicsContext.Create(dc)
+
         draw_mode = self.context.draw_mode
         if draw_mode & DRAW_MODE_VARIABLES:
             # Only if flag show the translated values
@@ -809,8 +811,25 @@ class LaserRender:
                 text = text.lower()
         svgfont_to_wx(node)
         gc.SetFont(node.wxfont, wx.WHITE)
-        gc.DrawText(text, 0, 0)
         f_width, f_height, f_descent, f_external_leading = gc.GetFullTextExtent(text)
+        needs_revision = False
+        revision_factor = 3
+        if revision_factor * f_width >= dimension_x:
+            dimension_x = revision_factor * f_width
+            needs_revision = True
+        if revision_factor * f_height > dimension_y:
+            dimension_y = revision_factor * f_height
+            needs_revision = True
+        if needs_revision:
+            bmp = wx.Bitmap(dimension_x, dimension_y, 32)
+            dc = wx.MemoryDC()
+            dc.SelectObject(bmp)
+            dc.SetBackground(wx.BLACK_BRUSH)
+            dc.Clear()
+            gc = wx.GraphicsContext.Create(dc)
+            gc.SetFont(node.wxfont, wx.WHITE)
+
+        gc.DrawText(text, 0, 0)
         try:
             img = bmp.ConvertToImage()
             buf = img.GetData()


### PR DESCRIPTION
        The subvariant --outer requires one additional pass where we disassemble
        the first outline and fill the subpaths, This will effectively deal with
        donut-type shapes

        The need for --inner was't high on my priority list (as it is somewhat
        difficult to implement, --outer just uses a clever hack to deal with
        topology edge cases. So if we are in need of inner we need to create
        the outline shape, break it in subpaths and delete the outer shapes
        manually. Sorry.