### PR TITLE
Allow suppression of machine origin widget / Fix two commands

### DIFF
--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -7644,6 +7644,12 @@ msgid "Don't use icons in the tree"
 msgstr "Verzichte auf die Anzeige von Icons im Baum"
 
 #: meerk40t/gui/wxmmain.py:2114
+msgid "Hide Origin-Indicator"
+msgstr "Ursprung ausblenden"
+
+msgid "Don't show the origin indicator"
+msgstr "Unterdrücke die Anzeige des Ursprungs-Indikator"
+
 msgid "Hide Grid"
 msgstr "Gitter ausblenden"
 

--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -2645,13 +2645,13 @@ def init_commands(kernel):
                     x_pos = -1 * radius
                     y_pos = 0
                     # e *= "translate(%f, %f)" % (x_pos, y_pos)
-                    e *= f"rotate({currentangle}rad, {center_x}, {center_y})"
+                    e.matrix *= f"rotate({currentangle}rad, {center_x}, {center_y})"
                 else:
                     x_pos = -1 * radius + radius * cos(currentangle)
                     y_pos = radius * sin(currentangle)
-                    e *= f"translate({x_pos}, {y_pos})"
+                    e.matrix *= f"translate({x_pos}, {y_pos})"
+                self.elem_branch.add_node(e)
 
-            self.add_elems(add_elem)
             data_out.extend(add_elem)
 
             currentangle += segment_len
@@ -2739,14 +2739,15 @@ def init_commands(kernel):
                 if rotate:
                     x_pos = radius
                     y_pos = 0
-                    e *= f"translate({x_pos}, {y_pos})"
-                    e *= f"rotate({currentangle}rad, {center_x}, {center_y})"
+                    e.matrix *= f"translate({x_pos}, {y_pos})"
+                    e.matrix *= f"rotate({currentangle}rad, {center_x}, {center_y})"
+                    e.modified()
                 else:
                     x_pos = radius * cos(currentangle)
                     y_pos = radius * sin(currentangle)
-                    e *= f"translate({x_pos}, {y_pos})"
-
-            self.add_elems(add_elem)
+                    e.matrix *= f"translate({x_pos}, {y_pos})"
+                    e.modified()
+                self.elem_branch.add_node(e)
             data_out.extend(add_elem)
             currentangle += segment_len
 

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -61,7 +61,7 @@ DRAW_MODE_INVERT = 0x400000
 DRAW_MODE_FLIPXY = 0x800000
 DRAW_MODE_LINEWIDTH = 0x1000000
 DRAW_MODE_ALPHABLACK = 0x2000000  # Set means do not alphablack images
-
+DRAW_MODE_ORIGIN = 0x4000000
 
 def swizzlecolor(c):
     if c is None:

--- a/meerk40t/gui/scenewidgets/machineoriginwidget.py
+++ b/meerk40t/gui/scenewidgets/machineoriginwidget.py
@@ -1,6 +1,6 @@
 import wx
 
-from meerk40t.gui.laserrender import DRAW_MODE_BACKGROUND
+from meerk40t.gui.laserrender import DRAW_MODE_ORIGIN
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN
 from meerk40t.gui.scene.widget import Widget
 
@@ -32,24 +32,25 @@ class MachineOriginWidget(Widget):
         """
         Draws the background on the scene.
         """
-        if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
-            margin = 5000
-            context = self.scene.context
-            x, y = context.device.show_to_scene_position(0, 0)
-            x_dx, x_dy = context.device.show_to_scene_position(50000, 0)
-            xa1_dx, xa1_dy = context.device.show_to_scene_position(45000, 5000)
-            xa2_dx, xa2_dy = context.device.show_to_scene_position(45000, -5000)
-            y_dx, y_dy = context.device.show_to_scene_position(0, 50000)
-            ya1_dx, ya1_dy = context.device.show_to_scene_position(5000, 45000)
-            ya2_dx, ya2_dy = context.device.show_to_scene_position(-5000, 45000)
-            gc.SetBrush(self.brush)
-            gc.DrawRectangle(x - margin, y - margin, margin * 2, margin * 2)
-            gc.SetBrush(wx.NullBrush)
-            gc.SetPen(self.x_axis_pen)
-            gc.DrawLines(
-                [(x, y), (x_dx, x_dy), (xa1_dx, xa1_dy), (x_dx, x_dy), (xa2_dx, xa2_dy)]
-            )
-            gc.SetPen(self.y_axis_pen)
-            gc.DrawLines(
-                [(x, y), (y_dx, y_dy), (ya1_dx, ya1_dy), (y_dx, y_dy), (ya2_dx, ya2_dy)]
-            )
+        if self.scene.context.draw_mode & DRAW_MODE_ORIGIN != 0:
+            return
+        margin = 5000
+        context = self.scene.context
+        x, y = context.device.show_to_scene_position(0, 0)
+        x_dx, x_dy = context.device.show_to_scene_position(50000, 0)
+        xa1_dx, xa1_dy = context.device.show_to_scene_position(45000, 5000)
+        xa2_dx, xa2_dy = context.device.show_to_scene_position(45000, -5000)
+        y_dx, y_dy = context.device.show_to_scene_position(0, 50000)
+        ya1_dx, ya1_dy = context.device.show_to_scene_position(5000, 45000)
+        ya2_dx, ya2_dy = context.device.show_to_scene_position(-5000, 45000)
+        gc.SetBrush(self.brush)
+        gc.DrawRectangle(x - margin, y - margin, margin * 2, margin * 2)
+        gc.SetBrush(wx.NullBrush)
+        gc.SetPen(self.x_axis_pen)
+        gc.DrawLines(
+            [(x, y), (x_dx, x_dy), (xa1_dx, xa1_dy), (x_dx, x_dy), (xa2_dx, xa2_dy)]
+        )
+        gc.SetPen(self.y_axis_pen)
+        gc.DrawLines(
+            [(x, y), (y_dx, y_dy), (ya1_dx, ya1_dy), (y_dx, y_dy), (ya2_dx, ya2_dy)]
+        )

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -91,6 +91,7 @@ from .laserrender import (
     DRAW_MODE_STROKES,
     DRAW_MODE_TEXT,
     DRAW_MODE_VARIABLES,
+    DRAW_MODE_ORIGIN,
     swizzlecolor,
 )
 from .mwindow import MWindow
@@ -2180,6 +2181,16 @@ class MeerK40t(MWindow):
                 "subsegment": "Tree",
             },
             ### Scene-Appearance
+            {
+                "label": _("Hide Origin-Indicator"),
+                "help": _("Don't show the origin indicator"),
+                "criteria": self.context.draw_mode & DRAW_MODE_ORIGIN != 0,
+                "action": toggle_draw_mode,
+                "parameter": DRAW_MODE_ORIGIN,
+                "level": 2,
+                "segment": "Scene Appearance",
+                "subsegment": "Scene",
+            },
             {
                 "label": _("Hide Grid"),
                 "help": _("Don't show the sizing grid"),


### PR DESCRIPTION
Sorry, two independent changes combined, did it only realise after the commit. Anyway:
- Fix for circ_copy and radial crash
- Allow suppression of machine origin widget