### PR TITLE
Timed simulation (beta)

### DIFF
--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -409,6 +409,42 @@ class CutCode(CutGroup):
             yield "plot", cutobject
         yield "plot_start"
 
+    def provide_statistics(self, include_start=False):
+        result = []
+        cutcode = list(self.flat())
+        if len(cutcode) == 0:
+            return result
+        stop_at = len(cutcode)
+        distance_travel = 0
+        distance_cut = 0
+        extra = 0
+        duration_cut = 0
+        duration_travel = 0
+        if include_start:
+            if self.start is not None:
+                distance_travel += abs(complex(*self.start) - complex(*cutcode[0].start))
+            else:
+                distance_travel += abs(0 - complex(*cutcode[0].start))
+        for i in range(0, stop_at):
+            if i>0:
+                prev = cutcode[i - 1]
+                delta = Point.distance(prev.end, curr.start)
+                distance_travel += delta
+            curr = cutcode[i]
+            distance_cut += curr.length()
+            extra += curr.extra()
+            native_speed = curr.settings.get("native_speed", curr.speed)
+            if native_speed != 0:
+                duration_cut += curr.length() / native_speed
+            rapid_speed = self._native_speed(cutcode)
+            if rapid_speed is not None:
+                duration_travel = distance_travel / rapid_speed
+            item = (i, distance_travel, distance_cut, extra, duration_travel, duration_cut)
+            # print (item)
+            result.append(item)
+
+        return result
+
     def length_travel(self, include_start=False, stop_at=-1):
         """
         Calculates the distance traveled between cutcode objects.

--- a/meerk40t/core/cutcode.py
+++ b/meerk40t/core/cutcode.py
@@ -434,7 +434,9 @@ class CutCode(CutGroup):
         total_duration_travel = 0
         if include_start:
             if self.start is not None:
-                distance_travel += abs(complex(*self.start) - complex(*cutcode[0].start))
+                distance_travel += abs(
+                    complex(*self.start) - complex(*cutcode[0].start)
+                )
             else:
                 distance_travel += abs(0 - complex(*cutcode[0].start))
         prev_end = 0
@@ -442,7 +444,7 @@ class CutCode(CutGroup):
             duration_of_this_travel = 0
             duration_of_this_burn = 0
             length_of_this_travel = 0
-            if i>0:
+            if i > 0:
                 prev = cutcode[i - 1]
                 length_of_this_travel = Point.distance(prev.end, curr.start)
                 distance_travel += length_of_this_travel
@@ -464,7 +466,9 @@ class CutCode(CutGroup):
                 total_duration_cut += duration_of_this_burn
 
             end_of_this_travel = prev_end + duration_of_this_travel
-            end_of_this_burn = prev_end + duration_of_this_travel + this_extra + duration_of_this_burn
+            end_of_this_burn = (
+                prev_end + duration_of_this_travel + this_extra + duration_of_this_burn
+            )
             item = {
                 "type": cut_type,
                 "total_distance_travel": distance_travel,

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -122,9 +122,17 @@ class SimulationPanel(wx.Panel, Job):
         self.radio_time_seconds = wx.RadioButton(self, wx.ID_ANY, _("Time (sec.)"))
         self.radio_time_minutes = wx.RadioButton(self, wx.ID_ANY, _("Time (min)"))
         self.radio_cut.SetValue(True)
-        self.radio_cut.SetToolTip(_("Cut operations Playback-Mode: play will jump from one completed operations to next"))
-        self.radio_time_seconds.SetToolTip(_("Timed Playback-Mode: play will jump from one second to next"))
-        self.radio_time_minutes.SetToolTip(_("Timed Playback-Mode: play will jump from one minute to next"))
+        self.radio_cut.SetToolTip(
+            _(
+                "Cut operations Playback-Mode: play will jump from one completed operations to next"
+            )
+        )
+        self.radio_time_seconds.SetToolTip(
+            _("Timed Playback-Mode: play will jump from one second to next")
+        )
+        self.radio_time_minutes.SetToolTip(
+            _("Timed Playback-Mode: play will jump from one minute to next")
+        )
         self.available_devices = list(self.context.kernel.services("device"))
         self.selected_device = self.context.device
         index = -1
@@ -157,8 +165,12 @@ class SimulationPanel(wx.Panel, Job):
         self.Bind(wx.EVT_BUTTON, self.on_button_spool, self.button_spool)
         self.Bind(wx.EVT_RIGHT_DOWN, self.on_mouse_right_down)
         self.Bind(wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_cut)
-        self.Bind(wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_time_seconds)
-        self.Bind(wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_time_minutes)
+        self.Bind(
+            wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_time_seconds
+        )
+        self.Bind(
+            wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_time_minutes
+        )
         self.view_pane.scene_panel.Bind(wx.EVT_RIGHT_DOWN, self.on_mouse_right_down)
         # end wxGlade
 
@@ -837,9 +849,9 @@ class SimulationWidget(Widget):
                     path_width = 0
                     for numpair in sparse.findall(spath):
                         comma_idx = numpair.find(",")
-                        if comma_idx>=0:
+                        if comma_idx >= 0:
                             left_num = numpair[:comma_idx]
-                            right_num = numpair[comma_idx+1:]
+                            right_num = numpair[comma_idx + 1 :]
                             # print (f"'{numpair}' -> '{left_num}', '{right_num}'")
                             try:
                                 c_x = float(left_num)
@@ -863,10 +875,7 @@ class SimulationWidget(Widget):
                     #     print(f"{cv}={c_vars[cv]}")
                     rect_y = cutstart[1]
                     rect_x = self.sim.cutcode[idx].offset_x
-                    rect_w = max(
-                        2 * self.sim.cutcode[idx].width,
-                        path_width
-                    )
+                    rect_w = max(2 * self.sim.cutcode[idx].width, path_width)
                     rect_h = residual * (cutend[1] - cutstart[1])
                     interim_pen = wx.Pen(wx.GREEN, 1, wx.PENSTYLE_SOLID)
                     gc.SetPen(interim_pen)

--- a/meerk40t/gui/toolwidgets/toolcontainer.py
+++ b/meerk40t/gui/toolwidgets/toolcontainer.py
@@ -9,6 +9,7 @@ class ToolContainer(Widget):
 
     def __init__(self, scene):
         Widget.__init__(self, scene, all=False)
+        self._active_tool = None
 
     def hit(self):
         return HITCHAIN_DELEGATE_AND_HIT
@@ -24,6 +25,9 @@ class ToolContainer(Widget):
             self.set_tool(tool)
 
     def set_tool(self, tool):
+        if self._active_tool == tool:
+            return
+        self._active_tool = tool
         self.scene.tool_active = False
         self.remove_all_widgets()
         self.scene.cursor("arrow")


### PR DESCRIPTION
Allow a time-based view of simulation.
While the usual simulation jumps from one completed cutcode operation to the next, you can now choose a timed mode: the simulation jumps from one second to the next and displaying the progress so far:
 
![simulation](https://user-images.githubusercontent.com/2670784/198855016-b6a3857e-d32f-4cb1-8436-9cfa49067c83.gif)

There are some limitations still:
- intermediate cutcode operations are interpolated with a linear move from cutcode start to end 
- Raster operations are only shown as a growing rectangle
- Very fast units like balor might need a subsecond resolution  