### PR TITLE
Fix drag&drop for regmark nodes

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -1634,6 +1634,8 @@ def init_commands(kernel):
                 channel(_("No elements to transfer"))
             else:
                 move_nodes_to(target, data)
+                if cmd == "free" and self.classify_new:
+                    self.classify(data)
         elif cmd == "clear":
             self.clear_regmarks()
             data = None

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1366,16 +1366,22 @@ class Elemental(Service):
         data = dragging_nodes
         success = False
         special_occasion = False
+        to_classify = []
         for drag_node in data:
             if drop_node is drag_node:
                 continue
             if drop_node.drop(drag_node, modify=False):
+                # Is the drag node coming from the regmarks branch?
+                # If yes then we might need to classify.
+                if drag_node._parent.type == "branch reg":
+                    to_classify.append(drag_node)
                 if special_occasion:
                     for ref in list(drag_node._references):
                         ref.remove_node()
                 drop_node.drop(drag_node, modify=True)
                 success = True
-
+        if self.classify_new and len(to_classify) > 0:
+            self.classify(to_classify)
         # Refresh the target node so any changes like color materialize...
         self.signal("element_property_reload", drop_node)
         return success

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -108,7 +108,7 @@ class CutOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd:
+            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -108,7 +108,7 @@ class CutOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
+            if drag_node.type not in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -87,7 +87,7 @@ class DotsOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
+            if drag_node.type not in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -87,7 +87,7 @@ class DotsOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd:
+            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -114,7 +114,7 @@ class EngraveOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
+            if drag_node.type not in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -114,7 +114,7 @@ class EngraveOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd:
+            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -109,7 +109,7 @@ class HatchOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd:
+            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -109,7 +109,7 @@ class HatchOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
+            if drag_node.type not in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -100,7 +100,7 @@ class ImageOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
+            if drag_node.type not in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -100,7 +100,7 @@ class ImageOpNode(Node, Parameters):
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("elem"):
-            if not drag_node.type in self._allowed_elements_dnd:
+            if not drag_node.type in self._allowed_elements_dnd or drag_node._parent.type == "branch reg":
                 return False
             # Dragging element onto operation adds that element to the op.
             if modify:

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -131,7 +131,7 @@ class RasterOpNode(Node, Parameters):
         count = 0
         existing = 0
         result = False
-        if drag_node.type.startswith("elem"):
+        if drag_node.type.startswith("elem") and not drag_node._parent.type == "branch reg":
             existing += 1
             # if drag_node.type == "elem image":
             #     return False


### PR DESCRIPTION
a) Drag & drop of regmark nodes directly to an operation was possible -> prevented
b) Drag & drop of regmark nodes back to elements did not classify (if option set) 