### PR TITLE
Duplicate Reference Elements in Series. Optimization Disables.

### DIFF
--- a/meerk40t/core/element_treeops.py
+++ b/meerk40t/core/element_treeops.py
@@ -1092,10 +1092,19 @@ def init_tree(kernel):
         help="",
     )
     def dup_n_copies(node, copies=1, **kwargs):
+        # Code in series.
+        # add_nodes = list(node.children)
+        # add_nodes *= copies
+        # for n in add_nodes:
+        #     node.add_reference(n.node)
+
+        # Code in parallel.
         add_nodes = list(node.children)
-        add_nodes *= copies
-        for n in add_nodes:
-            node.add_reference(n.node)
+        for i in range(len(add_nodes) - 1, -1, -1):
+            n = add_nodes[i]
+            for k in range(copies):
+                node.add_reference(n.node, pos=i)
+
         self.signal("refresh_tree")
 
     @tree_operation(

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -42,69 +42,6 @@ def plugin(kernel, lifecycle=None):
 
         choices = [
             {
-                "attr": "opt_inner_first",
-                "object": context,
-                "default": True,
-                "type": bool,
-                "label": _("Burn Inner First"),
-                "tip": _(
-                    "Ensure that inside burns are done before an outside cut in order to ensure that burns inside "
-                    + "a cut-out piece are done before the cut piece shifts or drops out of the material."
-                )
-                + "\n\n"
-                + _(
-                    "If you find that using this option significantly increases the optimisation time, "
-                    + "alternatives are: \n"
-                    + "* Deselecting Cut Inner First if you are not cutting fully through your material \n"
-                    + "* Putting the inner paths into a separate earlier operation(s) and not using Merge Operations or Cut Inner First \n"
-                    + "* If you are using multiple passes, check Merge Passes"
-                ),
-                "page": "Optimizations",
-                "section": "Burn sequence",
-                # "subsection": "Inner burn",
-            },
-            {
-                "attr": "opt_inner_tolerance",
-                "object": context,
-                "default": "0",
-                "type": Length,
-                "label": _("Tolerance"),
-                "tip": _("Tolerance to decide if a shape is truly inside another one."),
-                "page": "Optimizations",
-                "section": "Burn sequence",
-                # "subsection": "Inner burn",
-                "conditional": (context, "opt_inner_first"),
-            },
-            {
-                "attr": "opt_inners_grouped",
-                "object": context,
-                "default": False,
-                "type": bool,
-                "label": _("Group Inner Burns"),
-                "tip": _(
-                    "Try to complete a set of inner burns and the associated outer cut before moving onto other elements."
-                    + "This option only does something if Burn Inner First is also selected. "
-                    + "If your design has multiple separate pieces on it, "
-                    + "this should mostly cause each piece to be burned in entirety "
-                    + "before moving on to burn another piece. "
-                    + "This can reduce the risk of e.g. a shift ruining an entire piece of material "
-                    + "by trying to ensure that one piece is finished before starting on another."
-                )
-                + "\n\n"
-                + _(
-                    "This optimization works best with Merge Operations also checked though this is not a requirement. "
-                )
-                + "\n\n"
-                + _(
-                    "Because this optimisation is done once rasters have been turned into images, "
-                    + "inner elements may span multiple design pieces, "
-                    + "in which case they may be optimised together."
-                ),
-                "page": "Optimizations",
-                "section": "Burn sequence",
-                "conditional": (context, "opt_inner_first"),
-            },
-            {
                 "attr": "opt_reduce_travel",
                 "object": context,
                 "default": True,
@@ -153,8 +90,7 @@ def plugin(kernel, lifecycle=None):
                     + "at the point the burns join. "
                 ),
                 "page": "Optimizations",
-                "section": "",
-                "conditional": (context, "opt_reduce_travel"),
+                "section": "Burn sequence",
             },
             {
                 "attr": "opt_merge_passes",
@@ -182,8 +118,7 @@ def plugin(kernel, lifecycle=None):
                     + "or even an increased risk of the material catching fire."
                 ),
                 "page": "Optimizations",
-                "section": "",
-                "conditional": (context, "opt_reduce_travel"),
+                "section": "Merging",
             },
             {
                 "attr": "opt_merge_ops",
@@ -207,8 +142,68 @@ def plugin(kernel, lifecycle=None):
                     + "using this option can significantly INCREASE the optimisation time. "
                 ),
                 "page": "Optimizations",
-                "section": "",
-                "conditional": (context, "opt_reduce_travel"),
+                "section": "Merging",
+            },
+            {
+                "attr": "opt_inner_first",
+                "object": context,
+                "default": True,
+                "type": bool,
+                "label": _("Burn Inner First"),
+                "tip": _(
+                    "Ensure that inside burns are done before an outside cut in order to ensure that burns inside "
+                    + "a cut-out piece are done before the cut piece shifts or drops out of the material."
+                )
+                       + "\n\n"
+                       + _(
+                    "If you find that using this option significantly increases the optimisation time, "
+                    + "alternatives are: \n"
+                    + "* Deselecting Cut Inner First if you are not cutting fully through your material \n"
+                    + "* Putting the inner paths into a separate earlier operation(s) and not using Merge Operations or Cut Inner First \n"
+                    + "* If you are using multiple passes, check Merge Passes"
+                ),
+                "page": "Optimizations",
+                "section": "Burn sequence",
+                "subsection": "Inner burn", },
+            {
+                "attr": "opt_inner_tolerance",
+                "object": context,
+                "default": "0",
+                "type": Length,
+                "label": _("Tolerance"),
+                "tip": _("Tolerance to decide if a shape is truly inside another one."),
+                "page": "Optimizations",
+                "section": "Burn sequence",
+                "subsection": "Inner burn",
+                "conditional": (context, "opt_inner_first"),
+            },
+            {
+                "attr": "opt_inners_grouped",
+                "object": context,
+                "default": False,
+                "type": bool,
+                "label": _("Group Inner Burns"),
+                "tip": _(
+                    "Try to complete a set of inner burns and the associated outer cut before moving onto other elements."
+                    + "This option only does something if Burn Inner First is also selected. "
+                    + "If your design has multiple separate pieces on it, "
+                    + "this should mostly cause each piece to be burned in entirety "
+                    + "before moving on to burn another piece. "
+                    + "This can reduce the risk of e.g. a shift ruining an entire piece of material "
+                    + "by trying to ensure that one piece is finished before starting on another."
+                )
+                       + "\n\n"
+                       + _(
+                    "This optimization works best with Merge Operations also checked though this is not a requirement. "
+                )
+                       + "\n\n"
+                       + _(
+                    "Because this optimisation is done once rasters have been turned into images, "
+                    + "inner elements may span multiple design pieces, "
+                    + "in which case they may be optimised together."
+                ),
+                "page": "Optimizations",
+                "section": "Burn sequence",
             },
             {
                 "attr": "opt_closed_distance",

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -91,6 +91,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_merge_passes",
@@ -119,6 +120,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Merging",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_merge_ops",
@@ -143,6 +145,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Merging",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_inner_first",
@@ -164,7 +167,8 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
-                "subsection": "Inner burn",            },
+                "subsection": "Inner burn",
+            },
             {
                 "attr": "opt_inner_tolerance",
                 "object": context,
@@ -204,6 +208,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
+                "conditional": (context, "opt_inner_first"),
             },
             {
                 "attr": "opt_closed_distance",

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -91,6 +91,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_merge_passes",
@@ -119,6 +120,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Merging",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_merge_ops",
@@ -143,6 +145,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Merging",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_inner_first",
@@ -164,7 +167,8 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
-                "subsection": "Inner burn", },
+                "subsection": "Inner burn",
+            },
             {
                 "attr": "opt_inner_tolerance",
                 "object": context,
@@ -204,6 +208,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
+                "conditional": (context, "opt_inner_first"),
             },
             {
                 "attr": "opt_closed_distance",

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -42,112 +42,6 @@ def plugin(kernel, lifecycle=None):
 
         choices = [
             {
-                "attr": "opt_reduce_travel",
-                "object": context,
-                "default": True,
-                "type": bool,
-                "label": _("Reduce Travel Time"),
-                "tip": _(
-                    "Using this option can significantly reduce the time spent "
-                    + "moving between elements with the laser off "
-                    + "by optimizing the sequence that elements are burned. "
-                )
-                + "\n\n"
-                + _(
-                    "When this option is NOT checked, elements are burned strictly "
-                    + "in the order they appear in the Operation tree, "
-                    + "and the Merge options will have no effect on the burn time. "
-                )
-                + "\n\n"
-                + _(
-                    "When this option IS checked, Meerk40t will burn each subpath "
-                    + "and then move to the nearest remaining subpath instead, "
-                    + "reducing the time taken moving between burn items."
-                ),
-                "page": "Optimizations",
-                "section": "",
-            },
-            {
-                "attr": "opt_complete_subpaths",
-                "object": context,
-                "default": True,
-                "type": bool,
-                "label": _("Burn Complete Subpaths"),
-                "tip": _(
-                    "By default Reduce Travel Time optimises using SVG individual path segments, "
-                    + "which means that non-closed subpaths can be burned in several shorter separate burns "
-                    + "rather than one continuous burn from start to end. "
-                )
-                + "\n\n"
-                + _(
-                    "This option only affects non-closed paths. "
-                    + "When this option is checked, non-closed subpaths are always burned in one continuous burn "
-                    + "from start to end rather than having burns start in the middle. "
-                    + "Whilst this may create a longer travel move to the end of the subpath,"
-                    + "it also avoids later travel moves to or from the intermediate point. "
-                    + "The total travel time may therefore be shorter or longer. "
-                    + "It may also avoid minor differences in total burn depth "
-                    + "at the point the burns join. "
-                ),
-                "page": "Optimizations",
-                "section": "Burn sequence",
-                "conditional": (context, "opt_reduce_travel"),
-            },
-            {
-                "attr": "opt_merge_passes",
-                "object": context,
-                "default": False,
-                "type": bool,
-                "label": _("Merge Passes"),
-                "tip": _(
-                    "Combine multiple passes into the same optimization. "
-                    + "This will typically result in each subpath being burned multiple times in succession, "
-                    + "burning closed paths round-and-round "
-                    + "and non-closed paths back-and-forth, "
-                    + "before Meerk40t moves to the next path. "
-                )
-                + "\n\n"
-                + _(
-                    "If you have a complex design with many paths and are burning with multiple passes, "
-                    + "using this option can significantly REDUCE the optimisation time. "
-                )
-                + "\n\n"
-                + _(
-                    "NOTE: Where you burn very short paths multiple times in quick succession, "
-                    + "this does not allow time for the material to cool down between burns, "
-                    + "and this can result in greater charring "
-                    + "or even an increased risk of the material catching fire."
-                ),
-                "page": "Optimizations",
-                "section": "Merging",
-                "conditional": (context, "opt_reduce_travel"),
-            },
-            {
-                "attr": "opt_merge_ops",
-                "object": context,
-                "default": False,
-                "type": bool,
-                "label": _("Merge Operations"),
-                "tip": _(
-                    "Combine multiple consecutive burn operations and optimise across them globally. "
-                    + "Operations of different types will be optimised together to reduce travel time, "
-                    + "so vector and raster burns will be mixed. "
-                )
-                + "\n\n"
-                + _(
-                    "If Merge Passes is not checked, Operations with >1 passes will only have the same passes merged. "
-                    + "If Merge Passes is also checked, then all burns will be optimised globally."
-                )
-                + "\n\n"
-                + _(
-                    "If you have a complex design with many paths across multiple consecutive burn operations, "
-                    + "using this option can significantly INCREASE the optimisation time. "
-                ),
-                "page": "Optimizations",
-                "section": "Merging",
-                "conditional": (context, "opt_reduce_travel"),
-            },
-            {
                 "attr": "opt_inner_first",
                 "object": context,
                 "default": True,
@@ -167,7 +61,7 @@ def plugin(kernel, lifecycle=None):
                 ),
                 "page": "Optimizations",
                 "section": "Burn sequence",
-                "subsection": "Inner burn",
+                # "subsection": "Inner burn",
             },
             {
                 "attr": "opt_inner_tolerance",
@@ -178,7 +72,7 @@ def plugin(kernel, lifecycle=None):
                 "tip": _("Tolerance to decide if a shape is truly inside another one."),
                 "page": "Optimizations",
                 "section": "Burn sequence",
-                "subsection": "Inner burn",
+                # "subsection": "Inner burn",
                 "conditional": (context, "opt_inner_first"),
             },
             {
@@ -209,6 +103,112 @@ def plugin(kernel, lifecycle=None):
                 "page": "Optimizations",
                 "section": "Burn sequence",
                 "conditional": (context, "opt_inner_first"),
+            },
+            {
+                "attr": "opt_reduce_travel",
+                "object": context,
+                "default": True,
+                "type": bool,
+                "label": _("Reduce Travel Time"),
+                "tip": _(
+                    "Using this option can significantly reduce the time spent "
+                    + "moving between elements with the laser off "
+                    + "by optimizing the sequence that elements are burned. "
+                )
+                       + "\n\n"
+                       + _(
+                    "When this option is NOT checked, elements are burned strictly "
+                    + "in the order they appear in the Operation tree, "
+                    + "and the Merge options will have no effect on the burn time. "
+                )
+                       + "\n\n"
+                       + _(
+                    "When this option IS checked, Meerk40t will burn each subpath "
+                    + "and then move to the nearest remaining subpath instead, "
+                    + "reducing the time taken moving between burn items."
+                ),
+                "page": "Optimizations",
+                "section": "",
+            },
+            {
+                "attr": "opt_complete_subpaths",
+                "object": context,
+                "default": True,
+                "type": bool,
+                "label": _("Burn Complete Subpaths"),
+                "tip": _(
+                    "By default Reduce Travel Time optimises using SVG individual path segments, "
+                    + "which means that non-closed subpaths can be burned in several shorter separate burns "
+                    + "rather than one continuous burn from start to end. "
+                )
+                       + "\n\n"
+                       + _(
+                    "This option only affects non-closed paths. "
+                    + "When this option is checked, non-closed subpaths are always burned in one continuous burn "
+                    + "from start to end rather than having burns start in the middle. "
+                    + "Whilst this may create a longer travel move to the end of the subpath,"
+                    + "it also avoids later travel moves to or from the intermediate point. "
+                    + "The total travel time may therefore be shorter or longer. "
+                    + "It may also avoid minor differences in total burn depth "
+                    + "at the point the burns join. "
+                ),
+                "page": "Optimizations",
+                "section": "",
+                "conditional": (context, "opt_reduce_travel"),
+            },
+            {
+                "attr": "opt_merge_passes",
+                "object": context,
+                "default": False,
+                "type": bool,
+                "label": _("Merge Passes"),
+                "tip": _(
+                    "Combine multiple passes into the same optimization. "
+                    + "This will typically result in each subpath being burned multiple times in succession, "
+                    + "burning closed paths round-and-round "
+                    + "and non-closed paths back-and-forth, "
+                    + "before Meerk40t moves to the next path. "
+                )
+                       + "\n\n"
+                       + _(
+                    "If you have a complex design with many paths and are burning with multiple passes, "
+                    + "using this option can significantly REDUCE the optimisation time. "
+                )
+                       + "\n\n"
+                       + _(
+                    "NOTE: Where you burn very short paths multiple times in quick succession, "
+                    + "this does not allow time for the material to cool down between burns, "
+                    + "and this can result in greater charring "
+                    + "or even an increased risk of the material catching fire."
+                ),
+                "page": "Optimizations",
+                "section": "",
+                "conditional": (context, "opt_reduce_travel"),
+            },
+            {
+                "attr": "opt_merge_ops",
+                "object": context,
+                "default": False,
+                "type": bool,
+                "label": _("Merge Operations"),
+                "tip": _(
+                    "Combine multiple consecutive burn operations and optimise across them globally. "
+                    + "Operations of different types will be optimised together to reduce travel time, "
+                    + "so vector and raster burns will be mixed. "
+                )
+                       + "\n\n"
+                       + _(
+                    "If Merge Passes is not checked, Operations with >1 passes will only have the same passes merged. "
+                    + "If Merge Passes is also checked, then all burns will be optimised globally."
+                )
+                       + "\n\n"
+                       + _(
+                    "If you have a complex design with many paths across multiple consecutive burn operations, "
+                    + "using this option can significantly INCREASE the optimisation time. "
+                ),
+                "page": "Optimizations",
+                "section": "",
+                "conditional": (context, "opt_reduce_travel"),
             },
             {
                 "attr": "opt_closed_distance",

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -52,14 +52,14 @@ def plugin(kernel, lifecycle=None):
                     + "moving between elements with the laser off "
                     + "by optimizing the sequence that elements are burned. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "When this option is NOT checked, elements are burned strictly "
                     + "in the order they appear in the Operation tree, "
                     + "and the Merge options will have no effect on the burn time. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "When this option IS checked, Meerk40t will burn each subpath "
                     + "and then move to the nearest remaining subpath instead, "
                     + "reducing the time taken moving between burn items."
@@ -78,8 +78,8 @@ def plugin(kernel, lifecycle=None):
                     + "which means that non-closed subpaths can be burned in several shorter separate burns "
                     + "rather than one continuous burn from start to end. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "This option only affects non-closed paths. "
                     + "When this option is checked, non-closed subpaths are always burned in one continuous burn "
                     + "from start to end rather than having burns start in the middle. "
@@ -106,13 +106,13 @@ def plugin(kernel, lifecycle=None):
                     + "and non-closed paths back-and-forth, "
                     + "before Meerk40t moves to the next path. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "If you have a complex design with many paths and are burning with multiple passes, "
                     + "using this option can significantly REDUCE the optimisation time. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "NOTE: Where you burn very short paths multiple times in quick succession, "
                     + "this does not allow time for the material to cool down between burns, "
                     + "and this can result in greater charring "
@@ -133,13 +133,13 @@ def plugin(kernel, lifecycle=None):
                     + "Operations of different types will be optimised together to reduce travel time, "
                     + "so vector and raster burns will be mixed. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "If Merge Passes is not checked, Operations with >1 passes will only have the same passes merged. "
                     + "If Merge Passes is also checked, then all burns will be optimised globally."
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "If you have a complex design with many paths across multiple consecutive burn operations, "
                     + "using this option can significantly INCREASE the optimisation time. "
                 ),
@@ -157,8 +157,8 @@ def plugin(kernel, lifecycle=None):
                     "Ensure that inside burns are done before an outside cut in order to ensure that burns inside "
                     + "a cut-out piece are done before the cut piece shifts or drops out of the material."
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "If you find that using this option significantly increases the optimisation time, "
                     + "alternatives are: \n"
                     + "* Deselecting Cut Inner First if you are not cutting fully through your material \n"
@@ -196,12 +196,12 @@ def plugin(kernel, lifecycle=None):
                     + "This can reduce the risk of e.g. a shift ruining an entire piece of material "
                     + "by trying to ensure that one piece is finished before starting on another."
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "This optimization works best with Merge Operations also checked though this is not a requirement. "
                 )
-                       + "\n\n"
-                       + _(
+                + "\n\n"
+                + _(
                     "Because this optimisation is done once rasters have been turned into images, "
                     + "inner elements may span multiple design pieces, "
                     + "in which case they may be optimised together."


### PR DESCRIPTION
* on an op, `duplicate elements n times` will duplicate these references in series rather than in parallel.

The reasoning here is that elements are always elsewhere duplicated in parallel.
* Adding a pass to the operation pass value.
* Duplicating the operation as a whole.
* Setting the Job Run passes to a pass value. 

![duplicate in series](https://user-images.githubusercontent.com/3302478/199847294-ea54c31b-1a43-430a-a9be-9bff46e220dd.png)

Each duplicates the passes, such that they run in parallel. One full pass finishes then another full pass occurs. Here we modify this to occur in series so that an an unoptimized job will run in series if duplicated in this fashion.

