### PR TITLE
Cosmetics and cutcode 2 operation

### DIFF
--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -114,7 +114,10 @@ class CircleTool(ToolWidget):
             self.scene.tool_active = False
             try:
                 if self.p1 is None:
-                    return
+                    self.scene.request_refresh()
+                    self.scene.context.signal("statusmsg", "")
+                    response = RESPONSE_ABORT
+                    return response
                 if nearest_snap is None:
                     self.p2 = complex(space_pos[0], space_pos[1])
                 else:
@@ -123,6 +126,14 @@ class CircleTool(ToolWidget):
                 cy = self.p1.imag
                 dx = self.p1.real - self.p2.real
                 dy = self.p1.imag - self.p2.imag
+                if abs(dx) < 1E-10 or abs(dy) < 1E-10:
+                    # Degenerate? Ignore!
+                    self.p1 = None
+                    self.p2 = None
+                    self.scene.request_refresh()
+                    self.scene.context.signal("statusmsg", "")
+                    response = RESPONSE_ABORT
+                    return response
                 radius = sqrt(dx * dx + dy * dy)
                 x0 = min(self.p1.real, self.p2.real)
                 y0 = min(self.p1.imag, self.p2.imag)

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -103,6 +103,16 @@ class EllipseTool(ToolWidget):
                 y0 = min(self.p1.imag, self.p2.imag)
                 x1 = max(self.p1.real, self.p2.real)
                 y1 = max(self.p1.imag, self.p2.imag)
+                dx = self.p1.real - self.p2.real
+                dy = self.p1.imag - self.p2.imag
+                if abs(dx) < 1E-10 or abs(dy) < 1E-10:
+                    # Degenerate? Ignore!
+                    self.p1 = None
+                    self.p2 = None
+                    self.scene.request_refresh()
+                    self.scene.context.signal("statusmsg", "")
+                    response = RESPONSE_ABORT
+                    return response
                 ellipse = Ellipse(
                     (x1 + x0) / 2.0,
                     (y1 + y0) / 2.0,

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -103,6 +103,16 @@ class RectTool(ToolWidget):
                 y0 = min(self.p1.imag, self.p2.imag)
                 x1 = max(self.p1.real, self.p2.real)
                 y1 = max(self.p1.imag, self.p2.imag)
+                dx = self.p1.real - self.p2.real
+                dy = self.p1.imag - self.p2.imag
+                if abs(dx) < 1E-10 or abs(dy) < 1E-10:
+                    # Degenerate? Ignore!
+                    self.p1 = None
+                    self.p2 = None
+                    self.scene.request_refresh()
+                    self.scene.context.signal("statusmsg", "")
+                    response = RESPONSE_ABORT
+                    return response
                 rect = Rect(x0, y0, x1 - x0, y1 - y0)
                 if not rect.is_degenerate():
                     elements = self.scene.context.elements


### PR DESCRIPTION
Some small changes for Simulation-panel
a) Display icons in operations panel
![grafik](https://user-images.githubusercontent.com/2670784/200191915-a34ca481-7314-4ed7-b7dc-e27a5c0bc7bb.png)

b) Allow reverting cutcode into operations:
![grafik](https://user-images.githubusercontent.com/2670784/200191971-71600af9-73ab-4239-bbd7-70ca33541cce.png)
(intentionally nearly hidden...)
![grafik](https://user-images.githubusercontent.com/2670784/200192000-a7326672-e4ef-4d69-90eb-7c31fdb4fc6b.png)
