### PR TITLE
Add in PostExec kernel commands

### DIFF
--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -1699,20 +1699,6 @@ class Elemental(Service):
             self._emphasized_bounds_painted = None
             self.set_emphasis(None)
 
-    @signal_listener("classify_new")
-    def ask_for_classification(self, origin, data, *args):
-        # Why are we doing it here? An immediate classification
-        # at the end of the element creation might not provide
-        # the right assignment as additional commands might be
-        # chained to it:
-        # e.g. "circle 1cm 1cm 1cm" will classify differently than
-        # "circle 1cm 1cm 1cm stroke red"
-        if not isinstance(data, (list, tuple)):
-            data = [data]
-        if self.classify_new and len(data) > 0:
-            self.classify(data)
-            self.signal("tree_changed")
-
     def classify(self, elements, operations=None, add_op_function=None):
         """
         @param elements: list of elements to classify.


### PR DESCRIPTION
The use case of `classify` is that it should happen once a command completing data is executed. However, due to the nature of command chaining there's not a good indication of when that would be.

`circle 3in 3in 1in stroke blue fill green rotate 0.4turn` -- is 4 commands. If classification happened after `circle` then it might miss that `stroke blue` happened which changed the classification. If it happened after `stroke blue` it might miss the `fill green` command which could change the classification. And if we looked at the `rotate 0.4turn` we might not consider that this shape requires classification at all.

We expand the kernel commands adding in `post` which is a list of commands to be executed. This command is fed the final chained information, channel, data, data_type it ended with and all the commands from `post_data`, which could contain nearly anything. The `post_data` could also be used as a simple chained dictionary from the previous commands. So checking it for flags or other data that could have been set by previous commands would be acceptable. 