### PR TITLE
DPI display in Tree

### DIFF
--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -54,6 +54,7 @@ class ImageOpNode(Node, Parameters):
     def default_map(self, default_map=None):
         default_map = super(ImageOpNode, self).default_map(default_map=default_map)
         default_map["element_type"] = "Image"
+        default_map["dpi"] = str(self.dpi)
         default_map["danger"] = "❌" if self.dangerous else ""
         default_map["defop"] = "✓" if self.default else ""
         default_map["enabled"] = "(Disabled) " if not self.output else ""

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -1242,6 +1242,8 @@ class ImagePropertyPanel(ScrolledPanel):
     def on_text_dpi(self):
         new_step = float(self.text_dpi.GetValue())
         self.node.dpi = new_step
+        self.node.update(self.context)
+        self.context.signal("element_property_reload", self.node)
 
     def on_dither(self, event=None):
         # Dither can be set by two different means:

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1191,7 +1191,11 @@ class ShadowTree:
                     value = _(pattern + std)
                     if not value.startswith(pattern):
                         mymap[key] = value
-            return text.format_map(mymap)
+            try:
+                result = text.format_map(mymap)
+            except KeyError:
+                result = "<???>"
+            return result
 
         def get_formatter(nodetype):
             default = self.context.elements.lookup(f"format/{nodetype}")


### PR DESCRIPTION
a) Cover crash for invalid keys in Tree node format string
b) Provide 'dpi' as possible key for image operation
c) Update elem image tree node

- Still the discussion around the use of the dpi parameter as had in the discord dev group needs to be brought forward. 