### PR TITLE
Logging Service for Spooler History

### DIFF
--- a/meerk40t/core/core.py
+++ b/meerk40t/core/core.py
@@ -1,0 +1,35 @@
+
+def plugin(kernel, lifecycle=None):
+    _ = kernel.translation
+    if lifecycle == "plugins":
+        plugins = []
+
+        from . import spoolers
+
+        plugins.append(spoolers.plugin)
+
+        from . import elements
+
+        plugins.append(elements.plugin)
+
+        from . import logging
+
+        plugins.append(logging.plugin)
+
+        from . import bindalias
+
+        plugins.append(bindalias.plugin)
+
+        from . import webhelp
+
+        plugins.append(webhelp.plugin)
+
+        from . import planner
+
+        plugins.append(planner.plugin)
+
+        from . import svg_io
+
+        plugins.append(svg_io.plugin)
+
+        return plugins

--- a/meerk40t/core/logging.py
+++ b/meerk40t/core/logging.py
@@ -1,0 +1,30 @@
+from meerk40t.kernel import Service, Settings
+
+
+def plugin(kernel, lifecycle=None):
+    _ = kernel.translation
+    if lifecycle == "register":
+        kernel.add_service("logging", Logging(kernel))
+
+
+class Logging(Service):
+    """
+    The logging service is located at .logging and stores and saves logged information. This should not store critical
+    data and if the logging file is destroyed or deleted it should have no bearing on anything other than saved logs.
+    """
+
+    def __init__(self, kernel, *args, **kwargs):
+        Service.__init__(self, kernel, "logging")
+        self._setting_config = Settings(self.kernel.name, "meerk40t.log")
+        self.logs = self._setting_config.literal_dict()
+
+    def shutdown(self, *args, **kwargs):
+        self._setting_config.set_dict(self.logs)
+        self._setting_config.write_configuration()
+
+    def service_detach(self, *args, **kwargs):
+        pass
+
+    def service_attach(self, *args, **kwargs):
+        pass
+

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -793,59 +793,62 @@ class SpoolerPanel(wx.Panel):
             self.list_job_history.SetItemData(list_id, idx - 1)
 
     def reload_history(self):
-        self.history = []
-        directory = os.path.dirname(self.context.elements.op_data._config_file)
-        filename = os.path.join(directory, "history.json")
-        if os.path.exists(filename):
-            try:
-                with open(filename, "r") as f:
-                    self.history = json.load(f)
-            except (json.JSONDecodeError, PermissionError, OSError, FileNotFoundError):
-                pass
-        if len(self.history) > 0:
-            if len(self.history[0]) < 5:
-                # Incompatible
-                self.history = []
+        spooler_log = self.context.logging.logs.get("spooler", dict())
+        self.history = spooler_log.get("history", list())
+        # self.history = []
+        # directory = os.path.dirname(self.context.elements.op_data._config_file)
+        # filename = os.path.join(directory, "history.json")
+        # if os.path.exists(filename):
+        #     try:
+        #         with open(filename, "r") as f:
+        #             self.history = json.load(f)
+        #     except (json.JSONDecodeError, PermissionError, OSError, FileNotFoundError):
+        #         pass
+        # if len(self.history) > 0:
+        #     if len(self.history[0]) < 5:
+        #         # Incompatible
+        #         self.history = []
         self.refresh_history()
 
     def save_history(self):
-        def escaped(s):
-            return s.replace('"', "'")
-
-        directory = os.path.dirname(self.context.elements.op_data._config_file)
-        filename = os.path.join(directory, "history.json")
-        try:
-            with open(filename, "w") as f:
-                json.dump(self.history, f)
-        except (json.JSONDecodeError, PermissionError, OSError, FileNotFoundError):
-            pass
-        filename = os.path.join(directory, "history.csv")
-        try:
-            with open(filename, "w", encoding="utf-8") as f:
-                simpleline = "device;jobname;start;end;duration;passes"
-                f.write(simpleline + "\n")
-                for info in self.history:
-                    if info[1] is None:
-                        continue
-                    simpleline = escaped(info[3])
-                    simpleline += ";" + escaped(info[0])
-                    starttime = (
-                        self.datestr(info[1]) + " " + self.timestr(info[1], True)
-                    )
-                    simpleline += ";" + starttime
-                    starttime = self.timestr(info[1] + info[2], True)
-                    simpleline += ";" + starttime
-                    runtime = self.timestr(info[2], False)
-                    simpleline += ";" + runtime
-                    # First passes then device
-                    if len(info) >= 5:
-                        simpleline += ";" + escaped(info[4])
-                    else:
-                        simpleline += ";''"
-                    f.write(simpleline + "\n")
-
-        except (PermissionError, OSError, FileNotFoundError):
-            pass
+        self.context.logging.logs["spooler"] = {"history": self.history}
+        # def escaped(s):
+        #     return s.replace('"', "'")
+        #
+        # directory = os.path.dirname(self.context.elements.op_data._config_file)
+        # filename = os.path.join(directory, "history.json")
+        # try:
+        #     with open(filename, "w") as f:
+        #         json.dump(self.history, f)
+        # except (json.JSONDecodeError, PermissionError, OSError, FileNotFoundError):
+        #     pass
+        # filename = os.path.join(directory, "history.csv")
+        # try:
+        #     with open(filename, "w", encoding="utf-8") as f:
+        #         simpleline = "device;jobname;start;end;duration;passes"
+        #         f.write(simpleline + "\n")
+        #         for info in self.history:
+        #             if info[1] is None:
+        #                 continue
+        #             simpleline = escaped(info[3])
+        #             simpleline += ";" + escaped(info[0])
+        #             starttime = (
+        #                 self.datestr(info[1]) + " " + self.timestr(info[1], True)
+        #             )
+        #             simpleline += ";" + starttime
+        #             starttime = self.timestr(info[1] + info[2], True)
+        #             simpleline += ";" + starttime
+        #             runtime = self.timestr(info[2], False)
+        #             simpleline += ";" + runtime
+        #             # First passes then device
+        #             if len(info) >= 5:
+        #                 simpleline += ";" + escaped(info[4])
+        #             else:
+        #                 simpleline += ";''"
+        #             f.write(simpleline + "\n")
+        #
+        # except (PermissionError, OSError, FileNotFoundError):
+        #     pass
 
     def before_history_update(self, event):
         list_id = event.GetIndex()  # Get the current row

--- a/meerk40t/kernel/settings.py
+++ b/meerk40t/kernel/settings.py
@@ -76,6 +76,29 @@ class Settings:
         except PermissionError:
             return
 
+    def literal_dict(self):
+        literal_dict = dict()
+        for section in self._config_dict:
+            section_dict = self._config_dict[section]
+            literal_section_dict = dict()
+            literal_dict[section] = literal_section_dict
+            for key in section_dict:
+                value = section_dict[key]
+                try:
+                    value = ast.literal_eval(value)
+                except (ValueError, SyntaxError):
+                    pass
+                literal_section_dict[key] = value
+        return literal_dict
+
+    def set_dict(self, literal_dict):
+        self._config_dict.clear()
+        for section in literal_dict:
+            section_dict = dict()
+            self._config_dict[section] = section_dict
+            for key in literal_dict[section]:
+                section_dict[key] = str(literal_dict[section][key])
+
     def read_persistent(
         self,
         t: type,

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -121,33 +121,13 @@ def static_plugins(kernel, lifecycle):
 
         plugins.append(rotary.plugin)
 
-        from .core import spoolers
+        from .core import core
 
-        plugins.append(spoolers.plugin)
-
-        from .core import elements
-
-        plugins.append(elements.plugin)
-
-        from .core import bindalias
-
-        plugins.append(bindalias.plugin)
-
-        from .core import webhelp
-
-        plugins.append(webhelp.plugin)
-
-        from .core import planner
-
-        plugins.append(planner.plugin)
+        plugins.append(core.plugin)
 
         from .image import imagetools
 
         plugins.append(imagetools.plugin)
-
-        from .core import svg_io
-
-        plugins.append(svg_io.plugin)
 
         from .fill import fills
 


### PR DESCRIPTION
This PR primarily adds a logging service. The service is mostly a stub. It loads and saves the `.logs` dictionary at `logging.logs` with literals. So any `int` placed in that dictionary of dictionaries will be loaded and saved as an integer. Feel free to add any logic you need into the service. 

This is intended to replace the `.json` and `.csv` currently doing that logging. These are not easily human-readable but if stored as a dictionary entry with keys corresponding to what that data is, this should increase readability. The current implementation is a list of lists in the "history" entry of the "spooler" dictionary. This is mostly for consistency since it requires no major changes.

Current logging suffers from several problems.
* Logging is done through signals sent and gui caught data. This means the logging of jobs in CLI does not exist.
* Logging is caught though the spooler gui. If the spooler-window isn't open, this will not log.
* Current log files are not easily read by users who wish to view them.
* The logs are currently static entries of 7 items. This makes it very hard to extend them to add additional information. EG. #1518 -- Adding this information to the log requires somewhat in depth understanding of how the logs work and what each entry is and how that all works. Rather we should be able to add a simple data point without affecting anything and be able to view this data in the logs without needing to display it.
* Currently the last job needs to have run on the current meerk40t execution. The info-widget can't display a job completed in the previous execution even though that information is technically availible.
* We could fill up all our logs with useful information and have to clear it, rather than being able to hide it. More info could allow us to set a list of "shown" jobs, reserving clear all previous jobs for when we want to purge the logs rather than when we just don't want to see those jobs.

The intention here is to facilitate a better logging situation. Everything in `logging.logs` will be persistent in both data placed there and data type. So if used more centrally by both the spooler and the spooler window, we should use the signal to just notify the window if it exists that it should update, rather than using the window to store our logs. 
