### PR TITLE
Extended path simplification

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -3927,12 +3927,23 @@ def init_commands(kernel):
             channel("Requires a selected polygon")
             return None
         for node in data:
+            try:
+                sub_before = len(list(node.as_path().as_subpaths()))
+            except AttributeError:
+                sub_before = 0
+
             changed, before, after = self.simplify_node(node)
             if changed:
-                s = node.type
-                channel(f"Simplified {s} ({node.label}): from {before} to {after}")
                 node.altered()
+                try:
+                    sub_after = len(list(node.as_path().as_subpaths()))
+                except AttributeError:
+                    sub_after = 0
+                channel(f"Simplified {node.type} ({node.label}): from {before} to {after}")
+                channel(f"Subpaths before: {sub_before} to {sub_after}")
                 data_changed.append(node)
+            else:
+                channel(f"Could not simplify {node.type} ({node.label})")
         if len(data_changed)>0:
             self.signal("element_property_update", data_changed)
             self.signal("refresh_scene", "Scene")

--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -69,8 +69,6 @@ def init_commands(kernel):
     ]
     kernel.register_choices("preferences", choices)
 
-
-
     def classify_new(data):
         """
         Why are we doing it here? An immediate classification
@@ -85,10 +83,12 @@ def init_commands(kernel):
 
         @return: post classification function.
         """
+
         def post_classify_function(**kwargs):
             if self.classify_new and len(data) > 0:
                 self.classify(data)
                 self.signal("tree_changed")
+
         return post_classify_function
 
     @self.console_argument("filename")
@@ -3742,7 +3742,9 @@ def init_commands(kernel):
         output_type="elements",
         all_arguments_required=True,
     )
-    def element_ellipse(channel, _, x_pos, y_pos, rx_pos, ry_pos, data=None, post=None, **kwargs):
+    def element_ellipse(
+        channel, _, x_pos, y_pos, rx_pos, ry_pos, data=None, post=None, **kwargs
+    ):
         ellip = Ellipse(
             cx=float(x_pos), cy=float(y_pos), rx=float(rx_pos), ry=float(ry_pos)
         )
@@ -3862,7 +3864,9 @@ def init_commands(kernel):
         input_type=(None, "elements"),
         output_type="elements",
     )
-    def element_text(command, channel, _, data=None, text=None, size=None, post=None,  **kwargs):
+    def element_text(
+        command, channel, _, data=None, text=None, size=None, post=None, **kwargs
+    ):
         if text is None:
             channel(_("No text specified"))
             return
@@ -3917,8 +3921,10 @@ def init_commands(kernel):
             e.altered()
         return "elements", data
 
-    @self.console_command("simplify", input_type=("elements", None), output_type="elements")
-    def simplify_path(command, channel, _,  data=None, post=None, **kwargs):
+    @self.console_command(
+        "simplify", input_type=("elements", None), output_type="elements"
+    )
+    def simplify_path(command, channel, _, data=None, post=None, **kwargs):
 
         if data is None:
             data = list(self.elems(emphasized=True))
@@ -3939,18 +3945,22 @@ def init_commands(kernel):
                     sub_after = len(list(node.as_path().as_subpaths()))
                 except AttributeError:
                     sub_after = 0
-                channel(f"Simplified {node.type} ({node.label}): from {before} to {after}")
+                channel(
+                    f"Simplified {node.type} ({node.label}): from {before} to {after}"
+                )
                 channel(f"Subpaths before: {sub_before} to {sub_after}")
                 data_changed.append(node)
             else:
                 channel(f"Could not simplify {node.type} ({node.label})")
-        if len(data_changed)>0:
+        if len(data_changed) > 0:
             self.signal("element_property_update", data_changed)
             self.signal("refresh_scene", "Scene")
         return "elements", data
 
-    @self.console_command("polycut", input_type=("elements", None), output_type="elements")
-    def create_pattern(command, channel, _,  data=None, post=None, **kwargs):
+    @self.console_command(
+        "polycut", input_type=("elements", None), output_type="elements"
+    )
+    def create_pattern(command, channel, _, data=None, post=None, **kwargs):
         if data is None:
             data = list(self.elems(emphasized=True))
         if len(data) <= 1:
@@ -3962,6 +3972,7 @@ def init_commands(kernel):
         data[1].remove_node()
 
         from meerk40t.tools.pathtools import VectorMontonizer
+
         vm = VectorMontonizer()
         outer_path = Polygon(
             [outer_path.point(i / 1000.0, error=1e4) for i in range(1001)]
@@ -3971,7 +3982,7 @@ def init_commands(kernel):
         for sub_inner in inner_path.as_subpaths():
             sub_inner = Path(sub_inner)
             pts_sub = [sub_inner.point(i / 1000.0, error=1e4) for i in range(1001)]
-            for i in range(len(pts_sub)-1, -1, -1):
+            for i in range(len(pts_sub) - 1, -1, -1):
                 pt = pts_sub[i]
                 if not vm.is_point_inside(pt[0], pt[1]):
                     del pts_sub[i]
@@ -4045,6 +4056,7 @@ def init_commands(kernel):
             return "elements", data
 
         from meerk40t.tools.geomstr import Geomstr
+
         geomstr = Geomstr()
         for node in data:
             try:
@@ -5903,7 +5915,9 @@ def init_commands(kernel):
         input_type="clipboard",
         output_type="elements",
     )
-    def clipboard_paste(command, channel, _, data=None, post=None, dx=None, dy=None, **kwargs):
+    def clipboard_paste(
+        command, channel, _, data=None, post=None, dx=None, dy=None, **kwargs
+    ):
         destination = self._clipboard_default
         try:
             pasted = [copy(e) for e in self._clipboard[destination]]
@@ -6233,14 +6247,26 @@ def init_commands(kernel):
         help=_("Method to use (one of quick, hull, complex, segment, circle)"),
     )
     @self.console_argument("resolution")
-    @self.console_option("start", "s", type=int, help=_("0=immediate, 1=User interaction, 2=wait for 5 seconds"))
+    @self.console_option(
+        "start",
+        "s",
+        type=int,
+        help=_("0=immediate, 1=User interaction, 2=wait for 5 seconds"),
+    )
     @self.console_command(
         "trace",
         help=_("trace the given elements"),
         input_type=("elements", "shapes", None),
     )
     def trace_trace_spooler(
-        command, channel, _, method=None, resolution=None, start=None, data=None, **kwargs
+        command,
+        channel,
+        _,
+        method=None,
+        resolution=None,
+        start=None,
+        data=None,
+        **kwargs,
     ):
         if method is None:
             method = "quick"
@@ -6276,10 +6302,10 @@ def init_commands(kernel):
                     pass
                 elif startmethod == 1:
                     # Dialog
-                    yield ('console', 'interrupt "Trace is about to start"')
+                    yield ("console", 'interrupt "Trace is about to start"')
                 elif startmethod == 2:
                     # Wait for some seconds
-                    yield ('wait', 5000)
+                    yield ("wait", 5000)
 
                 yield "wait_finish"
                 yield "rapid_mode"
@@ -6312,7 +6338,14 @@ def init_commands(kernel):
         output_type="elements",
     )
     def trace_trace_generator(
-        command, channel, _, method=None, resolution=None, data=None, post=None, **kwargs
+        command,
+        channel,
+        _,
+        method=None,
+        resolution=None,
+        data=None,
+        post=None,
+        **kwargs,
     ):
         if method is None:
             method = "quick"

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -2869,7 +2869,6 @@ class Elemental(Service):
                 filetypes.append(f"*.{extension}")
         return "|".join(filetypes)
 
-
     def simplify_node(self, node):
         def my_sign(x):
             # Returns +1 for positive figures, -1 for negative and 0 for Zero
@@ -2882,23 +2881,27 @@ class Elemental(Service):
             for current, seg in enumerate(obj._segments):
                 if isinstance(seg, Move):
                     if start >= 0:
-                        result.append( (start, current - 1, obj._segments[start].start.x) )
+                        result.append(
+                            (start, current - 1, obj._segments[start].start.x)
+                        )
                         start = -1
                 elif isinstance(seg, Close):
                     if start >= 0:
-                        result.append( (start, current - 1, obj._segments[start].start.x) )
+                        result.append(
+                            (start, current - 1, obj._segments[start].start.x)
+                        )
                         start = -1
                 else:
                     if start < 0:
                         start = current
             if start >= 0:
-                result.append( (start, len(obj) - 1, obj._segments[start].start.x) )
+                result.append((start, len(obj) - 1, obj._segments[start].start.x))
             # Now let's sort the list according to the X-start position
             result.sort(key=lambda a: a[2])
             return result
 
-
         from time import time
+
         time_start = time()
 
         changed = False
@@ -2916,9 +2919,12 @@ class Elemental(Service):
             # Pass 0: Dropping zero length line segments
             for idx in range(len(obj._segments) - 1, -1, -1):
                 seg = obj._segments[idx]
-                if isinstance(seg, Line) and seg.start.x == seg.end.x and seg.start.y == seg.end.y:
+                if (
+                    isinstance(seg, Line)
+                    and seg.start.x == seg.end.x
+                    and seg.start.y == seg.end.y
+                ):
                     obj._segments.pop(idx)
-
 
             # Pass 1: look inside the nodes and bring small line segments back together...
             for idx in range(len(obj._segments) - 1, -1, -1):
@@ -2938,9 +2944,9 @@ class Elemental(Service):
                         denom = thisdx * lastdy - thisdy * lastdx
 
                         same = (
-                            abs(denom) < basically_zero and
-                            my_sign(lastdx) == my_sign(thisdx) and
-                            my_sign(lastdy) == my_sign(thisdy)
+                            abs(denom) < basically_zero
+                            and my_sign(lastdx) == my_sign(thisdx)
+                            and my_sign(lastdy) == my_sign(thisdy)
                         )
                         # if thisdx == 0 or lastdx == 0:
                         #     channel(f"One Vertical line, {thisdx:.1f}, {thisdy:1f} vs {lastdx:1f},{lastdy:.1f}")
@@ -2977,7 +2983,7 @@ class Elemental(Service):
                 results = list_subpath_bounds(obj)
                 # print (f"Examine {len(results)} chains")
                 if len(results) <= 1:
-                    print ("only one chain, exit")
+                    print("only one chain, exit")
                     break
                 # for current, seg in enumerate(obj._segments):
                 #     flag = ""
@@ -2988,7 +2994,6 @@ class Elemental(Service):
                 #             flag += f"end[{idx}] "
 
                 #     print(f"#{current}: {type(seg).__name__} - {flag}")
-
 
                 for idx, entry in enumerate(results):
                     this_start = entry[0]
@@ -3014,12 +3019,15 @@ class Elemental(Service):
                         coincident = False
                         # Do the lines overlap or have a common end / startpoint together?
                         if (
-                            abs(this_endseg.end.x - other_startseg.start.x) < tolerance and
-                            abs(this_endseg.end.y - other_startseg.start.y) < tolerance
+                            abs(this_endseg.end.x - other_startseg.start.x) < tolerance
+                            and abs(this_endseg.end.y - other_startseg.start.y)
+                            < tolerance
                         ):
                             for idx3 in range(other_end - other_start + 1):
                                 # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                obj._segments.insert(
+                                    this_end + 1, obj._segments.pop(other_end)
+                                )
                                 # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
                             joined += 1
                             redo = True
@@ -3058,15 +3066,24 @@ class Elemental(Service):
                                     continue
 
                                 # e) They could still be just parallel, so let's establish this...
-                                if abs(lastdx) < basically_zero or abs(thisdx) < basically_zero:
+                                if (
+                                    abs(lastdx) < basically_zero
+                                    or abs(thisdx) < basically_zero
+                                ):
                                     # Was coming from zero length lines, now removed ahead
 
                                     # print (f"Strange: This: dx={thisdx:.4f}, dy={thisdy:.4f}, Other: dx={lastdx:.4f}, dy={lastdy:.4f}, denom={denom:.4f}")
                                     # print (f"End-Segment: Start: ({this_endseg.start.x:.1f}, {this_endseg.start.y:.1f}) - ({this_endseg.end.x:.1f}, {this_endseg.end.y:.1f})")
                                     # print (f"Start-Segment: Start: ({other_startseg.start.x:.1f}, {other_startseg.start.y:.1f}) - ({other_startseg.end.x:.1f}, {other_startseg.end.y:.1f})")
                                     continue
-                                b1 = this_endseg.start.y - thisdy / thisdx * this_endseg.start.x
-                                b2 = other_startseg.start.y - lastdy / lastdx * other_startseg.start.x
+                                b1 = (
+                                    this_endseg.start.y
+                                    - thisdy / thisdx * this_endseg.start.x
+                                )
+                                b2 = (
+                                    other_startseg.start.y
+                                    - lastdy / lastdx * other_startseg.start.x
+                                )
                                 if abs(b1 - b2) > tolerance:
                                     continue
 
@@ -3076,7 +3093,9 @@ class Elemental(Service):
                                         # Can be eliminated....
                                         obj._segments.pop(other_start)
                                         redo = True
-                                        reason = f"Removed segment {idx2} fully inside {idx}"
+                                        reason = (
+                                            f"Removed segment {idx2} fully inside {idx}"
+                                        )
                                         break
                                     else:
                                         continue
@@ -3088,7 +3107,9 @@ class Elemental(Service):
                                 # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
                                 for idx3 in range(other_end - other_start + 1):
                                     # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                    obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                    obj._segments.insert(
+                                        this_end + 1, obj._segments.pop(other_end)
+                                    )
                                     # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
                                 joined += 1
                                 redo = True
@@ -3106,7 +3127,10 @@ class Elemental(Service):
 
                                 # e) They could still be just parallel, so let's establish this...
 
-                                if abs(other_startseg.start.x - this_endseg.start.x) > tolerance:
+                                if (
+                                    abs(other_startseg.start.x - this_endseg.start.x)
+                                    > tolerance
+                                ):
                                     continue
 
                                 # f) Lying completely inside, only if the second chain is a single line we can remove it...
@@ -3127,7 +3151,9 @@ class Elemental(Service):
                                 # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
                                 for idx3 in range(other_end - other_start + 1):
                                     # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                    obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                    obj._segments.insert(
+                                        this_end + 1, obj._segments.pop(other_end)
+                                    )
                                     # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
                                 joined += 1
                                 reason = f"Added overlapping vertical segment {idx2} to {idx}"
@@ -3139,7 +3165,7 @@ class Elemental(Service):
                         # print(f"Redo required inner loop: {reason}")
                         changed = True
                         break
-                #end of outer loop
+                # end of outer loop
             time_pass2 = time()
             lastseg = None
             for idx in range(len(obj._segments) - 1, -1, -1):
@@ -3179,12 +3205,11 @@ class Elemental(Service):
                     thisdy = pt[1] - pt_old[1]
                     denom = thisdx * lastdy - thisdy * lastdx
                     same = (
-                        abs(denom) < 1.0e-6 and
-                        my_sign(lastdx) == my_sign(thisdx) and
-                        my_sign(lastdy) == my_sign(thisdy)
+                        abs(denom) < 1.0e-6
+                        and my_sign(lastdx) == my_sign(thisdx)
+                        and my_sign(lastdy) == my_sign(thisdy)
                     )
                     # Opposing directions may not happen
-
 
                     if same:
                         # We can just merge the two segments by

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -2870,6 +2870,9 @@ class Elemental(Service):
         return "|".join(filetypes)
 
     def simplify_node(self, node):
+        basically_zero = 1.0e-6
+        tolerance = UNITS_PER_MIL * 1
+
         def my_sign(x):
             # Returns +1 for positive figures, -1 for negative and 0 for Zero
             return bool(x > 0) - bool(x < 0)
@@ -3196,9 +3199,6 @@ class Elemental(Service):
         changed = False
         before = 0
         after = 0
-
-        basically_zero = 1.0e-6
-        tolerance = UNITS_PER_MIL * 1
 
         if node.type == "elem path" and len(node.path._segments) > 1:
             obj = node.path

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -2869,37 +2869,56 @@ class Elemental(Service):
                 filetypes.append(f"*.{extension}")
         return "|".join(filetypes)
 
-    def list_subpath_bounds(self, obj):
-        start = -1
-        for current, seg in enumerate(obj._segments):
-            if isinstance(seg, Move):
-                if start >= 0:
-                    yield (start, current - 1)
-                    start = -1
-            elif isinstance(seg, Close):
-                if start >= 0:
-                    yield (start, current - 1)
-                    start = -1
-            else:
-                if start < 0:
-                    start = current
-        if start >= 0:
-            yield (start, len(obj) - 1)
 
     def simplify_node(self, node):
         def my_sign(x):
             # Returns +1 for positive figures, -1 for negative and 0 for Zero
             return bool(x > 0) - bool(x < 0)
 
+        def list_subpath_bounds(obj):
+            # Return a sorted list of subpaths in the given path (from left to right): tuples with first index, last index, x-coordinate of
+            result = []
+            start = -1
+            for current, seg in enumerate(obj._segments):
+                if isinstance(seg, Move):
+                    if start >= 0:
+                        result.append( (start, current - 1, obj._segments[start].start.x) )
+                        start = -1
+                elif isinstance(seg, Close):
+                    if start >= 0:
+                        result.append( (start, current - 1, obj._segments[start].start.x) )
+                        start = -1
+                else:
+                    if start < 0:
+                        start = current
+            if start >= 0:
+                result.append( (start, len(obj) - 1, obj._segments[start].start.x) )
+            # Now let's sort the list according to the X-start position
+            result.sort(key=lambda a: a[2])
+            return result
+
+
+        from time import time
+        time_start = time()
 
         changed = False
         before = 0
         after = 0
+        removed = 0
+
         basically_zero = 1.0e-6
+        tolerance = UNITS_PER_MIL * 1
+
         if node.type == "elem path" and len(node.path._segments) > 1:
             obj = node.path
             last = None
             before = len(obj._segments)
+            # Pass 0: Dropping zero length line segments
+            for idx in range(len(obj._segments) - 1, -1, -1):
+                seg = obj._segments[idx]
+                if isinstance(seg, Line) and seg.start.x == seg.end.x and seg.start.y == seg.end.y:
+                    obj._segments.pop(idx)
+
 
             # Pass 1: look inside the nodes and bring small line segments back together...
             for idx in range(len(obj._segments) - 1, -1, -1):
@@ -2944,14 +2963,22 @@ class Elemental(Service):
                 else:
                     last = None
 
+            time_pass1 = time()
             # Pass 2: look at the subpaths....
-            tolerance = UNITS_PER_MIL * 1
-            redo = True
+
             joined = 0
+            removed = 0
+
+            redo = True
             while redo:
                 # Dont do it again unless indicated...
                 redo = False
-                results = list(self.list_subpath_bounds(obj))
+                reason = ""
+                results = list_subpath_bounds(obj)
+                # print (f"Examine {len(results)} chains")
+                if len(results) <= 1:
+                    print ("only one chain, exit")
+                    break
                 # for current, seg in enumerate(obj._segments):
                 #     flag = ""
                 #     for idx, entry in enumerate(results):
@@ -2966,146 +2993,171 @@ class Elemental(Service):
                 for idx, entry in enumerate(results):
                     this_start = entry[0]
                     this_end = entry[1]
-                    this_startseg = obj._segments[this_start]
                     this_endseg = obj._segments[this_end]
-                    this_startline = bool(isinstance(this_startseg, Line))
                     this_endline = bool(isinstance(this_endseg, Line))
-                    # print (f"Checking now subpath {idx} from {this_start} to {this_end} (startline={this_startline}, endline={this_endline})")
-                    if this_startline or this_endline:
-                        for idx2 in range(idx + 1, len(results)):
-                            other_entry = results[idx2]
-                            other_start = other_entry[0]
-                            other_end = other_entry[1]
-                            if other_start < 0:
-                                other_startline = False
-                            else:
-                                other_startseg = obj._segments[other_start]
-                                other_startline = bool(isinstance(other_startseg, Line))
-                            if other_end < 0:
-                                other_endline = False
-                            else:
-                                other_endseg = obj._segments[other_end]
-                                other_endline = bool(isinstance(other_endseg, Line))
-                            # print (f"    Comparing to subpath {idx2} from {other_start} to {other_end} (startline={other_startline}, endline={other_endline})")
-                            if this_endline and other_startline:
-                                # Do the lines overlap or have a common end / startpoint together?
-                                can_be_joined = False
-                                coincident = False
-                                if (
-                                    abs(this_endseg.end.x - other_startseg.start.x) < tolerance and
-                                    abs(this_endseg.end.y - other_startseg.start.y) < tolerance
-                                ):
-                                    can_be_joined = True
-                                else:
-                                    thisdx = this_endseg.start.x - this_endseg.end.x
-                                    thisdy = this_endseg.start.y - this_endseg.end.y
-                                    lastdx = other_startseg.start.x - other_startseg.end.x
-                                    lastdy = other_startseg.start.y - other_startseg.end.y
-                                    denom = thisdx * lastdy - thisdy * lastdx
-                                    if abs(denom) <= basically_zero:
-                                        print(f"end-to-start Denominator: {denom:.4f}")
-                                        print(f"this-segment, dx: {thisdx:.4f}, dy: {thisdy:.4f}")
-                                        print(f"other-segment, dx: {lastdx:.4f}, dy: {lastdy:.4f}")
-                                        # parallel but coincident + overlapping?
-                                        if abs(lastdx) < basically_zero or abs(thisdx)< basically_zero:
-                                            # Special case of a vertical line:
-                                            if abs(other_startseg.start.x - this_endseg.end.x) < basically_zero:
-                                                coincident = True
-                                            if coincident and this_endseg.end.y >= other_startseg.start.y and this_endseg.end.y <= other_startseg.end.y:
-                                                # overlap:
-                                                can_be_joined = True
-                                        else:
-                                            b1 = this_endseg.start.y - thisdy / thisdx * this_endseg.start.x
-                                            b2 = other_startseg.start.y - lastdy / lastdx * other_startseg.start.x
-                                            if abs(b1 - b2) < tolerance:
-                                                coincident = True
-                                            if coincident and this_endseg.end.x >= other_startseg.start.x and this_endseg.end.x <= other_startseg.end.x:
-                                                # overlap:
-                                                can_be_joined = True
-                                if can_be_joined:
-                                    other_startseg.start.x = this_endseg.end.x
-                                    other_startseg.start.y = this_endseg.end.y
-                                    # Now copy the segments together:
-                                    # We know that the to be copied segments, ie the source segments, lie behind the target segments
-                                    # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
-                                    for idx3 in range(other_end - other_start + 1):
-                                        # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                        obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
-                                        # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                    joined += 1
-                                    redo = True
-                                    break
-                            if this_startline and other_endline:
-                                can_be_joined = False
-                                coincident = False
-                                # Do the lines overlap or have a common end / startpoint together?
-                                if (
-                                    abs(other_endseg.end.x - this_startseg.start.x) < tolerance and
-                                    abs(other_endseg.end.y - this_startseg.start.y) < tolerance
-                                ):
-                                    this_startseg.start.x = other_endseg.end.x
-                                    this_startseg.start.y = other_endseg.end.y
-                                    # Now copy the segments together:
-                                    # We know that the to be copied segments, ie the source segments, lie behind the target segments
-                                    # print (f"We copy [{other_start}:{other_end}] to the beginning at {this_start}")
-                                    can_be_joined = True
-                                else:
-                                    thisdx = this_startseg.start.x - this_startseg.end.x
-                                    thisdy = this_startseg.start.y - this_startseg.end.y
-                                    lastdx = other_endseg.start.x - other_endseg.end.x
-                                    lastdy = other_endseg.start.y - other_endseg.end.y
-                                    denom = thisdx * lastdy - thisdy * lastdx
-                                    if abs(denom) <= basically_zero:
-                                        print(f"start-to-end, Denominator: {denom:.4f}")
-                                        print(f"this-segment, dx: {thisdx:.4f}, dy: {thisdy:.4f}")
-                                        print(f"other-segment, dx: {lastdx:.4f}, dy: {lastdy:.4f}")
-                                        # parallel but coincident + overlapping?
-                                        if abs(lastdx) < basically_zero or abs(thisdx) < basically_zero:
-                                            # Special case of a vertical line:
-                                            if abs(other_endseg.end.x - this_startseg.start.x) < basically_zero:
-                                                coincident = True
-                                            if coincident and this_startseg.start.y >= other_endseg.start.y and this_startseg.start.y <= other_endseg.end.y:
-                                                # overlap:
-                                                can_be_joined = True
-                                        else:
-                                            b1 = this_startseg.start.y - thisdy / thisdx * this_startseg.start.x
-                                            b2 = other_endseg.start.y - lastdy / lastdx * other_endseg.start.x
-                                            if abs(b1 - b2) < tolerance:
-                                                coincident = True
-                                            if coincident and this_startseg.end.x >= other_endseg.start.x and this_startseg.end.x <= other_endseg.end.x:
-                                                # overlap:
-                                                can_be_joined = True
-                                if can_be_joined:
-                                    this_startseg.start.x = other_endseg.end.x
-                                    this_startseg.start.y = other_endseg.end.y
-                                    for idx3 in range(other_end - other_start + 1):
-                                        obj._segments.insert(this_start, obj._segments.pop(other_end))
-                                    joined += 1
-                                    redo = True
-                                    break
-                    # Did we break out of the loop? Start anew
-                    if redo:
-                        lastseg = None
-                        removed = 0
-                        for idx in range(len(obj._segments) - 1, -1, -1):
-                            seg = obj._segments[idx]
-                            if isinstance(seg, Move):
-                                if lastseg is None:
-                                    # Move as the very last segment -> Delete
-                                    obj._segments.pop(idx)
-                                    removed += 1
-                                else:
-                                    if isinstance(lastseg, Move):
-                                        # Two consecutive moves? Delete
-                                        obj._segments.pop(idx)
-                                        removed += 1
+
+                    # print (f"Checking now subpath {idx} from {this_start} to {this_end}")
+
+                    # Look at all subsequent chains, as they are sorted we know we can just look at
+                    # a) the last point and the first point or the two chains, if they are identical
+                    #    the two chains can be joined (regardless of the type of the two path segments at the end / start)
+                    # b) if the last segemnt of the first chain and the first segment of the second chain
+                    #    are lines the we look whether they overlap
+                    for idx2 in range(idx + 1, len(results)):
+                        other_entry = results[idx2]
+                        other_start = other_entry[0]
+                        other_end = other_entry[1]
+                        other_startseg = obj._segments[other_start]
+                        other_startline = bool(isinstance(other_startseg, Line))
+                        # print (f"    Comparing to subpath {idx2} from {other_start} to {other_end} (startline={other_startline}, endline={other_endline})")
+                        can_be_joined = False
+                        coincident = False
+                        # Do the lines overlap or have a common end / startpoint together?
+                        if (
+                            abs(this_endseg.end.x - other_startseg.start.x) < tolerance and
+                            abs(this_endseg.end.y - other_startseg.start.y) < tolerance
+                        ):
+                            for idx3 in range(other_end - other_start + 1):
+                                # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                                obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                            joined += 1
+                            redo = True
+                            reason = f"Join segments at endpoints {idx} - {idx2}"
+                            break
+                        else:
+                            if not other_startline or not this_endline:
+                                # incompatible types, need two lines
+                                continue
+                            thisdx = this_endseg.start.x - this_endseg.end.x
+                            thisdy = this_endseg.start.y - this_endseg.end.y
+                            lastdx = other_startseg.start.x - other_startseg.end.x
+                            lastdy = other_startseg.start.y - other_startseg.end.y
+                            denom = thisdx * lastdy - thisdy * lastdx
+
+                            # print(f"end-to-start Denominator: {denom:.4f}")
+                            # print(f"this-segment, dx: {thisdx:.4f}, dy: {thisdy:.4f}")
+                            # print(f"other-segment, dx: {lastdx:.4f}, dy: {lastdy:.4f}")
+
+                            # We have a couple of base cases
+                            # a) end point of first line identical to start point of second line
+                            # -> already covered above
+
+                            # b) Lines are not parallel -> ignore
+                            if abs(denom) > basically_zero:
+                                continue
+
+                            if abs(thisdx) > basically_zero:
+                                # Non-vertical lines
+                                # c) second segment starts left of the first -> ignore
+                                if other_startseg.start.x < this_endseg.start.x:
+                                    continue
+
+                                # d) second segment fully to the right of the first -> ignore
+                                if other_startseg.start.x > this_endseg.end.x:
+                                    continue
+
+                                # e) They could still be just parallel, so let's establish this...
+                                if abs(lastdx) < basically_zero or abs(thisdx) < basically_zero:
+                                    # Was coming from zero length lines, now removed ahead
+
+                                    # print (f"Strange: This: dx={thisdx:.4f}, dy={thisdy:.4f}, Other: dx={lastdx:.4f}, dy={lastdy:.4f}, denom={denom:.4f}")
+                                    # print (f"End-Segment: Start: ({this_endseg.start.x:.1f}, {this_endseg.start.y:.1f}) - ({this_endseg.end.x:.1f}, {this_endseg.end.y:.1f})")
+                                    # print (f"Start-Segment: Start: ({other_startseg.start.x:.1f}, {other_startseg.start.y:.1f}) - ({other_startseg.end.x:.1f}, {other_startseg.end.y:.1f})")
+                                    continue
+                                b1 = this_endseg.start.y - thisdy / thisdx * this_endseg.start.x
+                                b2 = other_startseg.start.y - lastdy / lastdx * other_startseg.start.x
+                                if abs(b1 - b2) > tolerance:
+                                    continue
+
+                                # f) Lying completely inside, only if the second chain is a single line we can remove it...
+                                if other_startseg.end.x <= this_endseg.end.x:
+                                    if other_start == other_end:
+                                        # Can be eliminated....
+                                        obj._segments.pop(other_start)
+                                        redo = True
+                                        reason = f"Removed segment {idx2} fully inside {idx}"
+                                        break
                                     else:
-                                        lastseg = seg
+                                        continue
+                                # g) the remaining case is an overlap on x, so we can adjust the start to the end and join
+                                other_startseg.start.x = this_endseg.end.x
+                                other_startseg.start.y = this_endseg.end.y
+                                # Now copy the segments together:
+                                # We know that the to be copied segments, ie the source segments, lie behind the target segments
+                                # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
+                                for idx3 in range(other_end - other_start + 1):
+                                    # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                                    obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                    # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                                joined += 1
+                                redo = True
+                                reason = f"Added overlapping segment {idx2} to {idx}"
+                                break
                             else:
-                                lastseg = seg
-                        if removed > 0:
-                            print(f"{removed} unneeded moves removed")
+                                # vertical lines but still the same logic applies...
+                                # c) second segment starts on top of the first -> ignore
+                                if other_startseg.start.y < this_endseg.start.y:
+                                    continue
+
+                                # d) second segment fully below the first -> ignore
+                                if other_startseg.start.y > this_endseg.end.y:
+                                    continue
+
+                                # e) They could still be just parallel, so let's establish this...
+
+                                if abs(other_startseg.start.x - this_endseg.start.x) > tolerance:
+                                    continue
+
+                                # f) Lying completely inside, only if the second chain is a single line we can remove it...
+                                if other_startseg.end.y <= this_endseg.end.y:
+                                    if other_start == other_end:
+                                        # Can be eliminated....
+                                        obj._segments.pop(other_start)
+                                        redo = True
+                                        reason = f"Removed vertical segment {idx2} fully inside {idx}"
+                                        break
+                                    else:
+                                        continue
+                                # g) the remaining case is an overlap on y, so we can adjust the start to the end and join
+                                other_startseg.start.x = this_endseg.end.x
+                                other_startseg.start.y = this_endseg.end.y
+                                # Now copy the segments together:
+                                # We know that the to be copied segments, ie the source segments, lie behind the target segments
+                                # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
+                                for idx3 in range(other_end - other_start + 1):
+                                    # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                                    obj._segments.insert(this_end + 1, obj._segments.pop(other_end))
+                                    # print(f"done #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
+                                joined += 1
+                                reason = f"Added overlapping vertical segment {idx2} to {idx}"
+                                redo = True
+                                break
+                    # end of inner loop
+
+                    if redo:
+                        # print(f"Redo required inner loop: {reason}")
+                        changed = True
                         break
+                #end of outer loop
+            time_pass2 = time()
+            lastseg = None
+            for idx in range(len(obj._segments) - 1, -1, -1):
+                seg = obj._segments[idx]
+                if isinstance(seg, Move):
+                    if lastseg is None:
+                        # Move as the very last segment -> Delete
+                        obj._segments.pop(idx)
+                        removed += 1
+                    else:
+                        if isinstance(lastseg, Move):
+                            # Two consecutive moves? Delete
+                            obj._segments.pop(idx)
+                            removed += 1
+                        else:
+                            lastseg = seg
+                else:
+                    lastseg = seg
             after = len(obj._segments)
         elif node.type == "elem polyline" and len(node.shape.points) > 2:
             obj = node.shape
@@ -3146,4 +3198,10 @@ class Elemental(Service):
                 pt_older = pt_old
                 pt_old = pt
             after = len(obj.points)
+            time_pass1 = time()
+            time_pass2 = time()
+
+        time_end = time()
+        # print (f"Ready. overall time: {time_end - time_start:.3f}, Pass 1: {time_pass1 - time_start:.3f}, Pass 2: {time_pass2 - time_pass1:.3f}")
+        # print (f"Before: {before}, After: {after}")
         return changed, before, after

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -254,7 +254,6 @@ class PathPropertyPanel(ScrolledPanel):
         total_length = total_length / _mm
         numpaths, points = calc_points(self.node)
 
-
         self.lbl_info_area.SetValue(f"{total_area:.0f} mm² ({second_area:.0f} mm²)")
         self.lbl_info_length.SetValue(f"{total_length:.1f} mm")
         self.lbl_info_segments.SetValue(f"{numpaths:d}")
@@ -271,7 +270,6 @@ class PathPropertyPanel(ScrolledPanel):
         self.lbl_info_length.SetValue("")
         self.lbl_info_points.SetValue("")
         self.lbl_info_segments.SetValue("")
-
 
         self.Refresh()
 

--- a/meerk40t/tools/livinghinges.py
+++ b/meerk40t/tools/livinghinges.py
@@ -461,8 +461,15 @@ class HingePanel(wx.Panel):
                     b=0,
                     c=0,
                     d=ratio,
-                    tx=ratio * (0.05 * self.hinge_generator.width - self.hinge_generator.start_x),
-                    ty=ratio * (0.05 * self.hinge_generator.height - self.hinge_generator.start_y),
+                    tx=ratio
+                    * (
+                        0.05 * self.hinge_generator.width - self.hinge_generator.start_x
+                    ),
+                    ty=ratio
+                    * (
+                        0.05 * self.hinge_generator.height
+                        - self.hinge_generator.start_y
+                    ),
                 )
             else:
                 matrix = gc.CreateMatrix(
@@ -502,7 +509,9 @@ class HingePanel(wx.Panel):
                 mypen_path = wx.Pen(wx.RED, linewidth, wx.PENSTYLE_SOLID)
                 # flag = self.check_debug_outline.GetValue()
                 self.hinge_generator.generate(
-                    show_outline=False, force=False, final=False,
+                    show_outline=False,
+                    force=False,
+                    final=False,
                 )
                 gc.SetPen(mypen_path)
                 gspath = self.hinge_generator.preview_path
@@ -543,6 +552,7 @@ class HingePanel(wx.Panel):
 
     def on_button_generate(self, event):
         from time import time
+
         oldlabel = self.button_generate.Label
         self.button_generate.Enable(False)
         self.button_generate.SetLabel(_("Processing..."))
@@ -595,7 +605,7 @@ class HingePanel(wx.Panel):
             group_node.append_child(self.hinge_generator.outershape)
             group_node.append_child(node)
         end_time = time()
-        self.Parent.SetTitle(_("Living-Hinges")+ f" ({end_time-start_time:.2f}s.)")
+        self.Parent.SetTitle(_("Living-Hinges") + f" ({end_time-start_time:.2f}s.)")
 
         self.context.signal("classify_new", node)
         self.context.signal("refresh_scene")


### PR DESCRIPTION
Extend simplify to use a multi-pass approach:
1) Delete zero length lines generated from the algorithms (new)
2) Simplify lines that have a lot of in-between points (old)
3) Join path segments that have a coinciding end points (new)
4) Join subpaths that end in a line segment that are coinciding
<img width="406" alt="image" src="https://user-images.githubusercontent.com/2670784/208726423-18a84391-0271-46d1-bd1b-811df7827c1d.png">

