### PR TITLE
Lihuiyu: Correct Override-Speed Fix

### DIFF
--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -224,7 +224,6 @@ class LihuiyuDriver(Parameters):
         """
         Asks that the laser be paused.
 
-        @param args:
         @return:
         """
         self(b"~PN!\n~")
@@ -250,7 +249,6 @@ class LihuiyuDriver(Parameters):
 
         Asks that the device resets, and clears all current work.
 
-        @param args:
         @return:
         """
         self.service.spooler.clear_queue()
@@ -274,7 +272,7 @@ class LihuiyuDriver(Parameters):
         bunch of .rd code, or Lihuiyu device it could be .egv code. It's a method of sending pre-chewed data to the
         device.
 
-        @param type:
+        @param blob_type:
         @param data:
         @return:
         """
@@ -336,7 +334,6 @@ class LihuiyuDriver(Parameters):
         """
         Turn laser off in place.
 
-        @param values:
         @return:
         """
         if not self.laser:
@@ -359,7 +356,6 @@ class LihuiyuDriver(Parameters):
         """
         Turn laser on in place.
 
-        @param values:
         @return:
         """
         if self.laser:

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -1038,13 +1038,13 @@ class LihuiyuDriver(Parameters):
             self._goto_octent(dx, dy, on=False)
         elif x_speed <= y_speed and abs(dx) >= abs(dy):
             # x_speed is slowest and dx is larger than dy. The x-shift will take longer than y-shift. Combine.
-            self._set_speed(y_speed)
+            self._set_speed(x_speed)
             self.program_mode()
             self._goto_octent(dx, dy, on=False)
         else:
             # The faster speed is going longer. The slower speed is going shorter. Full zig.
             if dx != 0:
-                self._set_speed(y_speed)
+                self._set_speed(x_speed)
                 self.program_mode()
                 self._goto_octent(dx, 0, on=False)
             if dy != 0:

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -1018,7 +1018,8 @@ class LihuiyuDriver(Parameters):
         @param y_speed: max allowed speed in y direction
         @return:
         """
-
+        if y_speed is None:
+            y_speed = x_speed
         original_accel = self.acceleration
         original_speed = self.speed
         original_steps = self.raster_step_x, self.raster_step_y
@@ -1026,6 +1027,10 @@ class LihuiyuDriver(Parameters):
         # Do not allow custom accel codes, or raster steps.
         self._set_acceleration(None)
         self._set_step(0, 0)
+        # We know we will travel dx, dy. Set the initial direction requests.
+        self._request_leftward = dx < 0
+        self._request_topward = dy < 0
+        self._request_horizontal_major = abs(dx) > abs(dy)
         if y_speed <= x_speed and abs(dy) >= abs(dx):
             # y_speed is slowest and dy is larger than dx. The y-shift will take longer than x-shift. Combine.
             self._set_speed(y_speed)

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -1035,12 +1035,16 @@ class LihuiyuDriver(Parameters):
             # y_speed is slowest and dy is larger than dx. The y-shift will take longer than x-shift. Combine.
             self._set_speed(y_speed)
             self.program_mode()
-            self._goto_octent(dx, dy, on=False)
+            dy_m = math.copysign(dx, dy)  # magnitude of shorter in the direction of longer.
+            self._goto_octent(dx, dy_m, on=False)
+            self._goto_octent(0, dy - dy_m, on=False)
         elif x_speed <= y_speed and abs(dx) >= abs(dy):
             # x_speed is slowest and dx is larger than dy. The x-shift will take longer than y-shift. Combine.
             self._set_speed(x_speed)
             self.program_mode()
-            self._goto_octent(dx, dy, on=False)
+            dx_m = math.copysign(dy, dx)  # magnitude of shorter in the direction of longer.
+            self._goto_octent(dx_m, dy, on=False)
+            self._goto_octent(dx - dx_m, 0, on=False)
         else:
             # The faster speed is going longer. The slower speed is going shorter. Full zig.
             if dx != 0:

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -1035,14 +1035,14 @@ class LihuiyuDriver(Parameters):
             # y_speed is slowest and dy is larger than dx. The y-shift will take longer than x-shift. Combine.
             self._set_speed(y_speed)
             self.program_mode()
-            dy_m = math.copysign(dx, dy)  # magnitude of shorter in the direction of longer.
+            dy_m = int(math.copysign(dx, dy))  # magnitude of shorter in the direction of longer.
             self._goto_octent(dx, dy_m, on=False)
             self._goto_octent(0, dy - dy_m, on=False)
         elif x_speed <= y_speed and abs(dx) >= abs(dy):
             # x_speed is slowest and dx is larger than dy. The x-shift will take longer than y-shift. Combine.
             self._set_speed(x_speed)
             self.program_mode()
-            dx_m = math.copysign(dy, dx)  # magnitude of shorter in the direction of longer.
+            dx_m = int(math.copysign(dy, dx))  # magnitude of shorter in the direction of longer.
             self._goto_octent(dx_m, dy, on=False)
             self._goto_octent(dx - dx_m, 0, on=False)
         else:

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -339,6 +339,20 @@ class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
             self.assertEqual("ICV1551941002013022CNRTS1EM100Tzzzzzzz115FNSE-\n", data[-2])
             self.assertEqual(data[-3], data[-1])
 
-
+            # Y fast, X long (-/0 Values)
+            kernel.console("operation* delete\n")
+            kernel.console("element* delete\n")
+            kernel.console("rapid_override 1 10\n")
+            kernel.console("rect 2in 2in 1in 1in\n")
+            kernel.console("rect 0in 2in 1in 1in\n")
+            kernel.console(f"element* engrave -s 15 plan preprocess validate blob save_job {file1}\n")
+            kernel.console("plan clear\n")
+            with open(file1, "r") as f:
+                data = f.readlines()
+            self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
+            self.assertEqual(rect_1in_at_15, data[-3])
+            # RT switch, RT 0 , T 2000
+            self.assertEqual("ICV1551941002013022CNRTS1Ezzzzzzz215FNSE-\n", data[-2])
+            self.assertEqual(data[-3], data[-1])
         finally:
             kernel.shutdown()

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -257,7 +257,7 @@ class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
                 data = f.readlines()
             self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
             self.assertEqual(rect_1in_at_15, data[-3])
-            self.assertEqual("ICV1551941002013022CNBRS1EB100Rzzzzzzz215FNSE-\n", data[-2])
+            self.assertEqual("ICV1551941002013022CNBRS1EM100Rzzzzzzz115FNSE-\n", data[-2])
             self.assertEqual(data[-3], data[-1])
 
             # Y fast, Y long.
@@ -287,7 +287,7 @@ class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
                 data = f.readlines()
             self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
             self.assertEqual(rect_1in_at_15, data[-3])
-            self.assertEqual("ICV1551941002013022CNRBS1Ezzzzzzz215R100FNSE-\n", data[-2])
+            self.assertEqual("ICV1551941002013022CNRBS1EM100Bzzzzzzz115FNSE-\n", data[-2])
             self.assertEqual(data[-3], data[-1])
 
         finally:

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -287,8 +287,58 @@ class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
                 data = f.readlines()
             self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
             self.assertEqual(rect_1in_at_15, data[-3])
+            # RB switch, RB 100, B 1900
             self.assertEqual("ICV1551941002013022CNRBS1EM100Bzzzzzzz115FNSE-\n", data[-2])
             self.assertEqual(data[-3], data[-1])
+
+            # Y fast, X long (Negative Values)
+            kernel.console("operation* delete\n")
+            kernel.console("element* delete\n")
+            kernel.console("rapid_override 1 10\n")
+            kernel.console("rect 2in 2in 1in 1in\n")
+            kernel.console("rect 0in 0.1in 1in 1in\n")
+            kernel.console(f"element* engrave -s 15 plan preprocess validate blob save_job {file1}\n")
+            kernel.console("plan clear\n")
+            with open(file1, "r") as f:
+                data = f.readlines()
+            self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
+            self.assertEqual(rect_1in_at_15, data[-3])
+            # LT switch, LT 1900, T 100
+            self.assertEqual("ICV1551941002013022CNLTS1EMzzzzzzz115T100FNSE-\n", data[-2])
+            self.assertEqual(data[-3], data[-1])
+
+            # Y fast, X long (+/- Values)
+            kernel.console("operation* delete\n")
+            kernel.console("element* delete\n")
+            kernel.console("rapid_override 1 10\n")
+            kernel.console("rect 2in 2in 1in 1in\n")
+            kernel.console("rect 4in 0.1in 1in 1in\n")
+            kernel.console(f"element* engrave -s 15 plan preprocess validate blob save_job {file1}\n")
+            kernel.console("plan clear\n")
+            with open(file1, "r") as f:
+                data = f.readlines()
+            self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
+            self.assertEqual(rect_1in_at_15, data[-3])
+            # LB switch, LB 1900, B 100
+            self.assertEqual("ICV1551941002013022CNLBS1EMzzzzzzz115B100FNSE-\n", data[-2])
+            self.assertEqual(data[-3], data[-1])
+
+            # Y fast, X long (-/+ Values)
+            kernel.console("operation* delete\n")
+            kernel.console("element* delete\n")
+            kernel.console("rapid_override 1 10\n")
+            kernel.console("rect 2in 2in 1in 1in\n")
+            kernel.console("rect 0in 2.1in 1in 1in\n")
+            kernel.console(f"element* engrave -s 15 plan preprocess validate blob save_job {file1}\n")
+            kernel.console("plan clear\n")
+            with open(file1, "r") as f:
+                data = f.readlines()
+            self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
+            self.assertEqual(rect_1in_at_15, data[-3])
+            # RT switch, RT 100 , T 1900
+            self.assertEqual("ICV1551941002013022CNRTS1EM100Tzzzzzzz115FNSE-\n", data[-2])
+            self.assertEqual(data[-3], data[-1])
+
 
         finally:
             kernel.shutdown()

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -354,5 +354,21 @@ class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
             # RT switch, RT 0 , T 2000
             self.assertEqual("ICV1551941002013022CNRTS1Ezzzzzzz215FNSE-\n", data[-2])
             self.assertEqual(data[-3], data[-1])
+
+            # Same as previous but changed Y rather than X (should change speed)
+            kernel.console("operation* delete\n")
+            kernel.console("element* delete\n")
+            kernel.console("rapid_override 1 10\n")
+            kernel.console("rect 2in 2in 1in 1in\n")
+            kernel.console("rect 2in 0in 1in 1in\n")
+            kernel.console(f"element* engrave -s 15 plan preprocess validate blob save_job {file1}\n")
+            kernel.console("plan clear\n")
+            with open(file1, "r") as f:
+                data = f.readlines()
+            self.assertEqual("ICV1551941002013022CNBRS1EMzzzzzzz215FNSE-\n", data[-4])
+            self.assertEqual(rect_1in_at_15, data[-3])
+            # BL switch, BL 0 , L 2000
+            self.assertEqual("ICV2452421011000060CNBLS1Ezzzzzzz215FNSE-\n", data[-2])
+            self.assertEqual(data[-3], data[-1])
         finally:
             kernel.shutdown()


### PR DESCRIPTION
* Jogs between objects ignored the settings for traveling at restricted speed.
* Correct the jog directions to combine the x and y at the speed of the slower when the slower is longer.
* If x is faster and y is slower but x is longer, does a proper zig at the respective speeds.