### PR TITLE
Hull methods divided. Correct two main crashes.

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -6208,6 +6208,7 @@ def init_commands(kernel):
                         (bounds[0], bounds[3]),
                         (bounds[2], bounds[1]),
                         (bounds[2], bounds[3]),
+                        (bounds[0], bounds[1]),
                     ])
         return pts
 
@@ -6306,12 +6307,13 @@ def init_commands(kernel):
                     pts += [p]
             else:
                 bounds = node.bounds
-                pts += [
-                    (bounds[0], bounds[1]),
-                    (bounds[0], bounds[3]),
-                    (bounds[2], bounds[1]),
-                    (bounds[2], bounds[3]),
-                ]
+                if bounds:
+                    pts += [
+                        (bounds[0], bounds[1]),
+                        (bounds[0], bounds[3]),
+                        (bounds[2], bounds[1]),
+                        (bounds[2], bounds[3]),
+                    ]
 
         mec_center, mec_radius = welzl(pts)
 

--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -6187,98 +6187,149 @@ def init_commands(kernel):
         center, radius = welzl_helper(P_copy, [], len(P_copy))
         return center, radius
 
-    def generate_hull_shape(method, data, resolution=None):
-        if resolution is None:
-            DETAIL = 500  # How coarse / fine shall a subpath be split
-        else:
-            DETAIL = int(resolution)
+    def generate_hull_shape_segment(data):
         pts = []
+        for node in data:
+            try:
+                path = node.as_path()
+            except AttributeError:
+                path = None
+            if path is not None:
+                p = path.first_point
+                pts.append(p)
+                for segment in path:
+                    p = segment.end
+                    pts.append(p)
+            else:
+                bounds = node.bounds
+                pts.extend([
+                    (bounds[0], bounds[1]),
+                    (bounds[0], bounds[3]),
+                    (bounds[2], bounds[1]),
+                    (bounds[2], bounds[3]),
+                ])
+        return pts
+
+    def generate_hull_shape_quick(data):
         min_val = [float("inf"), float("inf")]
         max_val = [-float("inf"), -float("inf")]
         for node in data:
-            if method in ("hull", "segment", "circle"):
-                try:
-                    path = node.as_path()
-                except AttributeError:
-                    path = None
-                if path is not None:
-                    p = path.first_point
-                    pts += [(p.x, p.y)]
-                    for segment in path:
-                        p = segment.end
-                        pts += [(p.x, p.y)]
-                else:
-                    bounds = node.bounds
-                    pts += [
-                        (bounds[0], bounds[1]),
-                        (bounds[0], bounds[3]),
-                        (bounds[2], bounds[1]),
-                        (bounds[2], bounds[3]),
-                    ]
-            elif method == "complex":
-                try:
-                    path = node.as_path()
-                except AttributeError:
-                    path = None
+            bounds = node.bounds
+            min_val[0] = min(min_val[0], bounds[0])
+            min_val[1] = min(min_val[1], bounds[1])
+            max_val[0] = max(max_val[0], bounds[2])
+            max_val[1] = max(max_val[1], bounds[3])
 
-                if path is not None:
+        if (
+            not isinf(min_val[0])
+            and not isinf(min_val[1])
+            and not isinf(max_val[0])
+            and not isinf(max_val[0])
+        ):
+            return [
+                (min_val[0], min_val[1]),
+                (min_val[0], max_val[1]),
+                (max_val[0], min_val[1]),
+                (max_val[0], max_val[1]),
+            ]
+        return []
 
-                    from numpy import linspace
-
-                    for subpath in path.as_subpaths():
-                        psp = Path(subpath)
-                        p = psp.first_point
-                        pts += [(p.x, p.y)]
-                        positions = linspace(0, 1, num=DETAIL, endpoint=True)
-                        subj = psp.npoint(positions)
-                        # Not sure why we need to do that, its already rows x 2
-                        # subj.reshape((2, DETAIL))
-                        s = list(map(Point, subj))
-                        for p in s:
-                            pts += [(p.x, p.y)]
-                else:
-                    bounds = node.bounds
-                    pts += [
-                        (bounds[0], bounds[1]),
-                        (bounds[0], bounds[3]),
-                        (bounds[2], bounds[1]),
-                        (bounds[2], bounds[3]),
-                    ]
-            elif method == "quick":
+    def generate_hull_shape_hull(data):
+        pts = []
+        for node in data:
+            try:
+                path = node.as_path()
+            except AttributeError:
+                path = None
+            if path is not None:
+                p = path.first_point
+                pts += [p]
+                for segment in path:
+                    p = segment.end
+                    pts += [p]
+            else:
                 bounds = node.bounds
-                min_val[0] = min(min_val[0], bounds[0])
-                min_val[1] = min(min_val[1], bounds[1])
-                max_val[0] = max(max_val[0], bounds[2])
-                max_val[1] = max(max_val[1], bounds[3])
-        if method == "quick":
-            if (
-                not isinf(min_val[0])
-                and not isinf(min_val[1])
-                and not isinf(max_val[0])
-                and not isinf(max_val[0])
-            ):
                 pts += [
-                    (min_val[0], min_val[1]),
-                    (min_val[0], max_val[1]),
-                    (max_val[0], min_val[1]),
-                    (max_val[0], max_val[1]),
+                    (bounds[0], bounds[1]),
+                    (bounds[0], bounds[3]),
+                    (bounds[2], bounds[1]),
+                    (bounds[2], bounds[3]),
                 ]
-        if method == "segment":
-            hull = [p for p in pts]
-        elif method == "circle":
-            mec_center, mec_radius = welzl(pts)
-            # So now we have a circle with (mec[0], mec[1]), and mec_radius
-            hull = []
-            RES = 100
-            for i in range(RES):
-                hull += [
-                    (
-                        mec_center[0] + mec_radius * cos(i / RES * tau),
-                        mec_center[1] + mec_radius * sin(i / RES * tau),
-                    )
-                ]
+        return list(Point.convex_hull(pts))
+
+    def generate_hull_shape_complex(data, resolution=None):
+        if resolution is None:
+            resolution = 500  # How coarse / fine shall a subpath be split
         else:
-            hull = [p for p in Point.convex_hull(pts)]
+            resolution = int(resolution)
+        pts = []
+        for node in data:
+            try:
+                path = node.as_path()
+            except AttributeError:
+                path = None
+
+            if path is not None:
+
+                from numpy import linspace
+
+                for subpath in path.as_subpaths():
+                    psp = Path(subpath)
+                    p = psp.first_point
+                    pts += [p]
+                    positions = linspace(0, 1, num=resolution, endpoint=True)
+                    subj = psp.npoint(positions)
+                    # Not sure why we need to do that, its already rows x 2
+                    s = list(map(Point, subj))
+                    for p in s:
+                        pts += [p]
+            else:
+                bounds = node.bounds
+                pts += [
+                    (bounds[0], bounds[1]),
+                    (bounds[0], bounds[3]),
+                    (bounds[2], bounds[1]),
+                    (bounds[2], bounds[3]),
+                ]
+        hull = [p for p in Point.convex_hull(pts)]
+        if len(hull) != 0:
+            hull.append(hull[0])  # loop
+        return hull
+
+    def generate_hull_shape_circle(data):
+        pts = []
+        for node in data:
+            try:
+                path = node.as_path()
+            except AttributeError:
+                path = None
+            if path is not None:
+                p = path.first_point
+                pts += [p]
+                for segment in path:
+                    p = segment.end
+                    pts += [p]
+            else:
+                bounds = node.bounds
+                pts += [
+                    (bounds[0], bounds[1]),
+                    (bounds[0], bounds[3]),
+                    (bounds[2], bounds[1]),
+                    (bounds[2], bounds[3]),
+                ]
+
+        mec_center, mec_radius = welzl(pts)
+
+        # So now we have a circle with (mec[0], mec[1]), and mec_radius
+        hull = []
+        RES = 100
+        for i in range(RES):
+            hull += [
+                (
+                    mec_center[0] + mec_radius * cos(i / RES * tau),
+                    mec_center[1] + mec_radius * sin(i / RES * tau),
+                )
+            ]
         if len(hull) != 0:
             hull.append(hull[0])  # loop
         return hull
@@ -6326,7 +6377,18 @@ def init_commands(kernel):
         if len(data) == 0:
             channel(_("No elements bounds to trace"))
             return
-        hull = generate_hull_shape(method, data, resolution)
+        if method == "segment":
+            hull = generate_hull_shape_segment(data)
+        elif method == "quick":
+            hull = generate_hull_shape_quick(data)
+        elif method == "hull":
+            hull = generate_hull_shape_hull(data)
+        elif method == "complex":
+            hull = generate_hull_shape_complex(data, resolution)
+        elif method == "circle":
+            hull = generate_hull_shape_circle(data)
+        else:
+            raise ValueError
         if start is None:
             # Lets take system default
             start = self.trace_start_method
@@ -6401,7 +6463,18 @@ def init_commands(kernel):
 
         if data is None:
             data = list(self.elems(emphasized=True))
-        hull = generate_hull_shape(method, data, resolution=resolution)
+        if method == "segment":
+            hull = generate_hull_shape_segment(data)
+        elif method == "quick":
+            hull = generate_hull_shape_quick(data)
+        elif method == "hull":
+            hull = generate_hull_shape_hull(data)
+        elif method == "complex":
+            hull = generate_hull_shape_complex(data, resolution)
+        elif method == "circle":
+            hull = generate_hull_shape_circle(data)
+        else:
+            raise ValueError
         if len(hull) == 0:
             channel(_("No elements bounds to trace."))
             return

--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -6202,12 +6202,13 @@ def init_commands(kernel):
                     pts.append(p)
             else:
                 bounds = node.bounds
-                pts.extend([
-                    (bounds[0], bounds[1]),
-                    (bounds[0], bounds[3]),
-                    (bounds[2], bounds[1]),
-                    (bounds[2], bounds[3]),
-                ])
+                if bounds:
+                    pts.extend([
+                        (bounds[0], bounds[1]),
+                        (bounds[0], bounds[3]),
+                        (bounds[2], bounds[1]),
+                        (bounds[2], bounds[3]),
+                    ])
         return pts
 
     def generate_hull_shape_quick(data):
@@ -6217,10 +6218,13 @@ def init_commands(kernel):
         max_val = [-float("inf"), -float("inf")]
         for node in data:
             bounds = node.bounds
-            min_val[0] = min(min_val[0], bounds[0])
-            min_val[1] = min(min_val[1], bounds[1])
-            max_val[0] = max(max_val[0], bounds[2])
-            max_val[1] = max(max_val[1], bounds[3])
+            if bounds:
+                min_val[0] = min(min_val[0], bounds[0])
+                min_val[1] = min(min_val[1], bounds[1])
+                max_val[0] = max(max_val[0], bounds[2])
+                max_val[1] = max(max_val[1], bounds[3])
+        if isinf(min_val[0]):
+            return []
         return [
             (min_val[0], min_val[1]),
             (max_val[0], min_val[1]),
@@ -6241,13 +6245,13 @@ def init_commands(kernel):
                 pts.append(p)
             except AttributeError:
                 bounds = node.bounds
-                pts += [
-                    (bounds[0], bounds[1]),
-                    (bounds[0], bounds[3]),
-                    (bounds[2], bounds[1]),
-                    (bounds[2], bounds[3]),
-                    (bounds[0], bounds[1]),
-                ]
+                if bounds:
+                    pts.extend([
+                        (bounds[0], bounds[1]),
+                        (bounds[0], bounds[3]),
+                        (bounds[2], bounds[1]),
+                        (bounds[2], bounds[3]),
+                    ])
         hull = list(Point.convex_hull(pts))
         if len(hull) != 0:
             hull.append(hull[0])  # loop
@@ -6275,12 +6279,13 @@ def init_commands(kernel):
                     pts.extend(s)
             except AttributeError:
                 bounds = node.bounds
-                pts += [
-                    (bounds[0], bounds[1]),
-                    (bounds[0], bounds[3]),
-                    (bounds[2], bounds[1]),
-                    (bounds[2], bounds[3]),
-                ]
+                if bounds:
+                    pts.extend([
+                        (bounds[0], bounds[1]),
+                        (bounds[0], bounds[3]),
+                        (bounds[2], bounds[1]),
+                        (bounds[2], bounds[3]),
+                    ])
         hull = list(Point.convex_hull(pts))
         if len(hull) != 0:
             hull.append(hull[0])  # loop


### PR DESCRIPTION
```python
MeerK40t crash log. Version: 0.8.1000 on Windows: Python 3.7.9: AMD64 - wxPython: 4.1.1 msw (phoenix) wxWidgets 3.1.5
Traceback (most recent call last):
  File "meerk40t\gui\navigationpanels.py", line 622, in on_button_align_trace_quick
  File "meerk40t\kernel\context.py", line 33, in __call__
  File "meerk40t\kernel\kernel.py", line 2097, in console
  File "meerk40t\kernel\kernel.py", line 2146, in _console_parse
  File "meerk40t\kernel\functions.py", line 279, in inner
  File "meerk40t\core\elements.py", line 6429, in trace_trace_spooler
  File "meerk40t\core\elements.py", line 6362, in generate_hull_shape
TypeError: 'NoneType' object is not subscriptable
```

Object bounds is None. Crash.

```python
MeerK40t crash log. Version: 0.8.1002 on Windows: Python 3.7.9: AMD64 - wxPython: 4.1.1 msw (phoenix) wxWidgets 3.1.5
Traceback (most recent call last):
  File "meerk40t\gui\laserpanel.py", line 326, in on_button_outline
  File "meerk40t\kernel\context.py", line 33, in __call__
  File "meerk40t\kernel\kernel.py", line 2097, in console
  File "meerk40t\kernel\kernel.py", line 2146, in _console_parse
  File "meerk40t\kernel\functions.py", line 279, in inner
  File "meerk40t\core\element_commands.py", line 6081, in trace_trace_spooler
  File "meerk40t\core\element_commands.py", line 5971, in generate_hull_shape
AttributeError: 'NoneType' object has no attribute 'x'
```

Points assumed `first_point` had x, y. But, in the case of NumPath/Geomstr it didn't. 