### PR TITLE
Modify `make_path` transformed segments

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -4296,10 +4296,10 @@ def init_commands(kernel):
             if hasattr(e, "lock") and e.lock:
                 channel(_("Can't modify a locked element: {name}").format(name=str(e)))
                 continue
-
-            stroke_scale = sqrt(abs(e.matrix.determinant)) if e.stroke_scaled else 1.0
-            e.stroke_width = stroke_width / stroke_scale
-            e.altered()
+            stroke_one = sqrt(abs(e.matrix.determinant))
+            e.stroke_width = stroke_width
+            e.stroke_zero = stroke_one
+            e.modified()
         return "elements", data
 
     @self.console_command(

--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -4266,9 +4266,8 @@ def init_commands(kernel):
                     continue
                 if e.stroke_scaled:
                     typename = "scaled-stroke"
-                    stroke_one = sqrt(abs(e.matrix.determinant))
                     try:
-                        factor = stroke_one / e.stroke_zero
+                        factor = e.stroke_factor
                     except AttributeError:
                         factor = 1.0
                 else:
@@ -4296,9 +4295,11 @@ def init_commands(kernel):
             if hasattr(e, "lock") and e.lock:
                 channel(_("Can't modify a locked element: {name}").format(name=str(e)))
                 continue
-            stroke_one = sqrt(abs(e.matrix.determinant))
             e.stroke_width = stroke_width
-            e.stroke_zero = stroke_one
+            try:
+                e.stroke_width_zero()
+            except AttributeError:
+                pass
             e.modified()
         return "elements", data
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -26,7 +26,7 @@ class EllipseNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.fillrule = Fillrule.FILLRULE_EVENODD
 
         super(EllipseNode, self).__init__(type="elem ellipse", **kwargs)
@@ -47,10 +47,10 @@ class EllipseNode(Node, Stroked):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -3,6 +3,7 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Node
+from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -40,6 +41,7 @@ class EllipseNode(Node, Stroked):
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
             self.stroke_width = self.shape.stroke_width
+            self.stroke_width *= UNITS_PER_PIXEL
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
@@ -49,8 +51,6 @@ class EllipseNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
-            if self.stroke_width is not None:
-                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -47,6 +47,8 @@ class EllipseNode(Node):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
+            if self.stroke_width is not None:
+                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -1,6 +1,7 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -12,7 +13,7 @@ from meerk40t.svgelements import (
 )
 
 
-class EllipseNode(Node):
+class EllipseNode(Node, Stroked):
     """
     EllipseNode is the bootstrapped node type for the 'elem ellipse' type.
     """
@@ -67,30 +68,6 @@ class EllipseNode(Node):
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        """
-        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
-        the toggling of the stroke-scaling without the current stroke_width being affected.
-
-        @param v:
-        @return:
-        """
-        if bool(v) == bool(self.stroke_scale):
-            # Unchanged.
-            return
-        matrix = self.matrix
-        stroke_one = sqrt(abs(matrix.determinant))
-        stroke_factor = stroke_one / self.stroke_zero
-        if not v:
-            self.stroke_width *= stroke_factor
-        self.stroke_zero = stroke_one
-        self.stroke_scale = v
 
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -7,7 +7,8 @@ from meerk40t.svgelements import (
     SVG_VALUE_NON_SCALING_STROKE,
     Circle,
     Ellipse,
-    Path, Matrix,
+    Path,
+    Matrix,
 )
 
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -40,8 +40,7 @@ class EllipseNode(Node, Stroked):
         if self.stroke is None:
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
-            self.stroke_width = self.shape.stroke_width
-            self.stroke_width *= UNITS_PER_PIXEL
+            self.stroke_width = self.shape.implicit_stroke_width
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -80,10 +80,15 @@ class EllipseNode(Node):
         @param v:
         @return:
         """
-        if not v and self.stroke_scale:
-            self.stroke_width *= sqrt(abs(self.matrix.determinant))
-        if v and not self.stroke_scale:
-            self.stroke_width /= sqrt(abs(self.matrix.determinant))
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        stroke_factor = stroke_one / self.stroke_zero
+        if not v:
+            self.stroke_width *= stroke_factor
+        self.stroke_zero = stroke_one
         self.stroke_scale = v
 
     def preprocess(self, context, matrix, plan):

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -86,18 +86,6 @@ class EllipseNode(Node):
             self.stroke_width /= sqrt(abs(self.matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke, and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scaled:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = True
         self.matrix *= matrix

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -9,8 +9,8 @@ from meerk40t.svgelements import (
     SVG_VALUE_NON_SCALING_STROKE,
     Circle,
     Ellipse,
-    Path,
     Matrix,
+    Path,
 )
 
 

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -7,7 +7,7 @@ from meerk40t.svgelements import (
     SVG_VALUE_NON_SCALING_STROKE,
     Circle,
     Ellipse,
-    Path,
+    Path, Matrix,
 )
 
 
@@ -23,6 +23,7 @@ class EllipseNode(Node):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
+        self.stroke_zero = None
         self.fillrule = Fillrule.FILLRULE_EVENODD
 
         super(EllipseNode, self).__init__(type="elem ellipse", **kwargs)
@@ -42,6 +43,11 @@ class EllipseNode(Node):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
+        if self.stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(self.shape.values.get("viewport_transform", ""))
+            self.stroke_zero = sqrt(abs(m.determinant))
+
         self.set_dirty_bounds()
 
     def __repr__(self):

--- a/meerk40t/core/node/elem_geomstr.py
+++ b/meerk40t/core/node/elem_geomstr.py
@@ -52,18 +52,6 @@ class GeomstrNode(Node, Parameters):
             self.stroke_width /= sqrt(abs(matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke, and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scaled:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def bbox(self, transformed=True, with_stroke=False):
         return self.path.bbox(self.matrix)
 

--- a/meerk40t/core/node/elem_geomstr.py
+++ b/meerk40t/core/node/elem_geomstr.py
@@ -18,6 +18,7 @@ class GeomstrNode(Node, Parameters):
         self.stroke = None
         self.stroke_width = 1000
         self.stroke_scale = False
+        self.stroke_zero = 1.0
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD

--- a/meerk40t/core/node/elem_geomstr.py
+++ b/meerk40t/core/node/elem_geomstr.py
@@ -1,12 +1,13 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.core.parameters import Parameters
 from meerk40t.svgelements import Matrix
 
 
-class GeomstrNode(Node, Parameters):
+class GeomstrNode(Node, Parameters, Stroked):
     """
     GeomstrNode is the bootstrapped node type for the 'elem geomstr' type.
     """
@@ -18,7 +19,7 @@ class GeomstrNode(Node, Parameters):
         self.stroke = None
         self.stroke_width = 1000
         self.stroke_scale = False
-        self.stroke_zero = 1.0
+        self._stroke_zero = 1.0
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -37,20 +38,6 @@ class GeomstrNode(Node, Parameters):
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(len(self.path))}, {str(self._parent)})"
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        if not v and self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width *= sqrt(abs(matrix.determinant))
-        if v and not self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width /= sqrt(abs(matrix.determinant))
-        self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):
         return self.path.bbox(self.matrix)

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -39,8 +39,7 @@ class LineNode(Node, Stroked):
         if self.stroke is None:
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
-            self.stroke_width = self.shape.stroke_width
-            self.stroke_width *= UNITS_PER_PIXEL
+            self.stroke_width = self.shape.implicit_stroke_width
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -6,7 +6,7 @@ from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
-    SimpleLine,
+    SimpleLine, Matrix,
 )
 
 
@@ -22,6 +22,7 @@ class LineNode(Node):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
+        self.stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -41,6 +42,11 @@ class LineNode(Node):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
+        if self.stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(self.shape.values.get("viewport_transform", ""))
+            self.stroke_zero = sqrt(abs(m.determinant))
+
         self.set_dirty_bounds()
 
     def __copy__(self):

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -6,7 +6,8 @@ from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
-    SimpleLine, Matrix,
+    SimpleLine,
+    Matrix,
 )
 
 
@@ -85,7 +86,6 @@ class LineNode(Node):
             self.stroke_width *= stroke_factor
         self.stroke_zero = stroke_one
         self.stroke_scale = v
-
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -46,6 +46,8 @@ class LineNode(Node):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
+            if self.stroke_width is not None:
+                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -3,6 +3,7 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
+from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -39,6 +40,7 @@ class LineNode(Node, Stroked):
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
             self.stroke_width = self.shape.stroke_width
+            self.stroke_width *= UNITS_PER_PIXEL
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
@@ -48,8 +50,6 @@ class LineNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
-            if self.stroke_width is not None:
-                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -83,18 +83,6 @@ class LineNode(Node):
             self.stroke_width /= sqrt(abs(matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scaled:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -25,7 +25,7 @@ class LineNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -46,10 +46,10 @@ class LineNode(Node, Stroked):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -7,9 +7,9 @@ from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
+    Matrix,
     Path,
     SimpleLine,
-    Matrix,
 )
 
 

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -75,13 +75,17 @@ class LineNode(Node):
         @param v:
         @return:
         """
-        if not v and self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width *= sqrt(abs(matrix.determinant))
-        if v and not self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width /= sqrt(abs(matrix.determinant))
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        stroke_factor = stroke_one / self.stroke_zero
+        if not v:
+            self.stroke_width *= stroke_factor
+        self.stroke_zero = stroke_one
         self.stroke_scale = v
+
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -1,6 +1,7 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -11,7 +12,7 @@ from meerk40t.svgelements import (
 )
 
 
-class LineNode(Node):
+class LineNode(Node, Stroked):
     """
     LineNode is the bootstrapped node type for the 'elem line' type.
     """
@@ -62,30 +63,6 @@ class LineNode(Node):
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self.shape)}, {str(self._parent)})"
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        """
-        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
-        the toggling of the stroke-scaling without the current stroke_width being affected.
-
-        @param v:
-        @return:
-        """
-        if bool(v) == bool(self.stroke_scale):
-            # Unchanged.
-            return
-        matrix = self.matrix
-        stroke_one = sqrt(abs(matrix.determinant))
-        stroke_factor = stroke_one / self.stroke_zero
-        if not v:
-            self.stroke_width *= stroke_factor
-        self.stroke_zero = stroke_one
-        self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -48,6 +48,8 @@ class PathNode(Node):
             # This defines the stroke-width zero point scale
             m = Matrix(self.path.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
+            if self.stroke_width is not None:
+                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -1,6 +1,7 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -10,7 +11,7 @@ from meerk40t.svgelements import (
 )
 
 
-class PathNode(Node):
+class PathNode(Node, Stroked):
     """
     PathNode is the bootstrapped node type for the 'elem path' type.
     """
@@ -64,30 +65,6 @@ class PathNode(Node):
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(len(self.path))}, {str(self._parent)})"
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        """
-        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
-        the toggling of the stroke-scaling without the current stroke_width being affected.
-
-        @param v:
-        @return:
-        """
-        if bool(v) == bool(self.stroke_scale):
-            # Unchanged.
-            return
-        matrix = self.matrix
-        stroke_one = sqrt(abs(matrix.determinant))
-        stroke_factor = stroke_one / self.stroke_zero
-        if not v:
-            self.stroke_width *= stroke_factor
-        self.stroke_zero = stroke_one
-        self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -5,7 +5,8 @@ from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path, Matrix,
+    Path,
+    Matrix,
 )
 
 

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -7,8 +7,8 @@ from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path,
     Matrix,
+    Path,
 )
 
 

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -78,18 +78,6 @@ class PathNode(Node):
             self.stroke_width /= sqrt(abs(matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke, and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scaled:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()
         return self.path.bbox(transformed=transformed, with_stroke=with_stroke)

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -70,12 +70,22 @@ class PathNode(Node):
 
     @stroke_scaled.setter
     def stroke_scaled(self, v):
-        if not v and self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width *= sqrt(abs(matrix.determinant))
-        if v and not self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width /= sqrt(abs(matrix.determinant))
+        """
+        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
+        the toggling of the stroke-scaling without the current stroke_width being affected.
+
+        @param v:
+        @return:
+        """
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        stroke_factor = stroke_one / self.stroke_zero
+        if not v:
+            self.stroke_width *= stroke_factor
+        self.stroke_zero = stroke_one
         self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -41,8 +41,7 @@ class PathNode(Node, Stroked):
         if self.stroke is None:
             self.stroke = self.path.stroke
         if self.stroke_width is None:
-            self.stroke_width = self.path.stroke_width
-            self.stroke_width *= UNITS_PER_PIXEL
+            self.stroke_width = self.path.implicit_stroke_width
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.path.values.get(SVG_ATTR_VECTOR_EFFECT)

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -3,6 +3,7 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
+from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -41,6 +42,7 @@ class PathNode(Node, Stroked):
             self.stroke = self.path.stroke
         if self.stroke_width is None:
             self.stroke_width = self.path.stroke_width
+            self.stroke_width *= UNITS_PER_PIXEL
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.path.values.get(SVG_ATTR_VECTOR_EFFECT)
@@ -50,8 +52,6 @@ class PathNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(self.path.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
-            if self.stroke_width is not None:
-                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -5,7 +5,7 @@ from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
-    Path,
+    Path, Matrix,
 )
 
 
@@ -23,6 +23,7 @@ class PathNode(Node):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
+        self.stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -43,6 +44,11 @@ class PathNode(Node):
                 self.path.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
+        if self.stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(self.path.values.get("viewport_transform", ""))
+            self.stroke_zero = sqrt(abs(m.determinant))
+
         self.set_dirty_bounds()
 
     def __copy__(self):

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -26,7 +26,7 @@ class PathNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -48,10 +48,10 @@ class PathNode(Node, Stroked):
                 self.path.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(self.path.values.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -7,7 +7,7 @@ from meerk40t.svgelements import (
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
     Polygon,
-    Polyline,
+    Polyline, Matrix,
 )
 
 
@@ -23,6 +23,7 @@ class PolylineNode(Node):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
+        self.stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -43,6 +44,11 @@ class PolylineNode(Node):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
+        if self.stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(self.path.values.get("viewport_transform", ""))
+            self.stroke_zero = sqrt(abs(m.determinant))
+
         self.set_dirty_bounds()
 
     def __copy__(self):

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -7,7 +7,8 @@ from meerk40t.svgelements import (
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
     Polygon,
-    Polyline, Matrix,
+    Polyline,
+    Matrix,
 )
 
 
@@ -87,7 +88,6 @@ class PolylineNode(Node):
             self.stroke_width *= stroke_factor
         self.stroke_zero = stroke_one
         self.stroke_scale = v
-
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -7,10 +7,10 @@ from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
+    Matrix,
     Path,
     Polygon,
     Polyline,
-    Matrix,
 )
 
 

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -78,18 +78,6 @@ class PolylineNode(Node):
             self.stroke_width /= sqrt(abs(matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke, and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scale:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()
         return self.shape.bbox(transformed=True, with_stroke=with_stroke)

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -70,13 +70,24 @@ class PolylineNode(Node):
 
     @stroke_scaled.setter
     def stroke_scaled(self, v):
-        if not v and self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width *= sqrt(abs(matrix.determinant))
-        if v and not self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width /= sqrt(abs(matrix.determinant))
+        """
+        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
+        the toggling of the stroke-scaling without the current stroke_width being affected.
+
+        @param v:
+        @return:
+        """
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        stroke_factor = stroke_one / self.stroke_zero
+        if not v:
+            self.stroke_width *= stroke_factor
+        self.stroke_zero = stroke_one
         self.stroke_scale = v
+
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -41,8 +41,7 @@ class PolylineNode(Node, Stroked):
         if self.stroke is None:
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
-            self.stroke_width = self.shape.stroke_width
-            self.stroke_width *= UNITS_PER_PIXEL
+            self.stroke_width = self.shape.implicit_stroke_width
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -46,8 +46,10 @@ class PolylineNode(Node):
             )
         if self.stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.path.values.get("viewport_transform", ""))
+            m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
+            if self.stroke_width is not None:
+                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -3,6 +3,7 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
+from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -41,6 +42,7 @@ class PolylineNode(Node, Stroked):
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
             self.stroke_width = self.shape.stroke_width
+            self.stroke_width *= UNITS_PER_PIXEL
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
@@ -50,8 +52,6 @@ class PolylineNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
-            if self.stroke_width is not None:
-                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -1,6 +1,7 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -12,7 +13,7 @@ from meerk40t.svgelements import (
 )
 
 
-class PolylineNode(Node):
+class PolylineNode(Node, Stroked):
     """
     PolylineNode is the bootstrapped node type for the 'elem polyline' type.
     """
@@ -64,30 +65,6 @@ class PolylineNode(Node):
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self.shape)}, {str(self._parent)})"
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        """
-        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
-        the toggling of the stroke-scaling without the current stroke_width being affected.
-
-        @param v:
-        @return:
-        """
-        if bool(v) == bool(self.stroke_scale):
-            # Unchanged.
-            return
-        matrix = self.matrix
-        stroke_one = sqrt(abs(matrix.determinant))
-        stroke_factor = stroke_one / self.stroke_zero
-        if not v:
-            self.stroke_width *= stroke_factor
-        self.stroke_zero = stroke_one
-        self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -26,7 +26,7 @@ class PolylineNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.linecap = Linecap.CAP_BUTT
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
@@ -48,10 +48,10 @@ class PolylineNode(Node, Stroked):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -3,6 +3,7 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linejoin, Node
+from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -39,6 +40,7 @@ class RectNode(Node, Stroked):
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
             self.stroke_width = self.shape.stroke_width
+            self.stroke_width *= UNITS_PER_PIXEL
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
@@ -48,8 +50,6 @@ class RectNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
-            if self.stroke_width is not None:
-                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -39,8 +39,7 @@ class RectNode(Node, Stroked):
         if self.stroke is None:
             self.stroke = self.shape.stroke
         if self.stroke_width is None:
-            self.stroke_width = self.shape.stroke_width
-            self.stroke_width *= UNITS_PER_PIXEL
+            self.stroke_width = self.shape.implicit_stroke_width
         if self.stroke_scale is None:
             self.stroke_scale = (
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -7,9 +7,9 @@ from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
+    Matrix,
     Path,
     Rect,
-    Matrix,
 )
 
 

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -6,7 +6,7 @@ from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
-    Rect,
+    Rect, Matrix,
 )
 
 
@@ -22,6 +22,7 @@ class RectNode(Node):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
+        self.stroke_zero = None
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
         super(RectNode, self).__init__(type="elem rect", **kwargs)
@@ -41,6 +42,11 @@ class RectNode(Node):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
+        if self.stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(self.shape.values.get("viewport_transform", ""))
+            self.stroke_zero = sqrt(abs(m.determinant))
+
         self.set_dirty_bounds()
 
     def __repr__(self):

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -6,7 +6,8 @@ from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
     Path,
-    Rect, Matrix,
+    Rect,
+    Matrix,
 )
 
 
@@ -85,7 +86,6 @@ class RectNode(Node):
             self.stroke_width *= stroke_factor
         self.stroke_zero = stroke_one
         self.stroke_scale = v
-
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -76,18 +76,6 @@ class RectNode(Node):
             self.stroke_width /= sqrt(abs(matrix.determinant))
         self.stroke_scale = v
 
-    def implied_stroke_width(self, zoomscale=1.0):
-        """If the stroke is not scaled, the matrix scale will scale the stroke, and we
-        need to countermand that scaling by dividing by the square root of the absolute
-        value of the determinant of the local matrix (1d matrix scaling)"""
-        scalefactor = sqrt(abs(self.matrix.determinant))
-        if self.stroke_scale:
-            # Our implied stroke-width is prescaled.
-            return self.stroke_width
-        else:
-            sw = self.stroke_width / scalefactor
-            return sw
-
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -68,13 +68,24 @@ class RectNode(Node):
 
     @stroke_scaled.setter
     def stroke_scaled(self, v):
-        if not v and self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width *= sqrt(abs(matrix.determinant))
-        if v and not self.stroke_scale:
-            matrix = self.matrix
-            self.stroke_width /= sqrt(abs(matrix.determinant))
+        """
+        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
+        the toggling of the stroke-scaling without the current stroke_width being affected.
+
+        @param v:
+        @return:
+        """
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        stroke_factor = stroke_one / self.stroke_zero
+        if not v:
+            self.stroke_width *= stroke_factor
+        self.stroke_zero = stroke_one
         self.stroke_scale = v
+
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -25,7 +25,7 @@ class RectNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = None
         self.stroke_scale = None
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
         super(RectNode, self).__init__(type="elem rect", **kwargs)
@@ -46,10 +46,10 @@ class RectNode(Node, Stroked):
                 self.shape.values.get(SVG_ATTR_VECTOR_EFFECT)
                 != SVG_VALUE_NON_SCALING_STROKE
             )
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -1,6 +1,7 @@
 from copy import copy
 from math import sqrt
 
+from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -11,7 +12,7 @@ from meerk40t.svgelements import (
 )
 
 
-class RectNode(Node):
+class RectNode(Node, Stroked):
     """
     RectNode is the bootstrapped node type for the 'elem rect' type.
     """
@@ -62,30 +63,6 @@ class RectNode(Node):
         nd["fill"] = copy(self.fill)
         nd["stroke_width"] = copy(self.stroke_width)
         return RectNode(**nd)
-
-    @property
-    def stroke_scaled(self):
-        return self.stroke_scale
-
-    @stroke_scaled.setter
-    def stroke_scaled(self, v):
-        """
-        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
-        the toggling of the stroke-scaling without the current stroke_width being affected.
-
-        @param v:
-        @return:
-        """
-        if bool(v) == bool(self.stroke_scale):
-            # Unchanged.
-            return
-        matrix = self.matrix
-        stroke_one = sqrt(abs(matrix.determinant))
-        stroke_factor = stroke_one / self.stroke_zero
-        if not v:
-            self.stroke_width *= stroke_factor
-        self.stroke_zero = stroke_one
-        self.stroke_scale = v
 
     def bbox(self, transformed=True, with_stroke=False):
         self._sync_svg()

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -46,6 +46,8 @@ class RectNode(Node):
             # This defines the stroke-width zero point scale
             m = Matrix(self.shape.values.get("viewport_transform", ""))
             self.stroke_zero = sqrt(abs(m.determinant))
+            if self.stroke_width is not None:
+                self.stroke_width *= self.stroke_zero
 
         self.set_dirty_bounds()
 

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -55,7 +55,7 @@ class TextNode(Node, Stroked):
         self.stroke = None
         self.stroke_width = 0
         self.stroke_scale = True
-        self.stroke_zero = None
+        self._stroke_zero = None
         self.underline = False
         self.strikethrough = False
         # For sake of completeness, afaik there is no way to display it with wxpython
@@ -101,10 +101,10 @@ class TextNode(Node, Stroked):
             self.font_stretch = getattr(self, SVG_ATTR_FONT_STRETCH, None)
             self.font_family = getattr(self, SVG_ATTR_FONT_FAMILY, None)
             self.validate_font()
-        if self.stroke_zero is None:
+        if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
             m = Matrix(kwargs.get("viewport_transform", ""))
-            self.stroke_zero = sqrt(abs(m.determinant))
+            self._stroke_zero = sqrt(abs(m.determinant))
 
     def __copy__(self):
         nd = self.node_dict

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -45,7 +45,7 @@ class Stroked:
         matrix = self.matrix
         stroke_one = sqrt(abs(matrix.determinant))
         try:
-            return stroke_one / self.stroke_zero
+            return stroke_one / self._stroke_zero
         except AttributeError:
             return 1.0
 
@@ -55,4 +55,4 @@ class Stroked:
         @return:
         """
         matrix = self.matrix
-        self.stroke_zero = sqrt(abs(matrix.determinant))
+        self._stroke_zero = sqrt(abs(matrix.determinant))

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -1,0 +1,42 @@
+from math import sqrt
+
+
+class Stroked:
+    @property
+    def stroke_scaled(self):
+        return self.stroke_scale
+
+    @stroke_scaled.setter
+    def stroke_scaled(self, v):
+        """
+        Setting stroke_scale directly will not resize the stroke-width based on current scaling. This function allows
+        the toggling of the stroke-scaling without the current stroke_width being affected.
+
+        @param v:
+        @return:
+        """
+        if bool(v) == bool(self.stroke_scale):
+            # Unchanged.
+            return
+        if not v:
+            self.stroke_width *= self.stroke_factor
+        self.stroke_width_zero()
+        self.stroke_scale = v
+
+    @property
+    def stroke_factor(self):
+        """
+        The stroke factor is the ratio of the new to old stroke-width scale.
+
+        @return:
+        """
+        matrix = self.matrix
+        stroke_one = sqrt(abs(matrix.determinant))
+        try:
+            return stroke_one / self.stroke_zero
+        except AttributeError:
+            return 1.0
+
+    def stroke_width_zero(self):
+        matrix = self.matrix
+        self.stroke_zero = sqrt(abs(matrix.determinant))

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -50,5 +50,9 @@ class Stroked:
             return 1.0
 
     def stroke_width_zero(self):
+        """
+        Ensures the current stroke scale is marked as stroke_zero.
+        @return:
+        """
         matrix = self.matrix
         self.stroke_zero = sqrt(abs(matrix.determinant))

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -24,6 +24,18 @@ class Stroked:
         self.stroke_scale = v
 
     @property
+    def implied_stroke_width(self):
+        """
+        The implied stroke width is stroke_width if not scaled or the scaled stroke_width if scaled.
+
+        @return:
+        """
+        if self.stroke_scale:
+            return self.stroke_width * self.stroke_factor
+        else:
+            return self.stroke_width
+
+    @property
     def stroke_factor(self):
         """
         The stroke factor is the ratio of the new to old stroke-width scale.

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -469,7 +469,13 @@ class SVGWriter:
                 if stroke_opacity != 1.0 and stroke_opacity is not None:
                     subelement.set(SVG_ATTR_STROKE_OPACITY, str(stroke_opacity))
                 try:
-                    stroke_width = str(c.stroke_width)  # Natively sized
+                    if hasattr(c, "stroke_scaled") and c.stroke_scaled:
+                        # Natively sized
+                        stroke_width = str(c.stroke_width)
+                    else:
+                        # Non-scaling stroke, px sized.
+                        stroke_width = str(c.stroke_width / UNITS_PER_PIXEL)
+
                     subelement.set(SVG_ATTR_STROKE_WIDTH, stroke_width)
                 except AttributeError as Err:
                     # print (f"Shit happened when trying to set stroke_width: {Err}")

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -470,20 +470,6 @@ class SVGWriter:
                     subelement.set(SVG_ATTR_STROKE_OPACITY, str(stroke_opacity))
                 try:
                     stroke_width = str(c.stroke_width)  # Natively sized
-
-                    # Note this is the reversed scaling in `implied_stroke_width`
-                    # stroke_scale = (
-                    #     math.sqrt(abs(c.matrix.determinant)) if c.stroke_scaled else 1.0
-                    # )
-                    # stroke_width = (
-                    #     Length(
-                    #         amount=c.stroke_width * stroke_scale,
-                    #         digits=6,
-                    #         preferred_units="px",
-                    #     ).preferred_length
-                    #     if c.stroke_width is not None
-                    #     else SVG_VALUE_NONE
-                    # )
                     subelement.set(SVG_ATTR_STROKE_WIDTH, stroke_width)
                 except AttributeError as Err:
                     # print (f"Shit happened when trying to set stroke_width: {Err}")

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -469,13 +469,7 @@ class SVGWriter:
                 if stroke_opacity != 1.0 and stroke_opacity is not None:
                     subelement.set(SVG_ATTR_STROKE_OPACITY, str(stroke_opacity))
                 try:
-                    if hasattr(c, "stroke_scaled") and c.stroke_scaled:
-                        # Natively sized
-                        stroke_width = str(c.stroke_width)
-                    else:
-                        # Non-scaling stroke, px sized.
-                        stroke_width = str(c.stroke_width / UNITS_PER_PIXEL)
-
+                    stroke_width = str(c.stroke_width)
                     subelement.set(SVG_ATTR_STROKE_WIDTH, stroke_width)
                 except AttributeError as Err:
                     # print (f"Shit happened when trying to set stroke_width: {Err}")

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -566,11 +566,19 @@ class LaserRender:
         """Default draw routine for the shape element."""
         matrix = node.matrix
         gc.PushState()
-        if not hasattr(node, "_cache") or node._cache is None:
+        try:
+            cache = node._cache
+        except AttributeError:
+            cache = None
+        if cache is None:
             node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.shape)
             node._cache = cache
-        elif matrix != node._cache_matrix:
+        try:
+            cache_matrix = node._cache_matrix
+        except AttributeError:
+            cache_matrix = None
+        if matrix != cache_matrix:
             q = ~node._cache_matrix * matrix
             gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(q)))
         self._set_linecap_by_node(node)
@@ -593,11 +601,19 @@ class LaserRender:
         """Default draw routine for the laser path element."""
         matrix = node.matrix
         gc.PushState()
-        if not hasattr(node, "_cache") or node._cache is None:
+        try:
+            cache = node._cache
+        except AttributeError:
+            cache = None
+        if cache is None:
             node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.path)
             node._cache = cache
-        elif matrix != node._cache_matrix:
+        try:
+            cache_matrix = node._cache_matrix
+        except AttributeError:
+            cache_matrix = None
+        if matrix != cache_matrix:
             q = ~node._cache_matrix * matrix
             gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(q)))
         self._set_linecap_by_node(node)
@@ -620,11 +636,19 @@ class LaserRender:
         """Default draw routine for the laser path element."""
         matrix = node.matrix
         gc.PushState()
-        if not hasattr(node, "_cache") or node._cache is None:
+        try:
+            cache = node._cache
+        except AttributeError:
+            cache = None
+        if cache is None:
             node._cache_matrix = copy(matrix)
             cache = self.make_geomstr(gc, node.path)
             node._cache = cache
-        elif matrix != node._cache_matrix:
+        try:
+            cache_matrix = node._cache_matrix
+        except AttributeError:
+            cache_matrix = None
+        if matrix != cache_matrix:
             q = ~node._cache_matrix * matrix
             gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(q)))
         self._set_linecap_by_node(node)

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -611,12 +611,11 @@ class LaserRender:
             stroke_factor = 1.0 / sqrt(abs(q.determinant))
         self._set_linecap_by_node(node)
         self._set_linejoin_by_node(node)
-        if node.stroke_scaled:
-            # our stroke is scaled, so we scale it up by the change between stroke1 and stroke2
-            stroke_one = sqrt(abs(matrix.determinant))
-            stroke_factor *= stroke_one / node.stroke_zero
-
-        self._set_penwidth(node.stroke_width * stroke_factor)
+        sw = node.implied_stroke_width * stroke_factor
+        if draw_mode & DRAW_MODE_LINEWIDTH:
+            # No stroke rendering.
+            sw = 1000
+        self._set_penwidth(sw)
         self.set_pen(
             gc,
             node.stroke,
@@ -666,17 +665,18 @@ class LaserRender:
         gc.PushState()
         if matrix is not None and not matrix.is_identity():
             gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(matrix)))
-        if draw_mode & DRAW_MODE_LINEWIDTH:
-            stroke_scale = sqrt(abs(matrix.determinant)) if matrix else 1.0
-            self._set_penwidth(1000 / stroke_scale)
-        else:
-            self._set_penwidth(node.implied_stroke_width(zoomscale))
-        self.set_pen(
-            gc,
-            node.stroke,
-            alpha=alpha,
-        )
-        self.set_brush(gc, node.fill, alpha=255)
+        #
+        # sw = node.implied_stroke_width
+        # if draw_mode & DRAW_MODE_LINEWIDTH:
+        #     # No stroke rendering.
+        #     sw = 1000
+        # self._set_penwidth(sw)
+        # self.set_pen(
+        #     gc,
+        #     node.stroke,
+        #     alpha=alpha,
+        # )
+        # self.set_brush(gc, node.fill, alpha=255)
 
         if node.fill is None or node.fill == "none":
             fill_color = wx.BLACK

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -564,18 +564,18 @@ class LaserRender:
 
     def draw_shape_node(self, node, gc, draw_mode, zoomscale=1.0, alpha=255):
         """Default draw routine for the shape element."""
-        try:
-            matrix = node.matrix
-        except AttributeError:
-            matrix = None
-        if not hasattr(node, "_cache") or node._cache is None or matrix != node._cache_matrix:
+        matrix = node.matrix
+        gc.PushState()
+        if not hasattr(node, "_cache") or node._cache is None:
             node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.shape)
             node._cache = cache
+        elif matrix != node._cache_matrix:
+            q = ~node._cache_matrix * matrix
+            gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(q)))
         self._set_linecap_by_node(node)
         self._set_linejoin_by_node(node)
 
-        gc.PushState()
         self._set_penwidth(node.stroke_width)
         self.set_pen(
             gc,
@@ -591,18 +591,18 @@ class LaserRender:
 
     def draw_path_node(self, node, gc, draw_mode, zoomscale=1.0, alpha=255):
         """Default draw routine for the laser path element."""
-        try:
-            matrix = node.matrix
-        except AttributeError:
-            matrix = None
-        if not hasattr(node, "_cache") or node._cache is None or matrix != node._cache_matrix:
+        matrix = node.matrix
+        gc.PushState()
+        if not hasattr(node, "_cache") or node._cache is None:
             node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.path)
             node._cache = cache
+        elif matrix != node._cache_matrix:
+            q = ~node._cache_matrix * matrix
+            gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(q)))
         self._set_linecap_by_node(node)
         self._set_linejoin_by_node(node)
 
-        gc.PushState()
         self._set_penwidth(node.stroke_width)
         self.set_pen(
             gc,

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -1,3 +1,4 @@
+from copy import copy
 from math import ceil, isnan, sqrt
 
 import wx
@@ -567,7 +568,8 @@ class LaserRender:
             matrix = node.matrix
         except AttributeError:
             matrix = None
-        if not hasattr(node, "_cache") or node._cache is None:
+        if not hasattr(node, "_cache") or node._cache is None or matrix != node._cache_matrix:
+            node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.shape)
             node._cache = cache
         self._set_linecap_by_node(node)
@@ -589,7 +591,12 @@ class LaserRender:
 
     def draw_path_node(self, node, gc, draw_mode, zoomscale=1.0, alpha=255):
         """Default draw routine for the laser path element."""
-        if not hasattr(node, "_cache") or node._cache is None:
+        try:
+            matrix = node.matrix
+        except AttributeError:
+            matrix = None
+        if not hasattr(node, "_cache") or node._cache is None or matrix != node._cache_matrix:
+            node._cache_matrix = copy(matrix)
             cache = self.make_path(gc, node.path)
             node._cache = cache
         self._set_linecap_by_node(node)

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -650,17 +650,13 @@ class LaserRender:
         point = node.point
         if point is None:
             return
-        try:
-            matrix = node.matrix
-        except AttributeError:
-            matrix = None
-        if matrix is None:
-            return
+        matrix = node.matrix
+        if matrix is not None and not matrix.is_identity():
+            point = matrix.point_in_matrix_space(point)
+            node.point = point
+            matrix.reset()
         gc.PushState()
         gc.SetPen(wx.BLACK_PEN)
-        point = matrix.point_in_matrix_space(point)
-        node.point = point
-        matrix.reset()
         dif = 5 * zoomscale
         gc.StrokeLine(point.x - dif, point.y, point.x + dif, point.y)
         gc.StrokeLine(point.x, point.y - dif, point.x, point.y + dif)

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -157,7 +157,13 @@ class StrokeWidget(StatusBarWidget):
         )
         self.combo_units.SetMinSize(wx.Size(30, -1))
         self.combo_units.SetMaxSize(wx.Size(120, -1))
-        self.combo_units.SetSelection(0)
+        self.context.setting(int, "strokewidth_default_units", 0)
+        if (
+            0 > self.context.strokewidth_default_units
+            or self.context.strokewidth_default_units >= len(self.unit_choices)
+        ):
+            self.context.strokewidth_default_units = 0
+        self.combo_units.SetSelection(self.context.strokewidth_default_units)
 
         self.chk_scale = wx.CheckBox(self.parent, wx.ID_ANY, _("Scale"))
         self.chk_scale.SetToolTip(
@@ -168,8 +174,7 @@ class StrokeWidget(StatusBarWidget):
             + _("Inactive: stroke grows/shrink with scaled element")
         )
 
-        self.parent.Bind(wx.EVT_COMBOBOX, self.on_stroke_width, self.combo_units)
-        # self.parent.Bind(wx.EVT_TEXT_ENTER, self.on_stroke_width, self.spin_width)
+        self.parent.Bind(wx.EVT_COMBOBOX, self.on_stroke_width_combo, self.combo_units)
         self.parent.Bind(wx.EVT_TEXT_ENTER, self.on_stroke_width, self.spin_width)
         self.parent.Bind(wx.EVT_CHECKBOX, self.on_chk_scale, self.chk_scale)
         self.Add(self.strokewidth_label, 0, 0, 0)
@@ -184,6 +189,23 @@ class StrokeWidget(StatusBarWidget):
             self.context("enable_stroke_scale")
         else:
             self.context("disable_stroke_scale")
+        self.update_stroke_magnitude()
+
+    def on_stroke_width_combo(self, event):
+        if self.startup or self.combo_units.GetSelection() < 0:
+            return
+        if self.context.strokewidth_default_units == self.combo_units.GetSelection():
+            # No change.
+            return
+        original = self.unit_choices[self.context.strokewidth_default_units]
+        units = self.unit_choices[self.combo_units.GetSelection()]
+        new_text = Length(f"{float(self.spin_width.GetValue())}{original}", preferred_units=units)
+        self.spin_width.SetValue(f"{new_text.preferred:.3f}")
+        try:
+            self.context(f"stroke-width {float(self.spin_width.GetValue())}{units}")
+        except ValueError:
+            pass
+        self.context.strokewidth_default_units = self.combo_units.GetSelection()
 
     def on_stroke_width(self, event):
         if self.startup or self.combo_units.GetSelection() < 0:
@@ -194,72 +216,35 @@ class StrokeWidget(StatusBarWidget):
         except ValueError:
             pass
 
+    def update_stroke_magnitude(self):
+        sw_default = None
+        for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
+            if hasattr(e, "stroke_width"):
+                sw_default = e.stroke_width
+                try:
+                    sw_default = e.implied_stroke_width
+                except AttributeError:
+                    pass
+                break
+        if sw_default is None:
+            # Nothing
+            return
+        self.context.setting(int, "strokewidth_default_units", 0)
+        unit = self.unit_choices[self.context.strokewidth_default_units]
+        std = float(Length(f"1{unit}"))
+        value = sw_default / std
+        self.spin_width.SetValue(str(round(value, 4)))
+
+    def update_stroke_scale_check(self):
+        for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
+            if hasattr(e, "stroke_scaled"):
+                self.chk_scale.SetValue(e.stroke_scaled)
+                return
+
     def Signal(self, signal, *args):
         if signal == "emphasized":
-            value = self.context.elements.has_emphasis()
-            sw_default = None
-            ck_default = True
-            mat_default = None
-            for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
-                if hasattr(e, "stroke_width") and hasattr(e, "stroke_scaled"):
-                    if sw_default is None:
-                        sw_default = e.stroke_width
-                        mat_default = e.matrix
-                        ck_default = e.stroke_scaled
-                        break
-            if sw_default is not None:
-                # Set Values
-                self.startup = True
-                # Lets establish which unit might be the best to represent the display
-                found_something = False
-                if sw_default == 0:
-                    value = 0
-                    idxunit = 0  # px
-                    found_something = True
-                else:
-                    best_post = 99999999
-                    delta = 0.99999999
-                    best_pre = 0
-                    factor = sqrt(abs(mat_default.determinant)) if ck_default else 1.0
-                    node_stroke_width = sw_default * factor
-                    for idx, unit in enumerate(self.unit_choices):
-                        std = float(Length(f"1{unit}"))
-                        fraction = abs(node_stroke_width / std)
-                        if fraction == 0:
-                            continue
-                        curr_post = 0
-                        curr_pre = int(fraction)
-                        while fraction < 1:
-                            curr_post += 1
-                            fraction *= 10
-                        fraction -= curr_pre
-                        # print (f"unit={unit}, fraction={fraction}, digits={curr_post}, value={self.node.stroke_width / std}")
-                        takespref = False
-                        if fraction < delta:
-                            takespref = True
-                        elif fraction == delta and curr_pre > best_pre:
-                            takespref = True
-                        elif fraction == delta and curr_post < best_post:
-                            takespref = True
-                        if takespref:
-                            best_pre = curr_pre
-                            delta = fraction
-                            best_post = curr_post
-                            idxunit = idx
-                            value = node_stroke_width / std
-                            found_something = True
-
-                    if not found_something:
-                        std = float(Length(f"1mm"))
-                        if node_stroke_width / std < 0.1:
-                            idxunit = 0  # px
-                        else:
-                            idxunit = 2  # mm
-                        unit = self.unit_choices[idxunit]
-                        std = float(Length(f"1{unit}"))
-                        value = node_stroke_width / std
-
-                self.spin_width.SetValue(str(round(value, 4)))
-                self.combo_units.SetSelection(idxunit)
-                self.chk_scale.SetValue(ck_default)
-                self.startup = False
+            self.update_stroke_magnitude()
+            self.update_stroke_scale_check()
+            self.startup = False
+        if signal == "modified":
+            self.update_stroke_magnitude()

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -1,5 +1,3 @@
-from math import sqrt
-
 import wx
 
 from ...core.element_types import elem_nodes
@@ -199,7 +197,9 @@ class StrokeWidget(StatusBarWidget):
             return
         original = self.unit_choices[self.context.strokewidth_default_units]
         units = self.unit_choices[self.combo_units.GetSelection()]
-        new_text = Length(f"{float(self.spin_width.GetValue())}{original}", preferred_units=units)
+        new_text = Length(
+            f"{float(self.spin_width.GetValue())}{original}", preferred_units=units
+        )
         self.spin_width.SetValue(f"{new_text.preferred:.3f}")
         try:
             self.context(f"stroke-width {float(self.spin_width.GetValue())}{units}")

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -189,11 +189,8 @@ class StrokeWidget(StatusBarWidget):
         if self.startup or self.combo_units.GetSelection() < 0:
             return
         try:
-            self.context.signal(
-                "selstrokewidth",
-                f"{float(self.spin_width.GetValue()):.2f}"
-                f"{self.unit_choices[self.combo_units.GetSelection()]}",
-            )
+            units = self.unit_choices[self.combo_units.GetSelection()]
+            self.context(f"stroke-width {float(self.spin_width.GetValue())}{units}")
         except ValueError:
             pass
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -284,6 +284,12 @@ class MeerK40t(MWindow):
         if self.widgets_created:
             self.main_statusbar.Signal("element_property_update", *args)
 
+    @signal_listener("modified")
+    def on_element_update(self, origin, *args):
+        if self.widgets_created:
+            self.main_statusbar.Signal("modified", *args)
+
+
     @signal_listener("rebuild_tree")
     @signal_listener("refresh_tree")
     @signal_listener("tree_changed")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -289,7 +289,6 @@ class MeerK40t(MWindow):
         if self.widgets_created:
             self.main_statusbar.Signal("modified", *args)
 
-
     @signal_listener("rebuild_tree")
     @signal_listener("refresh_tree")
     @signal_listener("tree_changed")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -285,7 +285,7 @@ class MeerK40t(MWindow):
             self.main_statusbar.Signal("element_property_update", *args)
 
     @signal_listener("modified")
-    def on_element_update(self, origin, *args):
+    def on_element_modified(self, origin, *args):
         if self.widgets_created:
             self.main_statusbar.Signal("modified", *args)
 

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -965,23 +965,6 @@ class MeerK40tScenePanel(wx.Panel):
             color = Color(rgb[0], rgb[1], rgb[2])
         self.widget_scene.context.elements.default_fill = color
 
-    @signal_listener("selstrokewidth")
-    def on_selstrokewidth(self, origin, stroke_width, *args):
-        # Stroke_width is a text
-        # print("Signal with %s" % stroke_width)
-        sw = float(Length(stroke_width))
-        for e in self.context.elements.flat(types=elem_nodes, emphasized=True):
-            try:
-                stroke_scale = (
-                    sqrt(abs(e.matrix.determinant)) if e.stroke_scaled else 1.0
-                )
-                e.stroke_width = sw / stroke_scale
-                e.altered()
-            except AttributeError:
-                # Ignore and carry on...
-                continue
-        self.request_refresh()
-
     def on_key_down(self, event):
         keyvalue = get_key_name(event)
         ignore = self.widget_scene.tool_active


### PR DESCRIPTION
Intended to fix #1596 and #1507.

This affects the drawn size of the paths so as to avoid the `round()` then `scale()` issues within wxPython. Where if we have a scale of 2800 then we round to 1, 2, 3 etc then scale by 2800 giving our values units of 2800, 5600, 8400 etc. This causes a number of very detectable artifacts. The number system used is 1/65535 of an inch because it won't show any artifacts even at the sub-mil level and can still do designs in linux the size of a football field (2^24 range).

This messes with the stroke-scaling and stroke-width since they expected to be scaled up and then manipulated. For most cases the default native stroke value is correct, but this doesn't work for stroke scaling.