### PR TITLE
Fix Stroke-Sizes for Rasters

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -4264,15 +4264,15 @@ def init_commands(kernel):
                         )
                     )
                     continue
+                factor = 1.0
                 if e.stroke_scaled:
                     typename = "scaled-stroke"
                     try:
                         factor = e.stroke_factor
                     except AttributeError:
-                        factor = 1.0
+                        pass
                 else:
                     typename = "non-scaling-stroke"
-                    factor = 1.0
                 implied_value = factor * stroke_width
                 channel(
                     _(

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -48,8 +48,11 @@ class EllipseNode(Node, Stroked):
             )
         if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self._stroke_zero = sqrt(abs(m.determinant))
+            m = self.shape.values.get("viewport_transform")
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
         self.set_dirty_bounds()
 
@@ -69,6 +72,7 @@ class EllipseNode(Node, Stroked):
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, plan):
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -47,8 +47,11 @@ class LineNode(Node, Stroked):
             )
         if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self._stroke_zero = sqrt(abs(m.determinant))
+            m = self.shape.values.get("viewport_transform")
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
         self.set_dirty_bounds()
 
@@ -68,6 +71,7 @@ class LineNode(Node, Stroked):
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, plan):
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -3,7 +3,6 @@ from math import sqrt
 
 from meerk40t.core.node.mixins import Stroked
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
-from meerk40t.core.units import UNITS_PER_PIXEL
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
     SVG_VALUE_NON_SCALING_STROKE,
@@ -49,8 +48,11 @@ class PathNode(Node, Stroked):
             )
         if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.path.values.get("viewport_transform", ""))
-            self._stroke_zero = sqrt(abs(m.determinant))
+            m = self.path.values.get("viewport_transform")
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
         self.set_dirty_bounds()
 
@@ -70,6 +72,7 @@ class PathNode(Node, Stroked):
         return self.path.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, plan):
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -49,8 +49,11 @@ class PolylineNode(Node, Stroked):
             )
         if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self._stroke_zero = sqrt(abs(m.determinant))
+            m = self.shape.values.get("viewport_transform")
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
         self.set_dirty_bounds()
 
@@ -70,6 +73,7 @@ class PolylineNode(Node, Stroked):
         return self.shape.bbox(transformed=True, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, plan):
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -47,8 +47,11 @@ class RectNode(Node, Stroked):
             )
         if self._stroke_zero is None:
             # This defines the stroke-width zero point scale
-            m = Matrix(self.shape.values.get("viewport_transform", ""))
-            self._stroke_zero = sqrt(abs(m.determinant))
+            m = self.shape.values.get("viewport_transform")
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
         self.set_dirty_bounds()
 
@@ -68,6 +71,7 @@ class RectNode(Node, Stroked):
         return self.shape.bbox(transformed=transformed, with_stroke=with_stroke)
 
     def preprocess(self, context, matrix, plan):
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -105,6 +105,13 @@ class TextNode(Node, Stroked):
             # This defines the stroke-width zero point scale
             m = Matrix(kwargs.get("viewport_transform", ""))
             self._stroke_zero = sqrt(abs(m.determinant))
+        if self._stroke_zero is None:
+            # This defines the stroke-width zero point scale
+            m = Matrix(kwargs.get("viewport_transform"))
+            if m:
+                self._stroke_zero = sqrt(abs(Matrix(m).determinant))
+            else:
+                self.stroke_width_zero()
 
     def __copy__(self):
         nd = self.node_dict
@@ -133,6 +140,7 @@ class TextNode(Node, Stroked):
             commands.append(self.remove_text)
             return
         self.text = context.elements.wordlist_translate(self.text, self)
+        self.stroke_scaled = False
         self.stroke_scaled = True
         self.matrix *= matrix
         self.stroke_scaled = False

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -1,7 +1,8 @@
 from math import sqrt
+from abc import ABC, abstractmethod as abstract
 
 
-class Stroked:
+class Stroked(ABC):
     @property
     def stroke_scaled(self):
         return self.stroke_scale

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -695,6 +695,7 @@ class Node:
             pass
         try:
             del self._cache
+            del self._cache_matrix
         except AttributeError:
             pass
         self._cache = None
@@ -708,6 +709,7 @@ class Node:
             pass
         try:
             del self._cache
+            del self._cache_matrix
         except AttributeError:
             pass
 


### PR DESCRIPTION
The nuked attempt at a Beta3 was nuked because stroke-size changes caused all rasters to suppose their stroke sizes were always massive.

This happens because there's two modes for stroke scaling. None and scaling. Basically if at transform `matrix0` we are exactly equal to `stroke-size` then at a different transform `matrix1` we are at a different scaling. If we are non-scaling the stroke size at `matrix1` is the same as at `matrix0` since the stroke size remains constant. If we are scaling then the stroke size is different by `sqrt(abs(det(matrix1))) / sqrt(abs(det(matrix0)))` Which is to say the difference in 1d scaling at those two matrix positions.

For SVGs that are loaded this tends to discount all the the official scaling but not the viewport of the `height`, `width` and `viewbox` of the svg. And in inkscape this actually is changed between zooming. So if you zoom in, you get a the same stroke width regardless of how much you are zoomed into the view.

The issue here is that the math has some problems and when the MK scene native of 1/65535 inches per unit is changed into being more like 1/1000 inches per step, it actually gets the stroke width so wrong that it will no longer have the memory enough to make the raster.

The system currently caches the any paths at full resolution so the paths themselves in native screen resolution. If they are scaled after that, the difference between m0 and m1 is applied to the full scaled image. This includes calculating a `delta(stroke-scale)` between the identity and the difference matrix. So that we properly draw cached values. The matrix at the point of caching is stored to make these calculations easy.

The stroke widget in the status bar is updates correctly. But how to change the stroke for preprocessing when everything is scaled to the native resolution of the laser is still apparently wrong.