### PR TITLE
Flynt: Check for cases where format or % strings can be replaced with fstrings.

### DIFF
--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -98,10 +98,8 @@ class AboutPanel(wx.Panel):
             + _(
                 "* @joerlane for his hardware investigation wizardry into how the M2-Nano works.\n"
             )
-            + _(
-                "* All the MeerKittens, {developer}. \n".format(
-                    developer=", ".join(hall_of_fame)
-                )
+            + _("* All the MeerKittens, {developer}. \n").format(
+                developer=", ".join(hall_of_fame)
             )
             + _(
                 "* Beta testers and anyone who reported issues that helped us improve things.\n"

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -476,9 +476,7 @@ class SpoolerPanel(wx.Panel):
             remove_mode = "remove"
         item = menu.Append(
             wx.ID_ANY,
-            "{action} {name} [{label}]".format(
-                action=action, name=str(element)[:30], label=spooler.context.label
-            ),
+            f"{action} {str(element)[:30]} [{spooler.context.label}]",
             "",
             wx.ITEM_NORMAL,
         )

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2941,7 +2941,7 @@ class MeerK40t(MWindow):
     def on_cutplan_error(self, origin, error):
         dlg = wx.MessageDialog(
             None,
-            _("Cut planning failed because: {error}".format(error=error)),
+            _("Cut planning failed because: {error}").format(error=error),
             _("Cut Planning Failed"),
             wx.OK | wx.ICON_WARNING,
         )

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -166,7 +166,7 @@ class Kernel(Settings):
             def wrapper_debug(*args, **kwargs):
                 args_repr = [repr(a) for a in args]
 
-                kwargs_repr = ["%s=%s" % (k, v) for k, v in kwargs.items()]
+                kwargs_repr = [f"{k}={v}" for k, v in kwargs.items()]
                 signature = ", ".join(args_repr + kwargs_repr)
                 start = f"Calling {str(obj)}.{func.__name__}({signature})"
                 debug_file.write(start + "\n")

--- a/meerk40t/tools/polybool.py
+++ b/meerk40t/tools/polybool.py
@@ -96,10 +96,10 @@ class Point:
         return abs(self.x - __o.x) < tolerance and abs(self.y - __o.y) < tolerance
 
     def __repr__(self) -> str:
-        return "{},{}".format(self.x, self.y)
+        return f"{self.x},{self.y}"
 
     def __str__(self) -> str:
-        return "{},{}".format(self.x, self.y)
+        return f"{self.x},{self.y}"
 
 
 class Fill:
@@ -108,10 +108,10 @@ class Fill:
         self.above = above
 
     def __repr__(self) -> str:
-        return "{},{}".format(self.above, self.below)
+        return f"{self.above},{self.below}"
 
     def __str__(self) -> str:
-        return "{},{}".format(self.above, self.below)
+        return f"{self.above},{self.below}"
 
 
 class Segment:
@@ -124,10 +124,10 @@ class Segment:
         self.otherfill = otherfill
 
     def __repr__(self) -> str:
-        return "S: {}, E: {}".format(self.start, self.end)
+        return f"S: {self.start}, E: {self.end}"
 
     def __str__(self) -> str:
-        return "S: {}, E: {}".format(self.start, self.end)
+        return f"S: {self.start}, E: {self.end}"
 
 
 class PolySegments:

--- a/test/test_kernel.py
+++ b/test/test_kernel.py
@@ -23,7 +23,7 @@ class TestKernel(unittest.TestCase):
                 if "interrupt" in command:
                     continue
                 if not cmd.regex:
-                    print("Testing command: %s" % command)
+                    print(f"Testing command: {command}")
                     # command should be generated with something like
                     # kernel.console(" ".join(command.split("/")[1:]) + "\n")
                     # if first parameter is not base but this fails so not
@@ -109,7 +109,7 @@ class TestEchoCommand(unittest.TestCase):
         kernel = bootstrap.bootstrap()
         try:
             for echo in echo_commands:
-                print("Testing echo command: %s" % echo)
+                print(f"Testing echo command: {echo}")
                 kernel.console(echo + "\n")
         finally:
             kernel.shutdown()


### PR DESCRIPTION
In a couple places where it was decidedly possible, these are to be translatable and thus were formatted wrongly.