### PR TITLE
op nodes show + sign

### DIFF
--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -304,7 +304,7 @@ class OperationAssignPanel(wx.Panel):
         if len(args) > 0:
             # Need to do all?!
             element = args[0]
-            if element is None:
+            if element is None or element.type is None:
                 return
             if isinstance(element, (tuple, list)):
                 for node in element:

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -755,16 +755,7 @@ class ShadowTree:
 
         # if node is None:
         #     return
-        # tree = self.wxtree
-        # child, cookie = tree.GetFirstChild(node)
-        # while child.IsOk():
-        #     child_node = self.wxtree.GetItemData(child)
-        #     if child_node.type in ("group", "file"):
-        #         self.update_decorations(child_node, force=True)
-        #     ct = self.wxtree.GetChildrenCount(child, recursively=False)
-        #     if ct > 0:
-        #         self.refresh_tree(child, level + 1)
-        #     child, cookie = tree.GetNextChild(node, cookie)
+        self.update_op_labels()
 
         self.wxtree._freeze = False
         self.wxtree.Expand(self.elements.get(type="branch ops")._item)


### PR DESCRIPTION
a) If op property was open and context menu 'Convert operation' was done then a crash could occur
b) Reestablish logic to force + sign at op nodes.