### PR TITLE
Address strange wxp 4.2 assertion error

### DIFF
--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -81,6 +81,7 @@ class ColorPanel(wx.Panel):
         )
         self.btn_color[self.last_col_idx].SetFont(font)
         self.SetSizer(self.main_sizer)
+        self.main_sizer.Fit(self)
         self.Layout()
         self.set_widgets(self.node)
 
@@ -251,6 +252,7 @@ class IdPanel(wx.Panel):
         main_sizer.Add(sizer_id_label, 0, wx.EXPAND, 0)
 
         self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
         self.Layout()
         self.text_id.SetActionRoutine(self.on_text_id_change)
         self.text_label.SetActionRoutine(self.on_text_label_change)
@@ -347,6 +349,7 @@ class LinePropPanel(wx.Panel):
         main_sizer.Add(sizer_attributes, 0, wx.EXPAND, 0)
 
         self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
         self.Layout()
         self.combo_cap.Bind(wx.EVT_COMBOBOX, self.on_cap)
         self.combo_join.Bind(wx.EVT_COMBOBOX, self.on_join)
@@ -465,6 +468,7 @@ class StrokeWidthPanel(wx.Panel):
         self.Bind(wx.EVT_TEXT_ENTER, self.on_stroke_width, self.text_width)
         self.Bind(wx.EVT_CHECKBOX, self.on_chk_scale, self.chk_scale)
         self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
         self.Layout()
         self.set_widgets(self.node)
 
@@ -951,6 +955,7 @@ class RoundedRectPanel(wx.Panel):
         main_sizer.Add(sizer_x, 1, wx.EXPAND, 0)
         main_sizer.Add(sizer_y, 1, wx.EXPAND, 0)
         self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
         self.Layout()
         self.set_widgets(self.node)
         self.slider_x.Bind(wx.EVT_SLIDER, self.on_slider_x)


### PR DESCRIPTION
There was a strange wxpython 4.2 assertion error, this could be ciurcumvented (?! - I did not encounter it any more...) to add a ``sizer.Fit`` statement before the ``self.Layout()`` invocation. That might just be coincidence, but it does not hurt either...
```
MeerK40t crash log. Version: 0.8.1006 git on Windows: Python 3.9.13: AMD64 - wxPython: 4.2.0 msw (phoenix) wxWidgets 3.2.0
Traceback (most recent call last):
  File "C:\temp\meerk40t-living-hinges\meerk40t\kernel\kernel.py", line 1763, in schedule_run
    job.process(*job.args)
  File "C:\temp\meerk40t-living-hinges\meerk40t\kernel\kernel.py", line 1978, in process_queue
    self._process_signal_queue(queue)
  File "C:\temp\meerk40t-living-hinges\meerk40t\kernel\kernel.py", line 1948, in _process_signal_queue
    listener(origin, *message)
  File "C:\temp\meerk40t-living-hinges\meerk40t\gui\propertypanels\propertywindow.py", line 103, in on_selected
    page_panel = prop_sheet(
  File "C:\temp\meerk40t-living-hinges\meerk40t\gui\propertypanels\pathproperty.py", line 73, in __init__
    panel_width = StrokeWidthPanel(
  File "C:\temp\meerk40t-living-hinges\meerk40t\gui\propertypanels\attributes.py", line 468, in __init__
    self.Layout()
wx._core.wxAssertionError: C++ assertion ""((HWND)GetHWND())"" failed at ..\..\src\msw\window.cpp(1273) in wxWindow::GetLayoutDirection(): invalid window
```