### PR TITLE
Add Test for Spooler Non-Regular Job

### DIFF
--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -575,8 +575,8 @@ class Spooler:
     def clear_queue(self):
         with self._lock:
             for element in self._queue:
-                loop = element.loops_executed
-                total = element.loops
+                loop = getattr(element, "loops_executed", 0)
+                total = getattr(element, "loops", 0)
                 if isinf(total):
                     status = "stopped"
                 elif loop < total:

--- a/test/bootstrap.py
+++ b/test/bootstrap.py
@@ -12,21 +12,9 @@ def bootstrap():
 
     kernel.add_plugin(dummydevice.plugin)
 
-    from meerk40t.core import elements
+    from meerk40t.core import core
 
-    kernel.add_plugin(elements.plugin)
-
-    from meerk40t.core import bindalias
-
-    kernel.add_plugin(bindalias.plugin)
-
-    from meerk40t.core import webhelp
-
-    kernel.add_plugin(webhelp.plugin)
-
-    from meerk40t.core import planner
-
-    kernel.add_plugin(planner.plugin)
+    kernel.add_plugin(core.plugin)
 
     from meerk40t.image import imagetools
 

--- a/test/test_spooler.py
+++ b/test/test_spooler.py
@@ -1,0 +1,58 @@
+import unittest
+from test import bootstrap
+
+
+class TestJob:
+    def __init__(
+        self,
+        service,
+    ):
+        self.stopped = False
+        self.service = service
+        self.runtime = 0
+        self.priority = 0
+
+    @property
+    def status(self):
+        if self.is_running:
+            return "Running"
+        else:
+            return "Queued"
+
+    def is_running(self):
+        return not self.stopped
+
+    def execute(self, driver):
+        driver.home()
+        return True
+
+    def stop(self):
+        self.stopped = True
+
+    def elapsed_time(self):
+        """
+        How long is this job already running...
+        """
+        result = 0
+        return result
+
+    def estimate_time(self):
+        return 0
+
+
+class TestSpooler(unittest.TestCase):
+    def test_spoolerjob(self):
+        """
+        Test spooler job
+
+        :return:
+        """
+        kernel = bootstrap.bootstrap()
+        try:
+            kernel.device.spooler.send(TestJob(kernel.device))
+            kernel.device.spooler.clear_queue()
+            j = TestJob(kernel.device)
+            kernel.device.spooler.send(j)
+            kernel.device.spooler.remove(j)
+        finally:
+            kernel.shutdown()


### PR DESCRIPTION
Sends a job to the spooler that is not a laser job to test for the regular fail conditions for non-regular jobs.