### PR TITLE
Ruidacontrol Fixes

### DIFF
--- a/meerk40t/core/cutcode/plotcut.py
+++ b/meerk40t/core/cutcode/plotcut.py
@@ -228,19 +228,34 @@ class PlotCut(CutObject):
     def plot(self):
         x0 = None
         y0 = None
+        last_dx = 0
+        last_dy = 0
         for i in range(0, len(self._points)):
             x1, y1 = self._points[i]
             if x0 is not None:
+                current_dx = x1 - x0
+                current_dy = y1 - y0
                 power = self._powers[i - 1]
-                if self.h_raster and y1 != y0:
-                    yield x0, y0, power, x1, y0
-                    yield x1, y0, power, x1, y1
-                elif self.v_raster and x1 != x0:
-                    yield x0, y0, power, x0, y1
-                    yield x0, y1, power, x1, y1
-
+                if x1 != x0 and y1 != y0:
+                    # Raster directional step.
+                    if (
+                        (last_dx > 0) == (current_dx > 0)  # dx same direction
+                        and self.h_raster
+                        or (last_dy > 0) != (current_dy > 0)  # dy different directions
+                        and self.v_raster
+                    ):
+                        # Y-Step then X-Step.
+                        yield x0, y0, power, x0, y1
+                        yield x0, y1, power, x1, y1
+                    else:
+                        # X-Step then Y-Step
+                        yield x0, y0, power, x1, y0
+                        yield x1, y0, power, x1, y1
                 else:
+                    # Single step.
                     yield x0, y0, power, x1, y1
+                last_dx = current_dx
+                last_dy = current_dy
             x0 = x1
             y0 = y1
 

--- a/meerk40t/core/cutcode/plotcut.py
+++ b/meerk40t/core/cutcode/plotcut.py
@@ -239,9 +239,9 @@ class PlotCut(CutObject):
                 if x1 != x0 and y1 != y0:
                     # Raster directional step.
                     if (
-                        (last_dx > 0) == (current_dx > 0)  # dx same direction
+                        (last_dx > 0) != (current_dx > 0)  # dx same direction
                         and self.h_raster
-                        or (last_dy > 0) != (current_dy > 0)  # dy different directions
+                        or (last_dy > 0) == (current_dy > 0)  # dy different directions
                         and self.v_raster
                     ):
                         # Y-Step then X-Step.

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -126,6 +126,9 @@ class RuidaEmulator:
         """
         matrix = self.units_to_device_matrix
         if self.plotcut is None:
+            if self.program_mode:
+                self.x = x
+                self.y = y
             ox, oy = matrix.transform_point([self.x * UNITS_PER_uM, self.y * UNITS_PER_uM])
             self.plotcut = PlotCut(settings=dict(self.settings))
             self.plotcut.plot_init(int(round(ox)), int(round(oy)))

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -858,6 +858,10 @@ class RuidaEmulator:
                 self.filestream = None
             self.program_mode = False
             self.plot_commit()
+            try:
+                self.driver.plot_start()
+            except AttributeError:
+                pass
             desc = "End Of File"
         elif array[0] == 0xD8:
             if array[1] == 0x00:

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -126,10 +126,10 @@ class RuidaEmulator:
         """
         matrix = self.units_to_device_matrix
         if self.plotcut is None:
-            ox, oy = matrix.transform_point([self.x, self.y])
+            ox, oy = matrix.transform_point([self.x * UNITS_PER_uM, self.y * UNITS_PER_uM])
             self.plotcut = PlotCut(settings=dict(self.settings))
             self.plotcut.plot_init(int(round(ox)), int(round(oy)))
-        tx, ty = matrix.transform_point([x, y])
+        tx, ty = matrix.transform_point([x * UNITS_PER_uM, y * UNITS_PER_uM])
         self.plotcut.plot_append(int(round(tx)), int(round(ty)), power)
         if not self.program_mode:
             self.plot_commit()
@@ -403,9 +403,7 @@ class RuidaEmulator:
         elif array[0] == 0x88:  # 0b10001000 11 characters.
             self.x = self.abscoord(array[1:6])
             self.y = self.abscoord(array[6:11])
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 0
-            )
+            self.plot_location(self.x, self.y, 0)
             desc = f"Move Absolute ({self.x * UNITS_PER_uM} units, {self.y * UNITS_PER_uM} units)"
         elif array[0] == 0x89:  # 0b10001001 5 characters
             if len(array) > 1:
@@ -413,25 +411,19 @@ class RuidaEmulator:
                 dy = self.relcoord(array[3:5])
                 self.x += dx
                 self.y += dy
-                self.plot_location(
-                    int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 0
-                )
+                self.plot_location(self.x, self.y, 0)
                 desc = f"Move Relative ({dx * UNITS_PER_uM} units, {dy * UNITS_PER_uM} units)"
             else:
                 desc = "Move Relative (no coords)"
         elif array[0] == 0x8A:  # 0b10101010 3 characters
             dx = self.relcoord(array[1:3])
             self.x += dx
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 0
-            )
+            self.plot_location(self.x, self.y, 0)
             desc = f"Move Horizontal Relative ({dx * UNITS_PER_uM} units)"
         elif array[0] == 0x8B:  # 0b10101011 3 characters
             dy = self.relcoord(array[1:3])
             self.y += dy
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 0
-            )
+            self.plot_location(self.x, self.y, 0)
             desc = f"Move Vertical Relative ({dy * UNITS_PER_uM} units)"
         elif array[0] == 0x97:
             desc = "Lightburn Swizzle Modulation 97"
@@ -594,34 +586,26 @@ class RuidaEmulator:
         elif array[0] == 0xA8:  # 0b10101000 11 characters.
             self.x = self.abscoord(array[1:6])
             self.y = self.abscoord(array[6:11])
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 1
-            )
+            self.plot_location(self.x, self.y, 1)
             desc = f"Cut Absolute ({self.x * UNITS_PER_uM} units, {self.y * UNITS_PER_uM} units)"
         elif array[0] == 0xA9:  # 0b10101001 5 characters
             dx = self.relcoord(array[1:3])
             dy = self.relcoord(array[3:5])
             self.x += dx
             self.y += dy
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 1
-            )
+            self.plot_location(self.x, self.y, 1)
             desc = (
                 f"Cut Relative ({dx * UNITS_PER_uM} units, {dy * UNITS_PER_uM} units)"
             )
         elif array[0] == 0xAA:  # 0b10101010 3 characters
             dx = self.relcoord(array[1:3])
             self.x += dx
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 1
-            )
+            self.plot_location(self.x, self.y, 1)
             desc = f"Cut Horizontal Relative ({dx * UNITS_PER_uM} units)"
         elif array[0] == 0xAB:  # 0b10101011 3 characters
             dy = self.relcoord(array[1:3])
             self.y += dy
-            self.plot_location(
-                int(self.x * UNITS_PER_uM), int(self.y * UNITS_PER_uM), 1
-            )
+            self.plot_location(self.x, self.y, 0)
             desc = f"Cut Vertical Relative ({dy * UNITS_PER_uM} units)"
         elif array[0] == 0xC7:
             v0 = self.parse_power(array[1:3])  # TODO: Check command fewer values.
@@ -1082,12 +1066,12 @@ class RuidaEmulator:
                     coord = self.abscoord(array[3:8])
                     self.x += coord
                     desc = f"Move {param} X: {coord} ({self.x},{self.y})"
-                    self.plot_location(self.x * UNITS_PER_uM, self.y * UNITS_PER_uM, 0)
+                    self.plot_location(self.x, self.y, 0)
                 elif array[1] == 0x01 or array[1] == 0x51:
                     coord = self.abscoord(array[3:8])
                     self.y += coord
                     desc = f"Move {param} Y: {coord} ({self.x},{self.y})"
-                    self.plot_location(self.x * UNITS_PER_uM, self.y * UNITS_PER_uM, 0)
+                    self.plot_location(self.x, self.y, 0)
                 elif array[1] == 0x02 or array[1] == 0x52:
                     oz = self.z
                     coord = self.abscoord(array[3:8])

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -319,10 +319,10 @@ class RuidaEmulator:
 
         if checksum_check == checksum_sum:
             response = b"\xCC"
-            self.reply(response, desc="Checksum match")
+            self.msg_reply(response, desc="Checksum match")
         else:
             response = b"\xCF"
-            self.reply(
+            self.msg_reply(
                 response, desc=f"Checksum Fail ({checksum_sum} != {checksum_check})"
             )
             if self.channel:
@@ -338,7 +338,7 @@ class RuidaEmulator:
         @return: bytes to write.
         """
         self.swizzle_mode = False
-        self.reply(b"\xCC")  # Clear ACK.
+        self.msg_reply(b"\xCC")  # Clear ACK.
         self.write(BytesIO(bytes_to_write))
 
     def write(self, data):
@@ -360,7 +360,7 @@ class RuidaEmulator:
                 if self.channel:
                     self.channel(f"Crashed processing: {str(bytes(array).hex())}")
                     self.channel(str(e))
-                raise e
+                # raise RuidaCommandError from e
 
     def set_speed(self, speed):
         self.settings["speed"] = speed
@@ -1441,8 +1441,7 @@ class RuidaEmulator:
         if self.channel:
             self.channel(f"--> {str(bytes(array).hex())}\t({desc})")
         if respond is not None:
-            if self.reply:
-                self.reply(respond, desc=respond_desc)
+            self.msg_reply(respond, desc=respond_desc)
 
     def mem_lookup(self, mem) -> Tuple[str, Union[int, bytes]]:
         if mem == 0x0002:
@@ -2033,33 +2032,33 @@ class RuidaEmulator:
         if mem == 0x021F:
             return "Ring Number", 0
         if mem == 0x0221:
-            return "Axis Preferred Position 1, Pos X", self.x
+            return "Axis Preferred Position 1, Pos X", int(self.x)
         if mem == 0x0223:
             return "X Total Travel (m)", 0
         if mem == 0x0224:
             return "Position Point 0", 0
         if mem == 0x0231:
-            return "Axis Preferred Position 2, Pos Y", self.y
+            return "Axis Preferred Position 2, Pos Y", int(self.y)
         if mem == 0x0233:
             return "Y Total Travel (m)", 0
         if mem == 0x0234:
             return "Position Point 1", 0
         if mem == 0x0241:
-            return "Axis Preferred Position 3, Pos Z", self.z
+            return "Axis Preferred Position 3, Pos Z", int(self.z)
         if mem == 0x0243:
             return "Z Total Travel (m)", 0
         if mem == 0x0251:
-            return "Axis Preferred Position 4, Pos U", self.u
+            return "Axis Preferred Position 4, Pos U", int(self.u)
         if mem == 0x0253:
             return "U Total Travel (m)", 0
         if mem == 0x025A:
-            return "Axis Preferred Position 5, Pos A", self.a
+            return "Axis Preferred Position 5, Pos A", int(self.a)
         if mem == 0x025B:
-            return "Axis Preferred Position 6, Pos B", self.b
+            return "Axis Preferred Position 6, Pos B", int(self.b)
         if mem == 0x025C:
-            return "Axis Preferred Position 7, Pos C", self.c
+            return "Axis Preferred Position 7, Pos C", int(self.c)
         if mem == 0x025D:
-            return "Axis Preferred Position 8, Pos D", self.d
+            return "Axis Preferred Position 8, Pos D", int(self.d)
         if mem == 0x0260:
             return "DocumentWorkNum", 0
         if 0x0261 <= mem < 0x02C4:

--- a/meerk40t/ruida/plugin.py
+++ b/meerk40t/ruida/plugin.py
@@ -38,20 +38,13 @@ def plugin(kernel, lifecycle=None):
             action="store_true",
             help=_("shutdown current ruidaserver"),
         )
-        @kernel.console_option(
-            "laser",
-            "l",
-            type=str,
-            default=None,
-            help=_("relay commands to physical laser at the given network address"),
-        )
         @kernel.console_command(
-            ("ruidacontrol", "ruidadesign", "ruidaemulator"),
+            "ruidacontrol",
             help=_("activate the ruidaserver."),
             hidden=True,
         )
         def ruidaserver(
-            command, channel, _, laser=None, verbose=False, quit=False, **kwargs
+            command, channel, _, verbose=False, quit=False, **kwargs
         ):
             """
             The ruidaserver emulation methods provide a simulation of a ruida device.
@@ -69,40 +62,23 @@ def plugin(kernel, lifecycle=None):
             ruidabounce sends data to the ruidaemulator but sends data to the set bounce server.
             """
             root = kernel.root
-            # root.setting(bool, "developer_mode", False)
-            # if not root.developer_mode:
-            #     channel(
-            #         "Use the 0.7.x series version of ruidacontrol. This still had some bugs in it and was disabled for now."
-            #     )
-            #     return
             try:
                 r2m = root.open_as("module/UDPServer", "rd2mk", port=50200)
                 r2mj = root.open_as("module/UDPServer", "rd2mk-jog", port=50207)
-                if laser:
-                    m2l = root.open_as(
-                        "module/UDPServer",
-                        "mk2lz",
-                        port=40200,
-                        upd_address=(laser, 50200),
-                    )
-                    m2lj = root.open_as(
-                        "module/UDPServer",
-                        "mk2lz-jog",
-                        port=40207,
-                        upd_address=(laser, 50207),
-                    )
-                else:
-                    m2l = None
-                    m2lj = None
-                emulator = root.open("emulator/ruida")
+
                 if quit:
                     root.close("rd2mk")
                     root.close("rd2mk-jog")
                     root.close("mk2lz")
                     root.close("mk2lz-jog")
-                    root.close("emulator/ruida")
+                    emulator = r2m.emulator
+                    emulator.driver = None
+                    del emulator
                     channel(_("RuidaServer shutdown."))
                     return
+
+                emulator = RuidaEmulator(root.device.driver, root.device.scene_to_device_matrix())
+                r2m.emulator = emulator
                 if r2m:
                     channel(
                         _("Ruida Data Server opened on port {port}.").format(port=50200)
@@ -111,59 +87,23 @@ def plugin(kernel, lifecycle=None):
                     channel(
                         _("Ruida Jog Server opened on port {port}.").format(port=50207)
                     )
-                if m2l:
-                    channel(
-                        _("Ruida Data Destination opened on port {port}.").format(
-                            port=40200
-                        )
-                    )
-                if m2lj:
-                    channel(
-                        _("Ruida Jog Destination opened on port {port}.").format(
-                            port=40207
-                        )
-                    )
 
+                emulator.reply = root.channel("ruida_reply")
+                emulator.realtime = root.channel("ruida_reply_realtime")
+                emulator.channel = root.channel("ruida")
                 if verbose:
                     console = kernel.channel("console")
-                    chan = "ruida"
-                    root.channel(chan).watch(console)
+                    emulator.channel.watch(console)
                     if r2m:
                         r2m.events_channel.watch(console)
                     if r2mj:
                         r2mj.events_channel.watch(console)
-                    if m2l:
-                        m2l.events_channel.watch(console)
-                    if m2lj:
-                        m2lj.events_channel.watch(console)
-
                 root.channel("rd2mk/recv").watch(emulator.checksum_write)
                 root.channel("rd2mk-jog/recv").watch(emulator.realtime_write)
-                if laser:
-                    root.channel("mk2lz/recv").watch(emulator.checksum_write)
-                    root.channel("mk2lz-jog/recv").watch(emulator.realtime_write)
-
-                    root.channel("mk2lz/recv").watch("rd2mk/send")
-                    root.channel("mk2lz-jog/recv").watch("rd2mk-jog/send")
-
-                    root.channel("rd2mk/recv").watch("mk2lz/send")
-                    root.channel("rd2mk-jog/recv").watch("mk2lz-jog/send")
-                else:
-                    root.channel("ruida_reply").watch(root.channel("rd2mk/send"))
-                    root.channel("ruida_reply_realtime").watch(
-                        root.channel("rd2mk-jog/send")
-                    )
-
-                emulator.spooler = kernel.device.spooler
-                emulator.device = kernel.device
-                emulator.elements = kernel.elements
-
-                if command == "ruidadesign":
-                    emulator.design = True
-                elif command == "ruidacontrol":
-                    emulator.control = True
-                elif command == "ruidaemulator":
-                    pass
+                emulator.reply.watch(root.channel("rd2mk/send"))
+                emulator.realtime.watch(
+                    root.channel("rd2mk-jog/send")
+                )
             except OSError as e:
                 channel(_("Server failed."))
                 channel(str(e.strerror))


### PR DESCRIPTION
0.8.x required some changes to the rasters and caused some garbling of the rasters. This is an attempt to finally fix those.

1. Converts ruidaemulator to a driver-like emulator. This means that the code operates on a something that works like a driver.
2. Converts the rapid movement objects to movements at a speed. The move panel lets you do movements at a speed, this was a complaint in the older version, the speed was not respected.
3. Use plotcut more centrally as the core data structure.