### PR TITLE
Fix treatment of fill='currentColor'

### DIFF
--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -1164,13 +1164,16 @@ class SVGLoader:
             else:
                 width = None
                 height = None
+            # The color attribute of SVG.parse decides which default color
+            # a stroke / fill will get if the attribute "currentColor" is
+            # set - we opt for "black"
             svg = SVG.parse(
                 source=source,
                 reify=False,
                 width=width,
                 height=height,
                 ppi=ppi,
-                color="none",
+                color="black",
                 transform=f"scale({scale_factor})",
             )
         except ParseError as e:


### PR DESCRIPTION
Fixes treatment of files like this:
![bugreport](https://user-images.githubusercontent.com/2670784/221140099-06d2d2bc-0f12-4ae9-a1b4-7e363b7c4d42.svg)
where ``fill='currentColor'`` or ``stroke='currentColor'`` are used.
Addresses: https://github.com/meerk40t/meerk40t/discussions/1657
