### PR TITLE
Divide Emulator and Job for GRBL and Ruida

### DIFF
--- a/meerk40t/core/element_treeops.py
+++ b/meerk40t/core/element_treeops.py
@@ -1021,7 +1021,8 @@ def init_tree(kernel):
     )
     def blob_execute(node, **kwargs):
         spooler_job = self.lookup(f"spoolerjob/{node.data_type}")
-        job_object = spooler_job(self.device.driver, self.device.scene_to_show_matrix())
+        matrix = self.device.scene_to_device_matrix()
+        job_object = spooler_job(self.device.driver, matrix)
         job_object.write_blob(node.data)
         self.device.spooler.send(job_object)
 

--- a/meerk40t/core/element_treeops.py
+++ b/meerk40t/core/element_treeops.py
@@ -1011,6 +1011,20 @@ def init_tree(kernel):
             d2p.parse(node.data_type, node.data, self)
         return True
 
+    @tree_conditional_try(
+        lambda node: kernel.lookup(f"spoolerjob/{node.data_type}") is not None
+    )
+    @tree_operation(
+        _("Execute Blob"),
+        node_type="blob",
+        help=_("Run the given blob on the current device"),
+    )
+    def blob_execute(node, **kwargs):
+        spooler_job = self.lookup(f"spoolerjob/{node.data_type}")
+        job_object = spooler_job(self.device.driver, self.device.scene_to_show_matrix())
+        job_object.write_blob(node.data)
+        self.device.spooler.send(job_object)
+
     @tree_conditional_try(lambda node: hasattr(node, "as_cutobjects"))
     @tree_operation(
         _("Convert to Cutcode"),

--- a/meerk40t/core/element_treeops.py
+++ b/meerk40t/core/element_treeops.py
@@ -972,7 +972,7 @@ def init_tree(kernel):
         node.replace_node(CutCode.from_lasercode(node.commands), type="cutcode")
 
     @tree_conditional_try(
-        lambda node: kernel.lookup(f"emulator/{node.data_type}") is not None
+        lambda node: kernel.lookup(f"spoolerjob/{node.data_type}") is not None
     )
     @tree_operation(
         _("Convert to Elements"),

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -371,6 +371,71 @@ def plugin(kernel, lifecycle):
             return "spooler", spooler
 
 
+class SpoolerJob:
+    """
+    Example of Spooler Job.
+
+    The primary methodology of a spoolerjob is that it has an `execute` function that takes the driver as an argument
+    it should then perform driver-like commands on the given driver to perform whatever actions the job should
+    execute.
+
+    The `priority` attribute is required.
+
+    The job should be permitted to `stop()` and respond to `is_running()`, and other checks as to elapsed_time(),
+    estimate_time(), and status.
+    """
+    def __init__(
+        self,
+        service,
+    ):
+        self.stopped = False
+        self.service = service
+        self.runtime = 0
+        self.priority = 0
+
+    @property
+    def status(self):
+        """
+        Status is simply a status as to the job. This will be relayed by things that check the job status of jobs
+        in the spooler.
+
+        @return:
+        """
+        if self.is_running:
+            return "Running"
+        else:
+            return "Queued"
+
+    def execute(self, driver):
+        """
+        This is the primary method of the SpoolerJob. In this example we call the "home()" function.
+        @param driver:
+        @return:
+        """
+        try:
+            driver.home()
+        except AttributeError:
+            pass
+
+        return True
+
+    def stop(self):
+        self.stopped = True
+
+    def is_running(self):
+        return not self.stopped
+
+    def elapsed_time(self):
+        """
+        How long is this job already running...
+        """
+        result = 0
+        return result
+
+    def estimate_time(self):
+        return 0
+
+
 class Spooler:
     """
     Spoolers store spoolable events in a two synchronous queue, and a single idle job that

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -617,15 +617,20 @@ class Spooler:
             self._lock.notify()
         self.context.signal("spooler;queue", len(self._queue))
 
-    def send(self, job):
+    def send(self, job, prevent_duplicate=False):
         """
         Send a job to the spooler queue
 
         @param job: job to send to the spooler.
+        @param prevent_duplicate: prevents the same job from being added again.
         @return:
         """
         job.uid = self.context.logging.uid("job")
         with self._lock:
+            if prevent_duplicate:
+                for q in self._queue:
+                    if q is job:
+                        return
             self._stop_lower_priority_running_jobs(job.priority)
             self._queue.append(job)
             self._queue.sort(key=lambda e: e.priority, reverse=True)

--- a/meerk40t/grbl/control.py
+++ b/meerk40t/grbl/control.py
@@ -58,7 +58,7 @@ class GRBLControl:
                 server.events_channel.watch(console)
 
             emulator = GRBLEmulator(
-                root.device.driver, root.device.scene_to_device_matrix()
+                root.device, root.device.scene_to_device_matrix()
             )
             self.emulator = emulator
 

--- a/meerk40t/grbl/emulator.py
+++ b/meerk40t/grbl/emulator.py
@@ -134,7 +134,6 @@ class GRBLEmulator:
 
         self._buffer = list()
         self.job = GcodeJob(
-            "grbl-emulator",
             driver=driver,
             priority=0,
             channel=self.channel,

--- a/meerk40t/grbl/emulator.py
+++ b/meerk40t/grbl/emulator.py
@@ -3,48 +3,11 @@ GRBL Emulator
 
 The GRBL Emulator converts our parsed Grbl/Gcode data into Driver-like calls.
 """
-
 import re
 
-from meerk40t.core.cutcode.plotcut import PlotCut
-from meerk40t.core.cutcode.waitcut import WaitCut
-from meerk40t.core.units import UNITS_PER_INCH, UNITS_PER_MM
-from meerk40t.svgelements import Arc
+from meerk40t.grbl.gcodejob import GcodeJob
 
 GRBL_SET_RE = re.compile(r"\$(\d+)=([-+]?[0-9]*\.?[0-9]*)")
-CODE_RE = re.compile(r"([A-Za-z])")
-FLOAT_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]*")
-
-
-def _tokenize_code(code_line):
-    pos = code_line.find("(")
-    while pos != -1:
-        end = code_line.find(")")
-        yield ["comment", code_line[pos + 1 : end]]
-        code_line = code_line[:pos] + code_line[end + 1 :]
-        pos = code_line.find("(")
-    pos = code_line.find(";")
-    if pos != -1:
-        yield ["comment", code_line[pos + 1 :]]
-        code_line = code_line[:pos]
-
-    code = None
-    for x in CODE_RE.split(code_line):
-        x = x.strip()
-        if len(x) == 0:
-            continue
-        if len(x) == 1 and x.isalpha():
-            if code is not None:
-                yield code
-            code = [x.lower()]
-            continue
-        if code is not None:
-            code.extend([float(v) for v in FLOAT_RE.findall(x) if len(v) != 0])
-            yield code
-        code = None
-    if code is not None:
-        yield code
-
 
 step_pulse_microseconds = 0
 step_idle_delay = 25
@@ -120,7 +83,7 @@ lookup = {
 
 
 class GRBLEmulator:
-    def __init__(self, driver, units_to_device_matrix):
+    def __init__(self, driver=None, units_to_device_matrix=None):
         self.driver = driver
         self.units_to_device_matrix = units_to_device_matrix
         self.settings = {
@@ -158,53 +121,44 @@ class GRBLEmulator:
             "x_axis_max_travel": 200.000,  # X-axis max travel mm.
             "y_axis_max_travel": 200.000,  # Y-axis max travel mm
             "z_axis_max_travel": 200.000,  # Z-axis max travel mm.
-            "speed": 0,
-            "power": 0,
         }
-
-        self.compensation = False
-        self.feed_convert = None
-        self.feed_invert = None
 
         self.speed_scale = 1.0
         self.rapid_scale = 1.0
         self.power_scale = 1.0
-        self.move_mode = 0
-        self.x = 0
-        self.y = 0
-        self.z = 0
-
-        # Initially assume mm mode. G21 mm DEFAULT
-        self.scale = UNITS_PER_MM
-
-        # G94 feedrate default, mm mode
-        self.g94_feedrate()
-
-        # G90 default.
-        self.relative = False
 
         self.reply = None
         self.channel = None
 
-        self._buffer = list()
         self._grbl_specific = False
-        self._interpolate = 50
-        self.program_mode = False
-        self.plotcut = None
+
+        self._buffer = list()
+        self.job = GcodeJob(
+            "grbl-emulator",
+            driver=driver,
+            priority=0,
+            channel=self.channel,
+            units_to_device_matrix=units_to_device_matrix,
+        )
 
     def __repr__(self):
         return "GRBLInterpreter()"
 
-    def grbl_write(self, data):
-        if self.reply:
-            self.reply(data)
+    def reply_code(self, cmd):
+        if cmd == 0:  # Execute GCode.
+            if self.reply:
+                self.reply("ok\r\n")
+        else:
+            if self.reply:
+                self.reply(f"error:{cmd}\r\n")
 
     def status_update(self):
+        # TODO: This should reference only the driver.status.
         # Idle, Run, Hold, Jog, Alarm, Door, Check, Home, Sleep
         pos, state, minor = self.driver.status()
         x, y = self.units_to_device_matrix.point_in_inverse_space(pos)
-        x /= self.scale
-        y /= self.scale
+        x /= self.job.scale
+        y /= self.job.scale
         z = 0.0
         self.x = x
         self.y = y
@@ -215,8 +169,8 @@ class GRBLEmulator:
             state = "Hold"
         else:
             state = "Idle"
-        f = self.feed_invert(self.settings.get("speed", 0))
-        s = self.settings.get("power", 0)
+        f = self.job.feed_invert(self.job.speed)
+        s = self.job.power
         return f"<{state}|MPos:{x:.3f},{y:.3f},{z:.3f}|FS:{f},{s}>\r\n"
 
     def write(self, data):
@@ -232,7 +186,8 @@ class GRBLEmulator:
         for c in data:
             # Process and extract any realtime grbl commands.
             if c == ord("?"):
-                self.grbl_write(self.status_update())
+                if self.reply:
+                    self.reply(self.status_update())
             elif c == ord("~"):
                 try:
                     self.driver.resume()
@@ -248,14 +203,12 @@ class GRBLEmulator:
                 line = "".join(self._buffer)
                 if self._grbl_specific:
                     self._grbl_specific = False
-                    cmd = self._grbl_special(line)
+                    self.reply_code(self._grbl_special(line))
                 else:
-                    cmd = self._process_gcode(line)
+                    self.driver.spooler.job(self.job)
+                    self.job.reply = self.reply
+                    self.job.write(line)
                 self._buffer.clear()
-                if cmd == 0:  # Execute GCode.
-                    self.grbl_write("ok\r\n")
-                else:
-                    self.grbl_write("error:%d\r\n" % cmd)
             elif c == 0x08:
                 # Process Backspaces.
                 if self._buffer:
@@ -377,17 +330,20 @@ class GRBLEmulator:
         @return:
         """
         if data == "$":
-            self.grbl_write(
-                "[HLP:$$ $# $G $I $N $x=val $Nx=line $J=line $SLP $C $X $H ~ ! ? ctrl-x]\r\n"
-            )
+            if self.reply:
+                self.reply(
+                    "[HLP:$$ $# $G $I $N $x=val $Nx=line $J=line $SLP $C $X $H ~ ! ? ctrl-x]\r\n"
+                )
             return 0
         elif data == "$$":
             for s in lookup:
                 v = self.settings.get(lookup[s], 0)
                 if isinstance(v, int):
-                    self.grbl_write("$%d=%d\r\n" % (s, v))
+                    if self.reply:
+                        self.reply("$%d=%d\r\n" % (s, v))
                 elif isinstance(v, float):
-                    self.grbl_write("$%d=%.3f\r\n" % (s, v))
+                    if self.reply:
+                        self.reply("$%d=%.3f\r\n" % (s, v))
             return 0
         if GRBL_SET_RE.match(data):
             settings = list(GRBL_SET_RE.findall(data))[0]
@@ -486,430 +442,3 @@ class GRBLEmulator:
             return 3  # not yet supported
         else:
             return 3  # GRBL '$' system command was not recognized or supported.
-
-    def _process_gcode(self, data, jog=False):
-        """
-        Processes the gcode commands which are parsed into different dictionary objects.
-
-        @param data: gcode line to process
-        @param jog: indicate this gcode line is operated as a jog.
-        @return:
-        """
-        gc = {}
-        for c in _tokenize_code(data):
-            g = c[0]
-            if g not in gc:
-                gc[g] = []
-            if len(c) >= 2:
-                gc[g].append(c[1])
-            else:
-                gc[g].append(None)
-        if "m" in gc:
-            for v in gc["m"]:
-                if v in (0, 1):
-                    # Stop or Unconditional Stop
-                    try:
-                        self.driver.rapid_mode()
-                    except AttributeError:
-                        pass
-                elif v == 2:
-                    # Program End
-                    try:
-                        self.driver.plot_start()
-                    except AttributeError:
-                        pass
-                    try:
-                        self.driver.rapid_mode()
-                    except AttributeError:
-                        pass
-                    return 0
-                elif v == 30:
-                    # Program Stop
-                    try:
-                        self.driver.rapid_mode()
-                    except AttributeError:
-                        pass
-                    return 0
-                elif v in (3, 4):
-                    # Spindle On - Clockwise/CCW Laser Mode
-                    self.program_mode = True
-                elif v == 5:
-                    # Spindle Off - Laser Mode
-                    if self.program_mode:
-                        try:
-                            self.plot_commit()
-                            self.driver.plot_start()
-                        except AttributeError:
-                            pass
-                    try:
-                        self.driver.rapid_mode()
-                    except AttributeError:
-                        pass
-                    self.program_mode = False
-                elif v == 7:
-                    #  Mist coolant control.
-                    pass
-                elif v == 8:
-                    # Flood coolant On
-                    try:
-                        self.driver.signal("coolant", True)
-                    except AttributeError:
-                        pass
-                elif v == 9:
-                    # Flood coolant Off
-                    try:
-                        self.driver.signal("coolant", False)
-                    except AttributeError:
-                        pass
-                elif v == 56:
-                    pass  # Parking motion override control.
-                elif v == 911:
-                    pass  # Set TMC2130 holding currents
-                elif v == 912:
-                    pass  # M912: Set TMC2130 running currents
-                else:
-                    return 20
-            del gc["m"]
-        if "g" in gc:
-            for v in gc["g"]:
-                if v is None:
-                    return 2
-                elif v == 0:
-                    # G0 Rapid Move.
-                    self.move_mode = 0
-                elif v == 1:
-                    # G1 Cut Move.
-                    self.move_mode = 1
-                elif v == 2:
-                    # G2 CW_ARC
-                    self.move_mode = 2
-                elif v == 3:
-                    # G3 CCW_ARC
-                    self.move_mode = 3
-                elif v == 4:
-                    # DWELL
-                    t = 0
-                    if "p" in gc:
-                        t = float(gc["p"].pop()) / 1000.0
-                        if len(gc["p"]) == 0:
-                            del gc["p"]
-                    if "s" in gc:
-                        t = float(gc["s"].pop())
-                        if len(gc["s"]) == 0:
-                            del gc["s"]
-                    if self.program_mode:
-                        self.plot_commit()
-                        self.plot(WaitCut(t))
-                    else:
-                        try:
-                            self.driver.wait(t)
-                        except AttributeError:
-                            pass
-                elif v == 17:
-                    # Set XY coords.
-                    pass
-                elif v == 18:
-                    # Set the XZ plane for arc.
-                    return 2
-                elif v == 19:
-                    # Set the YZ plane for arc.
-                    return 2
-                elif v in (20, 70):
-                    # g20 is inch mode.
-                    self.scale = UNITS_PER_INCH
-                elif v in (21, 71):
-                    # g21 is mm mode. 39.3701 mils in a mm
-                    self.scale = UNITS_PER_MM
-                elif v == 28:
-                    # Move to Origin (Home)
-                    try:
-                        self.driver.home()
-                    except AttributeError:
-                        pass
-                    try:
-                        self.driver.move_abs(0, 0)
-                    except AttributeError:
-                        pass
-                    self.x = 0
-                    self.y = 0
-                    self.z = 0
-                elif v == 38.1:
-                    # Touch Plate
-                    pass
-                elif v == 38.2:
-                    # Probe towards workpiece, stop on contact. Signal error.
-                    pass
-                elif v == 38.3:
-                    # Probe towards workpiece, stop on contact.
-                    pass
-                elif v == 38.4:
-                    # Probe away from workpiece, signal error
-                    pass
-                elif v == 38.5:
-                    # Probe away from workpiece.
-                    pass
-                elif v == 40.0:
-                    # Compensation Off
-                    self.compensation = False
-                elif v == 43.1:
-                    pass  # Dynamic tool Length offsets
-                elif v == 49:
-                    # Cancel tool offset.
-                    pass  # Dynamic tool length offsets
-                elif v == 53:
-                    # Absolute movement non-modal command.
-                    pass
-                elif 54 <= v <= 59:
-                    # Coord System Select
-                    pass  # Work Coordinate Systems
-                elif v == 61:
-                    # Exact path control mode. GRBL required
-                    pass
-                elif v == 80:
-                    # Motion mode cancel. Canned cycle.
-                    pass
-                elif v == 90:
-                    # Set to Absolute Positioning
-                    self.relative = False
-                elif v == 91:
-                    # Set to Relative Positioning
-                    self.relative = True
-                elif v == 92:
-                    # Set Position.
-                    # Change the current coords without moving.
-                    pass  # Coordinate Offset TODO: Implement
-                elif v == 92.1:
-                    # Clear Coordinate offset set by 92.
-                    pass  # Clear Coordinate offset TODO: Implement
-                elif v == 93:
-                    # Feed Rate Mode (Inverse Time Mode)
-                    self.g93_feedrate()
-                elif v == 94:
-                    # Feed Rate Mode (Units Per Minute)
-                    self.g94_feedrate()
-                else:
-                    return 20  # Unsupported or invalid g-code command found in block.
-            del gc["g"]
-
-        if "comment" in gc:
-            if self.channel:
-                self.channel(f'Comment: {gc["comment"]}')
-            del gc["comment"]
-
-        if "f" in gc:  # Feed_rate
-            for v in gc["f"]:
-                if v is None:
-                    return 2  # Numeric value format is not valid or missing an expected value.
-                feed_rate = self.feed_convert(v)
-                if self.settings.get("speed", 0) != feed_rate:
-                    self.settings["speed"] = feed_rate
-                    try:
-                        self.driver.set("speed", v)
-                    except AttributeError:
-                        pass
-                    self.plot_commit()  # Speed change means plot change
-            del gc["f"]
-        if "s" in gc:
-            for v in gc["s"]:
-                if v is None:
-                    return 2  # Numeric value format is not valid or missing an expected value.
-                if 0.0 < v <= 1.0:
-                    v *= 1000  # numbers between 0-1 are taken to be in range 0-1.
-                if self.settings["power"] != v:
-                    try:
-                        self.driver.set("power", v)
-                    except AttributeError:
-                        pass
-                    self.settings["power"] = v
-            del gc["s"]
-        if "z" in gc:
-            oz = self.z
-            v = gc["z"].pop(0)
-            if v is None:
-                z = 0
-            else:
-                z = self.scale * v
-            if len(gc["z"]) == 0:
-                del gc["z"]
-            self.z = z
-            if oz != self.z:
-                try:
-                    self.plot_commit()  # We plot commit on z level change
-                    self.driver.axis("z", self.z)
-                except AttributeError:
-                    pass
-
-        if (
-            "x" in gc
-            or "y" in gc
-            or ("i" in gc or "j" in gc and self.move_mode in (2, 3))
-        ):
-            ox = self.x
-            oy = self.y
-            if "x" in gc:
-                x = gc["x"].pop(0)
-                if x is None:
-                    x = 0
-                else:
-                    x *= self.scale
-                if len(gc["x"]) == 0:
-                    del gc["x"]
-            else:
-                if self.relative:
-                    x = 0
-                else:
-                    x = self.x
-            if "y" in gc:
-                y = gc["y"].pop(0)
-                if y is None:
-                    y = 0
-                else:
-                    y *= self.scale
-                if len(gc["y"]) == 0:
-                    del gc["y"]
-            else:
-                if self.relative:
-                    y = 0
-                else:
-                    y = self.y
-
-            if self.relative:
-                nx = self.x + x
-                ny = self.y + y
-            else:
-                nx = x
-                ny = y
-            if self.move_mode == 0:
-                self.plot_commit()
-                if self.program_mode:
-                    self.plot_location(nx, ny, 0)
-                else:
-                    try:
-                        self.driver.move_abs(nx, ny)
-                        self.x = nx
-                        self.y = ny
-                    except AttributeError:
-                        pass
-            elif self.move_mode == 1:
-                self.plot_location(nx, ny, self.settings["power"])
-            elif self.move_mode in (2, 3):
-                # 2 = CW ARC
-                # 3 = CCW ARC
-
-                cx = ox
-                cy = oy
-                if "i" in gc:
-                    ix = gc["i"].pop(0)  # * self.scale
-                    cx += ix
-                if "j" in gc:
-                    jy = gc["j"].pop(0)  # * self.scale
-                    cy += jy
-                if "r" in gc:
-                    # Strictly speaking this uses the R parameter, but that wasn't coded.
-                    arc = Arc(
-                        start=(ox, oy),
-                        center=(cx, cy),
-                        end=(nx, ny),
-                        ccw=self.move_mode == 3,
-                    )
-                    power = self.settings["power"]
-                    for p in range(self._interpolate + 1):
-                        x, y = arc.point(p / self._interpolate)
-                        self.plot_location(x, y, power)
-                else:
-                    arc = Arc(
-                        start=(ox, oy),
-                        center=(cx, cy),
-                        end=(nx, ny),
-                        ccw=self.move_mode == 3,
-                    )
-                    power = self.settings["power"]
-                    for p in range(self._interpolate + 1):
-                        x, y = arc.point(p / self._interpolate)
-                        self.plot_location(x, y, power)
-        return 0
-
-    def plot_location(self, x, y, power):
-        """
-        Adds this particular location to the current plotcut.
-
-        Or, starts a new plotcut if one is not already started.
-
-        First plotcut is a 0-power move to the current position. X and Y are set to plotted location
-
-        @param x:
-        @param y:
-        @param power:
-        @return:
-        """
-        matrix = self.units_to_device_matrix
-        if self.plotcut is None:
-            ox, oy = matrix.transform_point([self.x, self.y])
-            self.plotcut = PlotCut(settings=dict(self.settings))
-            self.plotcut.plot_init(int(round(ox)), int(round(oy)))
-        tx, ty = matrix.transform_point([x, y])
-        self.plotcut.plot_append(int(round(tx)), int(round(ty)), power)
-        if not self.program_mode:
-            self.plot_commit()
-        self.x = x
-        self.y = y
-
-    def plot_commit(self):
-        """
-        Force commits the old plotcut and unsets the current plotcut.
-
-        @return:
-        """
-        if self.plotcut is None:
-            return
-        self.plot(self.plotcut)
-        self.plotcut = None
-
-    def plot(self, plot):
-        try:
-            self.driver.plot(plot)
-        except AttributeError:
-            pass
-        if not self.program_mode:
-            # If we plotted this, and we aren't in program mode execute all of these commands right away
-            try:
-                self.driver.plot_start()
-            except AttributeError:
-                pass
-
-    def g93_feedrate(self):
-        """
-        Feed Rate in Minutes / Unit
-        G93 - is Inverse Time Mode. In inverse time feed rate mode, an F word means the move
-        should be completed in [one divided by the F number] minutes. For example, if the
-        F number is 2.0, the move should be completed in half a minute.
-        When the inverse time feed rate mode is active, an F word must appear on every line
-        which has a G1, G2, or G3 motion, and an F word on a line that does not have
-        G1, G2, or G3 is ignored. Being in inverse time feed rate mode does not
-        affect G0 (rapid move) motions.
-        @return:
-        """
-
-        if self.scale == UNITS_PER_INCH:
-            self.feed_convert = lambda s: (60.0 * self.scale / UNITS_PER_INCH) / s
-            self.feed_invert = lambda s: (60.0 * UNITS_PER_INCH / self.scale) / s
-        else:
-            self.feed_convert = lambda s: (60.0 * self.scale / UNITS_PER_MM) / s
-            self.feed_invert = lambda s: (60.0 * UNITS_PER_MM / self.scale) / s
-
-    def g94_feedrate(self):
-        """
-        Feed Rate in Units / Minute
-        G94 - is Units per Minute Mode. In units per minute feed mode, an F word is interpreted
-        to mean the controlled point should move at a certain number of inches per minute,
-        millimeters per minute, or degrees per minute, depending upon what length units
-        are being used and which axis or axes are moving.
-        @return:
-        """
-
-        if self.scale == UNITS_PER_INCH:
-            self.feed_convert = lambda s: s / ((self.scale / UNITS_PER_INCH) * 60.0)
-            self.feed_invert = lambda s: s * ((self.scale / UNITS_PER_INCH) * 60.0)
-        else:
-            self.feed_convert = lambda s: s / ((self.scale / UNITS_PER_MM) * 60.0)
-            self.feed_invert = lambda s: s * ((self.scale / UNITS_PER_MM) * 60.0)

--- a/meerk40t/grbl/gcodejob.py
+++ b/meerk40t/grbl/gcodejob.py
@@ -1,0 +1,591 @@
+import threading
+import time
+from typing import re
+
+from meerk40t.core.cutcode.plotcut import PlotCut
+from meerk40t.core.cutcode.waitcut import WaitCut
+from meerk40t.core.units import UNITS_PER_MM, UNITS_PER_INCH
+from meerk40t.svgelements import Arc
+
+CODE_RE = re.compile(r"([A-Za-z])")
+FLOAT_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]*")
+
+
+def _tokenize_code(code_line):
+    pos = code_line.find("(")
+    while pos != -1:
+        end = code_line.find(")")
+        yield ["comment", code_line[pos + 1 : end]]
+        code_line = code_line[:pos] + code_line[end + 1 :]
+        pos = code_line.find("(")
+    pos = code_line.find(";")
+    if pos != -1:
+        yield ["comment", code_line[pos + 1 :]]
+        code_line = code_line[:pos]
+
+    code = None
+    for x in CODE_RE.split(code_line):
+        x = x.strip()
+        if len(x) == 0:
+            continue
+        if len(x) == 1 and x.isalpha():
+            if code is not None:
+                yield code
+            code = [x.lower()]
+            continue
+        if code is not None:
+            code.extend([float(v) for v in FLOAT_RE.findall(x) if len(v) != 0])
+            yield code
+        code = None
+    if code is not None:
+        yield code
+
+
+class GcodeJob:
+    def __init__(self, label, driver=None, priority=0, channel=None, units_to_device_matrix=None):
+        self.units_to_device_matrix = units_to_device_matrix
+        self.label = label
+        self._driver = driver
+        self.channel = channel
+        self.reply = None
+        self.buffer = list()
+
+        self.priority = priority
+
+        self.time_submitted = time.time()
+        self.time_started = None
+        self.runtime = 0
+
+        self._stopped = True
+        self._estimate = 0
+
+        # G94 feedrate default, mm mode
+        self.g94_feedrate()
+
+        # Initially assume mm mode. G21 mm DEFAULT
+        self.scale = UNITS_PER_MM
+
+        # G90 default.
+        self.relative = False
+
+        self.compensation = False
+        self.feed_convert = None
+        self.feed_invert = None
+        self._interpolate = 50
+        self.program_mode = False
+        self.plotcut = None
+
+        self.speed = None
+        self.power = None
+
+        self.move_mode = 0
+        self.x = 0
+        self.y = 0
+        self.z = 0
+
+        self.lock = threading.Lock
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.label}"
+
+    @property
+    def status(self):
+        if self.is_running and self.time_started is not None:
+            return "Running"
+        elif not self.is_running:
+            return "Disabled"
+        else:
+            return "Queued"
+
+    def reply_code(self, cmd):
+        if cmd == 0:  # Execute GCode.
+            if self.reply:
+                self.reply("ok\r\n")
+        else:
+            if self.reply:
+                self.reply(f"error:{cmd}\r\n")
+
+    def write(self, line):
+        with self.lock:
+            self.buffer.append(line)
+
+    def write_all(self, lines):
+        with self.lock:
+            self.buffer.extend(lines)
+
+    def execute(self, driver=None):
+        """
+        Execute calls each item in the list of items in order. This is intended to be called by the spooler thread. And
+        hold the spooler while these items are executing.
+        @return:
+        """
+        self._stopped = False
+        if self.time_started is None:
+            self.time_started = time.time()
+        with self.lock:
+            line = self.buffer.pop(0)
+        cmd = self._process_gcode(line)
+        self.reply_code(cmd)
+        if not self.buffer:
+            # Buffer is empty now. Job is complete
+            self.runtime += time.time() - self.time_started
+            self._stopped = True
+            return True  # All steps were executed.
+        return False
+
+    def stop(self):
+        """
+        Stop this current laser-job, cannot be called from the spooler thread.
+        @return:
+        """
+        if not self._stopped:
+            self.runtime += time.time() - self.time_started
+        self._stopped = True
+
+    def is_running(self):
+        return not self._stopped
+
+    def elapsed_time(self):
+        """
+        How long is this job already running...
+        """
+        result = 0
+        if self.is_running():
+            result = time.time() - self.time_started
+        else:
+            result = self.runtime
+        return result
+
+    def estimate_time(self):
+        """
+        Give laser job time estimate.
+        @return:
+        """
+        return self._estimate
+
+    def _process_gcode(self, data, jog=False):
+        """
+        Processes the gcode commands which are parsed into different dictionary objects.
+
+        @param data: gcode line to process
+        @param jog: indicate this gcode line is operated as a jog.
+        @return:
+        """
+        gc = {}
+        for c in _tokenize_code(data):
+            g = c[0]
+            if g not in gc:
+                gc[g] = []
+            if len(c) >= 2:
+                gc[g].append(c[1])
+            else:
+                gc[g].append(None)
+        if "m" in gc:
+            for v in gc["m"]:
+                if v in (0, 1):
+                    # Stop or Unconditional Stop
+                    try:
+                        self._driver.rapid_mode()
+                    except AttributeError:
+                        pass
+                elif v == 2:
+                    # Program End
+                    try:
+                        self._driver.plot_start()
+                    except AttributeError:
+                        pass
+                    try:
+                        self._driver.rapid_mode()
+                    except AttributeError:
+                        pass
+                    return 0
+                elif v == 30:
+                    # Program Stop
+                    try:
+                        self._driver.rapid_mode()
+                    except AttributeError:
+                        pass
+                    return 0
+                elif v in (3, 4):
+                    # Spindle On - Clockwise/CCW Laser Mode
+                    self.program_mode = True
+                elif v == 5:
+                    # Spindle Off - Laser Mode
+                    if self.program_mode:
+                        try:
+                            self.plot_commit()
+                            self._driver.plot_start()
+                        except AttributeError:
+                            pass
+                    try:
+                        self._driver.rapid_mode()
+                    except AttributeError:
+                        pass
+                    self.program_mode = False
+                elif v == 7:
+                    #  Mist coolant control.
+                    pass
+                elif v == 8:
+                    # Flood coolant On
+                    try:
+                        self._driver.signal("coolant", True)
+                    except AttributeError:
+                        pass
+                elif v == 9:
+                    # Flood coolant Off
+                    try:
+                        self._driver.signal("coolant", False)
+                    except AttributeError:
+                        pass
+                elif v == 56:
+                    pass  # Parking motion override control.
+                elif v == 911:
+                    pass  # Set TMC2130 holding currents
+                elif v == 912:
+                    pass  # M912: Set TMC2130 running currents
+                else:
+                    return 20
+            del gc["m"]
+        if "g" in gc:
+            for v in gc["g"]:
+                if v is None:
+                    return 2
+                elif v == 0:
+                    # G0 Rapid Move.
+                    self.move_mode = 0
+                elif v == 1:
+                    # G1 Cut Move.
+                    self.move_mode = 1
+                elif v == 2:
+                    # G2 CW_ARC
+                    self.move_mode = 2
+                elif v == 3:
+                    # G3 CCW_ARC
+                    self.move_mode = 3
+                elif v == 4:
+                    # DWELL
+                    t = 0
+                    if "p" in gc:
+                        t = float(gc["p"].pop()) / 1000.0
+                        if len(gc["p"]) == 0:
+                            del gc["p"]
+                    if "s" in gc:
+                        t = float(gc["s"].pop())
+                        if len(gc["s"]) == 0:
+                            del gc["s"]
+                    if self.program_mode:
+                        self.plot_commit()
+                        self.plot(WaitCut(t))
+                    else:
+                        try:
+                            self._driver.wait(t)
+                        except AttributeError:
+                            pass
+                elif v == 17:
+                    # Set XY coords.
+                    pass
+                elif v == 18:
+                    # Set the XZ plane for arc.
+                    return 2
+                elif v == 19:
+                    # Set the YZ plane for arc.
+                    return 2
+                elif v in (20, 70):
+                    # g20 is inch mode.
+                    self.scale = UNITS_PER_INCH
+                elif v in (21, 71):
+                    # g21 is mm mode. 39.3701 mils in a mm
+                    self.scale = UNITS_PER_MM
+                elif v == 28:
+                    # Move to Origin (Home)
+                    try:
+                        self._driver.home()
+                    except AttributeError:
+                        pass
+                    try:
+                        self._driver.move_abs(0, 0)
+                    except AttributeError:
+                        pass
+                    self.x = 0
+                    self.y = 0
+                    self.z = 0
+                elif v == 38.1:
+                    # Touch Plate
+                    pass
+                elif v == 38.2:
+                    # Probe towards workpiece, stop on contact. Signal error.
+                    pass
+                elif v == 38.3:
+                    # Probe towards workpiece, stop on contact.
+                    pass
+                elif v == 38.4:
+                    # Probe away from workpiece, signal error
+                    pass
+                elif v == 38.5:
+                    # Probe away from workpiece.
+                    pass
+                elif v == 40.0:
+                    # Compensation Off
+                    self.compensation = False
+                elif v == 43.1:
+                    pass  # Dynamic tool Length offsets
+                elif v == 49:
+                    # Cancel tool offset.
+                    pass  # Dynamic tool length offsets
+                elif v == 53:
+                    # Absolute movement non-modal command.
+                    pass
+                elif 54 <= v <= 59:
+                    # Coord System Select
+                    pass  # Work Coordinate Systems
+                elif v == 61:
+                    # Exact path control mode. GRBL required
+                    pass
+                elif v == 80:
+                    # Motion mode cancel. Canned cycle.
+                    pass
+                elif v == 90:
+                    # Set to Absolute Positioning
+                    self.relative = False
+                elif v == 91:
+                    # Set to Relative Positioning
+                    self.relative = True
+                elif v == 92:
+                    # Set Position.
+                    # Change the current coords without moving.
+                    pass  # Coordinate Offset TODO: Implement
+                elif v == 92.1:
+                    # Clear Coordinate offset set by 92.
+                    pass  # Clear Coordinate offset TODO: Implement
+                elif v == 93:
+                    # Feed Rate Mode (Inverse Time Mode)
+                    self.g93_feedrate()
+                elif v == 94:
+                    # Feed Rate Mode (Units Per Minute)
+                    self.g94_feedrate()
+                else:
+                    return 20  # Unsupported or invalid g-code command found in block.
+            del gc["g"]
+
+        if "comment" in gc:
+            if self.channel:
+                self.channel(f'Comment: {gc["comment"]}')
+            del gc["comment"]
+
+        if "f" in gc:  # Feed_rate
+            for v in gc["f"]:
+                if v is None:
+                    return 2  # Numeric value format is not valid or missing an expected value.
+                feed_rate = self.feed_convert(v)
+                if self.speed != feed_rate:
+                    self.speed = feed_rate
+                    try:
+                        self._driver.set("speed", v)
+                    except AttributeError:
+                        pass
+                    self.plot_commit()  # Speed change means plot change
+            del gc["f"]
+        if "s" in gc:
+            for v in gc["s"]:
+                if v is None:
+                    return 2  # Numeric value format is not valid or missing an expected value.
+                if 0.0 < v <= 1.0:
+                    v *= 1000  # numbers between 0-1 are taken to be in range 0-1.
+                if self.power != v:
+                    try:
+                        self._driver.set("power", v)
+                    except AttributeError:
+                        pass
+                    self.power = v
+            del gc["s"]
+        if "z" in gc:
+            oz = self.z
+            v = gc["z"].pop(0)
+            if v is None:
+                z = 0
+            else:
+                z = self.scale * v
+            if len(gc["z"]) == 0:
+                del gc["z"]
+            self.z = z
+            if oz != self.z:
+                try:
+                    self.plot_commit()  # We plot commit on z level change
+                    self._driver.axis("z", self.z)
+                except AttributeError:
+                    pass
+
+        if (
+            "x" in gc
+            or "y" in gc
+            or ("i" in gc or "j" in gc and self.move_mode in (2, 3))
+        ):
+            ox = self.x
+            oy = self.y
+            if "x" in gc:
+                x = gc["x"].pop(0)
+                if x is None:
+                    x = 0
+                else:
+                    x *= self.scale
+                if len(gc["x"]) == 0:
+                    del gc["x"]
+            else:
+                if self.relative:
+                    x = 0
+                else:
+                    x = self.x
+            if "y" in gc:
+                y = gc["y"].pop(0)
+                if y is None:
+                    y = 0
+                else:
+                    y *= self.scale
+                if len(gc["y"]) == 0:
+                    del gc["y"]
+            else:
+                if self.relative:
+                    y = 0
+                else:
+                    y = self.y
+
+            if self.relative:
+                nx = self.x + x
+                ny = self.y + y
+            else:
+                nx = x
+                ny = y
+            if self.move_mode == 0:
+                self.plot_commit()
+                if self.program_mode:
+                    self.plot_location(nx, ny, 0)
+                else:
+                    try:
+                        self._driver.move_abs(nx, ny)
+                        self.x = nx
+                        self.y = ny
+                    except AttributeError:
+                        pass
+            elif self.move_mode == 1:
+                self.plot_location(nx, ny, self.power)
+            elif self.move_mode in (2, 3):
+                # 2 = CW ARC
+                # 3 = CCW ARC
+
+                cx = ox
+                cy = oy
+                if "i" in gc:
+                    ix = gc["i"].pop(0)  # * self.scale
+                    cx += ix
+                if "j" in gc:
+                    jy = gc["j"].pop(0)  # * self.scale
+                    cy += jy
+                if "r" in gc:
+                    # Strictly speaking this uses the R parameter, but that wasn't coded.
+                    arc = Arc(
+                        start=(ox, oy),
+                        center=(cx, cy),
+                        end=(nx, ny),
+                        ccw=self.move_mode == 3,
+                    )
+                    power = self.power
+                    for p in range(self._interpolate + 1):
+                        x, y = arc.point(p / self._interpolate)
+                        self.plot_location(x, y, power)
+                else:
+                    arc = Arc(
+                        start=(ox, oy),
+                        center=(cx, cy),
+                        end=(nx, ny),
+                        ccw=self.move_mode == 3,
+                    )
+                    power = self.power
+                    for p in range(self._interpolate + 1):
+                        x, y = arc.point(p / self._interpolate)
+                        self.plot_location(x, y, power)
+        return 0
+
+    def plot_location(self, x, y, power):
+        """
+        Adds this particular location to the current plotcut.
+
+        Or, starts a new plotcut if one is not already started.
+
+        First plotcut is a 0-power move to the current position. X and Y are set to plotted location
+
+        @param x:
+        @param y:
+        @param power:
+        @return:
+        """
+        matrix = self.units_to_device_matrix
+        if self.plotcut is None:
+            ox, oy = matrix.transform_point([self.x, self.y])
+            self.plotcut = PlotCut(settings={"speed": self.speed, "power": self.power})
+            self.plotcut.plot_init(int(round(ox)), int(round(oy)))
+        tx, ty = matrix.transform_point([x, y])
+        self.plotcut.plot_append(int(round(tx)), int(round(ty)), power)
+        if not self.program_mode:
+            self.plot_commit()
+        self.x = x
+        self.y = y
+
+    def plot_commit(self):
+        """
+        Force commits the old plotcut and unsets the current plotcut.
+
+        @return:
+        """
+        if self.plotcut is None:
+            return
+        self.plot(self.plotcut)
+        self.plotcut = None
+
+    def plot(self, plot):
+        try:
+            self._driver.plot(plot)
+        except AttributeError:
+            pass
+        if not self.program_mode:
+            # If we plotted this, and we aren't in program mode execute all of these commands right away
+            try:
+                self._driver.plot_start()
+            except AttributeError:
+                pass
+
+    def g93_feedrate(self):
+        """
+        Feed Rate in Minutes / Unit
+        G93 - is Inverse Time Mode. In inverse time feed rate mode, an F word means the move
+        should be completed in [one divided by the F number] minutes. For example, if the
+        F number is 2.0, the move should be completed in half a minute.
+        When the inverse time feed rate mode is active, an F word must appear on every line
+        which has a G1, G2, or G3 motion, and an F word on a line that does not have
+        G1, G2, or G3 is ignored. Being in inverse time feed rate mode does not
+        affect G0 (rapid move) motions.
+        @return:
+        """
+
+        if self.scale == UNITS_PER_INCH:
+            self.feed_convert = lambda s: (60.0 * self.scale / UNITS_PER_INCH) / s
+            self.feed_invert = lambda s: (60.0 * UNITS_PER_INCH / self.scale) / s
+        else:
+            self.feed_convert = lambda s: (60.0 * self.scale / UNITS_PER_MM) / s
+            self.feed_invert = lambda s: (60.0 * UNITS_PER_MM / self.scale) / s
+
+    def g94_feedrate(self):
+        """
+        Feed Rate in Units / Minute
+        G94 - is Units per Minute Mode. In units per minute feed mode, an F word is interpreted
+        to mean the controlled point should move at a certain number of inches per minute,
+        millimeters per minute, or degrees per minute, depending upon what length units
+        are being used and which axis or axes are moving.
+        @return:
+        """
+
+        if self.scale == UNITS_PER_INCH:
+            self.feed_convert = lambda s: s / ((self.scale / UNITS_PER_INCH) * 60.0)
+            self.feed_invert = lambda s: s * ((self.scale / UNITS_PER_INCH) * 60.0)
+        else:
+            self.feed_convert = lambda s: s / ((self.scale / UNITS_PER_MM) * 60.0)
+            self.feed_invert = lambda s: s * ((self.scale / UNITS_PER_MM) * 60.0)

--- a/meerk40t/grbl/plugin.py
+++ b/meerk40t/grbl/plugin.py
@@ -5,6 +5,7 @@ Registers the required files to run the GRBL device.
 """
 from meerk40t.grbl.control import GRBLControl
 from meerk40t.grbl.device import GRBLDevice, GRBLDriver
+from meerk40t.grbl.gcodejob import GcodeJob
 from meerk40t.grbl.interpreter import GRBLInterpreter
 from meerk40t.grbl.emulator import GRBLEmulator
 from meerk40t.grbl.loader import GCodeLoader
@@ -27,6 +28,7 @@ def plugin(kernel, lifecycle=None):
 
         kernel.register("provider/device/grbl", GRBLDevice)
         kernel.register("driver/grbl", GRBLDriver)
+        kernel.register("spoolerjob/grbl", GcodeJob)
         kernel.register("interpreter/grbl", GRBLInterpreter)
         kernel.register("emulator/grbl", GRBLEmulator)
         kernel.register("load/GCodeLoader", GCodeLoader)

--- a/meerk40t/tools/driver_to_path.py
+++ b/meerk40t/tools/driver_to_path.py
@@ -2,7 +2,6 @@
 Driver to Path is code adapted from jpirnay's modifications of GRBL parser to read parsed data. When the GRBLParser
 was converted to a driverlike emulator, this functionality was spun off.
 """
-
 from math import isnan
 
 from meerk40t.core.cutcode.cubiccut import CubicCut
@@ -441,11 +440,11 @@ class DriverToPath:
             },
         ]
 
-    def parse(self, emulator, data, elements, options=None):
+    def parse(self, blob_type, data, elements, options=None):
         """Parse the data with the given emulator and create and add the relevant paths.
 
         Args:
-            emulator: the emulator to use to parse the data, suffix entry value.
+            blob_type: the emulator to use to parse the data, suffix entry value.
             data (bytes): the grbl code to parse
             elements (class): context for elements
             options (disctionary, optional): A dictionary with settings. Defaults to None.
@@ -456,9 +455,12 @@ class DriverToPath:
                 if hasattr(plotter, opt["attr"]):
                     setattr(plotter, opt["attr"], getattr(self, opt["attr"]))
 
-            emulator_class = elements.lookup(f"emulator/{emulator}")
-            emulator_object = emulator_class(plotter, elements.device.scene_to_show_matrix())
-            emulator_object.write(data)
+            spooler_job = elements.lookup(f"spoolerjob/{blob_type}")
+            job_object = spooler_job(plotter, elements.device.scene_to_show_matrix())
+            job_object.write_blob(data)
+            while not job_object.execute():
+                # Still more to execute.
+                pass
 
             op_nodes = {}
             color_index = 0

--- a/test/test_spooler.py
+++ b/test/test_spooler.py
@@ -1,46 +1,11 @@
 import unittest
+
+from meerk40t.core.spoolers import SpoolerJob
 from test import bootstrap
 
 
-class TestJob:
-    def __init__(
-        self,
-        service,
-    ):
-        self.stopped = False
-        self.service = service
-        self.runtime = 0
-        self.priority = 0
-
-    @property
-    def status(self):
-        if self.is_running:
-            return "Running"
-        else:
-            return "Queued"
-
-    def is_running(self):
-        return not self.stopped
-
-    def execute(self, driver):
-        driver.home()
-        return True
-
-    def stop(self):
-        self.stopped = True
-
-    def elapsed_time(self):
-        """
-        How long is this job already running...
-        """
-        result = 0
-        return result
-
-    def estimate_time(self):
-        return 0
-
-
 class TestSpooler(unittest.TestCase):
+
     def test_spoolerjob(self):
         """
         Test spooler job
@@ -49,9 +14,9 @@ class TestSpooler(unittest.TestCase):
         """
         kernel = bootstrap.bootstrap()
         try:
-            kernel.device.spooler.send(TestJob(kernel.device))
+            kernel.device.spooler.send(SpoolerJob(kernel.device))
             kernel.device.spooler.clear_queue()
-            j = TestJob(kernel.device)
+            j = SpoolerJob(kernel.device)
             kernel.device.spooler.send(j)
             kernel.device.spooler.remove(j)
         finally:


### PR DESCRIPTION
A principle reason why realtime commands don't work in the 0.8.2 version is that the emulator is really two parts. One governs the control over the laser. This is the reverse of the controller. Whereas the other governs the execution of code, this is the inverse of the driver. It's possible to use GRBL-like control interfaces while sending data that is not strictly grbl (except jog which is written in grbl code but is done in a non-modal fashion. 

So even with properly different threads to write the code to the emulator as to execute it, the realtime commands cannot execute until the execution catches up. The result is that we need a realtime commands to control the laser and the programmed commands to send to the laser as a program.