### PR TITLE
Fix text with pure numbers

### DIFF
--- a/meerk40t/core/element_treeops.py
+++ b/meerk40t/core/element_treeops.py
@@ -1864,9 +1864,9 @@ def init_tree(kernel):
         result = False
         txt = ""
         if hasattr(node, "text") and node.text is not None:
-            txt = node.text
+            txt = str(node.text)
         if hasattr(node, "mktext") and node.mktext is not None:
-            txt = node.mktext
+            txt = str(node.mktext)
         # Very stupid, but good enough
         if "{" in txt and "}" in txt:
             result = True

--- a/meerk40t/core/wordlist.py
+++ b/meerk40t/core/wordlist.py
@@ -428,7 +428,7 @@ class Wordlist:
         # list of tuples, (index found, old, new )
         # Lets gather the {} first...
         brackets = re.compile(r"\{[^}]+\}")
-        for bracketed_key in brackets.findall(orgtext):
+        for bracketed_key in brackets.findall(str(orgtext)):
             #            print(f"Key found: {bracketed_key}")
             newpattern = ""
             key = bracketed_key[1:-1].lower().strip()

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -187,7 +187,7 @@ class LineTextPropertyPanel(wx.Panel):
             return
         fontdir = fontdirectory(self.context)
         self.load_directory(fontdir)
-        self.text_text.SetValue(node.mktext)
+        self.text_text.SetValue(str(node.mktext))
         self.Show()
 
     def load_directory(self, fontdir):


### PR DESCRIPTION
Vectortext (or regular text) might crash during copying if they were containing just numbers (ie "5").