### PR TITLE
Signals RibbonToggle State

### DIFF
--- a/meerk40t/balormk/elementlightjob.py
+++ b/meerk40t/balormk/elementlightjob.py
@@ -63,7 +63,7 @@ class ElementLightJob:
         connection.abort()
         self.stopped = True
         self.runtime += time.time() - self.time_started
-        self.service.signal("stop_tracing", True)
+        self.service.signal("light_simulate", False)
 
         if self.service.redlight_preferred:
             connection.light_on()

--- a/meerk40t/balormk/gui/gui.py
+++ b/meerk40t/balormk/gui/gui.py
@@ -99,7 +99,7 @@ def plugin(service, lifecycle):
                     "icon": icons8_light_off_50,
                     "tip": _("Turn light off"),
                     "action": lambda v: service("stop\n"),
-                    "signal": "stop_tracing",
+                    "signal": "light_simulate",
                 },
             },
         )

--- a/meerk40t/balormk/livefulllightjob.py
+++ b/meerk40t/balormk/livefulllightjob.py
@@ -55,7 +55,7 @@ class LiveFullLightJob:
         self.stopped = True
         self.runtime += time.time() - self.time_started
         self.service.unlisten("emphasized", self.on_emphasis_changed)
-        self.service.signal("stop_tracing", True)
+        self.service.signal("light_simulate", False)
         if self.service.redlight_preferred:
             connection.light_on()
             connection.write_port()

--- a/meerk40t/balormk/liveselectionlightjob.py
+++ b/meerk40t/balormk/liveselectionlightjob.py
@@ -56,7 +56,7 @@ class LiveSelectionLightJob:
         connection.abort()
         self.stopped = True
         self.runtime += time.time() - self.time_started
-        self.service.signal("stop_tracing", True)
+        self.service.signal("light_simulate", False)
         if self.service.redlight_preferred:
             connection.light_on()
             connection.write_port()

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -522,7 +522,7 @@ class GRBLDevice(Service, ViewPort):
                 self.driver.move_mode = 0
                 # self.redlight_preferred = False
                 channel("Turning off redlight.")
-                self.signal("grbl_red_dot", True)
+                self.signal("grbl_red_dot", False)
             else:
                 # self.redlight_preferred = True
                 # self.driver.set("power", int(self.red_dot_level / 100 * 1000))
@@ -536,7 +536,7 @@ class GRBLDevice(Service, ViewPort):
                 # An arbitrary move to turn the laser really on!
                 # self.driver.grbl("G1")
                 channel("Turning on redlight.")
-                self.signal("grbl_red_dot", False)
+                self.signal("grbl_red_dot", True)
 
         @self.console_option(
             "idonotlovemyhouse",

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -403,14 +403,14 @@ class RibbonPanel(wx.Panel):
             return
         button.toggle = not button.toggle
         if button.toggle:
-            if button.identifier is not None:
-                setattr(button.object, button.identifier, True)
-                self.context.signal(button.identifier, True, button.object)
+            if button.toggle_attr is not None:
+                setattr(button.object, button.toggle_attr, True)
+                self.context.signal(button.toggle_attr, True, button.object)
             self._restore_button_aspect(button, button.state_pressed)
         else:
-            if button.identifier is not None:
-                setattr(button.object, button.identifier, False)
-                self.context.signal(button.identifier, False, button.object)
+            if button.toggle_attr is not None:
+                setattr(button.object, button.toggle_attr, False)
+                self.context.signal(button.toggle_attr, False, button.object)
             self._restore_button_aspect(button, button.state_unpressed)
         self.ensure_realize()
 
@@ -731,6 +731,7 @@ class RibbonPanel(wx.Panel):
             b.toggle = False
             b.parent = button_bar
             b.group = group
+            b.toggle_attr = button.get("toggle_attr")
             b.identifier = button.get("identifier")
             b.action = button.get("action")
             b.action_right = button.get("right")
@@ -775,7 +776,7 @@ class RibbonPanel(wx.Panel):
                         ),
                     )
                 # Set initial value by identifer and object
-                if b.identifier is not None and getattr(b.object, b.identifier, False):
+                if b.toggle_attr is not None and getattr(b.object, b.toggle_attr, False):
                     b.toggle = True
                     self._restore_button_aspect(b, b.state_pressed)
                     b.parent.ToggleButton(b.id, b.toggle)

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -594,14 +594,22 @@ class RibbonPanel(wx.Panel):
         return b
 
     def _setup_multi_button(self, button, b):
-        # Store alternative aspects for multi-buttons, load stored previous state.
+        """
+        Store alternative aspects for multi-buttons, load stored previous state.
+
+        @param button:
+        @param b:
+        @return:
+        """
         resize_param = button.get("size")
         multi_aspects = button["multi"]
+        # This is the key used for the multi button.
         multi_ident = button.get("identifier")
         b.save_id = multi_ident
-        initial_id = self.context.setting(str, b.save_id, "default")
+        initial_value = self.context.setting(str, b.save_id, "default")
 
         for i, v in enumerate(multi_aspects):
+            # These are values for the outer identifier
             key = v.get("identifier", i)
             self._store_button_aspect(b, key)
             self._update_button_aspect(b, key, **v)
@@ -629,12 +637,12 @@ class RibbonPanel(wx.Panel):
                     ),
                 )
             if "signal" in v:
-                self._create_signal_multi(b, key, v["signal"])
+                self._create_signal_for_multi(b, key, v["signal"])
 
-            if key == initial_id:
+            if key == initial_value:
                 self._restore_button_aspect(b, key)
 
-    def _create_signal_multi(self, button, key, signal):
+    def _create_signal_for_multi(self, button, key, signal):
         """
         Creates a signal to restore the state of a multi button.
 
@@ -654,7 +662,7 @@ class RibbonPanel(wx.Panel):
         self.context.listen(signal, signal_multi_listener)
         self._registered_signals.append((signal, signal_multi_listener))
 
-    def _create_signal_toggler(self, button, signal):
+    def _create_signal_for_toggle(self, button, signal):
         """
         Creates a signal toggle which will listen for the given signal and set the toggle-state to the given set_value
 
@@ -749,7 +757,7 @@ class RibbonPanel(wx.Panel):
                 toggle_action = button["toggle"]
                 key = toggle_action.get("identifier", "toggle")
                 if "signal" in toggle_action:
-                    self._create_signal_toggler(b, toggle_action["signal"])
+                    self._create_signal_for_toggle(b, toggle_action["signal"])
 
                 self._store_button_aspect(b, key, **toggle_action)
                 if "icon" in toggle_action:

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -302,7 +302,7 @@ class RibbonPanel(wx.Panel):
         self.button_lookup = {}
         self.group_lookup = {}
 
-        self.toggle_signals = list()
+        self._registered_signals = list()
 
         # Define Ribbon.
         self._ribbon = RB.RibbonBar(
@@ -652,7 +652,7 @@ class RibbonPanel(wx.Panel):
 
         signal_multi_listener = make_multi_click(button, key)
         self.context.listen(signal, signal_multi_listener)
-        self.toggle_signals.append((signal, signal_multi_listener))
+        self._registered_signals.append((signal, signal_multi_listener))
 
     def _create_signal_toggler(self, button, signal):
         """
@@ -683,7 +683,7 @@ class RibbonPanel(wx.Panel):
 
         signal_toggle_listener = make_toggle_click(button)
         self.context.listen(signal, signal_toggle_listener)
-        self.toggle_signals.append((signal, signal_toggle_listener))
+        self._registered_signals.append((signal, signal_toggle_listener))
 
     def set_buttons(self, new_values, button_bar):
         """
@@ -1157,7 +1157,7 @@ class RibbonPanel(wx.Panel):
         pass
 
     def pane_hide(self):
-        for key, listener in self.toggle_signals:
+        for key, listener in self._registered_signals:
             self.context.unlisten(key, listener)
 
     # def on_page_changing(self, event):

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -442,6 +442,7 @@ class RibbonPanel(wx.Panel):
         if button.state_pressed is None:
             # If there's a pressed state we should change the button state
             return
+
         button.toggle = not button.toggle
         if button.toggle:
             if button.toggle_attr is not None:
@@ -628,9 +629,7 @@ class RibbonPanel(wx.Panel):
                 kind=bkind,
             )
 
-        button_bar.Bind(
-            RB.EVT_RIBBONBUTTONBAR_CLICKED, self.button_click, id=new_id
-        )
+        button_bar.Bind(RB.EVT_RIBBONBUTTONBAR_CLICKED, self.button_click, id=new_id)
         button_bar.Bind(wx.EVT_RIGHT_UP, self.button_click_right)
         return b
 

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -658,7 +658,7 @@ class RibbonPanel(wx.Panel):
         """
         Creates a signal toggle which will listen for the given signal and set the toggle-state to the given set_value
 
-        E.G. If a toggle has a signal called "stop_tracing" and the context.signal("stop_tracing") is called this will
+        E.G. If a toggle has a signal called "tracing" and the context.signal("tracing", True) is called this will
         automatically set the toggle state.
 
         Note: It will not call any of the associated actions, it will simply set the toggle state.

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -596,12 +596,12 @@ class RibbonPanel(wx.Panel):
     def _setup_multi_button(self, button, b):
         # Store alternative aspects for multi-buttons, load stored previous state.
         resize_param = button.get("size")
-        multi_action = button["multi"]
+        multi_aspects = button["multi"]
         multi_ident = button.get("identifier")
         b.save_id = multi_ident
         initial_id = self.context.setting(str, b.save_id, "default")
 
-        for i, v in enumerate(multi_action):
+        for i, v in enumerate(multi_aspects):
             key = v.get("identifier", i)
             self._store_button_aspect(b, key)
             self._update_button_aspect(b, key, **v)

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -710,6 +710,7 @@ class RibbonPanel(wx.Panel):
         @param b:
         @return:
         """
+        resize_param = button.get("size")
 
         b.state_pressed = "toggle"
         b.state_unpressed = "original"

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -1,6 +1,41 @@
 """
 The WxmRibbon Bar is a core aspect of MeerK40t's interaction. All of the buttons are dynmically generated but the
-panels themselves are created in a static fashion here.
+panels themselves are created in a static fashion. But the contents of those individual ribbon panels are defined
+in the kernel lookup.
+
+        service.register(
+            "button/control/Redlight",
+            {
+                "label": _("Red Dot On"),
+                "icon": icons8_quick_mode_on_50,
+                "tip": _("Turn Redlight On"),
+                "action": lambda v: service("red on\n"),
+                "toggle": {
+                    "label": _("Red Dot Off"),
+                    "action": lambda v: service("red off\n"),
+                    "icon": icons8_flash_off_50,
+                    "signal": "grbl_red_dot",
+                },
+                "rule_enabled": lambda v: has_red_dot_enabled(),
+            },
+        )
+
+For example would register a button in the control panel with a discrete name "Redlight" the definitions for label,
+icon, tip, action are all pretty standard to setup a button. This can often be registered as part of a service such
+that if you switch the service it will change the lookup and that change will be detected here and rebuilt the buttons.
+
+The toggle defines an alternative set of values for the toggle state of the button.
+The multi defines a series of alternative states, and creates a hybrid button with a drop down to select the state
+    desired.
+Other properties like `rule_enabled` provides a check for whether this button should be enabled or not.
+
+The `toggle_attr` will permit a toggle to set an attribute on the given `object` which would default to the root
+context but could need to set a more local object attribute.
+
+If a `signal` is assigned as an aspect of multi it triggers that specfic option in the multi button.
+If a `signal` is assigned within the toggle it sets the state of the given toggle.
+
+The action is a function which is run when the button is pressed.
 """
 
 import copy

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -33,7 +33,8 @@ The `toggle_attr` will permit a toggle to set an attribute on the given `object`
 context but could need to set a more local object attribute.
 
 If a `signal` is assigned as an aspect of multi it triggers that specfic option in the multi button.
-If a `signal` is assigned within the toggle it sets the state of the given toggle.
+If a `signal` is assigned within the toggle it sets the state of the given toggle. These should be compatible with
+the signals issued by choice panels.
 
 The action is a function which is run when the button is pressed.
 """


### PR DESCRIPTION
The goal of this PR is to ensure that the ribbon toggle state is compatible with the choices panel signals of the same varieties.

Currently the state is the opposite of the sent signal state. So `stop_tracing True` would tell make the trace button state toggle to unpressed. This is the opposite of what the choice panel would send for the same sort of state. So if they reference the same variable they cannot be made to agree as things are currently set.

This changes that.

* We add `toggle_attr` for triggering the setting the toggle state's attr rather than `identifier` which is typical for multi-based buttons.
* We flip the current buttons for Galvo-Trace buttons. GRBL-RedLight buttons. And we will also switch Newly AutoExecute button.