### PR TITLE
Fix spacev/spaceh distribution logic

### DIFF
--- a/meerk40t/core/element_commands.py
+++ b/meerk40t/core/element_commands.py
@@ -2400,7 +2400,8 @@ def init_commands(kernel):
         output_type="align",
     )
     def subtype_align_spaceh(command, channel, _, data=None, **kwargs):
-        mode, group, bound, elements = data
+        mode, group, bound, raw_elements = data
+        elements = self.condense_elements(raw_elements)
         boundary_points = []
         for node in elements:
             boundary_points.append(node.bounds)
@@ -2432,13 +2433,15 @@ def init_commands(kernel):
             delta = subbox[0] - dim_pos
             matrix = f"translate({-delta}, 0)"
             if delta != 0:
-                for q in node.flat(types=elem_nodes):
-                    try:
-                        q.matrix *= matrix
-                        q.translated(-delta, 0)
-                    except AttributeError:
-                        continue
+                self.translate_node(node, -delta, 0)
+                # for q in node.flat(types=elem_nodes):
+                #     try:
+                #         q.matrix *= matrix
+                #         q.translated(-delta, 0)
+                #     except AttributeError:
+                #         continue
             dim_pos += subbox[2] - subbox[0] + distributed_distance
+        self.signal("refresh_scene", "Scene")
         return "align", (mode, group, bound, elements)
 
     @self.console_command(
@@ -2448,7 +2451,8 @@ def init_commands(kernel):
         output_type="align",
     )
     def subtype_align_spacev(command, channel, _, data=None, **kwargs):
-        mode, group, bound, elements = data
+        mode, group, bound, raw_elements = data
+        elements = self.condense_elements(raw_elements)
         boundary_points = []
         for node in elements:
             boundary_points.append(node.bounds)
@@ -2480,13 +2484,15 @@ def init_commands(kernel):
             delta = subbox[1] - dim_pos
             matrix = f"translate(0, {-delta})"
             if delta != 0:
-                for q in node.flat(types=elem_nodes):
-                    try:
-                        q.matrix *= matrix
-                        q.translated(0, -delta)
-                    except AttributeError:
-                        continue
+                self.translate_node(node, 0, -delta)
+                # for q in node.flat(types=elem_nodes):
+                #     try:
+                #         q.matrix *= matrix
+                #         q.translated(0, -delta)
+                #     except AttributeError:
+                #         continue
             dim_pos += subbox[3] - subbox[1] + distributed_distance
+        self.signal("refresh_scene", "Scene")
         return "align", (mode, group, bound, elements)
 
     @self.console_argument(

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -884,6 +884,7 @@ class Elemental(Service):
         (ie group or file) are in this set, then they will be
         replaced and represented by this parent element
         """
+
         def remove_children_from_list(list_to_deal, parent_node):
             for idx, node in enumerate(list_to_deal):
                 if node is None:

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -966,10 +966,12 @@ class Elemental(Service):
         # One special case though: if we have selected all
         # elements within a single group then we still deal
         # with all children
-        if len(data_to_align) == 1:
+        while len(data_to_align) == 1:
             node = data_to_align[0]
             if node is not None and node.type in ("file", "group"):
                 data_to_align = [e for e in node.children]
+            else:
+                break
         return data_to_align
 
     def translate_node(self, node, dx, dy):

--- a/meerk40t/core/elements.py
+++ b/meerk40t/core/elements.py
@@ -877,41 +877,13 @@ class Elemental(Service):
 
         return this_area, this_length
 
-    def align_elements(self, data, alignbounds, positionx, positiony, as_group):
+    def condense_elements(self, data):
         """
-
-        @param data: elements to align
-        @param alignbounds: boundary tuple (left, top, right, bottom)
-                            to which data needs to be aligned to
-        @param positionx:   one of "min", "max", "center"
-        @param positiony:   one of "min", "max", "center"
-        @param as_group:    0, align every element of data to the edge
-                            1, align the group in total
-        @return:
+        This routine looks at a given dataset and will condense
+        it in the sense that if all elements of a given hierarchy
+        (ie group or file) are in this set, then they will be
+        replaced and represented by this parent element
         """
-
-        def calc_dx_dy():
-            dx = 0
-            dy = 0
-            if positionx == "min":
-                dx = alignbounds[0] - left_edge
-            elif positionx == "max":
-                dx = alignbounds[2] - right_edge
-            elif positionx == "center":
-                dx = (alignbounds[2] + alignbounds[0]) / 2 - (
-                    right_edge + left_edge
-                ) / 2
-
-            if positiony == "min":
-                dy = alignbounds[1] - top_edge
-            elif positiony == "max":
-                dy = alignbounds[3] - bottom_edge
-            elif positiony == "center":
-                dy = (alignbounds[3] + alignbounds[1]) / 2 - (
-                    bottom_edge + top_edge
-                ) / 2
-            return dx, dy
-
         def remove_children_from_list(list_to_deal, parent_node):
             for idx, node in enumerate(list_to_deal):
                 if node is None:
@@ -920,21 +892,6 @@ class Elemental(Service):
                     list_to_deal[idx] = None
                     if len(node.children) > 0:
                         remove_children_from_list(list_to_deal, node)
-
-        def translate_node(node, dx, dy):
-            if hasattr(node, "lock") and node.lock and not self.lock_allows_move:
-                return
-            else:
-                if node.type in ("group", "file"):
-                    for c in node.children:
-                        translate_node(c, dx, dy)
-                    node.translated(dx, dy)
-                else:
-                    try:
-                        node.matrix.post_translate(dx, dy)
-                        node.translated(dx, dy)
-                    except AttributeError:
-                        pass
 
         align_data = [e for e in data]
         needs_repetition = True
@@ -1012,6 +969,59 @@ class Elemental(Service):
             node = data_to_align[0]
             if node is not None and node.type in ("file", "group"):
                 data_to_align = [e for e in node.children]
+        return data_to_align
+
+    def translate_node(self, node, dx, dy):
+        if hasattr(node, "lock") and node.lock and not self.lock_allows_move:
+            return
+        else:
+            if node.type in ("group", "file"):
+                for c in node.children:
+                    self.translate_node(c, dx, dy)
+                node.translated(dx, dy)
+            else:
+                try:
+                    node.matrix.post_translate(dx, dy)
+                    node.translated(dx, dy)
+                except AttributeError:
+                    pass
+
+    def align_elements(self, data, alignbounds, positionx, positiony, as_group):
+        """
+
+        @param data: elements to align
+        @param alignbounds: boundary tuple (left, top, right, bottom)
+                            to which data needs to be aligned to
+        @param positionx:   one of "min", "max", "center"
+        @param positiony:   one of "min", "max", "center"
+        @param as_group:    0, align every element of data to the edge
+                            1, align the group in total
+        @return:
+        """
+
+        def calc_dx_dy():
+            dx = 0
+            dy = 0
+            if positionx == "min":
+                dx = alignbounds[0] - left_edge
+            elif positionx == "max":
+                dx = alignbounds[2] - right_edge
+            elif positionx == "center":
+                dx = (alignbounds[2] + alignbounds[0]) / 2 - (
+                    right_edge + left_edge
+                ) / 2
+
+            if positiony == "min":
+                dy = alignbounds[1] - top_edge
+            elif positiony == "max":
+                dy = alignbounds[3] - bottom_edge
+            elif positiony == "center":
+                dy = (alignbounds[3] + alignbounds[1]) / 2 - (
+                    bottom_edge + top_edge
+                ) / 2
+            return dx, dy
+
+        data_to_align = self.condense_elements(data)
         # Selection boundaries
         boundary_points = []
         for node in data_to_align:
@@ -1046,7 +1056,7 @@ class Elemental(Service):
             else:
                 dx = groupdx
                 dy = groupdy
-            translate_node(q, dx, dy)
+            self.translate_node(q, dx, dy)
         self.signal("refresh_scene", "Scene")
 
     def wordlist_delta(self, orgtext, increase):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1324,8 +1324,13 @@ class MeerK40t(MWindow):
             {
                 "label": _("Distr. Hor."),
                 "icon": icons_evenspace_horiz,
-                "tip": _("Distribute Space Horizontally"),
+                "tip": _("Distribute Space Horizontally")
+                + "\n"
+                + _("Left click: Equal distances")
+                + "\n"
+                + _("Right click: Equal centers"),
                 "action": lambda v: kernel.elements("align spaceh\n"),
+                "right": lambda v: kernel.elements("align spaceh2\n"),
                 "size": bsize_small,
                 "rule_enabled": lambda cond: len(
                     list(kernel.elements.elems(emphasized=True))
@@ -1338,8 +1343,13 @@ class MeerK40t(MWindow):
             {
                 "label": _("Distr. Vert."),
                 "icon": icons_evenspace_vert,
-                "tip": _("Distribute Space Vertically"),
+                "tip": _("Distribute Space Vertically")
+                + "\n"
+                + _("Left click: Equal distances")
+                + "\n"
+                + _("Right click: Equal centers"),
                 "action": lambda v: kernel.elements("align spacev\n"),
+                "right": lambda v: kernel.elements("align spacev2\n"),
                 "size": bsize_small,
                 "rule_enabled": lambda cond: len(
                     list(kernel.elements.elems(emphasized=True))
@@ -3510,7 +3520,7 @@ class MeerK40t(MWindow):
         try:
             # Reset to standard tool
             self.context("tool none\n")
-            info = _("Loading File...")+ "\n" + pathname
+            info = _("Loading File...") + "\n" + pathname
             kernel.busyinfo.start(msg=info)
             n = self.context.elements.note
             results = self.context.elements.load(


### PR DESCRIPTION
Element distribution routines do recognise groups now
Start:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/2670784/228342477-404838c9-529e-4bc0-930a-c8a00bfca31a.png">
Before the fix (distribute vertically):
<img width="251" alt="image" src="https://user-images.githubusercontent.com/2670784/228343310-dc4fe4c5-7bb4-456e-9e59-32ad91128005.png">

After the fix:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/2670784/228342739-1212109e-99c9-4e48-b6b5-8b58347f0959.png">
