### PR TITLE
Fix delete behaviour

### DIFF
--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2451,7 +2451,7 @@ class MeerK40t(MWindow):
             self.context("window open Preferences\n")
 
         def on_click_delete():
-            self.context("element delete\n")
+            self.context("tree selected delete\n")
 
         def clipboard_filled():
             res = False

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2553,7 +2553,7 @@ class MeerK40t(MWindow):
                 "segment": "",
             },
             {
-                "label": _("Delete\tDel"),
+                "label": _("Delete"),
                 "help": _("Delete the selected elements"),
                 "action": on_click_delete,
                 "enabled": self.context.elements.has_emphasis,


### PR DESCRIPTION
The delete key binding was useless as the menu entry under "Edit - Delete" was called first.