### PR TITLE
Correct CutPlan Crash on Bounds

### DIFF
--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1133,18 +1133,17 @@ class Node:
         else:
             xmin, ymin, xmax, ymax = bounds
         for e in nodes:
-            if hasattr(e, attr):
-                box = getattr(e, attr)
-                if box is None:
-                    continue
-                if box[0] < xmin:
-                    xmin = box[0]
-                if box[2] > xmax:
-                    xmax = box[2]
-                if box[1] < ymin:
-                    ymin = box[1]
-                if box[3] > ymax:
-                    ymax = box[3]
+            box = getattr(e, attr, None)
+            if box is None:
+                continue
+            if box[0] < xmin:
+                xmin = box[0]
+            if box[2] > xmax:
+                xmax = box[2]
+            if box[1] < ymin:
+                ymin = box[1]
+            if box[3] > ymax:
+                ymax = box[3]
         return xmin, ymin, xmax, ymax
 
     @property


### PR DESCRIPTION
* register previous bounds on preprocess. If you somehow do phased additions to a plan it will maintain the correct bounds merging previous bounds into them.
* Only check for bounds union if the element has bounds.
     *  This should prevent cutcode crash as well as utility operations which should also crash.
* If our bounds are infinite, in that there are no bounds (negative space). We set outline equal to none.