### PR TITLE
Move penbox to being its own service.

### DIFF
--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -193,7 +193,7 @@ class BalorDriver:
             penbox = settings.get("penbox_value")
             if penbox is not None:
                 try:
-                    self.value_penbox = self.service.penbox.penbox[penbox]
+                    self.value_penbox = self.service.penbox.pens[penbox]
                 except KeyError:
                     self.value_penbox = None
             con.set_settings(settings)
@@ -321,7 +321,7 @@ class BalorDriver:
                             penbox = settings.get("penbox_value")
                             if penbox is not None:
                                 try:
-                                    self.value_penbox = self.service.penbox.penbox[
+                                    self.value_penbox = self.service.penbox.pens[
                                         penbox
                                     ]
                                 except KeyError:

--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -193,7 +193,7 @@ class BalorDriver:
             penbox = settings.get("penbox_value")
             if penbox is not None:
                 try:
-                    self.value_penbox = self.service.elements.penbox[penbox]
+                    self.value_penbox = self.service.penbox.penbox[penbox]
                 except KeyError:
                     self.value_penbox = None
             con.set_settings(settings)
@@ -321,7 +321,7 @@ class BalorDriver:
                             penbox = settings.get("penbox_value")
                             if penbox is not None:
                                 try:
-                                    self.value_penbox = self.service.elements.penbox[
+                                    self.value_penbox = self.service.penbox.penbox[
                                         penbox
                                     ]
                                 except KeyError:

--- a/meerk40t/core/core.py
+++ b/meerk40t/core/core.py
@@ -16,6 +16,10 @@ def plugin(kernel, lifecycle=None):
 
         plugins.append(elements.plugin)
 
+        from .elements import penbox
+
+        plugins.append(penbox.plugin)
+
         from . import logging
 
         plugins.append(logging.plugin)

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -33,7 +33,6 @@ def plugin(kernel, lifecycle=None):
         from . import trace
         from . import align
         from . import wordlist
-        from . import penbox
         from . import materials
         from . import shapes
         from . import tree_commands
@@ -49,7 +48,6 @@ def plugin(kernel, lifecycle=None):
             trace.plugin,
             align.plugin,
             wordlist.plugin,
-            penbox.plugin,
             materials.plugin,
             shapes.plugin,
             tree_commands.plugin,

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -455,10 +455,6 @@ class Elemental(Service):
         self.setting(bool, "operation_default_empty", True)
 
         self.op_data = Settings(self.kernel.name, "operations.cfg")
-        self.pen_data = Settings(self.kernel.name, "penbox.cfg")
-
-        self.penbox = {}
-        self.load_persistent_penbox()
 
         self.wordlists = {"version": [1, self.kernel.version]}
 
@@ -620,49 +616,6 @@ class Elemental(Service):
                 emptyset = True
                 break
         return emptyset
-
-    def load_persistent_penbox(self):
-        settings = self.pen_data
-        pens = settings.read_persistent_string_dict("pens", suffix=True)
-        for pen in pens:
-            length = int(pens[pen])
-            box = list()
-            for i in range(length):
-                penbox = dict()
-                settings.read_persistent_string_dict(f"{pen} {i}", penbox, suffix=True)
-                box.append(penbox)
-            self.penbox[pen] = box
-
-    def save_persistent_penbox(self):
-        sections = {}
-        for section in self.penbox:
-            sections[section] = len(self.penbox[section])
-        self.pen_data.write_persistent_dict("pens", sections)
-        for section in self.penbox:
-            for i, p in enumerate(self.penbox[section]):
-                self.pen_data.write_persistent_dict(f"{section} {i}", p)
-
-    def index_range(self, index_string):
-        """
-        Parses index ranges in the form <idx>,<idx>-<idx>,<idx>
-        @param index_string:
-        @return:
-        """
-        indexes = list()
-        for s in index_string.split(","):
-            q = list(s.split("-"))
-            if len(q) == 1:
-                indexes.append(int(q[0]))
-            else:
-                start = int(q[0])
-                end = int(q[1])
-                if start > end:
-                    for q in range(end, start + 1):
-                        indexes.append(q)
-                else:
-                    for q in range(start, end + 1):
-                        indexes.append(q)
-        return indexes
 
     def length(self, v):
         return float(Length(v))
@@ -1172,8 +1125,6 @@ class Elemental(Service):
 
     def shutdown(self, *args, **kwargs):
         self.save_persistent_operations("previous")
-        self.save_persistent_penbox()
-        self.pen_data.write_configuration()
         self.op_data.write_configuration()
         for e in self.flat():
             e.unregister()

--- a/meerk40t/core/elements/penbox.py
+++ b/meerk40t/core/elements/penbox.py
@@ -77,7 +77,7 @@ class Penbox(Service):
     def __init__(self, kernel, *args, **kwargs):
         Service.__init__(self, kernel, "penbox")
         self.pen_data = Settings(self.kernel.name, "penbox.cfg")
-        self.penbox = {}
+        self.pens = {}
         self.load_persistent_penbox()
 
         _ = kernel.translation
@@ -97,11 +97,11 @@ class Penbox(Service):
             if remainder is None or key is None:
                 channel("----------")
                 if key is None:
-                    for key in self.penbox:
+                    for key in self.pens:
                         channel(str(key))
                 else:
                     try:
-                        for i, value in enumerate(self.penbox[key]):
+                        for i, value in enumerate(self.pens[key]):
                             channel(f"{i}: {str(value)}")
                     except KeyError:
                         channel(_("penbox does not exist"))
@@ -120,10 +120,10 @@ class Penbox(Service):
         ):
             if count is None:
                 raise CommandSyntaxError
-            current = self.penbox.get(data)
+            current = self.pens.get(data)
             if current is None:
                 current = list()
-                self.penbox[data] = current
+                self.pens[data] = current
             current.extend([dict() for _ in range(count)])
             return "penbox", data
 
@@ -139,10 +139,10 @@ class Penbox(Service):
         ):
             if count is None:
                 raise CommandSyntaxError
-            current = self.penbox.get(data)
+            current = self.pens.get(data)
             if current is None:
                 current = list()
-                self.penbox[data] = current
+                self.pens[data] = current
             for _ in range(count):
                 try:
                     del current[-1]
@@ -172,10 +172,10 @@ class Penbox(Service):
         ):
             if not value:
                 raise CommandSyntaxError
-            current = self.penbox.get(data)
+            current = self.pens.get(data)
             if current is None:
                 current = list()
-                self.penbox[data] = current
+                self.pens[data] = current
             rex = re.compile(r"([+-]?[0-9]+)(?:[,-]([+-]?[0-9]+))?")
             m = rex.match(value)
             if not m:
@@ -286,15 +286,15 @@ class Penbox(Service):
                 penbox = dict()
                 settings.read_persistent_string_dict(f"{pen} {i}", penbox, suffix=True)
                 box.append(penbox)
-            self.penbox[pen] = box
+            self.pens[pen] = box
 
     def save_persistent_penbox(self):
         sections = {}
-        for section in self.penbox:
-            sections[section] = len(self.penbox[section])
+        for section in self.pens:
+            sections[section] = len(self.pens[section])
         self.pen_data.write_persistent_dict("pens", sections)
-        for section in self.penbox:
-            for i, p in enumerate(self.penbox[section]):
+        for section in self.pens:
+            for i, p in enumerate(self.pens[section]):
                 self.pen_data.write_persistent_dict(f"{section} {i}", p)
 
     def shutdown(self, *args, **kwargs):

--- a/meerk40t/core/elements/penbox.py
+++ b/meerk40t/core/elements/penbox.py
@@ -8,7 +8,7 @@ from copy import copy
 from math import cos, gcd, isinf, pi, sin, sqrt, tau
 from random import randint, shuffle
 
-from meerk40t.kernel import CommandSyntaxError
+from meerk40t.kernel import CommandSyntaxError, Service, Settings
 
 from meerk40t.svgelements import (
     SVG_RULE_EVENODD,
@@ -47,205 +47,256 @@ from meerk40t.core.units import (
 
 def plugin(kernel, lifecycle=None):
     _ = kernel.translation
-    if lifecycle == "postboot":
-        init_commands(kernel)
+    if lifecycle == "register":
+        kernel.add_service("penbox", Penbox(kernel))
 
 
-def init_commands(kernel):
-    self = kernel.elements
-
-    _ = kernel.translation
-
-    # ==========
-    # PENBOX COMMANDS
-    # ==========
-
-    @self.console_argument("key", help=_("Penbox key"))
-    @self.console_command(
-        "penbox",
-        help=_("Penbox base operation"),
-        input_type=None,
-        output_type="penbox",
-    )
-    def penbox(command, channel, _, key=None, remainder=None, **kwargs):
-        if remainder is None or key is None:
-            channel("----------")
-            if key is None:
-                for key in self.penbox:
-                    channel(str(key))
-            else:
-                try:
-                    for i, value in enumerate(self.penbox[key]):
-                        channel(f"{i}: {str(value)}")
-                except KeyError:
-                    channel(_("penbox does not exist"))
-            channel("----------")
-        return "penbox", key
-
-    @self.console_argument("count", help=_("Penbox count"), type=int)
-    @self.console_command(
-        "add",
-        help=_("add pens to the chosen penbox"),
-        input_type="penbox",
-        output_type="penbox",
-    )
-    def penbox_add(
-        command, channel, _, count=None, data=None, remainder=None, **kwargs
-    ):
-        if count is None:
-            raise CommandSyntaxError
-        current = self.penbox.get(data)
-        if current is None:
-            current = list()
-            self.penbox[data] = current
-        current.extend([dict() for _ in range(count)])
-        return "penbox", data
-
-    @self.console_argument("count", help=_("Penbox count"), type=int)
-    @self.console_command(
-        "del",
-        help=_("delete pens to the chosen penbox"),
-        input_type="penbox",
-        output_type="penbox",
-    )
-    def penbox_del(
-        command, channel, _, count=None, data=None, remainder=None, **kwargs
-    ):
-        if count is None:
-            raise CommandSyntaxError
-        current = self.penbox.get(data)
-        if current is None:
-            current = list()
-            self.penbox[data] = current
-        for _ in range(count):
-            try:
-                del current[-1]
-            except IndexError:
-                break
-        return "penbox", data
-
-    @self.console_argument("index", help=_("Penbox index"), type=self.index_range)
-    @self.console_argument("key", help=_("Penbox key"), type=str)
-    @self.console_argument("value", help=_("Penbox key"), type=str)
-    @self.console_command(
-        "set",
-        help=_("set value in penbox"),
-        input_type="penbox",
-        output_type="penbox",
-    )
-    def penbox_set(
-        command,
-        channel,
-        _,
-        index=None,
-        key=None,
-        value=None,
-        data=None,
-        remainder=None,
-        **kwargs,
-    ):
-        if not value:
-            raise CommandSyntaxError
-        current = self.penbox.get(data)
-        if current is None:
-            current = list()
-            self.penbox[data] = current
-        rex = re.compile(r"([+-]?[0-9]+)(?:[,-]([+-]?[0-9]+))?")
-        m = rex.match(value)
-        if not m:
-            raise CommandSyntaxError
-        value = float(m.group(1))
-        end = m.group(2)
-        if end:
-            end = float(end)
-
-        if not end:
-            for i in index:
-                try:
-                    current[i][key] = value
-                except IndexError:
-                    pass
+def index_range(index_string):
+    """
+    Parses index ranges in the form <idx>,<idx>-<idx>,<idx>
+    @param index_string:
+    @return:
+    """
+    indexes = list()
+    for s in index_string.split(","):
+        q = list(s.split("-"))
+        if len(q) == 1:
+            indexes.append(int(q[0]))
         else:
-            r = len(index)
-            try:
-                s = (end - value) / (r - 1)
-            except ZeroDivisionError:
-                s = 0
-            d = 0
-            for i in index:
+            start = int(q[0])
+            end = int(q[1])
+            if start > end:
+                for q in range(end, start + 1):
+                    indexes.append(q)
+            else:
+                for q in range(start, end + 1):
+                    indexes.append(q)
+    return indexes
+
+class Penbox(Service):
+    def __init__(self, kernel, *args, **kwargs):
+        Service.__init__(self, kernel, "penbox")
+        self.pen_data = Settings(self.kernel.name, "penbox.cfg")
+        self.penbox = {}
+        self.load_persistent_penbox()
+
+        _ = kernel.translation
+
+        # ==========
+        # PENBOX COMMANDS
+        # ==========
+
+        @self.console_argument("key", help=_("Penbox key"))
+        @self.console_command(
+            "penbox",
+            help=_("Penbox base operation"),
+            input_type=None,
+            output_type="penbox",
+        )
+        def penbox(command, channel, _, key=None, remainder=None, **kwargs):
+            if remainder is None or key is None:
+                channel("----------")
+                if key is None:
+                    for key in self.penbox:
+                        channel(str(key))
+                else:
+                    try:
+                        for i, value in enumerate(self.penbox[key]):
+                            channel(f"{i}: {str(value)}")
+                    except KeyError:
+                        channel(_("penbox does not exist"))
+                channel("----------")
+            return "penbox", key
+
+        @self.console_argument("count", help=_("Penbox count"), type=int)
+        @self.console_command(
+            "add",
+            help=_("add pens to the chosen penbox"),
+            input_type="penbox",
+            output_type="penbox",
+        )
+        def penbox_add(
+                command, channel, _, count=None, data=None, remainder=None, **kwargs
+        ):
+            if count is None:
+                raise CommandSyntaxError
+            current = self.penbox.get(data)
+            if current is None:
+                current = list()
+                self.penbox[data] = current
+            current.extend([dict() for _ in range(count)])
+            return "penbox", data
+
+        @self.console_argument("count", help=_("Penbox count"), type=int)
+        @self.console_command(
+            "del",
+            help=_("delete pens to the chosen penbox"),
+            input_type="penbox",
+            output_type="penbox",
+        )
+        def penbox_del(
+                command, channel, _, count=None, data=None, remainder=None, **kwargs
+        ):
+            if count is None:
+                raise CommandSyntaxError
+            current = self.penbox.get(data)
+            if current is None:
+                current = list()
+                self.penbox[data] = current
+            for _ in range(count):
                 try:
-                    current[i][key] = value + d
+                    del current[-1]
                 except IndexError:
-                    pass
-                d += s
-        return "penbox", data
+                    break
+            return "penbox", data
 
-    # ==========
-    # PENBOX OPERATION COMMANDS
-    # ==========
+        @self.console_argument("index", help=_("Penbox index"), type=index_range)
+        @self.console_argument("key", help=_("Penbox key"), type=str)
+        @self.console_argument("value", help=_("Penbox key"), type=str)
+        @self.console_command(
+            "set",
+            help=_("set value in penbox"),
+            input_type="penbox",
+            output_type="penbox",
+        )
+        def penbox_set(
+                command,
+                channel,
+                _,
+                index=None,
+                key=None,
+                value=None,
+                data=None,
+                remainder=None,
+                **kwargs,
+        ):
+            if not value:
+                raise CommandSyntaxError
+            current = self.penbox.get(data)
+            if current is None:
+                current = list()
+                self.penbox[data] = current
+            rex = re.compile(r"([+-]?[0-9]+)(?:[,-]([+-]?[0-9]+))?")
+            m = rex.match(value)
+            if not m:
+                raise CommandSyntaxError
+            value = float(m.group(1))
+            end = m.group(2)
+            if end:
+                end = float(end)
 
-    @self.console_argument("key", help=_("Penbox key"))
-    @self.console_command(
-        "penbox_pass",
-        help=_("Set the penbox_pass for the given operation"),
-        input_type="ops",
-        output_type="ops",
-    )
-    def penbox_pass(command, channel, _, key=None, remainder=None, data=None, **kwargs):
-        if data is not None:
-            if key is not None:
-                for op in data:
+            if not end:
+                for i in index:
                     try:
-                        op.settings["penbox_pass"] = key
-                        channel(f"{str(op)} penbox_pass changed to {key}.")
-                    except AttributeError:
+                        current[i][key] = value
+                    except IndexError:
                         pass
             else:
-                if key is None:
-                    channel("----------")
-                    for op in data:
-                        try:
-                            key = op.settings.get("penbox_pass")
-                            if key is None:
-                                channel(f"{str(op)} penbox_pass is not set.")
-                            else:
-                                channel(f"{str(op)} penbox_pass is set to {key}.")
-                        except AttributeError:
-                            pass  # No op.settings.
-                    channel("----------")
-        return "ops", data
-
-    @self.console_argument("key", help=_("Penbox key"))
-    @self.console_command(
-        "penbox_value",
-        help=_("Set the penbox_value for the given operation"),
-        input_type="ops",
-        output_type="ops",
-    )
-    def penbox_value(
-        command, channel, _, key=None, remainder=None, data=None, **kwargs
-    ):
-        if data is not None:
-            if key is not None:
-                for op in data:
+                r = len(index)
+                try:
+                    s = (end - value) / (r - 1)
+                except ZeroDivisionError:
+                    s = 0
+                d = 0
+                for i in index:
                     try:
-                        op.settings["penbox_value"] = key
-                        channel(f"{str(op)} penbox_value changed to {key}.")
-                    except AttributeError:
+                        current[i][key] = value + d
+                    except IndexError:
                         pass
-            else:
-                if key is None:
-                    channel("----------")
+                    d += s
+            return "penbox", data
+
+        # ==========
+        # PENBOX OPERATION COMMANDS
+        # ==========
+
+        @self.console_argument("key", help=_("Penbox key"))
+        @self.console_command(
+            "penbox_pass",
+            help=_("Set the penbox_pass for the given operation"),
+            input_type="ops",
+            output_type="ops",
+        )
+        def penbox_pass(command, channel, _, key=None, remainder=None, data=None, **kwargs):
+            if data is not None:
+                if key is not None:
                     for op in data:
                         try:
-                            key = op.settings.get("penbox_value")
-                            if key is None:
-                                channel(f"{str(op)} penbox_value is not set.")
-                            else:
-                                channel(f"{str(op)} penbox_value is set to {key}.")
+                            op.settings["penbox_pass"] = key
+                            channel(f"{str(op)} penbox_pass changed to {key}.")
                         except AttributeError:
-                            pass  # No op.settings.
-                    channel("----------")
-        return "ops", data
+                            pass
+                else:
+                    if key is None:
+                        channel("----------")
+                        for op in data:
+                            try:
+                                key = op.settings.get("penbox_pass")
+                                if key is None:
+                                    channel(f"{str(op)} penbox_pass is not set.")
+                                else:
+                                    channel(f"{str(op)} penbox_pass is set to {key}.")
+                            except AttributeError:
+                                pass  # No op.settings.
+                        channel("----------")
+            return "ops", data
 
-    # --------------------------- END COMMANDS ------------------------------
+        @self.console_argument("key", help=_("Penbox key"))
+        @self.console_command(
+            "penbox_value",
+            help=_("Set the penbox_value for the given operation"),
+            input_type="ops",
+            output_type="ops",
+        )
+        def penbox_value(
+                command, channel, _, key=None, remainder=None, data=None, **kwargs
+        ):
+            if data is not None:
+                if key is not None:
+                    for op in data:
+                        try:
+                            op.settings["penbox_value"] = key
+                            channel(f"{str(op)} penbox_value changed to {key}.")
+                        except AttributeError:
+                            pass
+                else:
+                    if key is None:
+                        channel("----------")
+                        for op in data:
+                            try:
+                                key = op.settings.get("penbox_value")
+                                if key is None:
+                                    channel(f"{str(op)} penbox_value is not set.")
+                                else:
+                                    channel(f"{str(op)} penbox_value is set to {key}.")
+                            except AttributeError:
+                                pass  # No op.settings.
+                        channel("----------")
+            return "ops", data
+
+        # --------------------------- END COMMANDS ------------------------------
+
+    def load_persistent_penbox(self):
+        settings = self.pen_data
+        pens = settings.read_persistent_string_dict("pens", suffix=True)
+        for pen in pens:
+            length = int(pens[pen])
+            box = list()
+            for i in range(length):
+                penbox = dict()
+                settings.read_persistent_string_dict(f"{pen} {i}", penbox, suffix=True)
+                box.append(penbox)
+            self.penbox[pen] = box
+
+    def save_persistent_penbox(self):
+        sections = {}
+        for section in self.penbox:
+            sections[section] = len(self.penbox[section])
+        self.pen_data.write_persistent_dict("pens", sections)
+        for section in self.penbox:
+            for i, p in enumerate(self.penbox[section]):
+                self.pen_data.write_persistent_dict(f"{section} {i}", p)
+
+    def shutdown(self, *args, **kwargs):
+        self.save_persistent_penbox()
+        self.pen_data.write_configuration()

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -316,7 +316,7 @@ class HatchOpNode(Node, Parameters):
             penbox_pass = self.settings.get("penbox_pass")
             if penbox_pass is not None:
                 try:
-                    penbox_pass = context.elements.penbox[penbox_pass]
+                    penbox_pass = context.penbox.penbox[penbox_pass]
                 except KeyError:
                     penbox_pass = None
             hatch_cache = dict()

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -316,7 +316,7 @@ class HatchOpNode(Node, Parameters):
             penbox_pass = self.settings.get("penbox_pass")
             if penbox_pass is not None:
                 try:
-                    penbox_pass = context.penbox.penbox[penbox_pass]
+                    penbox_pass = context.penbox.pens[penbox_pass]
                 except KeyError:
                     penbox_pass = None
             hatch_cache = dict()

--- a/test/test_elements_penbox.py
+++ b/test/test_elements_penbox.py
@@ -13,9 +13,9 @@ class TestPenbox(unittest.TestCase):
         try:
             kernel_root = kernel.get_context("/")
             kernel_root("penbox testpasses add 5 set 0-4 hatch_angle 0-90\n")
-            self.assertEqual(len(kernel_root.elements.penbox["testpasses"]), 5)
+            self.assertEqual(len(kernel_root.penbox.pens["testpasses"]), 5)
             self.assertEqual(
-                kernel_root.elements.penbox["testpasses"][-1]["hatch_angle"], 90
+                kernel_root.elements.penbox.pens["testpasses"][-1]["hatch_angle"], 90
             )
 
         finally:


### PR DESCRIPTION
Penbox was added to the elements service but isn't needed there. It merely stores a list of settings within ranges and shifts to allow mapping of value to particular overloaded settings or a different setting for each pass.