### PR TITLE
Change `maintain_zoom_reseize` to `autofocus_resize` default off

### DIFF
--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -321,7 +321,6 @@ class MeerK40t(MWindow):
     def register_options_and_choices(self, context):
         _ = context._
         context.setting(bool, "disable_tool_tips", False)
-        context.setting(bool, "maintain_zoom_resize", True)
         context.setting(bool, "enable_sel_move", True)
         context.setting(bool, "enable_sel_size", True)
         context.setting(bool, "enable_sel_rotate", True)
@@ -443,11 +442,11 @@ class MeerK40t(MWindow):
         context.kernel.register_choices("preferences", choices)
         choices = [
             {
-                "attr": "maintain_zoom_resize",
+                "attr": "autofocus_resize",
                 "object": self.context.root,
-                "default": True,
+                "default": False,
                 "type": bool,
-                "label": _("Maintain zoom on resize"),
+                "label": _("Autofocus bed on resize"),
                 "tip": _("Autofocus bed when resizing the main window"),
                 "page": "Gui",
                 "section": "Zoom",
@@ -3609,7 +3608,7 @@ class MeerK40t(MWindow):
         if self.context is None:
             return
         self.Layout()
-        if self.context.maintain_zoom_resize:
+        if self.context.autofocus_resize:
             zl = self.context.zoom_margin
             self.context(f"scene focus -{zl}% -{zl}% {100 + zl}% {100 + zl}%\n")
 


### PR DESCRIPTION
Fixes #1397

This was turned into a feature but it is ambiguous, if you resize something and maintain the zoom. You expect to not change the zoom. However, with maintain_zoom on it would issue the `scene focus` command to discard the zoom you were using.

Further this defaulted to True, meaning that refocus on resize was the default behavior.

Fixing this requires a name change to correct the ambiguity and to more correctly set default `autofocus_resize` to False, which means do not autofocus on resize.