### PR TITLE
Some changes around reference object

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1049,6 +1049,14 @@ def init_tree(kernel):
     def remove_n_elements(node, **kwargs):
         self("element delete\n")
 
+    @tree_operation(
+        _("Become reference object"),
+        node_type=elem_nodes,
+        help="",
+    )
+    def make_node_reference(node, **kwargs):
+        self.signal("make_reference", node)
+
     @tree_conditional(
         lambda node: isinstance(node.shape, Polygon) and len(node.shape.points) >= 3
     )

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -714,6 +714,7 @@ class MeerK40tScenePanel(wx.Panel):
     def reference_object(self, ref_object):
         prev = self._reference
         self._reference = ref_object
+        self.scene.reference_object = self._reference
         dlist = []
         if prev is not None:
             dlist.append(prev)
@@ -859,6 +860,12 @@ class MeerK40tScenePanel(wx.Panel):
             self._last_snap_ts = 0
         else:
             self._last_snap_ts = time.time()
+
+    @signal_listener("make_reference")
+    def listen_make_ref(self, origin, *args):
+        node = args[0]
+        self.reference_object = node
+        self.context.signal("reference")
 
     @signal_listener("draw_mode")
     def on_draw_mode(self, origin, *args):


### PR DESCRIPTION
- Sync status properly
- Allow regmarks to become ref object via context menu (needed previously to assign the status to a regular element and move it to regmark)