### PR TITLE
Position the Machine Origin Widget at the device origin (always).

### DIFF
--- a/meerk40t/gui/scenewidgets/machineoriginwidget.py
+++ b/meerk40t/gui/scenewidgets/machineoriginwidget.py
@@ -48,8 +48,10 @@ class MachineOriginWidget(Widget):
         y_dx, y_dy = space.display.iposition(0, 50000)
         ya1_dx, ya1_dy = space.display.iposition(5000, 45000)
         ya2_dx, ya2_dy = space.display.iposition(-5000, 45000)
+        dev0x, dev0y = self.scene.context.device.device_to_scene_position(0, 0)
         gc.SetBrush(self.brush)
-        gc.DrawRectangle(x - margin, y - margin, margin * 2, margin * 2)
+        gc.DrawRectangle(dev0x - margin, dev0y - margin, margin * 2, margin * 2)
+
         gc.SetBrush(wx.NullBrush)
         gc.SetPen(self.x_axis_pen)
         gc.DrawLines(


### PR DESCRIPTION
* The main angles for widget start from 0,0 and point x (red), and y (green). But the red rect actually is the machine origin which is not necessarily the same point as the display 0,0.