### PR TITLE
TCP Galvo Driver Connection

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -29,6 +29,11 @@ class BalorDevice(Service, ViewPort):
 
     def __init__(self, kernel, path, *args, choices=None, **kwargs):
         Service.__init__(self, kernel, path)
+        self.permit_usb = True
+        self.permit_tcp = True
+        self.interface = "tcp"
+        self.address = "localhost"
+        self.port = 25978
         self.name = "balor"
         self.extension = "lmc"
         self.job = None

--- a/meerk40t/balormk/mock_connection.py
+++ b/meerk40t/balormk/mock_connection.py
@@ -10,7 +10,7 @@ import struct
 
 
 class MockConnection:
-    def __init__(self, channel):
+    def __init__(self, service, channel):
         self.channel = channel
         self.send = None
         self.recv = None

--- a/meerk40t/balormk/tcp_connection.py
+++ b/meerk40t/balormk/tcp_connection.py
@@ -1,0 +1,79 @@
+"""
+Galvo USB Connection
+
+Performs the required interactions with the Galvo backend through pyusb and libusb.
+"""
+
+import socket
+
+
+class TCPConnection:
+    def __init__(self, service, channel):
+        super().__init__()
+
+        self.channel = channel
+        self.devices = {}
+        self.interface = {}
+        self.backend_error_code = None
+        self.timeout = 100
+
+        self.service = service
+        self._stream = None
+        self._read_buffer_size = 1024
+        self.read_buffer = bytearray()
+        self.name = service.name
+
+    @property
+    def connected(self):
+        return self._stream is not None
+
+    def open(self, index=0):
+        try:
+            self._stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._stream.connect((self.service.address, self.service.port))
+            self.service.signal("grbl;status", "connected")
+        except TimeoutError:
+            self.close(index)
+            self.service.signal("grbl;status", "timeout connect")
+        except ConnectionError:
+            self.close(index)
+            self.service.signal("grbl;status", "connection error")
+        except socket.gaierror as e:
+            self.close(index)
+            self.service.signal("grbl;status", "address resolve error")
+        except socket.herror as e:
+            self.close(index)
+            self.service.signal("grbl;status", f"herror: {str(e)}")
+        except OSError as e:
+            self.close(index)
+            self.service.signal("grbl;status", f"Host down {str(e)}")
+
+    def close(self, index=0):
+        self.service.signal("grbl;status", "disconnected")
+        self._stream.close()
+        self._stream = None
+
+    def write(self, index=0, packet=None, attempt=0):
+        while packet:
+            sent = self._stream.send(packet)
+            if sent == len(packet):
+                return
+            packet = packet[sent:]
+
+    def read(self, index=0, attempt=0):
+        f = self.read_buffer.find(b"\n")
+        if f == -1:
+            self.read_buffer += self._stream.recv(self._read_buffer_size)
+            f = self.read_buffer.find(b"\n")
+            if f == -1:
+                return
+        response = self.read_buffer[:f]
+        self.read_buffer = self.read_buffer[f + 1 :]
+        str_response = str(response, "latin-1")
+        str_response = str_response.strip()
+        return str_response
+
+    def __repr__(self):
+        if self.name is not None:
+            return f"TCPOutput('{self.service.location()}','{self.name}')"
+        return f"TCPOutput('{self.service.location()}')"

--- a/meerk40t/balormk/usb_connection.py
+++ b/meerk40t/balormk/usb_connection.py
@@ -24,7 +24,7 @@ READ_ENDPOINT = 0x88
 
 
 class USBConnection:
-    def __init__(self, channel):
+    def __init__(self, service, channel):
         self.channel = channel
         self.devices = {}
         self.interface = {}


### PR DESCRIPTION
* This likely requires `size, checksum, <payload>` chunks.
* Would require that the galvo driver not necessarily expect a reply that stalls the driver.
* This likely requires a protocol of send and response which also provides the original query command.
* The data would perhaps be better off sent according to the driver protocols. So "function()", "payload" information.