### PR TITLE
Remove double bound commands. 

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -144,7 +144,7 @@ DEFAULT_KEYMAP = {
         "rotaryscale",
     ),
     "ctrl+a": ("element* select",),
-    "ctrl+c": ("clipboard copy",),
+    "ctrl+c": ("", "clipboard copy",),
     "ctrl+shift+c": ("align bed group xy center center",),
     "ctrl+e": (
         "circle 0.5in 0.5in 0.5in stroke red classify",

--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -172,13 +172,23 @@ DEFAULT_KEYMAP = {
         "",
         "dialog_stroke",
     ),
-    "ctrl+v": ("clipboard paste",),
-    "ctrl+x": ("clipboard cut",),
+    "ctrl+v": (
+        "",
+        "clipboard paste",
+    ),
+    "ctrl+x": (
+        "",
+        "clipboard cut",
+    ),
     "ctrl+z": (
+        "",
         "undo",
         "reset",
     ),
-    "ctrl+shift+z": ("redo",),
+    "ctrl+shift+z": (
+        "",
+        "redo",
+    ),
     "ctrl+1": ("bind 1 move $x $y",),
     "ctrl+2": ("bind 2 move $x $y",),
     "ctrl+3": ("bind 3 move $x $y",),

--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -143,7 +143,7 @@ DEFAULT_KEYMAP = {
         "",
         "rotaryscale",
     ),
-    "ctrl+a": ("element* select",),
+    "ctrl+a": ("", "element* select",),
     "ctrl+c": ("", "clipboard copy",),
     "ctrl+shift+c": ("align bed group xy center center",),
     "ctrl+e": (

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2699,7 +2699,7 @@ class MeerK40t(MWindow):
         self.Bind(wx.EVT_MENU, self.on_click_exit, id=menu_item.GetId())
         self.main_menubar.Append(self.file_menu, _("File"))
 
-    def _update_status_edit_menu(self):
+    def _update_status_edit_menu(self, *args):
         choices = self.edit_menu_choice
 
         def handler(event):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -555,7 +555,7 @@ class MeerK40t(MWindow):
     @signal_listener("emphasized")
     def on_update_statusbar(self, origin, *args):
         value = self.context.elements.has_emphasis()
-        self._update_status_edit_menu()
+        self._update_status_edit_menu()(None)
         if not self.context.show_colorbar or not self.widgets_created:
             return
 
@@ -2714,7 +2714,8 @@ class MeerK40t(MWindow):
                         if menu_id != wx.NOT_FOUND:
                             menu_item = self.edit_menu.FindItemById(menu_id)
                             menu_item.Enable(flag)
-            event.Skip()
+            if event:
+                event.Skip()
 
         return handler
 
@@ -2731,7 +2732,7 @@ class MeerK40t(MWindow):
         else:
             self.main_menubar.Append(self.edit_menu, label)
 
-        self.edit_menu.Bind(wx.EVT_MENU_OPEN, self._update_status_edit_menu)
+        self.edit_menu.Bind(wx.EVT_MENU_OPEN, self._update_status_edit_menu())
 
     def __set_view_menu(self):
         def toggle_draw_mode(bits):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -308,6 +308,8 @@ class MeerK40t(MWindow):
 
     @signal_listener("emphasized")
     def on_update_statusbar(self, origin, *args):
+        for menu, title in self.main_menubar.Menus:
+            menu.UpdateUI()
         if not self.context.show_colorbar or not self.widgets_created:
             return
         value = self.context.elements.has_emphasis()

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2727,11 +2727,6 @@ class MeerK40t(MWindow):
             return handler
 
         self.edit_menu.Bind(wx.EVT_MENU_OPEN, update_status(choices))
-        for entry in choices:
-            menu_item = entry.get("menu_item")
-            if not menu_item:
-                continue
-            menu_item.SetItemLabel(menu_item.GetItemLabel())
 
     def __set_view_menu(self):
         def toggle_draw_mode(bits):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2732,7 +2732,7 @@ class MeerK40t(MWindow):
             },
         ]
         self.edit_menu = wx.Menu()
-        self._create_menu_from_choices(self.edit_menu, choices)
+
         label = _("Edit")
         index = self.main_menubar.FindMenu(label)
         if index != -1:
@@ -2740,6 +2740,7 @@ class MeerK40t(MWindow):
         else:
             self.main_menubar.Append(self.edit_menu, label)
 
+        self._create_menu_from_choices(self.edit_menu, choices)
         def update_status(choices):
             def handler(event):
                 for entry in choices:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2721,6 +2721,7 @@ class MeerK40t(MWindow):
                             if menu_id != wx.NOT_FOUND:
                                 menu_item = self.edit_menu.FindItemById(menu_id)
                                 menu_item.Enable(flag)
+                                menu_item.SetItemLabel(menu_item.GetItemLabel())
                         # print (entry["label"], entry["enabled"](), flag)
                 event.Skip()
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2409,7 +2409,7 @@ class MeerK40t(MWindow):
                         wx.ITEM_CHECK,
                     )
                     menu_item.Check(c_criteria)
-                current_menu.SetLabel(c_id, c_label)
+                menu_item.SetAccel(menu_item.GetAccel())
                 flag = True
                 if c_enabled is not None:
                     try:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2409,7 +2409,7 @@ class MeerK40t(MWindow):
                         wx.ITEM_CHECK,
                     )
                     menu_item.Check(c_criteria)
-                menu_item.SetAccel(menu_item.GetAccel())
+                choice["menu_item"] = menu_item
                 flag = True
                 if c_enabled is not None:
                     try:
@@ -2764,6 +2764,11 @@ class MeerK40t(MWindow):
             return handler
 
         self.edit_menu.Bind(wx.EVT_MENU_OPEN, update_status(choices))
+        for entry in choices:
+            menu_item = entry.get("menu_item")
+            if not menu_item:
+                continue
+            menu_item.SetItemLabel(menu_item.GetItemLabel())
 
     def __set_view_menu(self):
         def toggle_draw_mode(bits):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2309,56 +2309,16 @@ class MeerK40t(MWindow):
             except KeyError:
                 c_level = 1
 
-            try:
-                c_segment = choice["segment"]
-            except KeyError:
-                c_segment = ""
-
-            try:
-                c_subsegment = choice["subsegment"]
-            except KeyError:
-                c_subsegment = ""
-
-            try:
-                c_label = choice["label"]
-            except KeyError:
-                c_label = ""
-
-            try:
-                c_help = choice["help"]
-            except KeyError:
-                c_help = ""
-
-            try:
-                c_action = choice["action"]
-            except KeyError:
-                c_action = None
-
-            try:
-                c_criteria = choice["criteria"]
-            except KeyError:
-                c_criteria = None
-
-            try:
-                c_enabled = choice["enabled"]
-            except KeyError:
-                c_enabled = None
-
-            try:
-                c_segment = choice["segment"]
-            except KeyError:
-                c_segment = ""
-
-            try:
-                c_param = choice["parameter"]
-            except KeyError:
-                c_param = None
-
-            try:
-                c_id = choice["id"]
-            except KeyError:
-                c_id = wx.ID_ANY
-            # print(f"{c_segment}{c_subsegment},{c_level}: {c_label}")
+            c_segment = choice.get("segment", "")
+            c_subsegment = choice.get("subsegment", "")
+            c_label = choice.get("label", "")
+            c_help = choice.get("help", "")
+            c_action = choice.get("action")
+            c_criteria = choice.get("criteria")
+            c_enabled = choice.get("enabled")
+            c_segment = choice.get("segment", "")
+            c_param = choice.get("parameter")
+            c_id = choice.get("id", wx.ID_ANY)
             if c_segment != current_segment:
                 current_segment = c_segment
                 current_subsegment = ""

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2415,7 +2415,8 @@ class MeerK40t(MWindow):
                         flag = bool(c_enabled())
                     except (AttributeError, TypeError):
                         pass
-                menu_item.Enable(flag)
+                if not flag:
+                    menu_item.Enable(flag)
 
                 def deal_with(routine, parameter=None):
                     def done(event):
@@ -2762,7 +2763,6 @@ class MeerK40t(MWindow):
             return handler
 
         self.edit_menu.Bind(wx.EVT_MENU_OPEN, update_status(choices))
-        self.SetAcceleratorTable(self.AcceleratorTable)
 
     def __set_view_menu(self):
         def toggle_draw_mode(bits):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2697,6 +2697,7 @@ class MeerK40t(MWindow):
             },
         ]
         self.edit_menu = wx.Menu()
+        self._create_menu_from_choices(self.edit_menu, choices)
 
         label = _("Edit")
         index = self.main_menubar.FindMenu(label)
@@ -2705,7 +2706,6 @@ class MeerK40t(MWindow):
         else:
             self.main_menubar.Append(self.edit_menu, label)
 
-        self._create_menu_from_choices(self.edit_menu, choices)
         def update_status(choices):
             def handler(event):
                 for entry in choices:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -261,7 +261,7 @@ class MeerK40t(MWindow):
 
         self.assign_button_panel.show_stuff(False)
 
-    def setup_edit_menu_choice(self):
+    def _setup_edit_menu_choice(self):
 
         def on_click_undo():
             self.context("undo\n")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2762,6 +2762,7 @@ class MeerK40t(MWindow):
             return handler
 
         self.edit_menu.Bind(wx.EVT_MENU_OPEN, update_status(choices))
+        self.SetAcceleratorTable(self.AcceleratorTable)
 
     def __set_view_menu(self):
         def toggle_draw_mode(bits):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -555,7 +555,7 @@ class MeerK40t(MWindow):
     @signal_listener("emphasized")
     def on_update_statusbar(self, origin, *args):
         value = self.context.elements.has_emphasis()
-        self.__set_edit_menu()
+        self._update_status_edit_menu()
         if not self.context.show_colorbar or not self.widgets_created:
             return
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2409,6 +2409,7 @@ class MeerK40t(MWindow):
                         wx.ITEM_CHECK,
                     )
                     menu_item.Check(c_criteria)
+                current_menu.SetLabel(c_id, c_label)
                 flag = True
                 if c_enabled is not None:
                     try:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2700,10 +2700,8 @@ class MeerK40t(MWindow):
         self.main_menubar.Append(self.file_menu, _("File"))
 
     def _update_status_edit_menu(self, *args):
-        choices = self.edit_menu_choice
-
         def handler(event):
-            for entry in choices:
+            for entry in self.edit_menu_choice:
                 if "label" in entry and "enabled" in entry:
                     flag = True
                     label = entry["label"]
@@ -2725,15 +2723,13 @@ class MeerK40t(MWindow):
         Edit MENU
         """
         self.edit_menu = wx.Menu()
-        choices = self.edit_menu_choice
-        self._create_menu_from_choices(self.edit_menu, choices)
+        self._create_menu_from_choices(self.edit_menu, self.edit_menu_choice)
         label = _("Edit")
         index = self.main_menubar.FindMenu(label)
         if index != -1:
             self.main_menubar.Replace(index, self.edit_menu, label)
         else:
             self.main_menubar.Append(self.edit_menu, label)
-
 
         self.edit_menu.Bind(wx.EVT_MENU_OPEN, self._update_status_edit_menu)
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -308,11 +308,11 @@ class MeerK40t(MWindow):
 
     @signal_listener("emphasized")
     def on_update_statusbar(self, origin, *args):
-        for menu, title in self.main_menubar.Menus:
-            menu.UpdateUI()
+        value = self.context.elements.has_emphasis()
+        self.__set_edit_menu()
         if not self.context.show_colorbar or not self.widgets_created:
             return
-        value = self.context.elements.has_emphasis()
+
         self.main_statusbar.Signal("emphasized")
         # First enable/disable the controls in the statusbar
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2318,6 +2318,7 @@ class MeerK40t(MWindow):
             c_enabled = choice.get("enabled")
             c_segment = choice.get("segment", "")
             c_param = choice.get("parameter")
+            c_text_color = choice.get("text_color")
             c_id = choice.get("id", wx.ID_ANY)
             if c_segment != current_segment:
                 current_segment = c_segment
@@ -2370,14 +2371,16 @@ class MeerK40t(MWindow):
                     )
                     menu_item.Check(c_criteria)
                 choice["menu_item"] = menu_item
-                flag = True
-                if c_enabled is not None:
-                    try:
-                        flag = bool(c_enabled())
-                    except (AttributeError, TypeError):
-                        pass
-                if not flag:
-                    menu_item.Enable(flag)
+                if c_text_color:
+                    menu_item.SetTextColour(c_text_color)
+                # flag = True
+                # if c_enabled is not None:
+                #     try:
+                #         flag = bool(c_enabled())
+                #     except (AttributeError, TypeError):
+                #         pass
+                # if not flag:
+                #     menu_item.Enable(flag)
 
                 def deal_with(routine, parameter=None):
                     def done(event):


### PR DESCRIPTION
Anything that is already exists in Menubar cannot be a keybind here (at least by default)

Linux will execute both. Causing double-undos.