### PR TITLE
Mac OSX: Tree too large vs. Laser Pane

### DIFF
--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -64,7 +64,7 @@ def register_panel_tree(window, context):
         .CaptionVisible(not context.pane_lock)
         .TopDockable(False)
     )
-    pane.dock_proportion = 270
+    pane.dock_proportion = 500
     pane.control = wxtree
     window.on_pane_create(pane)
     context.register("pane/tree", pane)

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -50,13 +50,13 @@ _ = wx.GetTranslation
 
 def register_panel_tree(window, context):
     wxtree = TreePanel(window, wx.ID_ANY, context=context)
-    minwd = 75
     pane = (
         aui.AuiPaneInfo()
         .Name("tree")
         .Left()
-        .MinSize(minwd, -1)
-        .BestSize(300, 500)
+        .MinSize(200, 180)
+        .BestSize(300, 270)
+        .FloatingSize(300, 270)
         .LeftDockable()
         .RightDockable()
         .BottomDockable(False)
@@ -64,7 +64,7 @@ def register_panel_tree(window, context):
         .CaptionVisible(not context.pane_lock)
         .TopDockable(False)
     )
-    pane.dock_proportion = 500
+    pane.dock_proportion = 270
     pane.control = wxtree
     window.on_pane_create(pane)
     context.register("pane/tree", pane)


### PR DESCRIPTION
Default start on Mac fails