### PR TITLE
camserver was set to listen on localhost only. Fixed.

### DIFF
--- a/meerk40t/camera/plugin.py
+++ b/meerk40t/camera/plugin.py
@@ -391,7 +391,7 @@ def plugin(kernel, lifecycle=None):
                 server.server_close()
                 channel(_("MJPEG-SERVER: Closed"))
 
-            server = ThreadedHTTPServer(("localhost", port), MJPEGHandler)
+            server = ThreadedHTTPServer(("0.0.0.0", port), MJPEGHandler)
             server.shutting_down = False
             thread = kernel.threaded(server.serve_forever, thread_name=f"cam-server{port}", daemon=True)
             thread.stop = do_shutdown


### PR DESCRIPTION
Changed 'localhost' to '0.0.0.0'
Restricting who can access a TCP connection in this way is only useful in protecting dev environments, not production.