### PR TITLE
Safe Lihuiyu Status Control-Transfer

### DIFF
--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -509,8 +509,8 @@ class LihuiyuController:
             if self.state == "init":
                 # If we are initialized. Change that to active since we're running.
                 self.update_state("active")
-            if self.state in ("pause", "busy", "suspend"):
-                # If we are paused just keep sleeping until the state changes.
+            elif self.state in ("pause", "busy", "suspend"):
+                # If we are paused just wait until the state changes.
                 if len(self._realtime_buffer) == 0 and len(self._preempt) == 0:
                     # Only pause if there are no realtime commands to queue.
                     self.context.signal("pipe;running", False)

--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -847,6 +847,7 @@ class LihuiyuController:
             if self.abort_waiting:
                 self.abort_waiting = False
                 break  # Wait abort was requested.
+            time.sleep(0.001)  # Only if we are using control transfer status checks.
         self.update_state(original_state)
 
     def _confirm_serial(self):


### PR DESCRIPTION
Use Control Transfer with first 10 attempts being without delay. Then above 10 attempts we delay 0.001 seconds incrementing for each attempt or to a max of 0.1 seconds over a total of 500 attempts.

The last 400 attempts would be 40 seconds, which would not typically happen without a real break.