### PR TITLE
Effect hatch

### DIFF
--- a/meerk40t/core/elements/align.py
+++ b/meerk40t/core/elements/align.py
@@ -602,7 +602,7 @@ def init_commands(kernel):
 
         haslock = False
         for node in elements:
-            if hasattr(node, "can_move") and not node.can_move(self.lock_allows_move):
+            if not node.can_move(self.lock_allows_move):
                 haslock = True
                 break
         if haslock:

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -968,6 +968,25 @@ def init_tree(kernel):
     # ==========
     # REMOVE SINGLE (Tree Selected - ELEMENT)
     # ==========
+
+    @tree_conditional(lambda node: hasattr(node, "effect") and not node.effect)
+    @tree_operation(
+        _("Effect: On"),
+        node_type=effect_nodes,
+        help="",
+    )
+    def effect_on(node, **kwargs):
+        node.effect = not node.effect
+
+    @tree_conditional(lambda node: hasattr(node, "effect") and node.effect)
+    @tree_operation(
+        _("Effect: Off"),
+        node_type=effect_nodes,
+        help="",
+    )
+    def effect_off(node, **kwargs):
+        node.effect = not node.effect
+
     @tree_conditional(lambda node: node.can_remove)
     @tree_conditional(
         lambda cond: len(

--- a/meerk40t/core/elements/element_types.py
+++ b/meerk40t/core/elements/element_types.py
@@ -13,6 +13,7 @@ non_structural_nodes = (
     "op engrave",
     "op dots",
     "op hatch",
+    "effect hatch",
     "util console",
     "util wait",
     "util home",
@@ -43,6 +44,7 @@ op_parent_nodes = (
     "op engrave",
     "op dots",
     "op hatch",
+    "effect hatch",
 )
 op_nodes = (
     "op cut",
@@ -83,6 +85,7 @@ elem_group_nodes = (
     "elem rect",
     "elem line",
     "elem text",
+    "effect hatch",
     "group",
     "file",
 )

--- a/meerk40t/core/elements/element_types.py
+++ b/meerk40t/core/elements/element_types.py
@@ -75,6 +75,7 @@ elem_nodes = (
     "elem rect",
     "elem line",
     "elem text",
+    "effect hatch",
 )
 elem_group_nodes = (
     "elem ellipse",
@@ -98,5 +99,6 @@ elem_ref_nodes = (
     "elem rect",
     "elem line",
     "elem text",
+    "effect hatch",
     "reference",
 )

--- a/meerk40t/core/elements/element_types.py
+++ b/meerk40t/core/elements/element_types.py
@@ -65,6 +65,9 @@ place_nodes = (
     "place point",
     "place current",
 )
+effect_nodes = (
+    "effect hatch",
+)
 elem_nodes = (
     "elem ellipse",
     "elem image",

--- a/meerk40t/core/elements/element_types.py
+++ b/meerk40t/core/elements/element_types.py
@@ -44,7 +44,6 @@ op_parent_nodes = (
     "op engrave",
     "op dots",
     "op hatch",
-    "effect hatch",
 )
 op_nodes = (
     "op cut",

--- a/meerk40t/core/elements/offset.py
+++ b/meerk40t/core/elements/offset.py
@@ -680,6 +680,9 @@ def init_commands(kernel):
                 p = abs(node.as_path())
             else:
                 bb = node.bounds
+                if bb is None:
+                    # Node has no bounds or space, therefore no offset outline.
+                    return "elements", data_out
                 # TODO: Internal uses of Rect and Path.
                 r = Rect(x=bb[0], y=bb[1], width=bb[2] - bb[0], height=bb[3] - bb[1])
                 p = Path(r)

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -245,10 +245,20 @@ def init_commands(kernel):
         if data is not None:
             for n in data:
                 node.append_child(n)
-                n._can_emphasize = False
-                n._can_move = False
-                n.lock = True
         node.focus()
+
+    @self.console_command(
+        "toggle_effect",
+        help=_("Toggles effect from being group to an effect."),
+        input_type="elements"
+    )
+    def effect_hatch(command, data=None, **kwargs):
+        """
+        Add an effect hatch object
+        """
+        for n in data:
+            if n.type.startswith("effect "):
+                n.effect = not n.effect
 
     @self.console_option(
         "size", "s", type=float, default=16, help=_("font size to for object")

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -230,7 +230,7 @@ def init_commands(kernel):
         return "elements", data
 
     @self.console_command(
-        "hatch",
+        "effect-hatch",
         help=_("adds hatch-effect to scene"),
         input_type=None,
     )

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -232,16 +232,22 @@ def init_commands(kernel):
     @self.console_command(
         "effect-hatch",
         help=_("adds hatch-effect to scene"),
-        input_type=None,
+        input_type=(None, "elements")
     )
-    def effect_hatch(command, **kwargs):
+    def effect_hatch(command, data=None, **kwargs):
         """
-        Draws a svg line in the scene.
+        Add an effect hatch object
         """
         node = self.elem_branch.add(
             type="effect hatch", label="Hatch Effect"
         )
         self.set_emphasis([node])
+        if data is not None:
+            for n in data:
+                node.append_child(n)
+                n._can_emphasize = False
+                n._can_move = False
+                n.lock = True
         node.focus()
 
     @self.console_option(

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -640,8 +640,12 @@ def init_commands(kernel):
             channel("Requires a selected cutter polygon")
             return None
         data.sort(key=lambda n: n.emphasized_time)
-        outer_path = data[0].as_path()
-        inner_path = data[1].as_path()
+        try:
+            outer_path = data[0].as_path()
+            inner_path = data[1].as_path()
+        except AttributeError:
+            # elem text does not have an as_path() object
+            return "elements", data
         data[1].remove_node()
 
         from meerk40t.tools.pathtools import VectorMontonizer

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -248,13 +248,13 @@ def init_commands(kernel):
         node.focus()
 
     @self.console_command(
-        "toggle_effect",
+        "toggle",
         help=_("Toggles effect from being group to an effect."),
         input_type="elements"
     )
-    def effect_hatch(command, data=None, **kwargs):
+    def effect_toggle(command, data=None, **kwargs):
         """
-        Add an effect hatch object
+        Toggles effect hatch object
         """
         for n in data:
             if n.type.startswith("effect "):

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -454,7 +454,7 @@ def init_commands(kernel):
         else:
             for e in data:
                 if prop in ("x", "y"):
-                    if hasattr(e, "can_move") and not e.can_move(self.lock_allows_move):
+                    if not e.can_move(self.lock_allows_move):
                         channel(
                             _("Element can not be moved: {name}").format(name=str(e))
                         )

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -229,6 +229,21 @@ def init_commands(kernel):
         post.append(classify_new(data))
         return "elements", data
 
+    @self.console_command(
+        "hatch",
+        help=_("adds hatch-effect to scene"),
+        input_type=None,
+    )
+    def effect_hatch(command, **kwargs):
+        """
+        Draws a svg line in the scene.
+        """
+        node = self.elem_branch.add(
+            type="effect hatch", label="Hatch Effect"
+        )
+        self.set_emphasis([node])
+        node.focus()
+
     @self.console_option(
         "size", "s", type=float, default=16, help=_("font size to for object")
     )

--- a/meerk40t/core/node/bootstrap.py
+++ b/meerk40t/core/node/bootstrap.py
@@ -3,6 +3,7 @@ from meerk40t.core.node.branch_elems import BranchElementsNode
 from meerk40t.core.node.branch_ops import BranchOperationsNode
 from meerk40t.core.node.branch_regmark import BranchRegmarkNode
 from meerk40t.core.node.cutnode import CutNode
+from meerk40t.core.node.effect_hatch import HatchEffectNode
 from meerk40t.core.node.elem_ellipse import EllipseNode
 from meerk40t.core.node.elem_image import ImageNode
 from meerk40t.core.node.elem_line import LineNode
@@ -74,6 +75,7 @@ bootstrap = {
     "op image": ImageOpNode,
     "op dots": DotsOpNode,
     "op hatch": HatchOpNode,
+    "effect hatch": HatchEffectNode,
     "util console": ConsoleOperation,
     "util wait": WaitOperation,
     "util home": HomeOperation,

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -107,14 +107,14 @@ class HatchEffectNode(Node, Stroked):
         path = Geomstr()
         if not self.effect:
             return path
-        outlines = list()
         for node in self._operands:
             if node.type == "reference":
                 node = node.node
             path.append(node.as_geometry())
-            outlines.extend(path.as_interpolated_points(interpolate=100))
-            outlines.append(None)
+        outlines = list()
+        outlines.extend(path.as_interpolated_points(interpolate=100))
         if outlines:
+            path = Geomstr()
             for p in range(self.passes):
                 hatches = list(
                     self.hatch_algorithm(

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -131,11 +131,14 @@ class HatchEffectNode(Node, Stroked):
             if node.type == "reference":
                 node = node.node
             outlines.append(node.as_geometry())
+        outlines.transform(self.matrix)
         path = Geomstr()
         for p in range(self.passes):
             path.append(self.scanline_fill(outlines=outlines))
-        path.transform(self.matrix)
         return path
+
+    def modified(self):
+        self.altered()
 
     def scanline_fill(self, outlines):
         """

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -24,7 +24,7 @@ class HatchEffectNode(Node, Stroked):
         self.output = True
         Node.__init__(self, type="effect hatch", id=id, label=label, lock=lock)
         self._formatter = (
-            "{enabled}{element_type} - {distance} {angle}"
+            "{effect}{element_type} - {distance} {angle}"
         )
         if self.matrix is None:
             self.matrix = Matrix()
@@ -79,6 +79,7 @@ class HatchEffectNode(Node, Stroked):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Hatch"
         default_map["enabled"] = "(Disabled) " if not self.output else ""
+        default_map["effect"] = "+" if self.effect else "-"
         default_map["pass"] = (
             f"{self.passes}X " if self.passes and self.passes != 1 else ""
         )

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -19,9 +19,13 @@ class HatchEffectNode(Node, Stroked):
         self.stroke = Color("Blue")
         self.fill = None
         self.stroke_width = 1000.0
+        self.output = True
         self.stroke_scale = False
         self._stroke_zero = None
         Node.__init__(self, type="effect hatch", id=id, label=label, lock=lock)
+        self._formatter = (
+            "{enabled}{element_type} - {distance} {angle}"
+        )
         if self.matrix is None:
             self.matrix = Matrix()
 
@@ -41,6 +45,17 @@ class HatchEffectNode(Node, Stroked):
 
     def __copy__(self):
         return HatchEffectNode(self)
+
+    def default_map(self, default_map=None):
+        default_map = super().default_map(default_map=default_map)
+        default_map["element_type"] = "Hatch"
+        default_map["enabled"] = "(Disabled) " if not self.output else ""
+        default_map["pass"] = (
+            f"{self.passes}X " if self.passes and self.passes != 1 else ""
+        )
+        default_map["angle"] = str(self.hatch_angle)
+        default_map["distance"] = str(self.hatch_distance)
+        return default_map
 
     def as_geometry(self):
         path = Geomstr()

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -130,12 +130,11 @@ class HatchEffectNode(Node, Stroked):
         for node in self._operands:
             if node.type == "reference":
                 node = node.node
-            g = node.as_geometry()
-            outlines.append(Geomstr.lines(*g.as_interpolated_points(interpolate=50)))
+            outlines.append(node.as_geometry())
         outlines.transform(self.matrix)
         path = Geomstr()
         for p in range(self.passes):
-            path.append(self.scanline_fill(outlines=outlines))
+            path.append(self.scanline_fill(outlines=outlines.segmented()))
         return path
 
     def modified(self):

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -95,10 +95,13 @@ class HatchEffectNode(Node, Stroked):
         self._effect = value
         if self._effect:
             self._operands.extend(self._children)
+            for c in self._children:
+                c.matrix *= ~self.matrix
             self.remove_all_children(destroy=False)
             self.altered()
         else:
             for c in self._operands:
+                c.matrix *= self.matrix
                 self.add_node(c)
             self._operands.clear()
             self.altered()
@@ -131,6 +134,7 @@ class HatchEffectNode(Node, Stroked):
             # Dragging element onto operation adds that element to the op.
             if modify:
                 if self._effect:
+                    drag_node.matrix *= ~self.matrix
                     self._operands.append(drag_node)
                     drag_node.remove_node()
                 else:

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -97,14 +97,18 @@ class HatchEffectNode(Node, Stroked):
         if self._effect:
             self._operands.extend(self._children)
             for c in self._children:
+                c.set_dirty_bounds()
                 c.matrix *= ~self.matrix
             self.remove_all_children(destroy=False)
+            self.set_dirty_bounds()
             self.altered()
         else:
             for c in self._operands:
                 c.matrix *= self.matrix
+                self.set_dirty_bounds()
                 self.add_node(c)
             self._operands.clear()
+            self.set_dirty_bounds()
             self.altered()
 
     def as_geometry(self):

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -107,7 +107,7 @@ class HatchEffectNode(Node, Stroked):
         if drag_node.type.startswith("elem"):
             # Dragging element onto operation adds that element to the op.
             if modify:
-                self.add_reference(drag_node, pos=0)
+                self.append_child(drag_node)
                 self.altered()
             return True
         elif drag_node.type == "reference":

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -130,7 +130,8 @@ class HatchEffectNode(Node, Stroked):
         for node in self._operands:
             if node.type == "reference":
                 node = node.node
-            outlines.append(node.as_geometry())
+            g = node.as_geometry()
+            outlines.append(Geomstr.lines(*g.as_interpolated_points(interpolate=50)))
         outlines.transform(self.matrix)
         path = Geomstr()
         for p in range(self.passes):

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -44,7 +44,7 @@ class HatchEffectNode(Node, Stroked):
         self.hatch_algorithm = scanline_fill
         self.settings = kwargs
         self._operands = list()
-        self._effect = False
+        self._effect = True
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"
@@ -95,15 +95,15 @@ class HatchEffectNode(Node, Stroked):
         self._effect = value
         if self._effect:
             self._operands.extend(self._children)
-            self._children.clear()
+            self.remove_all_children(destroy=False)
             self.altered()
         else:
-            self._children.extend(self._operands)
+            for c in self._operands:
+                self.add_node(c)
             self._operands.clear()
             self.altered()
 
     def as_geometry(self):
-
         path = Geomstr()
         if not self.effect:
             return path
@@ -130,7 +130,11 @@ class HatchEffectNode(Node, Stroked):
         if drag_node.type.startswith("elem"):
             # Dragging element onto operation adds that element to the op.
             if modify:
-                self.append_child(drag_node)
+                if self._effect:
+                    self._operands.append(drag_node)
+                    drag_node.remove_node()
+                else:
+                    self.append_child(drag_node)
                 self.altered()
             return True
         elif drag_node.type == "reference":

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -1,0 +1,84 @@
+from copy import copy
+
+from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.node import Node
+from meerk40t.fill.fills import scanline_fill
+from meerk40t.svgelements import Matrix, Color
+from meerk40t.tools.geomstr import Geomstr
+
+
+class HatchEffectNode(Node, Stroked):
+    """
+    Default object defining any operation done on the laser.
+
+    This is a Node of type "hatch op".
+    """
+
+    def __init__(self, *args, id=None, label=None, lock=False,  **kwargs):
+        self.matrix = None
+        self.stroke = Color("Blue")
+        self.fill = None
+        self.stroke_width = 1000.0
+        self.stroke_scale = False
+        self._stroke_zero = None
+        Node.__init__(self, type="effect hatch", id=id, label=label, lock=lock)
+        if self.matrix is None:
+            self.matrix = Matrix()
+
+        if label is None:
+            self.label = "Hatch"
+        else:
+            self.label = label
+        self.hatch_type = "scanline"
+        self.passes = 1
+        self.hatch_distance = "1mm"
+        self.hatch_angle = "0deg"
+        self.hatch_algorithm = scanline_fill
+        self.settings = kwargs
+
+    def __repr__(self):
+        return "HatchEffectNode()"
+
+    def __copy__(self):
+        return HatchEffectNode(self)
+
+    def as_geometry(self):
+        path = Geomstr()
+        outlines = list()
+        for node in self.children:
+            if node.type == "reference":
+                node = node.node
+            path.append(node.as_geometry())
+            outlines.extend(path.as_interpolated_points(interpolate=100))
+            outlines.append(None)
+        if outlines:
+            for p in range(self.passes):
+                hatches = list(
+                    self.hatch_algorithm(
+                        settings=self.settings, outlines=outlines, matrix=self.matrix
+                    )
+                )
+                path.append(path.lines(*hatches))
+        return path
+
+    def drop(self, drag_node, modify=True):
+        # Default routine for drag + drop for an op node - irrelevant for others...
+        if drag_node.type.startswith("elem"):
+            # Dragging element onto operation adds that element to the op.
+            if modify:
+                self.add_reference(drag_node, pos=0)
+                self.altered()
+            return True
+        elif drag_node.type == "reference":
+            if modify:
+                self.append_child(drag_node)
+            return True
+        return False
+
+    def copy_children(self, obj):
+        for element in obj.children:
+            self.add_reference(element)
+
+    def copy_children_as_real(self, copy_node):
+        for node in copy_node.children:
+            self.add_node(copy(node.node))

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -1,4 +1,3 @@
-import math
 from copy import copy
 from math import cos, sin
 
@@ -150,11 +149,6 @@ class EllipseNode(Node, Stroked):
         self.notify_scaled(self, sx=sx, sy=sy, ox=ox, oy=oy)
 
     def bbox(self, transformed=True, with_stroke=False):
-        # self._sync_svg()
-        # bounds = self.shape.bbox(transformed=transformed, with_stroke=False)
-        # if bounds is None:
-        #     # degenerate paths can have no bounds.
-        #     return None
         geometry = self.as_geometry()
         if transformed:
             bounds = geometry.bbox(mx=self.matrix)

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -981,6 +981,7 @@ class Node:
         emphasized=None,
         targeted=None,
         highlighted=None,
+        lock=None,
     ):
         """
         Returned flat list of matching nodes. If cascade is set then any matching group will give all the descendants
@@ -1001,7 +1002,8 @@ class Node:
             (targeted is None or targeted == node.targeted)
             and (emphasized is None or emphasized == node.emphasized)
             and (selected is None or selected == node.selected)
-            and (highlighted is None or highlighted != node.highlighted)
+            and (highlighted is None or highlighted == node.highlighted)
+            and (lock is None or lock == node.lock)
         ):
             # Matches the emphases.
             if cascade:
@@ -1022,7 +1024,7 @@ class Node:
         # Check all children.
         for c in node.children:
             yield from c.flat(
-                types, cascade, depth, selected, emphasized, targeted, highlighted
+                types, cascade, depth, selected, emphasized, targeted, highlighted, lock
             )
 
     def count_children(self):
@@ -1150,6 +1152,8 @@ class Node:
         else:
             xmin, ymin, xmax, ymax = bounds
         for e in nodes:
+            if e.lock:
+                continue
             box = getattr(e, attr, None)
             if box is None:
                 continue

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -199,22 +199,21 @@ class Node:
                 return True
             else:
                 return self._is_visible
-        else:
-            if hasattr(self, "references"):
-                valid = False
-                flag = False
-                for n in self.references:
-                    if hasattr(n.parent, "output"):
-                        valid = True
-                        if n.parent.output is None or n.parent.output:
-                            flag = True
-                            break
-                        if n.parent.is_visible:
-                            flag = True
-                            break
-                # If there aren't any references then it is visible by default
-                if valid:
-                    result = flag
+        if hasattr(self, "references"):
+            valid = False
+            flag = False
+            for n in self.references:
+                if hasattr(n.parent, "output"):
+                    valid = True
+                    if n.parent.output is None or n.parent.output:
+                        flag = True
+                        break
+                    if n.parent.is_visible:
+                        flag = True
+                        break
+            # If there aren't any references then it is visible by default
+            if valid:
+                result = flag
         return result
 
     @is_visible.setter

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -898,7 +898,14 @@ class Node:
         """
         if node._parent is not None:
             raise ValueError("Cannot reparent node on add.")
-        self._attach_node(node, pos=pos)
+        node._parent = self
+        node._root = self._root
+        if pos is None:
+            self._children.append(node)
+        else:
+            self._children.insert(pos, node)
+        node.notify_attached(node, parent=self, pos=pos)
+        return node
 
     def create(self, type, **kwargs):
         """
@@ -921,22 +928,6 @@ class Node:
             self._root.notify_created(node)
         return node
 
-    def _attach_node(self, node, pos=None):
-        """
-        Attach a valid and created node to tree.
-        @param node:
-        @param pos:
-        @return:
-        """
-        node._parent = self
-        node._root = self._root
-        if pos is None:
-            self._children.append(node)
-        else:
-            self._children.insert(pos, node)
-        node.notify_attached(node, parent=self, pos=pos)
-        return node
-
     def add(self, type=None, pos=None, **kwargs):
         """
         Add a new node bound to the data_object of the type to the current node.
@@ -947,7 +938,7 @@ class Node:
         @return:
         """
         node = self.create(type=type, **kwargs)
-        self._attach_node(node, pos=pos)
+        self.add_node(node, pos=pos)
         return node
 
     def _flatten(self, node):

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1087,15 +1087,18 @@ class Node:
         self._item = None
         self._parent = None
         self._root = None
-        self.type = None
         self.unregister()
         return node
 
-    def remove_node(self, children=True, references=True, fast=False):
+    def remove_node(self, children=True, references=True, fast=False, destroy=True):
         """
         Remove the current node from the tree.
 
-        This also removes all the children of this node.
+        @param children: removes all the children of this node.
+        @param references: remove the references to this node.
+        @param fast: Do not send notifications of the detatches and destroys
+        @param destroy: Do not destroy the node.
+        @return:
         """
         if children:
             self.remove_all_children(fast=fast)
@@ -1104,7 +1107,8 @@ class Node:
             self._parent.set_dirty_bounds()
         if not fast:
             self.notify_detached(self)
-            self.notify_destroyed(self)
+            if destroy:
+                self.notify_destroyed(self)
         if references:
             for ref in list(self._references):
                 ref.remove_node(fast=fast)
@@ -1113,13 +1117,13 @@ class Node:
         self._root = None
         self.unregister()
 
-    def remove_all_children(self, fast=False):
+    def remove_all_children(self, fast=False, destroy=True):
         """
         Recursively removes all children of the current node.
         """
         for child in list(self.children):
-            child.remove_all_children(fast=fast)
-            child.remove_node(fast=fast)
+            child.remove_all_children(fast=fast, destroy=destroy)
+            child.remove_node(fast=fast, destroy=destroy)
 
     def get(self, type=None):
         """

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -301,9 +301,11 @@ class Node:
         return self._can_target
 
     def can_move(self, optional_permission=False):
-        if optional_permission is None:
-            optional_permission = False
-        return (self._can_move and not self.lock) or optional_permission
+        if not self._can_move:
+            return False
+        if optional_permission:
+            return True
+        return not self.lock
 
     @property
     def can_scale(self):

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1111,7 +1111,6 @@ class Node:
         self._item = None
         self._parent = None
         self._root = None
-        self.type = None
         self.unregister()
 
     def remove_all_children(self, fast=False):

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1031,7 +1031,9 @@ class Node:
 
     def append_child(self, new_child):
         """
-        Add the new_child node as the last child of the current node.
+        Moves the new_child node as the last child of the current node.
+        If the node exists elsewhere in the tree it will be removed from that location.
+
         """
         new_parent = self
         source_siblings = new_child.parent.children
@@ -1047,6 +1049,7 @@ class Node:
     def insert_sibling(self, new_sibling):
         """
         Add the new_sibling node next to the current node.
+        If the node exists elsewhere in the tree it will be removed from that location.
         """
         reference_sibling = self
         source_siblings = new_sibling.parent.children
@@ -1091,7 +1094,8 @@ class Node:
     def remove_node(self, children=True, references=True, fast=False):
         """
         Remove the current node from the tree.
-        This function must iterate down and first remove all children from the bottom.
+
+        This also removes all the children of this node.
         """
         if children:
             self.remove_all_children(fast=fast)
@@ -1112,7 +1116,7 @@ class Node:
 
     def remove_all_children(self, fast=False):
         """
-        Removes all children of the current node.
+        Recursively removes all children of the current node.
         """
         for child in list(self.children):
             child.remove_all_children(fast=fast)

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -36,6 +36,7 @@ class CutOpNode(Node, Parameters):
             "elem polyline",
             "elem rect",
             "elem line",
+            "effect hatch",
         )
         # Which elements do we consider for automatic classification?
         self._allowed_elements = (
@@ -44,6 +45,7 @@ class CutOpNode(Node, Parameters):
             "elem polyline",
             "elem rect",
             "elem line",
+            "effect hatch",
         )
         # To which attributes responds the classification color check
         self.allowed_attributes = [
@@ -108,7 +110,7 @@ class CutOpNode(Node, Parameters):
 
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
-        if drag_node.type.startswith("elem"):
+        if drag_node.type.startswith("elem") or drag_node.type.startswith("effect"):
             if (
                 drag_node.type not in self._allowed_elements_dnd
                 or drag_node._parent.type == "branch reg"
@@ -312,6 +314,8 @@ class CutOpNode(Node, Parameters):
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()
+            elif node.type.startswith("effect"):
+                path = node.as_geometry().as_path()
             elif node.type not in self._allowed_elements_dnd:
                 # These aren't valid.
                 continue

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -35,6 +35,7 @@ class EngraveOpNode(Node, Parameters):
             "elem polyline",
             "elem rect",
             "elem line",
+            "effect hatch",
         )
         # Which elements do we consider for automatic classification?
         self._allowed_elements = (
@@ -43,6 +44,7 @@ class EngraveOpNode(Node, Parameters):
             "elem polyline",
             "elem rect",
             "elem line",
+            "effect hatch",
         )
         # To which attributes does the classification color check respond
         # Can be extended / reduced by add_color_attribute / remove_color_attribute
@@ -103,7 +105,7 @@ class EngraveOpNode(Node, Parameters):
 
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
-        if drag_node.type.startswith("elem"):
+        if drag_node.type.startswith("elem") or drag_node.type.startswith("effect"):
             if (
                 drag_node.type not in self._allowed_elements_dnd
                 or drag_node._parent.type == "branch reg"
@@ -295,6 +297,8 @@ class EngraveOpNode(Node, Parameters):
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()
+            elif node.type.startswith("effect"):
+                path = node.as_geometry().as_path()
             elif node.type not in self._allowed_elements_dnd:
                 # These aren't valid.
                 continue

--- a/meerk40t/device/gui/formatterpanel.py
+++ b/meerk40t/device/gui/formatterpanel.py
@@ -55,6 +55,7 @@ class FormatterPanel(wx.Panel):
             "op raster": icons8_direction_20,
             "op hatch": icons8_diagonal_20,
             "op dots": icons8_scatter_plot_20,
+            "effect hatch": icons8_diagonal_20,
             "file": icons8_file_20,
             "group": icons8_group_objects_20,
             "elem point": icons8_scatter_plot_20,

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -4,7 +4,7 @@ from math import ceil, isnan, sqrt
 import wx
 from PIL import Image
 
-from meerk40t.core.elements.element_types import elem_nodes, place_nodes
+from meerk40t.core.elements.element_types import place_nodes
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     Arc,

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -183,7 +183,7 @@ class LaserRender:
         self.color = wx.Colour()
 
     def render_tree(self, node, gc, draw_mode=None, zoomscale=1.0, alpha=255):
-        self.node_render(node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
+        self.render_node(node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
         for c in node.children:
             self.render_tree(c, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
 
@@ -227,11 +227,11 @@ class LaserRender:
         for node in _nodes:
             if node.type == "reference":
                 # Reference nodes should be drawn per-usual, recurse.
-                self.node_render(node.node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
+                self.render_node(node.node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
                 continue
-            self.node_render(node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
+            self.render_node(node, gc, draw_mode=draw_mode, zoomscale=zoomscale, alpha=alpha)
 
-    def node_render(self, node, gc, draw_mode=None, zoomscale=1.0, alpha=255):
+    def render_node(self, node, gc, draw_mode=None, zoomscale=1.0, alpha=255):
         if node.type in elem_nodes:
             if not node.is_visible:
                 return

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -204,6 +204,7 @@ class LaserRender:
                     "elem polyline",
                     "elem rect",
                     "elem line",
+                    "effect hatch",
                 )
                 nodes = [e for e in nodes if e.type not in path_elements]
             if draw_mode & DRAW_MODE_IMAGE:  # Do not draw images.
@@ -240,24 +241,10 @@ class LaserRender:
                     "elem rect",
                     "elem line",
                     "elem polyline",
+                    "effect hatch",
                 ):
                     node.draw = self.draw_vector
                     node.make_cache = self.cache_geomstr
-                elif node.type == "elem path":
-                    node.draw = self.draw_vector
-                    node.make_cache = self.cache_path
-                elif node.type == "elem point":
-                    node.draw = self.draw_point_node
-                elif node.type in place_nodes:
-                    node.draw = self.draw_placement_node
-                elif node.type in (
-                    "elem rect",
-                    "elem line",
-                    "elem polyline",
-                    "elem ellipse",
-                ):
-                    node.draw = self.draw_vector
-                    node.make_cache = self.cache_shape
                 elif node.type == "elem image":
                     node.draw = self.draw_image_node
                 elif node.type == "elem text":

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -264,6 +264,10 @@ class LaserRender:
             ):
                 node.draw = self.draw_vector
                 node.make_cache = self.cache_geomstr
+            elif node.type == "elem point":
+                node.draw = self.draw_point_node
+            elif node.type in place_nodes:
+                node.draw = self.draw_placement_node
             elif node.type == "elem image":
                 node.draw = self.draw_image_node
             elif node.type == "elem text":

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -109,6 +109,8 @@ class PathPropertyPanel(ScrolledPanel):
             return False
         elif node.type.startswith("elem"):
             return True
+        elif node.type.startswith("effect"):
+            return True
         return False
 
     def covered_area(self, nodes):

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -335,12 +335,9 @@ class Scene(Module, Job):
         if not self.screen_refresh_is_requested:
             return
         if self.scene_lock.acquire(timeout=0.2):
-            try:
-                self._update_buffer_ui_thread()  # May hit runtime error.
-                self.gui.Refresh()
-                self.gui.Update()
-            except (RuntimeError, TypeError):
-                pass
+            self._update_buffer_ui_thread()  # May hit runtime error.
+            self.gui.Refresh()
+            self.gui.Update()
             self.screen_refresh_is_requested = False
             self.scene_lock.release()
         else:

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -53,20 +53,12 @@ class ElementsWidget(Widget):
                 zoomscale=zoom_scale,
                 alpha=96,
             )
-        self.renderer.render(
-            context.elements.elems_nodes(),
+        self.renderer.render_tree(
+            context.elements.elem_branch,
             gc,
             draw_mode,
             zoomscale=zoom_scale,
         )
-        # gc.PushState()
-        # gc.SetPen(wx.BLACK_PEN)
-        # dif = 500
-        # for elemnode in context.elements.elems_nodes(emphasized=True):
-        #     for p in elemnode.points:
-        #         gc.StrokeLine(p[0] - dif, p[1], p[0] + dif, p[1])
-        #         gc.StrokeLine(p[0], p[1] - dif, p[0], p[1] + dif)
-        # gc.PopState()
 
     def event(
         self, window_pos=None, space_pos=None, event_type=None, modifiers=None, **kwargs

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -53,8 +53,8 @@ class ElementsWidget(Widget):
                 zoomscale=zoom_scale,
                 alpha=96,
             )
-        self.renderer.render_tree(
-            context.elements.elem_branch,
+        self.renderer.render(
+            context.elements.elems_nodes(),
             gc,
             draw_mode,
             zoomscale=zoom_scale,

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -657,6 +657,7 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("property/LineNode/PathProperty", PathPropertyPanel)
         kernel.register("property/PolylineNode/PathProperty", PathPropertyPanel)
         kernel.register("property/RectNode/PathProperty", PathPropertyPanel)
+        kernel.register("property/HatchEffectNode/PathProperty", PathPropertyPanel)
         kernel.register("property/PointNode/PointProperty", PointPropertyPanel)
         kernel.register("property/TextNode/TextProperty", TextPropertyPanel)
         kernel.register("property/BlobNode/BlobProperty", BlobPropertyPanel)

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -382,6 +382,7 @@ class ShadowTree:
             "op raster": icons8_direction_20,
             "op hatch": icons8_diagonal_20,
             "op dots": icons8_scatter_plot_20,
+            "effect hatch": icons8_diagonal_20,
             "place current": icons8_home_location_20,
             "place point": icons8_home_location_20,
             "elem point": icons8_scatter_plot_20,

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -334,6 +334,8 @@ class Scanbeam:
         self.valid_high = self._high
 
         for i in range(self._geom.index):
+            if self._geom.segments[i][2] != TYPE_LINE:
+                continue
             if (self._geom.segments[i][0].imag, self._geom.segments[i][0].real) < (
                 self._geom.segments[i][-1].imag,
                 self._geom.segments[i][-1].real,

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1782,7 +1782,8 @@ class Geomstr:
             subject_polygons.append(subj.npoint(linspace(0, 1, interpolation)))
 
         if not subject_polygons:
-            return
+            # No polygon has area of 0.
+            return 0
         idx = -1
         last_x = 0
         last_y = 0

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -330,6 +330,9 @@ class Scanbeam:
         self._low = float("inf")
         self._high = -float("inf")
 
+        self.valid_low = self._low
+        self.valid_high = self._high
+
         for i in range(self._geom.index):
             if (self._geom.segments[i][0].imag, self._geom.segments[i][0].real) < (
                 self._geom.segments[i][-1].imag,
@@ -455,7 +458,10 @@ class Scanbeam:
         """
         y_min, index_min = self._sorted_edge_list[0]
         y_max, index_max = self._sorted_edge_list[-1]
-        return y_min, y_max
+        return y_min.imag, y_max.imag
+
+    def current_is_valid_range(self):
+        return self.valid_high >= self.scanline >= self.valid_low
 
     def _sort_actives(self):
         if not self._dirty_actives_sort:

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -458,6 +458,8 @@ class Scanbeam:
 
         @return:
         """
+        if not self._sorted_edge_list:
+            return self._low, self._low
         y_min, index_min = self._sorted_edge_list[0]
         y_max, index_max = self._sorted_edge_list[-1]
         return y_min.imag, y_max.imag

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -974,6 +974,8 @@ class Geomstr:
                 arcs = self._arc_position(e, np.linspace(0, 1, interpolate))
                 for a in arcs[1:]:
                     yield a
+            elif seg_type == TYPE_END:
+                at_start = True
 
     def segmented(self, interpolate=100):
         return Geomstr.lines(*self.as_interpolated_points(interpolate=interpolate))

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -975,6 +975,9 @@ class Geomstr:
                 for a in arcs[1:]:
                     yield a
 
+    def segmented(self, interpolate=100):
+        return Geomstr.lines(*self.as_interpolated_points(interpolate=interpolate))
+
     def _ensure_capacity(self, capacity):
         if self.capacity > capacity:
             return

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -762,11 +762,18 @@ class Geomstr:
             points = list(zip(*[iter(points)] * 2))
             first_point = points[0]
         if isinstance(first_point, (list, tuple)):
-            points = [pts[0] + pts[1] * 1j for pts in points]
+            points = [None if pts is None else pts[0] + pts[1] * 1j for pts in points]
             first_point = points[0]
         if isinstance(first_point, complex):
+            on = False
             for i in range(1, len(points)):
-                path.line(points[i - 1], points[i])
+                if points[i-1] is not None and points[i] is not None:
+                    on = True
+                    path.line(points[i - 1], points[i])
+                else:
+                    if on:
+                        path.end()
+                    on = False
         return path
 
     @classmethod


### PR DESCRIPTION
* Adds `effect hatch` as an effect node type.
* Contains a list of operands geometry.
* If the effect is enabled, the operands are used to build a hatch structure.
* If the effect is disabled, children are given rather than operands and the object works like a group.
* Adds tree effect on, effect off toggles.
* Effect nodes very similar to elem nodes.
* `op cut` and `op engrave` accept `effect hatch`.
* Adds `render_tree()` command (unused) in laserrender