### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/mac11_pyinst.yml
+++ b/.github/workflows/mac11_pyinst.yml
@@ -55,20 +55,16 @@ jobs:
     - name: Ensure latest pip and meerk40t-camera
       run: |
         python3.8 -m pip install --upgrade pip
-        ## python3.8 -m pip install --upgrade pip
+        python3.8 -m pip install wheel setuptools
         python3.8 -m pip install meerk40t-camera opencv-python-headless==3.4.13.47
-        ## python3.8 -m pip install meerk40t-camera opencv-python
-        ##python3.8 -m pip install --upgrade pyinstaller==4.3
         python3.8 -m pip install --no-use-pep517 pyinstaller==4.3
         
         ## numpy toggle based on 32 bit fix
-        python3.8 -m pip install wheel six numpy ezdxf
+        python3.8 -m pip install six numpy ezdxf
         ## python3.8 -m pip install wheel six ezdxf
         
         python3.8 -m pip install potracer
         
-        ## python3.8 -m pip install wheel six numpy
-        ## python3.8 -m pip install pyinstaller py2app wheel six numpy
         python3.8 -m pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython==4.1.1
         if [ -f requirements-nogui.txt ]; then python3.8 -m pip install -r requirements-nogui.txt; fi
         python3.8 -m pip uninstall -y meerk40t[gui]
@@ -177,6 +173,5 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: ${{ steps.build.outputs.mkversion }}
         files: |
           MeerK40t_unsigned.dmg

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -12,29 +12,36 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout meerk40t
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
-        architecture: 'x64'
+        # Latest version of python support by Windows 7 is Python 3.8
 
     - name: Install dependencies
       run: |
-        pip install .[all]
+        ## pip install . establishes meerk40t as a package in pip, so that meerk40t-barcodes can find it as a dependency
+        pip install .
         pip install wheel
         pip install potracer
+        pip install wxPython
+        pip install ezdxf
+        pip install pyserial
+        pip install bitarray
+        pip install scipy
+        pip install meerk40t-camera opencv-python-headless==4.5.3.56
         pip install meerk40t-barcodes
-# ==4.1.1
+
 # Compile bootloaders in order to reduce virus totals
 # PYTHONHASHSEED is an attempt to get deterministic builds for VirusTotal
-# 05/28/2022 JS - Locked pyinstaller at v4.9 because 4.10 couldn't find the icon 
-# when it branch v4 updated to commit e319ae3d00. Fixes made in v5 branches, not v4
     - name: Build pyinstaller, generate bootloaders
       env:
         PYTHONHASHSEED: 12506
       run: |
+        ## 05/28/2022 JS - Locked pyinstaller at v4.9 because 4.10 couldn't find the icon
+        ## when branch v4 updated to commit e319ae3d00. Fixes made in v5 branches, not v4
         git clone --depth=1 --branch=v4.9 https://github.com/pyinstaller/pyinstaller
         cd pyinstaller/bootloader
         python3 ./waf distclean all
@@ -44,20 +51,24 @@ jobs:
 
     - name: Build MeerK40t
       run: |
+        ## pyinstaller struggles recognizing and including imports that are dynamic (such as for the plugins)
+        ## So for build purposes, we replace the dynamic imports with the static listing that we include in builds
         cd meerk40t
         move external_plugins.py external_plugins.unused
         move external_plugins_build.py external_plugins.py
         cd ..
+
+        ## pyinstaller struggles with meerk40t.py having the same name as the package meerk40t. Rename for the build
         move meerk40t.py mk40t.py
         pyinstaller --windowed --onefile --name meerk40t .github/workflows/win/meerk40t.spec
         move mk40t.py meerk40t.py
-        cd meerk40t
-        move external_plugins.py external_plugins_build.py
-        move external_plugins.unused external_plugins.py 
-        cd ..
 
-# Switched to using softprops/action-gh-release@v1
-# because it supports uploading to existing release based on current tag.
+        ## Restore original configuration (not really necessary in build environment which is fresh each time)
+        ##cd meerk40t
+        ##move external_plugins.py external_plugins_build.py
+        ##move external_plugins.unused external_plugins.py
+        ##cd ..
+
     - name: Upload Release Assets
       id: release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This does a few things differently from Tat's build yml work.
It does a `pip install .` instead of a `pip install .[all]`
This prevents it from installing any extra deps from setup.py's [all]
Extra deps are explicitly listed in `pip install` commands
Updates the subactions used (actions/checkout@v2 -> v3 etc) to satisfy a runner warning.
Removes the explicit x64 architecture (it is the default, specifying it at all was in order to get x32)
Restablishes the version lock of opencv so that the build has the camera again.
Comments add/moved around so that everything is more readable.

This was tested in tiger12506's fork to produce Windows builds that seem valid.

Also, there is an update to the mac11 runner which fixes a build error.
A little cleanup of redundant comments.
And I removed the explicit tag_name which caused some issues (there is already a tag_name implicit when creating new release)
