### PR TITLE
Fix knocking for scanline distances between 15 and 5.

### DIFF
--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -1199,7 +1199,7 @@ class LihuiyuDriver(Parameters):
             and self._topward
             or remaining < 0
             and not self._topward
-            or abs(remaining) > 15
+            or abs(remaining) > 5
         ):
             # Remaining value is in the wrong direction, abort and move.
             self.finished_mode()
@@ -1245,7 +1245,7 @@ class LihuiyuDriver(Parameters):
             and self._leftward
             or remaining < 0
             and not self._leftward
-            or abs(remaining) > 15
+            or abs(remaining) > 5
         ):
             # Remaining value is in the wrong direction, abort and move.
             self.finished_mode()


### PR DESCRIPTION
DPI would typically only be a change of 1 or so, and while a few differences from a missing scanline is fine we're probably better off just aborting since lateral moves near 15 make a knock.