### PR TITLE
Estop for Galvo works too slow.

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -877,6 +877,11 @@ class BalorDevice(Service, ViewPort):
                 self.job.stop()
             self.spooler.clear_queue()
             self.driver.set_abort()
+            try:
+                channel("Resetting controller.")
+                self.driver.reset()
+            except ConnectionRefusedError:
+                pass
 
         @self.console_command(
             "pause",


### PR DESCRIPTION
Force abort of a working job, rather than waiting for the spooler thread to try to cause the abort.

As notified by Bzzrd in discord. This probably needs functional testing.

Light jobs have a faster cycle of data being sent and thus abort much faster and are constantly sending new data and the `live` version will abort anytime the backing data changes.

Whereas jobs that are sent via the spooler could be entirely composed and sent to the controller and live in memory and estop will not take effect on that until additional data is sent. 

---

Waiting on testing by @tiger12506 or @joerlane, but we should ensure that the estop button works instantly for galvo in all cases.