### PR TITLE
Restore the Win build architecture: x86 for libusb

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -19,11 +19,14 @@ jobs:
       with:
         python-version: 3.8
         # Latest version of python support by Windows 7 is Python 3.8
+        architecture: x86
+        # 32-bit architecture required for libusb to connect properly
 
     - name: Install dependencies
       run: |
         ## pip install . establishes meerk40t as a package in pip, so that meerk40t-barcodes can find it as a dependency
         pip install .
+        pip install pyusb
         pip install wheel
         pip install potracer
         pip install wxPython
@@ -33,6 +36,10 @@ jobs:
         pip install scipy
         pip install meerk40t-camera opencv-python-headless==4.5.3.56
         pip install meerk40t-barcodes
+
+    - name: pip list
+      run: |
+          pip list
 
 # Compile bootloaders in order to reduce virus totals
 # PYTHONHASHSEED is an attempt to get deterministic builds for VirusTotal


### PR DESCRIPTION
Tested. This fixes the libusb issue.

Recommendations:
Don't fix stuff that ain't broke.
Python architecture should show in About -> System Information? Is this possible?
