### PR TITLE
Cosmetics for Ribbonbar

### DIFF
--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -791,6 +791,7 @@ class RibbonBarPanel(wx.Control):
 
             panel_max_width = 0
             panel_max_height = 0
+            max_button_height = 0
             for panel in page.panels:
                 # Position for button top.
                 y = self.tab_height + self.page_panel_buffer
@@ -839,6 +840,7 @@ class RibbonBarPanel(wx.Control):
                         x + button_width,
                         y + button_height,
                     )
+                    max_button_height = max(max_button_height, button_height)
 
                     # Determine whether button is within overflow.
                     if button.position[2] > window_width - self.overflow_width:
@@ -859,6 +861,7 @@ class RibbonBarPanel(wx.Control):
                         )
                     x += button_width
                     panel_end_x = x
+
                 x += self.panel_button_buffer
                 y += self.panel_button_buffer
 
@@ -884,6 +887,19 @@ class RibbonBarPanel(wx.Control):
                     ]
                 # Step along x value between panels.
                 x += self.between_panel_buffer
+
+            # Now adjust all buttons, so that they have the same height:
+            for panel in page.panels:
+                # Position for button top.
+                y = self.tab_height + self.page_panel_buffer
+                y += self.panel_button_buffer
+                for button in panel.buttons:
+                    button.position = (
+                        button.position[0],
+                        button.position[1],
+                        button.position[2],
+                        y + max_button_height,
+                    )
 
             # Solve page max_x and max_y values
             max_x = 0

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -732,6 +732,8 @@ class RibbonBarPanel(wx.Control):
         self._hover_button = hover
         if hover is not None:
             self.SetToolTip(hover.tip)
+        else:
+            self.SetToolTip("")
         self.modified()
 
     def _check_hover_tab(self, pos):

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -756,18 +756,26 @@ class RibbonBarPanel(wx.Control):
         real_width_of_overflow = 0
         self._overflow.clear()
         self._overflow_position = None
+        xpos = 0
         for pn, page in enumerate(self.pages):
             # Set tab positioning.
+            # Compute tabwidth according to be displayed label,
+            # if bigger than default then extend width
+            line_width, line_height = dc.GetTextExtent(page.label)
+
+            tabwidth = max(line_width + 2 * BUFFER, self.tab_width)
+
             page.tab_position = (
                 pn * self.tab_tab_buffer
-                + pn * self.tab_width
+                + xpos
                 + self.tab_initial_buffer,
                 0,
                 pn * self.tab_tab_buffer
-                + (pn + 1) * self.tab_width
+                + xpos + tabwidth
                 + self.tab_initial_buffer,
                 self.tab_height * 2,
             )
+            xpos += tabwidth
             if page is not self._current_page:
                 continue
 

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -201,7 +201,7 @@ class MeerK40tScenePanel(wx.Panel):
         context.register("tool/edit", EditTool)
         context.register("tool/placement", PlacementTool)
 
-        buttonsize = int(STD_ICON_SIZE / 2)
+        bsize_normal = STD_ICON_SIZE
 
         def proxy_linetext():
             from meerk40t.extra.hershey import have_hershey_fonts
@@ -219,7 +219,7 @@ class MeerK40tScenePanel(wx.Panel):
                 "tip": _("Add a vector text element"),
                 "action": lambda v: proxy_linetext(),
                 "group": "tool",
-                "size": 50,
+                "size": bsize_normal,
                 "identifier": "linetext",
             },
         )
@@ -231,7 +231,7 @@ class MeerK40tScenePanel(wx.Panel):
                 "icon": icons8_r_white,
                 "tip": _("Toggle Reference Object Status"),
                 "action": lambda v: self.toggle_ref_obj(),
-                "size": buttonsize,
+                "size": bsize_normal,
                 "identifier": "refobj",
                 "rule_enabled": lambda cond: len(
                     list(context.kernel.elements.elems(emphasized=True))


### PR DESCRIPTION
This is addressing some of the inconsistencies of buttons on the new ribbonbar:
a) Tab-Width takes real text width into consideration
b) Button heights will be all the same in one page across multiple panels
c) Wrong iconsize for Ref Object button
d) Wrong tooltip if hovering over disabled buttons

Before:
<img width="275" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/a8125056-ac4e-4962-9512-fbac349fc21b">

<img width="621" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/f1642b5d-c455-44b7-8c30-20f80468ff10">

<img width="314" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/e8c5b367-f77b-4f18-b47f-78bb9b66c0c5">

After:
<img width="945" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/16444c43-1bc3-465a-90e0-7578ad1044ab">
<img width="629" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/5b3b7cbe-7f1e-4efc-b071-3667e27a6e93">


