### PR TITLE
Add config option near device selection

### DIFF
--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -195,6 +195,10 @@ class DevicePanel(wx.Panel):
 
         self.button_activate_device = wx.Button(self, wx.ID_ANY, _("Activate"))
         sizer_3.Add(self.button_activate_device, 0, 0, 0)
+        sizer_3.AddStretchSpacer()
+        self.button_config_device = wx.Button(self, wx.ID_ANY, _("Config"))
+        self.button_config_device.SetToolTip("Open the configuration window for the active device")
+        sizer_3.Add(self.button_config_device, 0, 0, 0)
 
         self.SetSizer(sizer_1)
 
@@ -225,6 +229,9 @@ class DevicePanel(wx.Panel):
         )
         self.Bind(
             wx.EVT_BUTTON, self.on_button_activate_device, self.button_activate_device
+        )
+        self.Bind(
+            wx.EVT_BUTTON, self.on_button_config_device, self.button_config_device
         )
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.on_end_edit, self.devices_list)
         self.Parent.Bind(wx.EVT_SIZE, self.on_resize)
@@ -411,6 +418,9 @@ class DevicePanel(wx.Panel):
                 self.Bind(wx.EVT_MENU, self.on_tree_popup_delete(data), item2)
                 item3 = menu.Append(wx.ID_ANY, _("Activate"), "", wx.ITEM_NORMAL)
                 self.Bind(wx.EVT_MENU, self.on_tree_popup_activate(data), item3)
+            else:
+                item4 = menu.Append(wx.ID_ANY, _("Config"), "", wx.ITEM_NORMAL)
+                self.Bind(wx.EVT_MENU, self.on_tree_popup_config(data), item4)
             self.PopupMenu(menu)
             menu.Destroy()
 
@@ -451,6 +461,13 @@ class DevicePanel(wx.Panel):
 
         return activateit
 
+    def on_tree_popup_config(self, service):
+        def configit(event=None):
+            if service is not None:
+                service("window toggle Configuration\n")
+
+        return configit
+
     def on_button_create_device(self, event):  # wxGlade: DevicePanel.<event_handler>
         dlg = SelectDevice(None, wx.ID_ANY, context=self.context)
         result = dlg.ShowModal()
@@ -486,6 +503,11 @@ class DevicePanel(wx.Panel):
         if service is not None:
             service.kernel.activate_service_path("device", service.path)
             self.recolor_device_items()
+
+    def on_button_config_device(self, event):  # wxGlade: DevicePanel.<event_handler>
+        service = self.get_selected_device()
+        if service is not None:
+            service("window toggle Configuration\n")
 
     def on_button_rename_device(self, event):  # wxGlade: DevicePanel.<event_handler>
         service = self.get_selected_device()

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -115,8 +115,14 @@ class LaserPanel(wx.Panel):
             _("Select device from list of configured devices")
         )
         self.combo_devices.SetSelection(index)
+        self.btn_config_laser = wx.Button(self, wx.ID_ANY, "*")
+        self.btn_config_laser.SetToolTip(
+            _("Opens device-specific configuration window")
+        )
 
-        sizer_devices.Add(self.combo_devices, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        sizer_devices.Add(self.combo_devices, 1, wx.EXPAND, 0)
+        self.btn_config_laser.SetMinSize(wx.Size(20, -1))
+        sizer_devices.Add(self.btn_config_laser, 0, wx.EXPAND, 0)
 
         sizer_control = wx.BoxSizer(wx.HORIZONTAL)
         sizer_main.Add(sizer_control, 0, wx.EXPAND, 0)
@@ -235,6 +241,7 @@ class LaserPanel(wx.Panel):
         self.Bind(wx.EVT_SLIDER, self.on_slider_speed, self.slider_speed)
         self.Bind(wx.EVT_SLIDER, self.on_slider_power, self.slider_power)
         self.Bind(wx.EVT_CHECKBOX, self.on_optimize, self.checkbox_optimize)
+        self.Bind(wx.EVT_BUTTON, self.on_config_button, self.btn_config_laser)
         # end wxGlade
         if index == -1:
             disable_window(self)
@@ -504,6 +511,8 @@ class LaserPanel(wx.Panel):
         self.context(f"scene focus -{zl}% -{zl}% {100 + zl}% {100 + zl}%\n")
         self.set_pause_color()
 
+    def on_config_button(self, event):
+        self.context.device("window toggle Configuration\n")
 
 class JobPanel(wx.Panel):
     """


### PR DESCRIPTION
In Laser-Control:
<img width="405" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/16873c22-9985-4741-8bcc-ccc287f7e932">

In device manager:
<img width="541" alt="image" src="https://github.com/meerk40t/meerk40t/assets/2670784/86fa2730-430f-46d6-b11c-1662a03d0ebb">

NB: only for active device! Not sure how to open the registered guis for non-active services