### PR TITLE
Scene Optimizations

### DIFF
--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -26,9 +26,6 @@ from meerk40t.gui.scene.scenespacewidget import SceneSpaceWidget
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point
 
-# TODO: _buffer can be updated partially rather than fully rewritten, especially with some layering.
-
-
 _reused_identity_widget = Matrix()
 XCELLS = 15
 YCELLS = 15


### PR DESCRIPTION
* Add in `invalidate()` for specific scene clipped scene redraws.
* Add in multiple buffers for redraw elements

Tools should be able to call `request_refresh()` to refresh entire scene. But, should also be able to call `invalidate()` to mark sections of the screen as dirty. This permits a clipped redraw of just the needed sections.

We should also permit multiple buffers for specific draw layers. If we have an interaction layer we don't need to redraw everything each time we select something with a rectangle or the like. We can draw the selection rectangle (and other widgets) within that layer by only invalidating the relevant part of the relevant layer.