### PR TITLE
Device specific power display in tree

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -65,6 +65,8 @@ class BalorDevice(Service, ViewPort):
             "{danger}{defop}{enabled}{pass}{element_type} {dwell_time}ms dwell {frequency}kHz {colcode} {opstop}",
         )
         self.register("format/util console", "{enabled}{command}")
+        # This device prefers to display power level in percent
+        self.setting(bool, "use_percent_for_power_display", True)
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(
             list, "dangerlevel_op_cut", (False, 0, False, 0, False, 0, False, 0)

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -106,6 +106,10 @@ class CutOpNode(Node, Parameters):
         default_map["opstop"] = "(stop)" if self.stopop else ""
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
+
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -107,8 +107,10 @@ class CutOpNode(Node, Parameters):
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
 
         return default_map
 

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -82,8 +82,10 @@ class DotsOpNode(Node, Parameters):
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -81,6 +81,9 @@ class DotsOpNode(Node, Parameters):
         default_map["opstop"] = "(stop)" if self.stopop else ""
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -102,8 +102,10 @@ class EngraveOpNode(Node, Parameters):
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -101,6 +101,9 @@ class EngraveOpNode(Node, Parameters):
         default_map["opstop"] = "(stop)" if self.stopop else ""
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -103,6 +103,9 @@ class HatchOpNode(Node, Parameters):
         default_map["opstop"] = "(stop)" if self.stopop else ""
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_hatch.py
+++ b/meerk40t/core/node/op_hatch.py
@@ -104,8 +104,10 @@ class HatchOpNode(Node, Parameters):
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -58,7 +58,7 @@ class ImageOpNode(Node, Parameters):
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Image"
-        default_map["dpi"] = str(self.dpi)
+        default_map["dpi"] = str(int(self.dpi))
         default_map["danger"] = "❌" if self.dangerous else ""
         default_map["defop"] = "✓" if self.default else ""
         default_map["enabled"] = "(Disabled) " if not self.output else ""
@@ -95,6 +95,9 @@ class ImageOpNode(Node, Parameters):
         default_map["colcode"] = self.color.hexrgb if self.color is not None else ""
         default_map["overscan"] = f"±{self.overscan}"
         # print(self.dangerous, self.stopop, self.raster_direction)
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -96,8 +96,10 @@ class ImageOpNode(Node, Parameters):
         default_map["overscan"] = f"±{self.overscan}"
         # print(self.dangerous, self.stopop, self.raster_direction)
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -80,7 +80,7 @@ class RasterOpNode(Node, Parameters):
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Raster"
-        default_map["dpi"] = str(self.dpi)
+        default_map["dpi"] = str(int(self.dpi))
         default_map["danger"] = "❌" if self.dangerous else ""
         default_map["defop"] = "✓" if self.default else ""
         default_map["enabled"] = "(Disabled) " if not self.output else ""
@@ -125,6 +125,9 @@ class RasterOpNode(Node, Parameters):
         default_map.update(self.settings)
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["overscan"] = f"±{self.overscan}"
+        default_map["percent"] = "100%"
+        if self.power is not None:
+            default_map["percent"] = f"{self.power / 10.0:.0f}%"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -126,8 +126,10 @@ class RasterOpNode(Node, Parameters):
         default_map["color"] = self.color.hexrgb if self.color is not None else ""
         default_map["overscan"] = f"±{self.overscan}"
         default_map["percent"] = "100%"
+        default_map["ppi"] = "default"
         if self.power is not None:
             default_map["percent"] = f"{self.power / 10.0:.0f}%"
+            default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
     def drop(self, drag_node, modify=True):

--- a/meerk40t/device/gui/formatterpanel.py
+++ b/meerk40t/device/gui/formatterpanel.py
@@ -89,7 +89,7 @@ class FormatterPanel(wx.Panel):
                 "tip": _("Active: Full power will be shown as 100%" + "\n" +
                          "Inactive: Full power will be shown as 1000 ppi"),
                 "subsection": "_10_General",
-                "signals": "rebuild_tree",
+                "signals": ("rebuild_tree", "power_percent"),
             },
         ]
         for node in self.node_list:

--- a/meerk40t/device/gui/formatterpanel.py
+++ b/meerk40t/device/gui/formatterpanel.py
@@ -78,7 +78,20 @@ class FormatterPanel(wx.Panel):
                 # wasnt in list...
                 pass
 
-        choices = []
+        self.context.setting(bool, "use_percent_for_power_display", False)
+        choices = [
+            {
+                "attr": "use_percent_for_power_display",
+                "object": self.context,
+                "default": False,
+                "type": bool,
+                "label": _("Display power as a percentage"),
+                "tip": _("Active: Full power will be shown as 100%" + "\n" +
+                         "Inactive: Full power will be shown as 1000 ppi"),
+                "subsection": "_10_General",
+                "signals": "rebuild_tree",
+            },
+        ]
         for node in self.node_list:
             imgsize = 20
             if node in images:

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -201,6 +201,9 @@ class GRBLDevice(Service, ViewPort):
             },
         ]
         self.register_choices("rotary", choices)
+        # This device prefers to display power level in percent
+        self.setting(bool, "use_percent_for_power_display", True)
+
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(
             list, "dangerlevel_op_cut", (False, 0, False, 0, False, 0, False, 0)

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1339,6 +1339,11 @@ class ShadowTree:
             # Just for the optical impression (who understands what a "Rect: None" means),
             # lets replace some of the more obvious ones...
             mymap = node.default_map()
+            # We change power to either ppi or percent
+            if "power" in mymap and "ppi" in mymap and "percent" in mymap:
+                self.context.device.setting(bool, "use_percent_for_power_display", False)
+                if self.context.device.use_percent_for_power_display:
+                    mymap["power"] = mymap["percent"]
             for key in mymap:
                 if hasattr(node, key) and key in mymap and mymap[key] == "None":
                     if getattr(node, key) is None:

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -386,6 +386,9 @@ class LihuiyuDevice(Service, ViewPort):
         ]
         self.register_choices("rotary", choices)
 
+        # This device prefers to display power level in ppi
+        self.setting(bool, "use_percent_for_power_display", False)
+
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(
             list, "dangerlevel_op_cut", (False, 0, False, 0, False, 0, False, 0)

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -486,6 +486,8 @@ class NewlyDevice(Service, ViewPort):
             },
         ]
         self.register_choices("newly-global", choices)
+        # This device prefers to display power level in percent
+        self.setting(bool, "use_percent_for_power_display", True)
 
         self.state = 0
 


### PR DESCRIPTION
Allow a per device setting whether power should be displayed as ppi (default) or as percentage.
Addresses [Issue #1943](https://github.com/meerk40t/meerk40t/issues/1943)

![power_setting](https://github.com/meerk40t/meerk40t/assets/2670784/5b787e64-3a56-4402-bc26-b923465a0003)
