### PR TITLE
Correct Issue #2027

### DIFF
--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -180,7 +180,7 @@ class GRBLDevice(Service, ViewPort):
                 "conditional": (self, "rotary_active"),
             },
             {
-                "attr": "rotary_mirror_x",
+                "attr": "rotary_flip_x",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -190,7 +190,7 @@ class GRBLDevice(Service, ViewPort):
                 "subsection": _("Mirror Output"),
             },
             {
-                "attr": "rotary_mirror_y",
+                "attr": "rotary_flip_y",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -236,6 +236,11 @@ class GRBLDevice(Service, ViewPort):
             swap_xy=self.swap_xy,
             origin_x=1.0 if self.home_right else 0.0,
             origin_y=1.0 if self.home_bottom else 0.0,
+            rotary_active=self.rotary_active,
+            rotary_scale_x=self.rotary_scale_x,
+            rotary_scale_y=self.rotary_scale_y,
+            rotary_flip_x=self.rotary_flip_x,
+            rotary_flip_y=self.rotary_flip_y,
         )
 
         self.settings = dict()

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -363,26 +363,26 @@ class LihuiyuDevice(Service, ViewPort):
                 "tip": _("Ignore Home-Command"),
                 "conditional": (self, "rotary_active"),
             },
-            # {
-            #     "attr": "rotary_mirror_x",
-            #     "object": self,
-            #     "default": False,
-            #     "type": bool,
-            #     "label": _("Mirror X"),
-            #     "tip": _("Mirror the elements on the X-Axis"),
-            #     "conditional": (self, "rotary_active"),
-            #     "subsection": _("Mirror Output"),
-            # },
-            # {
-            #     "attr": "rotary_mirror_y",
-            #     "object": self,
-            #     "default": False,
-            #     "type": bool,
-            #     "label": _("Mirror Y"),
-            #     "tip": _("Mirror the elements on the Y-Axis"),
-            #     "conditional": (self, "rotary_active"),
-            #     "subsection": _("Mirror Output"),
-            # },
+            {
+                "attr": "rotary_flip_x",
+                "object": self,
+                "default": False,
+                "type": bool,
+                "label": _("Mirror X"),
+                "tip": _("Mirror the elements on the X-Axis"),
+                "conditional": (self, "rotary_active"),
+                "subsection": _("Mirror Output"),
+            },
+            {
+                "attr": "rotary_flip_y",
+                "object": self,
+                "default": False,
+                "type": bool,
+                "label": _("Mirror Y"),
+                "tip": _("Mirror the elements on the Y-Axis"),
+                "conditional": (self, "rotary_active"),
+                "subsection": _("Mirror Output"),
+            },
         ]
         self.register_choices("rotary", choices)
 
@@ -421,6 +421,11 @@ class LihuiyuDevice(Service, ViewPort):
             flip_x=self.flip_x,
             flip_y=self.flip_y,
             swap_xy=self.swap_xy,
+            rotary_active=self.rotary_active,
+            rotary_scale_x=self.rotary_scale_x,
+            rotary_scale_y=self.rotary_scale_y,
+            rotary_flip_x=self.rotary_flip_x,
+            rotary_flip_y=self.rotary_flip_y,
         )
         self.setting(int, "buffer_max", 900)
         self.setting(bool, "buffer_limit", True)

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -228,7 +228,7 @@ class MoshiDevice(Service, ViewPort):
                 "conditional": (self, "rotary_active"),
             },
             {
-                "attr": "rotary_mirror_x",
+                "attr": "rotary_flip_x",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -238,7 +238,7 @@ class MoshiDevice(Service, ViewPort):
                 "subsection": _("Mirror Output"),
             },
             {
-                "attr": "rotary_mirror_y",
+                "attr": "rotary_flip_y",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -282,6 +282,11 @@ class MoshiDevice(Service, ViewPort):
             swap_xy=self.swap_xy,
             origin_x=1.0 if self.home_right else 0.0,
             origin_y=1.0 if self.home_bottom else 0.0,
+            rotary_active=self.rotary_active,
+            rotary_scale_x=self.rotary_scale_x,
+            rotary_scale_y=self.rotary_scale_y,
+            rotary_flip_x=self.rotary_flip_x,
+            rotary_flip_y=self.rotary_flip_y,
         )
 
         self.state = 0

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -122,7 +122,7 @@ class RuidaDevice(Service, ViewPort):
                 "conditional": (self, "rotary_active"),
             },
             {
-                "attr": "rotary_mirror_x",
+                "attr": "rotary_flip_x",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -132,7 +132,7 @@ class RuidaDevice(Service, ViewPort):
                 "subsection": _("Mirror Output"),
             },
             {
-                "attr": "rotary_mirror_y",
+                "attr": "rotary_flip_y",
                 "object": self,
                 "default": False,
                 "type": bool,
@@ -196,6 +196,11 @@ class RuidaDevice(Service, ViewPort):
             self.bedheight,
             user_scale_x=self.scale_x,
             user_scale_y=self.scale_y,
+            rotary_active=self.rotary_active,
+            rotary_scale_x=self.rotary_scale_x,
+            rotary_scale_y=self.rotary_scale_y,
+            rotary_flip_x=self.rotary_flip_x,
+            rotary_flip_y=self.rotary_flip_y,
         )
         self.state = 0
 


### PR DESCRIPTION
The rotary settings do not save because the rotary attributes are part of ViewPort.__init__() but are not called so regardless that the `rotary` choice actually loads the settings these settings are not passed to the init routine and thus are set to the default in that initialization routine thereby losing those parameters.