### PR TITLE
Disabled op treatment

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -227,6 +227,7 @@ def init_tree(kernel):
             self.validate_selected_area()
             self.signal("element_property_update", changes)
             self.signal("refresh_scene", "Scene")
+            self.signal("warn_state_update", "")
 
     @tree_conditional(
         lambda node: hasattr(node, "output")
@@ -707,12 +708,21 @@ def init_tree(kernel):
 
     def selected_active_ops():
         result = 0
+        selected = 0
+        contained = 0
         for op in self.ops():
             try:
-                if op.selected and op.output:
-                    result += 1
+                if op.selected:
+                    selected += 1
+                    contained += len(op.children)
+                    if op.output:
+                        result += 1
             except AttributeError:
                 pass
+        if contained == 0:
+            result = 0
+        elif selected == 1:
+            result = 1
         return result
 
     @tree_separator_after()
@@ -841,6 +851,7 @@ def init_tree(kernel):
             except AttributeError:
                 pass
         self.signal("element_property_update", ops)
+        self.signal("warn_state_update", "")
 
     @tree_separator_before()
     @tree_operation(

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -631,12 +631,36 @@ class Elemental(Service):
         #     pnode = pnode.parent
 
     def have_unassigned_elements(self):
-        emptyset = False
+        unassigned = False
         for node in self.elems():
             if len(node._references) == 0 and node.type not in ("file", "group"):
-                emptyset = True
+                unassigned = True
                 break
-        return emptyset
+        return unassigned
+
+    def have_unburnable_elements(self):
+        unassigned = False
+        nonburnt = False
+        for node in self.elems():
+            if len(node._references) == 0 and node.type not in ("file", "group"):
+                unassigned = True
+            else:
+                will_be_burnt = False
+                for refnode in node._references:
+                    op = refnode.parent
+                    if op is not None:
+                        try:
+                            if op.output:
+                                will_be_burnt = True
+                                break
+                        except AttributeError:
+                            pass
+                if not will_be_burnt:
+                    nonburnt = True
+            if nonburnt and unassigned:
+                break
+
+        return unassigned, nonburnt
 
     def length(self, v):
         return float(Length(v))

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -350,8 +350,10 @@ class Planner(Service):
             operations = data  # unused.
             if command == "copy-selected":
                 operations = list(self.elements.ops(emphasized=True))
+                copy_selected = True
             else:
                 operations = list(self.elements.ops())
+                copy_selected = False
 
             def init_settings():
                 for prefix in ("prepend", "append"):
@@ -478,11 +480,17 @@ class Planner(Service):
             #     "blob",
             # )
             for c in operations:
+                isactive = True
                 try:
                     if not c.output:
-                        continue
+                        isactive = False
                 except AttributeError:
                     pass
+                if not isactive and copy_selected and len(operations) == 1:
+                    # If it's the only one we make an exception
+                    isactive = True
+                if not isactive:
+                    continue
                 if not hasattr(c, "type") or c.type is None:
                     # Node must be a type of node.
                     continue

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -361,7 +361,7 @@ class ShadowTree:
         self._freeze = False
         self.iconsize = 20
         self.iconstates = {}
-        # self.last_call = 0
+        self.last_call = 0
 
         fact = get_default_scale_factor()
         if fact > 1.0:
@@ -838,13 +838,22 @@ class ShadowTree:
         op_node = self.elements.get(type="branch ops")
         op_item = op_node._item
         self.wxtree.Expand(op_item)
-        if self.elements.have_unassigned_elements():
+        unassigned, unburnt = self.elements.have_unburnable_elements()
+        if unassigned or unburnt:
             self.wxtree.SetItemState(op_item, self.iconstates["warning"])
-            op_node._tooltip = _("You have unassigned elements, that won't be burned")
-            op_node._tooltip_translated = True
+            s1 = _("You have elements in disabled operations, that won't be burned")
+            s2 = _("You have unassigned elements, that won't be burned")
+            if unassigned and unburnt:
+                status = s1 + "\n" + s2
+            elif unburnt:
+                status = s1
+            elif unassigned:
+                status = s2
         else:
             self.wxtree.SetItemState(op_item, wx.TREE_ITEMSTATE_NONE)
-            op_node._tooltip = ""
+            status = ""
+        op_node._tooltip = status
+        op_node._tooltip_translated = True
 
     def freeze_tree(self, status=None):
         if status is None:
@@ -1519,7 +1528,8 @@ class ShadowTree:
 
         state_num = -1
         if node is self.elements.get(type="branch ops"):
-            if self.elements.have_unassigned_elements():
+            unassigned, unburnt = self.elements.have_unburnable_elements()
+            if unassigned or unburnt:
                 state_num = self.iconstates["warning"]
         else:
             # Has the node a lock attribute?


### PR DESCRIPTION
a) Make the warnicon in the tree aware of disabled operations as they won't be burnt either
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/68812058-f45e-4607-9d57-fb8964ce2f0d)

b) Reestablish lost functionality to simulate disabled operations (only if the disbaled operation is the single selected one).