### PR TITLE
Correct RuidaControl/RD-loading.

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -2933,17 +2933,19 @@ class Elemental(Service):
                             # without attachm: 72.1 sec
                             # self.unlisten_tree(self)
                             elemcount_then = self.count_elems()
+                            opcount_then = self.count_op()
                             results = loader.load(
                                 self, self, filename_to_process, **kwargs
                             )
                             elemcount_now = self.count_elems()
+                            opcount_now = self.count_op()
                             self.remove_empty_groups()
                             # self.listen_tree(self)
                             end_time = time()
                             self._filename = pathname
                             self.set_end_time("load", display=True)
                             self.signal("file;loaded")
-                            if elemcount_now != elemcount_then:
+                            if elemcount_now != elemcount_then or opcount_then != opcount_now:
                                 return True
                         except FileNotFoundError:
                             return False

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -124,7 +124,6 @@ class RuidaEmulator:
                 self._set_magic(0x11)
             if data == b'-x\xf4\n':
                 self._set_magic(0x77)
-            print(hex(self.magic))
         if checksum_check == checksum_sum:
             response = b"\xCC"
             self.msg_reply(response, desc="Checksum match")

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -110,19 +110,19 @@ class RuidaEmulator:
         checksum_check = (sent_data[0] & 0xFF) << 8 | sent_data[1] & 0xFF
         checksum_sum = sum(data) & 0xFFFF
         if len(data) == 4:
-            if data == b'\xd9\x84\x08\xfe':
-                self._set_magic(0x83)
             if data == b'\xd4\x89\r\xf7':
                 self._set_magic(0x88)
-            if data == b'i4\xb8N':
+            elif data == b'\xd9\x84\x08\xfe':
+                self._set_magic(0x83)
+            elif data == b'i4\xb8N':
                 self._set_magic(0x33)
-            if data == b'I\x14\x98n':
+            elif data == b'I\x14\x98n':
                 self._set_magic(0x13)
-            if data == b'z#\xa7]':
+            elif data == b'z#\xa7]':
                 self._set_magic(0x22)
-            if data == b"K\x12\x96p":
+            elif data == b"K\x12\x96p":
                 self._set_magic(0x11)
-            if data == b'-x\xf4\n':
+            elif data == b'-x\xf4\n':
                 self._set_magic(0x77)
         if checksum_check == checksum_sum:
             response = b"\xCC"

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -109,11 +109,22 @@ class RuidaEmulator:
         data = sent_data[2:1472]
         checksum_check = (sent_data[0] & 0xFF) << 8 | sent_data[1] & 0xFF
         checksum_sum = sum(data) & 0xFFFF
-        if len(sent_data) > 3:
-            if self.magic != 0x88 and sent_data[2] == 0xD4:
+        if len(data) == 4:
+            if data == b'\xd9\x84\x08\xfe':
+                self._set_magic(0x83)
+            if data == b'\xd4\x89\r\xf7':
                 self._set_magic(0x88)
-            if self.magic != 0x11 and sent_data[2] == 0x4B:
+            if data == b'i4\xb8N':
+                self._set_magic(0x33)
+            if data == b'I\x14\x98n':
+                self._set_magic(0x13)
+            if data == b'z#\xa7]':
+                self._set_magic(0x22)
+            if data == b"K\x12\x96p":
                 self._set_magic(0x11)
+            if data == b'-x\xf4\n':
+                self._set_magic(0x77)
+            print(hex(self.magic))
         if checksum_check == checksum_sum:
             response = b"\xCC"
             self.msg_reply(response, desc="Checksum match")

--- a/meerk40t/ruida/loader.py
+++ b/meerk40t/ruida/loader.py
@@ -11,9 +11,12 @@ import os
 
 def data_viewer(data, data_type):
     from meerk40t.core.node.blobnode import BlobNode
-    from meerk40t.ruida.rdjob import decode_bytes
+    from meerk40t.ruida.rdjob import decode_bytes, determine_magic_via_histogram
 
-    return BlobNode.hex_view(data=decode_bytes(data), data_type=data_type)
+    return BlobNode.hex_view(
+        data=decode_bytes(data, determine_magic_via_histogram(data)),
+        data_type=data_type,
+    )
 
 
 def command_viewer(data, data_type):

--- a/meerk40t/ruida/rdjob.py
+++ b/meerk40t/ruida/rdjob.py
@@ -249,18 +249,7 @@ class RDJob:
         @return:
         """
         if magic is None:
-            d12 = 0
-            d89 = 0
-            for d in data:
-                if d == 0x12:
-                    d12 += 1
-                elif d == 0x89:
-                    d89 += 1
-            if d89 + d12 > 10:
-                if d89 > d12:
-                    magic = 0x88
-                else:
-                    magic = 0x11
+            self.magic = determine_magic_via_histogram(data)
         if magic is not None and magic != self.magic:
             self.magic = magic
             self.lut_swizzle, self.lut_unswizzle = swizzles_lut(self.magic)

--- a/meerk40t/ruida/rdjob.py
+++ b/meerk40t/ruida/rdjob.py
@@ -150,6 +150,27 @@ def decode_bytes(data, magic=0x88):
     return bytes(array)
 
 
+def determine_magic_via_histogram(data):
+    """
+    Determines magic number via histogram. The number which occurs most in RDWorks files is overwhelmingly 0. It's
+    about 50% of all data. The swizzle algorithm means that the swizzle for 0 is magic + 1, so we find the most
+    frequent number and subtract one from that and that is *most* likely the magic number.
+
+    @param data:
+    @return:
+    """
+    histogram = [0] * 256
+    for d in data:
+        histogram[d] += 1
+    m = 0
+    magic = None
+    for i in range(len(histogram)):
+        v = histogram[i]
+        if v > m:
+            m = v
+            magic = i - 1
+    return magic
+
 def encode_bytes(data, magic=0x88):
     lut_swizzle, lut_unswizzle = swizzles_lut(magic)
     array = list()

--- a/meerk40t/ruida/rdjob.py
+++ b/meerk40t/ruida/rdjob.py
@@ -249,7 +249,7 @@ class RDJob:
         @return:
         """
         if magic is None:
-            self.magic = determine_magic_via_histogram(data)
+            magic = determine_magic_via_histogram(data)
         if magic is not None and magic != self.magic:
             self.magic = magic
             self.lut_swizzle, self.lut_unswizzle = swizzles_lut(self.magic)


### PR DESCRIPTION
Several examples of crashing due to control software sending different values, but all control software sends a request for the CardID. Checking that we can determine the expected swizzle and automatically adjust for it.