### PR TITLE
Some fixes / improvements for default / basic ops

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -488,8 +488,6 @@ class Elemental(Service):
             # Something was loaded for default ops. Mark that.
             self.undo.mark("op-loaded")  # Mark defaulted
 
-        self.default_operations = []
-
         self._default_stroke = None
         self._default_strokewidth = None
         self._default_fill = None
@@ -500,6 +498,9 @@ class Elemental(Service):
         self._align_stack = []
 
         self._timing_stack = {}
+
+        self.default_operations = []
+        self.init_default_operations_nodes()
 
     def set_start_time(self, key):
         if key in self._timing_stack:
@@ -1309,14 +1310,16 @@ class Elemental(Service):
 
         # We first have a try at a device specific default_set
         needs_save = False
+        std_list = "_default"
         needs_signal = len(self.default_operations) != 0
         oplist = []
-        std_list = f"_default_{self.device.label}"
-        # We need to replace all ' ' by an underscore
-        for forbidden in (" ",):
-            std_list = std_list.replace(forbidden, "_")
-        # print(f"Try to load '{std_list}'")
-        oplist = self.load_persistent_op_list(std_list)
+        if hasattr(self, "device"):
+            std_list = f"_default_{self.device.label}"
+            # We need to replace all ' ' by an underscore
+            for forbidden in (" ",):
+                std_list = std_list.replace(forbidden, "_")
+            # print(f"Try to load '{std_list}'")
+            oplist = self.load_persistent_op_list(std_list)
         if len(oplist) == 0:
             std_list = "_default"
             # print(f"Try to load '{std_list}'")

--- a/meerk40t/gui/basicops.py
+++ b/meerk40t/gui/basicops.py
@@ -6,10 +6,10 @@ a simpler interface to operations
 
 import wx
 
-from meerk40t.core.elements.element_types import op_nodes, elem_nodes
+from meerk40t.core.elements.element_types import elem_nodes, op_nodes
 from meerk40t.gui.laserrender import swizzlecolor
 
-from ..kernel import lookup_listener, signal_listener, Job
+from ..kernel import Job, lookup_listener, signal_listener
 from ..svgelements import Color
 from .icons import (
     icons8_diagonal_20,

--- a/meerk40t/gui/basicops.py
+++ b/meerk40t/gui/basicops.py
@@ -4,13 +4,12 @@ fundamental properties of operations. This is supposed to provide
 a simpler interface to operations
 """
 
-from time import perf_counter
 import wx
 
 from meerk40t.core.elements.element_types import op_nodes, elem_nodes
 from meerk40t.gui.laserrender import swizzlecolor
 
-from ..kernel import lookup_listener, signal_listener
+from ..kernel import lookup_listener, signal_listener, Job
 from ..svgelements import Color
 from .icons import (
     icons8_diagonal_20,
@@ -37,7 +36,15 @@ class BasicOpPanel(wx.Panel):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)
         self.context = context
-        self.last_signal = 0
+        # Refresh logic
+        self.ignore_refill = False
+        self._refill_job = Job(
+            process=self.fill_operations,
+            job_name="basicops_fillop",
+            interval=0.5,
+            times=1,
+            run_main=True,
+        )
         choices = [
             _("Leave color"),
             _("Op inherits color"),
@@ -105,7 +112,6 @@ class BasicOpPanel(wx.Panel):
         self.op_ctrl_list = []
         self.std_color_back = None
         self.std_color_fore = None
-        # self.fill_operations()
 
     def set_display(self):
         self.context.device.setting(bool, "use_percent_for_power_display", False)
@@ -195,10 +201,10 @@ class BasicOpPanel(wx.Panel):
                             newflag = bool(not mynode.is_visible)
 
                     mynode.is_visible = newflag
-                    self.last_signal = perf_counter()
                     mynode.updated()
                     self.context.elements.validate_selected_area()
                     ops = [mynode]
+                    self.ignore_refill = True
                     self.context.elements.signal("element_property_update", ops)
                     self.context.elements.signal("refresh_scene", "Scene")
                 cb.SetValue(newflag)
@@ -223,7 +229,7 @@ class BasicOpPanel(wx.Panel):
                         myshow.Enable(False)
                     else:
                         myshow.Enable(True)
-                    self.last_signal = perf_counter()
+                    self.ignore_refill = True
                     ops = [mynode]
                     self.context.elements.signal("element_property_update", ops)
                     self.context.elements.signal("warn_state_update", "")
@@ -243,7 +249,7 @@ class BasicOpPanel(wx.Panel):
                         value /= 60
                     if mynode.speed != value:
                         mynode.speed = value
-                        self.last_signal = perf_counter()
+                        self.ignore_refill = True
                         self.context.elements.signal(
                             "element_property_reload", [mynode], "text_speed"
                         )
@@ -263,7 +269,7 @@ class BasicOpPanel(wx.Panel):
                         value *= 10
                     if mynode.power != value:
                         mynode.power = value
-                        self.last_signal = perf_counter()
+                        self.ignore_refill = True
                         self.context.elements.signal(
                             "element_property_reload", [mynode], "text_power"
                         )
@@ -583,81 +589,53 @@ class BasicOpPanel(wx.Panel):
             ctrl.Refresh()
 
     def pane_show(self, *args):
-        # self.fill_operations()
         pass
 
     def pane_hide(self, *args):
         pass
 
     @signal_listener("element_property_update")
-    def signal_handler_update(self, origin, *args, **kwargs):
-        pc = perf_counter()
-        if pc - self.last_signal > 0.5:
-            # print(f"Delta property update: {pc - self.last_signal:.2f}")
-            hadops = False
-            if len(args) > 0:
-                if isinstance(args[0], (list, tuple)):
-                    myl = args[0]
-                else:
-                    if args[0] is self.context.elements.op_branch:
-                        myl = list(self.context.elements.ops())
-                    else:
-                        myl = [args[0]]
-                for n in myl:
-                    if n.type.startswith("op "):
-                        hadops = True
-                        break
-            # print (f"Signal elem update called {args} / {kwargs} / {len(list(self.context.elements.ops()))}")
-            if hadops:
-                self.fill_operations()
-        self.last_signal = pc
-
     @signal_listener("element_property_reload")
-    def signal_handler_reload(self, origin, *args, **kwargs):
-        pc = perf_counter()
-        if pc - self.last_signal > 0.5:
-            # print(f"Delta property reload: {pc - self.last_signal:.2f}")
-            hadops = False
-            if len(args) > 0:
-                if isinstance(args[0], (list, tuple)):
-                    myl = args[0]
+    def signal_handler_update(self, origin, *args, **kwargs):
+        hadops = False
+        if len(args) > 0:
+            if isinstance(args[0], (list, tuple)):
+                myl = args[0]
+            else:
+                if args[0] is self.context.elements.op_branch:
+                    myl = list(self.context.elements.ops())
                 else:
-                    if args[0] is self.context.elements.op_branch:
-                        myl = list(self.context.elements.ops())
-                    else:
-                        myl = [args[0]]
-                for n in myl:
-                    if n.type.startswith("op "):
-                        hadops = True
-                        break
-            # print (f"Signal elem reload called {args} / {kwargs} / {len(list(self.context.elements.ops()))}")
-            if hadops:
-                self.fill_operations()
-        self.last_signal = pc
+                    myl = [args[0]]
+            for n in myl:
+                if n.type.startswith("op "):
+                    hadops = True
+                    break
+        # print (f"Signal elem update called {args} / {kwargs} / {len(list(self.context.elements.ops()))}")
+        if hadops:
+            self.ask_for_refill()
 
     @signal_listener("rebuild_tree")
+    @signal_listener("refresh_tree")
+    @signal_listener("tree_changed")
+    @signal_listener("operation_removed")
+    @signal_listener("add_operation")
     def signal_handler_rebuild(self, origin, *args, **kwargs):
         # print (f"Signal rebuild called {args} / {kwargs} / {len(list(self.context.elements.ops()))}")
-        pc = perf_counter()
-        # This needs to run every time
-        self.fill_operations()
-        self.last_signal = pc
+        self.ask_for_refill()
 
-    @signal_listener("tree_changed")
-    def signal_handler_tree(self, origin, *args, **kwargs):
-        # print (f"Signal tree changed called {args} / {kwargs} / {len(list(self.context.elements.ops()))}")
-        pc = perf_counter()
-        if pc - self.last_signal > 0.5:
-            # print(f"Delta tree: {pc - self.last_signal:.2f}")
-            self.fill_operations()
-        self.last_signal = pc
+    def ask_for_refill(self):
+        # Endless cup
+        if self.ignore_refill:
+            self.ignore_refill = False
+            return
+        self.context.schedule(self._refill_job)
 
     @signal_listener("power_percent")
     @signal_listener("speed_min")
     @lookup_listener("service/device/active")
     def on_device_update(self, *args):
         self.set_display()
-        self.fill_operations()
+        self.ask_for_refill()
 
     @signal_listener("emphasized")
     def signal_handler_emphasized(self, origin, *args, **kwargs):

--- a/meerk40t/gui/statusbarwidgets/defaultoperations.py
+++ b/meerk40t/gui/statusbarwidgets/defaultoperations.py
@@ -41,110 +41,6 @@ class DefaultOperationWidget(StatusBarWidget):
             slabel = ""
         return slabel
 
-    def init_nodes(self):
-        def next_color(primary, secondary, tertiary, delta=32):
-            secondary += delta
-            if secondary > 255:
-                secondary = 0
-                primary -= delta
-            if primary < 0:
-                primary = 255
-                tertiary += delta
-            if tertiary > 255:
-                tertiary = 0
-            return primary, secondary, tertiary
-
-        def create_cut():
-            # Cut op
-            idx = 0
-            blue = 0
-            green = 0
-            red = 255
-            for speed in (1, 2, 5):
-                for power in (1000,):
-                    idx += 1
-                    op_id = f"C{idx:01d}"
-                    op = CutOpNode(id=op_id, speed=speed, power=power)
-                    op.label = self.node_label(op)
-                    op.color = Color(red=red, blue=blue, green=green)
-                    red, blue, green = next_color(red, blue, green, delta=64)
-                    # print(f"Next for cut: {red} {blue} {green}")
-                    op.allowed_attributes = ["stroke"]
-                    oplist.append(op)
-
-        def create_engrave():
-            # Engrave op
-            idx = 0
-            blue = 255
-            green = 0
-            red = 0
-            for speed in (20, 35, 50):
-                for power in (1000, 750, 500):
-                    idx += 1
-                    op_id = f"E{idx:01d}"
-                    op = EngraveOpNode(id=op_id, speed=speed, power=power)
-                    op.label = self.node_label(op)
-                    op.color = Color(red=red, blue=blue, green=green)
-                    blue, green, red = next_color(blue, green, red, delta=24)
-                    # print(f"Next for engrave: {red} {blue} {green}")
-                    op.allowed_attributes = ["stroke"]
-                    oplist.append(op)
-
-        def create_raster():
-            # Raster op
-            idx = 0
-            blue = 0
-            green = 255
-            red = 0
-            for speed in (250, 200, 150, 100, 75):
-                for power in (1000,):
-                    idx += 1
-                    op_id = f"R{idx:01d}"
-                    op = RasterOpNode(id=op_id, speed=speed, power=power)
-                    op.label = self.node_label(op)
-                    op.color = Color(red=red, blue=blue, green=green, delta=60)
-                    green, red, blue = next_color(green, red, blue)
-                    # print(f"Next for raster: {red} {blue} {green}")
-                    op.allowed_attributes = ["fill"]
-                    oplist.append(op)
-
-        def create_image():
-            # Image op
-            idx = 0
-            blue = 0
-            green = 0
-            red = 0
-            for speed in (250, 200, 150, 100, 75):
-                for power in (1000,):
-                    idx += 1
-                    op_id = f"I{idx:01d}"
-                    op = ImageOpNode(id=op_id, speed=speed, power=power)
-                    op.label = self.node_label(op)
-                    op.color = Color(red=red, blue=blue, green=green, delta=48)
-                    green, blue, red = next_color(green, red, blue)
-                    # print(f"Next for Image: {red} {blue} {green}")
-
-                    oplist.append(op)
-
-        oplist = self.context.elements.load_persistent_op_list("_default")
-        needs_save = False
-        if len(oplist) == 0:
-            # Then let's create something useful
-            create_cut()
-            create_engrave()
-            create_raster()
-            create_image()
-            needs_save = True
-        # Ensure we have an id for everything
-        for opidx, opnode in enumerate(oplist):
-            if opnode.id is None:
-                opnode.id = f"{opidx:01d}"
-                needs_save = True
-        if needs_save:
-            self.context.elements.save_persistent_operations_list("_default", oplist)
-
-        self.context.elements.default_operations = oplist
-
     def GenerateControls(self, parent, panelidx, identifier, context):
         def size_it(ctrl, dimen_x, dimen_y):
             ctrl.SetMinSize(wx.Size(dimen_x, dimen_y))
@@ -175,7 +71,7 @@ class DefaultOperationWidget(StatusBarWidget):
         self.first_to_show = 0
         self.page_size = int((self.width - 2 * self.buttonsize_x) / self.buttonsize_x)
 
-        self.init_nodes()
+        self.context.elements.init_default_operations_nodes()
         self.assign_buttons.clear()
         for idx, op in enumerate(self.context.elements.default_operations):
             btn = wx.StaticBitmap(
@@ -391,5 +287,7 @@ class DefaultOperationWidget(StatusBarWidget):
             self.GenerateControls(
                 self.parent, self.panelidx, self.identifier, self.context
             )
+            # Repaint
+            self.show_stuff(True)
         elif signal == "emphasized":
             self.Enable(self.context.elements.has_emphasis())

--- a/meerk40t/gui/statusbarwidgets/defaultoperations.py
+++ b/meerk40t/gui/statusbarwidgets/defaultoperations.py
@@ -2,9 +2,8 @@ import wx
 
 from meerk40t.core.node.op_cut import CutOpNode
 from meerk40t.core.node.op_engrave import EngraveOpNode
-from meerk40t.core.node.op_raster import RasterOpNode
 from meerk40t.core.node.op_image import ImageOpNode
-
+from meerk40t.core.node.op_raster import RasterOpNode
 from meerk40t.gui.icons import EmptyIcon
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.svgelements import Color

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -3361,6 +3361,11 @@ class MeerK40t(MWindow):
         dlg.ShowModal()
         dlg.Destroy()
 
+    @signal_listener("activate;device")
+    def on_device_active(self, origin, value):
+        # A new device might have new default oeprations...
+        self.main_statusbar.Signal("default_operations")
+
     @signal_listener("pipe;failing")
     def on_usb_error(self, origin, value):
         if value == 5:

--- a/meerk40t/kernel/settings.py
+++ b/meerk40t/kernel/settings.py
@@ -307,9 +307,9 @@ class Settings:
         @return:
         """
         for section_name in self._config_dict:
-            section_name.split("/")
+            ss = section_name.split(" ")
 
-            if section_name.startswith(section):
+            if ss[0] == section:
                 yield section_name
 
     def section_set(self) -> Generator[str, None, None]:


### PR DESCRIPTION
a) Centralize code to load/save/generate default operations to elements.py
b) Allow to have device dependent default operations (save them under ``_default_``_devicelabel_) (so if your current device is called 'balor-device' then use ``_default_balor-device``)
c) a fix for the derivable function in the settings class to make the above work