### PR TITLE
Correct issue with multiple kernel log files with the same name.

### DIFF
--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -184,7 +184,7 @@ class Kernel(Settings):
 
         try:
             file_obj = self._open_file_objects.get(filename)
-            if file_obj is not None and file_obj.opened:
+            if file_obj is not None and not file_obj.closed:
                 # Give cached file object.
                 return file_obj
             file_obj = open(filename, *args)
@@ -1380,6 +1380,13 @@ class Kernel(Settings):
         if thread_count == 0:
             if channel:
                 channel(_("No threads required halting."))
+
+        # Close any safe_files that are still opened.
+        for key, file_obj in self._open_file_objects.items():
+            try:
+                file_obj.close()
+            except:
+                pass
 
         # Process any remove attempts that were occurred too late for standard removal.
         self._process_remove_listeners()

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -184,9 +184,11 @@ class Kernel(Settings):
 
         try:
             file_obj = self._open_file_objects.get(filename)
-            if file_obj is None:
-                file_obj = open(filename, *args)
-                self._open_file_objects[filename] = file_obj
+            if file_obj is not None and file_obj.opened:
+                # Give cached file object.
+                return file_obj
+            file_obj = open(filename, *args)
+            self._open_file_objects[filename] = file_obj
             return file_obj
         except PermissionError as e:
             original_dir = os.getcwd()


### PR DESCRIPTION
This updates the kernel to store `._file_objects` which were loaded with `open_save`. If the same file is set to open multiple times, then we merely return the cached values. These files are now closed during shutdown (previously they could get stuck open).