### PR TITLE
Improve/Standardize Op Dictionary Copying

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1190,7 +1190,11 @@ class Elemental(Service):
         op_tree = dict()
         for section in list(settings.derivable(name)):
             op_type = settings.read_persistent(str, section, "type")
-            op = Node().create(type=op_type)
+            try:
+                op = Node().create(type=op_type)
+            except ValueError:
+                # Attempted to create a non-boostrapped node type.
+                continue
             op.load(settings, section)
             op_tree[section] = op
         op_list = list()

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1190,13 +1190,7 @@ class Elemental(Service):
         op_tree = dict()
         for section in list(settings.derivable(name)):
             op_type = settings.read_persistent(str, section, "type")
-            # That should not happen, but it happens nonetheless...
-            # So recover gracefully
-            try:
-                op = Node().create(type=op_type)
-            except (AttributeError, RuntimeError, ValueError) as err:
-                print(f"That should not happen, but ops contained: '{op_type}' [{err}]")
-                continue
+            op = Node().create(type=op_type)
             op.load(settings, section)
             op_tree[section] = op
         op_list = list()

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -426,21 +426,6 @@ class Node:
         for c in self._children:
             c._build_copy_nodes(links=links)
             node_copy = copy(c)
-            for attr in (
-                "id",
-                "label",
-                "color",
-                "lock",
-                "allowed_attributes",
-                "stroke",
-                "fill",
-                "stroke_width",
-                "stroke_scaled",
-            ):
-                if getattr(node_copy, attr, None) != getattr(c, attr, None):
-                    print(f"{node_copy}, {attr}")
-
-                assert getattr(node_copy, attr, None) == getattr(c, attr, None)
             node_copy._root = self._root
             links[id(c)] = (c, node_copy)
         return links

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -437,8 +437,10 @@ class Node:
                 "stroke_width",
                 "stroke_scaled",
             ):
-                if hasattr(c, attr):
-                    setattr(node_copy, attr, getattr(c, attr))
+                if getattr(node_copy, attr, None) != getattr(c, attr, None):
+                    print(f"{node_copy}, {attr}")
+
+                assert getattr(node_copy, attr, None) == getattr(c, attr, None)
             node_copy._root = self._root
             links[id(c)] = (c, node_copy)
         return links

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -67,14 +67,6 @@ class CutOpNode(Node, Parameters):
         # As we don't have any logic, we just return the original path
         return path
 
-    # def is_dangerous(self, minpower, maxspeed):
-    #     result = False
-    #     if maxspeed is not None and self.speed > maxspeed:
-    #         result = True
-    #     if minpower is not None and self.power < minpower:
-    #         result = True
-    #     self.dangerous = result
-
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Cut"

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -16,19 +16,17 @@ class CutOpNode(Node, Parameters):
     This is a Node of type "op cut".
     """
 
-    def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        # Node.__init__(self, type="op cut", id=id, label=label, lock=lock)
-        Parameters.__init__(self, **kwargs)
-        self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
+    def __init__(self, settings=None, **kwargs):
+        if settings is not None:
+            settings = dict(settings)
+        Parameters.__init__(self, settings, **kwargs)
+        # Is this op out of useful bounds?
+        self.dangerous = False
+
+        self.label = "Cut"
         self.kerf = 0
         self._device_factor = 1.0
 
-        if len(args) == 1:
-            obj = args[0]
-            if hasattr(obj, "settings"):
-                self.settings = dict(obj.settings)
-            elif isinstance(obj, dict):
-                self.settings.update(obj)
         # Which elements can be added to an operation (manually via DND)?
         self._allowed_elements_dnd = (
             "elem ellipse",
@@ -51,12 +49,8 @@ class CutOpNode(Node, Parameters):
         self.allowed_attributes = [
             "stroke",
         ]
-        # Is this op out of useful bounds?
-        self.dangerous = False
-        if label is None:
-            self.label = "Cut"
-        else:
-            self.label = label
+        super().__init__(type="op cut", **kwargs)
+        self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
 
     def __repr__(self):
         return "CutOpNode()"
@@ -224,9 +218,6 @@ class CutOpNode(Node, Parameters):
 
     def load(self, settings, section):
         settings.read_persistent_attributes(section, self)
-        update_dict = settings.read_persistent_string_dict(section, suffix=True)
-        self.settings.update(update_dict)
-        self.validate()
         hexa = self.settings.get("hex_color")
         if hexa is not None:
             self.color = Color(hexa)
@@ -245,8 +236,8 @@ class CutOpNode(Node, Parameters):
         settings.write_persistent_dict(section, self.settings)
 
     def copy_children(self, obj):
-        for node in obj.children:
-            self.add_reference(node)
+        for element in obj.children:
+            self.add_reference(element)
 
     def copy_children_as_real(self, copy_node):
         for node in copy_node.children:

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -17,8 +17,8 @@ class CutOpNode(Node, Parameters):
     """
 
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        Node.__init__(self, type="op cut", id=id, label=label, lock=lock)
-        Parameters.__init__(self, None, **kwargs)
+        # Node.__init__(self, type="op cut", id=id, label=label, lock=lock)
+        Parameters.__init__(self, **kwargs)
         self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
         self.kerf = 0
         self._device_factor = 1.0
@@ -60,9 +60,6 @@ class CutOpNode(Node, Parameters):
 
     def __repr__(self):
         return "CutOpNode()"
-
-    def __copy__(self):
-        return CutOpNode(self)
 
     def offset_routine(self, path, offset_value=0):
         # This is a placeholder that will be overloaded by plugin routines

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -16,27 +16,20 @@ class DotsOpNode(Node, Parameters):
     This is a Node of type "op dots".
     """
 
-    def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        Node.__init__(self, type="op dots", id=id, label=label, lock=lock)
-        Parameters.__init__(self,  **kwargs)
-        self._formatter = "{enabled}{pass}{element_type} {dwell_time}ms dwell {color}"
-
-        if len(args) == 1:
-            obj = args[0]
-            if hasattr(obj, "settings"):
-                self.settings = dict(obj.settings)
-            elif isinstance(obj, dict):
-                self.settings.update(obj)
+    def __init__(self, settings=None, **kwargs):
+        if settings is not None:
+            settings = dict(settings)
+        Parameters.__init__(self, settings, **kwargs)
         self._allowed_elements_dnd = ("elem point",)
         self._allowed_elements = ("elem point",)
-        self.allowed_attributes = []
         # Is this op out of useful bounds?
         self.dangerous = False
         self.stopop = True
-        if label is None:
-            self.label = "Dots"
-        else:
-            self.label = label
+        self.label = "Dots"
+
+        self.allowed_attributes = []
+        super().__init__(type="op dots", **kwargs)
+        self._formatter = "{enabled}{pass}{element_type} {dwell_time}ms dwell {color}"
 
     def __repr__(self):
         return "DotsOpNode()"
@@ -188,9 +181,6 @@ class DotsOpNode(Node, Parameters):
 
     def load(self, settings, section):
         settings.read_persistent_attributes(section, self)
-        update_dict = settings.read_persistent_string_dict(section, suffix=True)
-        self.settings.update(update_dict)
-        self.validate()
         hexa = self.settings.get("hex_color")
         if hexa is not None:
             self.color = Color(hexa)

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -41,14 +41,6 @@ class DotsOpNode(Node, Parameters):
     def __repr__(self):
         return "DotsOpNode()"
 
-    # def is_dangerous(self, minpower, maxspeed):
-    #     result = False
-    #     if maxspeed is not None and self.speed > maxspeed:
-    #         result = True
-    #     if minpower is not None and self.power < minpower:
-    #         result = True
-    #     self.dangerous = result
-
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Dots"

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -18,7 +18,7 @@ class DotsOpNode(Node, Parameters):
 
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
         Node.__init__(self, type="op dots", id=id, label=label, lock=lock)
-        Parameters.__init__(self, None, **kwargs)
+        Parameters.__init__(self,  **kwargs)
         self._formatter = "{enabled}{pass}{element_type} {dwell_time}ms dwell {color}"
 
         if len(args) == 1:
@@ -40,9 +40,6 @@ class DotsOpNode(Node, Parameters):
 
     def __repr__(self):
         return "DotsOpNode()"
-
-    def __copy__(self):
-        return DotsOpNode(self)
 
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -16,18 +16,15 @@ class EngraveOpNode(Node, Parameters):
     This is a Node of type "op engrave".
     """
 
-    def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        # Node.__init__(self, type="op engrave", id=id, label=label, lock=lock)
-        super().__init__(type="op engrave", **kwargs)
-        Parameters.__init__(self, **kwargs)
-        self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
+    def __init__(self, settings=None, **kwargs):
+        if settings is not None:
+            settings = dict(settings)
+        Parameters.__init__(self, settings, **kwargs)
 
-        if len(args) == 1:
-            obj = args[0]
-            if hasattr(obj, "settings"):
-                self.settings = dict(obj.settings)
-            elif isinstance(obj, dict):
-                self.settings.update(obj)
+        # Is this op out of useful bounds?
+        self.dangerous = False
+
+        self.label = "Engrave"
         # We may want to add more advanced logic at a later time
         # to convert text to paths within dnd...
         self._allowed_elements_dnd = (
@@ -47,14 +44,15 @@ class EngraveOpNode(Node, Parameters):
             "elem line",
             "effect hatch",
         )
+
         # To which attributes does the classification color check respond
         # Can be extended / reduced by add_color_attribute / remove_color_attribute
         self.allowed_attributes = [
             "stroke",
         ]  # comma is relevant
-        # Is this op out of useful bounds?
-        self.dangerous = False
-        self.label = "Engrave" if label is None else label
+
+        super().__init__(type="op engrave", **kwargs)
+        self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
 
     def __repr__(self):
         return "EngraveOpNode()"
@@ -209,9 +207,6 @@ class EngraveOpNode(Node, Parameters):
 
     def load(self, settings, section):
         settings.read_persistent_attributes(section, self)
-        update_dict = settings.read_persistent_string_dict(section, suffix=True)
-        self.settings.update(update_dict)
-        self.validate()
         hexa = self.settings.get("hex_color")
         if hexa is not None:
             self.color = Color(hexa)

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -17,8 +17,9 @@ class EngraveOpNode(Node, Parameters):
     """
 
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        Node.__init__(self, type="op engrave", id=id, label=label, lock=lock)
-        Parameters.__init__(self, None, **kwargs)
+        # Node.__init__(self, type="op engrave", id=id, label=label, lock=lock)
+        super().__init__(type="op engrave", **kwargs)
+        Parameters.__init__(self, **kwargs)
         self._formatter = "{enabled}{pass}{element_type} {speed}mm/s @{power} {color}"
 
         if len(args) == 1:
@@ -57,9 +58,6 @@ class EngraveOpNode(Node, Parameters):
 
     def __repr__(self):
         return "EngraveOpNode()"
-
-    def __copy__(self):
-        return EngraveOpNode(self)
 
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -59,14 +59,6 @@ class EngraveOpNode(Node, Parameters):
     def __repr__(self):
         return "EngraveOpNode()"
 
-    # def is_dangerous(self, minpower, maxspeed):
-    #     result = False
-    #     if maxspeed is not None and self.speed > maxspeed:
-    #         result = True
-    #     if minpower is not None and self.power < minpower:
-    #         result = True
-    #     self.dangerous = result
-
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Engrave"

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -44,14 +44,6 @@ class ImageOpNode(Node, Parameters):
     def __repr__(self):
         return "ImageOpNode()"
 
-    # def is_dangerous(self, minpower, maxspeed):
-    #     result = False
-    #     if maxspeed is not None and self.speed > maxspeed:
-    #         result = True
-    #     if minpower is not None and self.power < minpower:
-    #         result = True
-    #     self.dangerous = result
-
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Image"

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -16,17 +16,11 @@ class ImageOpNode(Node, Parameters):
     This is a Node of type "op image".
     """
 
-    def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        Node.__init__(self, type="op image", id=id, label=label, lock=lock)
-        Parameters.__init__(self,  **kwargs)
-        self._formatter = "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power}"
+    def __init__(self, settings=None, **kwargs):
+        if settings is not None:
+            settings = dict(settings)
+        Parameters.__init__(self, settings, **kwargs)
 
-        if len(args) == 1:
-            obj = args[0]
-            if hasattr(obj, "settings"):
-                self.settings = dict(obj.settings)
-            elif isinstance(obj, dict):
-                self.settings.update(obj)
         # Which elements can be added to an operation (manually via DND)?
         self._allowed_elements_dnd = ("elem image",)
         # Which elements do we consider for automatic classification?
@@ -35,11 +29,11 @@ class ImageOpNode(Node, Parameters):
         # Is this op out of useful bounds?
         self.dangerous = False
         self.stopop = True
+        self.label = "Image"
+
         self.allowed_attributes = []
-        if label is None:
-            self.label = "Image"
-        else:
-            self.label = label
+        super().__init__(type="op image", **kwargs)
+        self._formatter = "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power}"
 
     def __repr__(self):
         return "ImageOpNode()"
@@ -148,9 +142,6 @@ class ImageOpNode(Node, Parameters):
 
     def load(self, settings, section):
         settings.read_persistent_attributes(section, self)
-        update_dict = settings.read_persistent_string_dict(section, suffix=True)
-        self.settings.update(update_dict)
-        self.validate()
         hexa = self.settings.get("hex_color")
         if hexa is not None:
             self.color = Color(hexa)

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -18,7 +18,7 @@ class ImageOpNode(Node, Parameters):
 
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
         Node.__init__(self, type="op image", id=id, label=label, lock=lock)
-        Parameters.__init__(self, None, **kwargs)
+        Parameters.__init__(self,  **kwargs)
         self._formatter = "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power}"
 
         if len(args) == 1:
@@ -43,9 +43,6 @@ class ImageOpNode(Node, Parameters):
 
     def __repr__(self):
         return "ImageOpNode()"
-
-    def __copy__(self):
-        return ImageOpNode(self)
 
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -66,14 +66,6 @@ class RasterOpNode(Node, Parameters):
     def __repr__(self):
         return "RasterOp()"
 
-    # def is_dangerous(self, minpower, maxspeed):
-    #     result = False
-    #     if maxspeed is not None and self.speed > maxspeed:
-    #         result = True
-    #     if minpower is not None and self.power < minpower:
-    #         result = True
-    #     self.dangerous = result
-
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Raster"

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -18,19 +18,11 @@ class RasterOpNode(Node, Parameters):
     This is a Node of type "op raster".
     """
 
-    def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
-        Node.__init__(self, type="op raster", id=id, label=label, lock=lock)
-        Parameters.__init__(self, **kwargs)
-        self._formatter = (
-            "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power} {color}"
-        )
+    def __init__(self, settings=None, **kwargs):
+        if settings is not None:
+            settings = dict(settings)
+        Parameters.__init__(self, settings, **kwargs)
 
-        # if len(args) == 1:
-        #     obj = args[0]
-        #     if hasattr(obj, "settings"):
-        #         self.settings = dict(obj.settings)
-        #     elif isinstance(obj, dict):
-        #         self.settings.update(obj)
         self._allowed_elements_dnd = (
             "elem ellipse",
             "elem path",
@@ -50,18 +42,21 @@ class RasterOpNode(Node, Parameters):
             "elem text",
             #            "elem image",
         )
-        # To which attributes do the classification color check respond
-        # Can be extended / reduced by add_color_attribute / remove_color_attribute
-        # An empty set indicates all nodes will be allowed
-        self.allowed_attributes = []
+
         # self.allowed_attributes.append("fill")
         # Is this op out of useful bounds?
         self.dangerous = False
         self.stopop = False
-        if label is None:
-            self.label = "Raster"
-        else:
-            self.label = label
+        self.label = "Raster"
+
+        # To which attributes do the classification color check respond
+        # Can be extended / reduced by add_color_attribute / remove_color_attribute
+        # An empty set indicates all nodes will be allowed
+        self.allowed_attributes = []
+        super().__init__(type="op raster", **kwargs)
+        self._formatter = (
+            "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power} {color}"
+        )
 
     def __repr__(self):
         return "RasterOp()"
@@ -264,9 +259,6 @@ class RasterOpNode(Node, Parameters):
 
     def load(self, settings, section):
         settings.read_persistent_attributes(section, self)
-        update_dict = settings.read_persistent_string_dict(section, suffix=True)
-        self.settings.update(update_dict)
-        self.validate()
         hexa = self.settings.get("hex_color")
         if hexa is not None:
             self.color = Color(hexa)

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -20,17 +20,17 @@ class RasterOpNode(Node, Parameters):
 
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
         Node.__init__(self, type="op raster", id=id, label=label, lock=lock)
-        Parameters.__init__(self, None, **kwargs)
+        Parameters.__init__(self, **kwargs)
         self._formatter = (
             "{enabled}{pass}{element_type}{direction}{speed}mm/s @{power} {color}"
         )
 
-        if len(args) == 1:
-            obj = args[0]
-            if hasattr(obj, "settings"):
-                self.settings = dict(obj.settings)
-            elif isinstance(obj, dict):
-                self.settings.update(obj)
+        # if len(args) == 1:
+        #     obj = args[0]
+        #     if hasattr(obj, "settings"):
+        #         self.settings = dict(obj.settings)
+        #     elif isinstance(obj, dict):
+        #         self.settings.update(obj)
         self._allowed_elements_dnd = (
             "elem ellipse",
             "elem path",
@@ -65,9 +65,6 @@ class RasterOpNode(Node, Parameters):
 
     def __repr__(self):
         return "RasterOp()"
-
-    def __copy__(self):
-        return RasterOpNode(self)
 
     # def is_dangerous(self, minpower, maxspeed):
     #     result = False

--- a/meerk40t/core/node/place_current.py
+++ b/meerk40t/core/node/place_current.py
@@ -20,10 +20,6 @@ class PlaceCurrentNode(Node):
         self.output = True
         self._formatter = "{enabled}{element_type}"
 
-    def __copy__(self):
-        nd = self.node_dict
-        return PlaceCurrentNode(**nd)
-
     def placements(self, context, outline, matrix, plan):
         if outline is None:
             return
@@ -41,8 +37,4 @@ class PlaceCurrentNode(Node):
         return default_map
 
     def drop(self, drag_node, modify=True):
-        # if drag_node.type.startswith("op"):
-        #     if modify:
-        #         self.insert_sibling(drag_node)
-        #     return True
         return False

--- a/meerk40t/core/node/place_point.py
+++ b/meerk40t/core/node/place_point.py
@@ -66,10 +66,6 @@ class PlacePointNode(Node):
             except ValueError:
                 self.loops = 1
 
-    def __copy__(self):
-        nd = self.node_dict
-        return PlacePointNode(**nd)
-
     def placements(self, context, outline, matrix, plan):
         if outline is None:
             # This job can't be placed.
@@ -127,8 +123,4 @@ class PlacePointNode(Node):
         return default_map
 
     def drop(self, drag_node, modify=True):
-        # if drag_node.type.startswith("op"):
-        #     if modify:
-        #         self.insert_sibling(drag_node)
-        #     return True
         return False

--- a/meerk40t/core/parameters.py
+++ b/meerk40t/core/parameters.py
@@ -1,3 +1,4 @@
+import ast
 from typing import Dict
 
 from meerk40t.svgelements import Color
@@ -98,38 +99,24 @@ class Parameters:
 
     def validate(self):
         settings = self.settings
-        for v in FLOAT_PARAMETERS:
-            if v in settings:
-                settings[v] = float(settings[v])
-        for v in INT_PARAMETERS:
-            if v in settings:
-                settings[v] = int(float(settings[v]))
-        for v in BOOL_PARAMETERS:
-            if v in settings:
-                settings[v] = str(settings[v]).lower() == "true"
-        for v in STRING_PARAMETERS:
-            if v in settings:
-                settings[v] = settings[v]
-        for v in COLOR_PARAMETERS:
-            if v in settings:
+        for v in settings:
+            if v in COLOR_PARAMETERS:
                 settings[v] = Color(settings[v])
-        for v in LIST_PARAMETERS:
-            if v in settings:
-                if isinstance(settings[v], str):
-                    myarr = []
-                    sett = settings[v]
-                    if sett != "":
-                        # First of all is it in the old format where we used eval?
-                        if sett.startswith("["):
-                            sett = sett[1:-1]
-                        if "'," in sett:
-                            slist = sett.split(",")
-                            for n in slist:
-                                n = n.strip().strip("'")
-                                myarr.append(n)
-                        else:
-                            myarr = [sett.strip().strip("'")]
-                    settings[v] = myarr
+                continue
+            elif v in FLOAT_PARAMETERS:
+                settings[v] = float(settings[v])
+            elif v in INT_PARAMETERS:
+                settings[v] = int(float(settings[v]))
+            elif v in BOOL_PARAMETERS:
+                settings[v] = str(settings[v]).lower() == "true"
+            elif v in STRING_PARAMETERS:
+                pass  # Already strings.
+            else:
+                # Includes LIST_PARAMETERS
+                try:
+                    settings[v] = ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    pass
 
     @property
     def color(self):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,0 +1,173 @@
+import unittest
+from copy import copy
+
+from meerk40t.core.node.op_cut import CutOpNode
+from meerk40t.core.node.op_engrave import EngraveOpNode
+from meerk40t.core.node.op_image import ImageOpNode
+from meerk40t.core.node.op_raster import RasterOpNode
+
+
+class TestOperations(unittest.TestCase):
+    def test_operation_copy_engrave(self):
+        """
+        Test code to ensure operations copy correctly
+
+        :return:
+        """
+        node = EngraveOpNode(
+            id="fake_id",
+            label="My label",
+            color="green",
+            lock=True,
+            allowed_attributes=["number_of_unicorns"],
+            stroke="green",
+            fill="gray",
+            stroke_width=7,
+            dancing_bear=0.2,
+        )
+        node_copy = copy(node)
+        for attr in (
+            "id",
+            "label",
+            "color",
+            "lock",
+            "allowed_attributes",
+            "stroke",
+            "fill",
+            "stroke_width",
+            "stroke_scaled",
+        ):
+            if hasattr(node, attr):
+                self.assertEqual(getattr(node_copy, attr), getattr(node, attr))
+        for item in node.settings:
+            self.assertEqual(node.settings[item], node_copy.settings[item])
+
+    def test_operation_copy_knockon(self):
+        """
+        Test code to ensure operations copy correctly
+
+        :return:
+        """
+        node = EngraveOpNode(
+            id="fake_id",
+            label="My label",
+            color="green",
+            lock=True,
+            allowed_attributes=["number_of_unicorns"],
+            stroke="green",
+            fill="gray",
+            stroke_width=7,
+            dancing_bear=0.2,
+        )
+        node_copy = copy(node)
+        for item in node.settings:
+            self.assertEqual(node.settings[item], node_copy.settings[item])
+        node_copy.dancing_bear = 0.5
+        self.assertNotEquals(node_copy.dancing_bear, node.dancing_bear)
+        node_copy_copy = copy(node_copy)
+        self.assertEquals(node_copy_copy.dancing_bear, node_copy.dancing_bear)
+
+    def test_operation_copy_cut(self):
+        """
+        Test code to ensure operations copy correctly
+
+        :return:
+        """
+        node = CutOpNode(
+            id="fake_id",
+            label="My label",
+            color="green",
+            lock=True,
+            allowed_attributes=["number_of_unicorns"],
+            stroke="green",
+            fill="gray",
+            stroke_width=7,
+            dancing_bear=0.2,
+        )
+        node_copy = copy(node)
+        for attr in (
+            "id",
+            "label",
+            "color",
+            "lock",
+            "allowed_attributes",
+            "stroke",
+            "fill",
+            "stroke_width",
+            "stroke_scaled",
+        ):
+            if hasattr(node, attr):
+                self.assertEqual(getattr(node_copy, attr), getattr(node, attr))
+        self.assertEqual(node_copy.settings["dancing_bear"], 0.2)
+        for item in node.settings:
+            self.assertEqual(node.settings[item], node_copy.settings[item])
+
+    def test_operation_copy_image(self):
+        """
+        Test code to ensure operations copy correctly
+
+        :return:
+        """
+        node = ImageOpNode(
+            id="fake_id",
+            label="My label",
+            color="green",
+            lock=True,
+            allowed_attributes=["number_of_unicorns"],
+            stroke="green",
+            fill="gray",
+            stroke_width=7,
+            dancing_bear=0.2,
+        )
+        node_copy = copy(node)
+        for attr in (
+            "id",
+            "label",
+            "color",
+            "lock",
+            "allowed_attributes",
+            "stroke",
+            "fill",
+            "stroke_width",
+            "stroke_scaled",
+        ):
+            if hasattr(node, attr):
+                self.assertEqual(getattr(node_copy, attr), getattr(node, attr))
+        self.assertEqual(node_copy.settings["dancing_bear"], 0.2)
+        for item in node.settings:
+            self.assertEqual(node.settings[item], node_copy.settings[item])
+
+    def test_operation_copy_raster(self):
+        """
+        Test code to ensure operations copy correctly
+
+        :return:
+        """
+        node = RasterOpNode(
+            id="fake_id",
+            label="My label",
+            color="green",
+            lock=True,
+            allowed_attributes=["number_of_unicorns"],
+            stroke="green",
+            fill="gray",
+            stroke_width=7,
+            dancing_bear=0.2,
+        )
+        node_copy = copy(node)
+        for attr in (
+            "id",
+            "label",
+            "color",
+            "lock",
+            "allowed_attributes",
+            "stroke",
+            "fill",
+            "stroke_width",
+            "stroke_scaled",
+        ):
+            if hasattr(node, attr):
+                self.assertEqual(getattr(node_copy, attr), getattr(node, attr))
+        self.assertEqual(node_copy.settings["dancing_bear"], 0.2)
+        for item in node.settings:
+            self.assertEqual(node.settings[item], node_copy.settings[item])

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,10 +1,13 @@
 import unittest
 from copy import copy
 
+from meerk40t.core.node.branch_ops import BranchOperationsNode
 from meerk40t.core.node.op_cut import CutOpNode
 from meerk40t.core.node.op_engrave import EngraveOpNode
 from meerk40t.core.node.op_image import ImageOpNode
 from meerk40t.core.node.op_raster import RasterOpNode
+from meerk40t.core.node.rootnode import RootNode
+from test import bootstrap
 
 
 class TestOperations(unittest.TestCase):
@@ -44,7 +47,7 @@ class TestOperations(unittest.TestCase):
 
     def test_operation_copy_knockon(self):
         """
-        Test code to ensure operations copy correctly
+        Ensure test copy is not reusing the same data.
 
         :return:
         """
@@ -66,6 +69,39 @@ class TestOperations(unittest.TestCase):
         self.assertNotEquals(node_copy.dancing_bear, node.dancing_bear)
         node_copy_copy = copy(node_copy)
         self.assertEquals(node_copy_copy.dancing_bear, node_copy.dancing_bear)
+        node.allowed_attributes.append("Fancy pants")
+        self.assertNotEquals(node_copy_copy.allowed_attributes, node.allowed_attributes)
+
+    def test_operation_copy_root(self):
+        """
+        Ensure that copy, does not copy the root of the node (it's a copy of the node not in the tree).
+
+        :return:
+        """
+        kernel = bootstrap.bootstrap()
+        try:
+            kernel_root = kernel.get_context("/")
+
+            root = RootNode(context=kernel_root, label="RootNode")
+            node = EngraveOpNode(
+                id="fake_id",
+                label="My label",
+                color="green",
+                lock=True,
+                allowed_attributes=["number_of_unicorns"],
+                stroke="green",
+                fill="gray",
+                stroke_width=7,
+                dancing_bear=0.2,
+            )
+            root.add_node(node)
+            self.assertIs(root, node._root)
+            
+            node_copy = copy(node)
+            self.assertIsNot(node_copy._root, root)
+
+        finally:
+            kernel.shutdown()
 
     def test_operation_copy_cut(self):
         """


### PR DESCRIPTION
Several operations have .attr values like `id` and `stopop` and these would be lost since they aren't stored in the .settings dictionary. This is not a problem with Elem nodes, where they copy the node dictionary correctly.

Here we standardize the op dictionary copying for operations.