### PR TITLE
Node editor + secondary tools

### DIFF
--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -1142,14 +1142,14 @@ class RibbonBarPanel(wx.Control):
         self._layout_dirty = True
         return page
 
-    def remove_page(self, id):
+    def remove_page(self, pageid):
         """
         Remove a page from the ribbonbar.
         @param id:
         @return:
         """
         for pidx, page in enumerate(self.pages):
-            if page.id == id:
+            if page.id == pageid:
                 if self.art.current_page is page:
                     self.art.current_page = None
                 for panel in page.panels:

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -3,6 +3,8 @@ from copy import copy
 
 import wx
 
+from meerk40t.tools.geomstr import Geomstr
+
 from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.mwindow import MWindow
@@ -19,6 +21,7 @@ from meerk40t.svgelements import (
     CubicBezier,
     Line,
     Move,
+    Path,
     Point,
     Polygon,
     Polyline,
@@ -377,6 +380,8 @@ class EditTool(ToolWidget):
         ToolWidget.__init__(self, scene)
         self._listener_active = False
         self.nodes = None
+        self.shape = None
+        self.path = None
         self.element = None
         self.selected_index = None
         self.move_type = "node"
@@ -501,7 +506,7 @@ class EditTool(ToolWidget):
     # def debug_path(self):
     #     if self.element is None or not hasattr(self.element, "path"):
     #         return
-    #     path = self.element.path
+    #     path = self.path
     #     starts = []
     #     ends = []
     #     types = []
@@ -554,21 +559,23 @@ class EditTool(ToolWidget):
         # self.debug_path()
         if selected_node is None:
             return
+        self.shape = None
+        self.path = None
         if selected_node.type == "elem polyline":
             self.node_type = "polyline"
             try:
-                shape = selected_node.shape
+                self.shape = selected_node.shape
             except AttributeError:
                 return
             start = 0
-            for idx, pt in enumerate(shape.points):
+            for idx, pt in enumerate(self.shape.points):
                 self.nodes.append(
                     {
                         "prev": None,
                         "next": None,
                         "point": pt,
                         "segment": None,
-                        "path": shape,
+                        "path": self.shape,
                         "type": "point",
                         "connector": -1,
                         "selected": False,
@@ -578,19 +585,29 @@ class EditTool(ToolWidget):
                 )
         else:
             self.node_type = "path"
-            try:
-                path = selected_node.path
-            except AttributeError:
+            #    self.path = selected_node.geometry.as_path()
+            if hasattr(selected_node, "path"):
+                self.path = selected_node.path
+            elif hasattr(selected_node, "geometry"):
+                self.path = selected_node.geometry.as_path()
+            elif hasattr(selected_node, "as_geometry"):
+                self.path = selected_node.as_geometry().as_path()
+            elif hasattr(selected_node, "as_path"):
+                self.path = selected_node.as_path()
+            else:
                 return
+            # try:
+            # except AttributeError:
+            #    return
             # print (f"Path: {str(path)}")
             prev_seg = None
             start = 0
             # Idx of last point
             l_idx = 0
-            for idx, segment in enumerate(path):
+            for idx, segment in enumerate(self.path):
                 # print (f"{idx}# {type(segment).__name__} - S={segment.start} - E={segment.end}")
-                if idx < len(path) - 1:
-                    next_seg = path[idx + 1]
+                if idx < len(self.path) - 1:
+                    next_seg = self.path[idx + 1]
                 else:
                     next_seg = None
                 if isinstance(segment, Move):
@@ -607,7 +624,7 @@ class EditTool(ToolWidget):
                             "next": next_seg,
                             "point": segment.end,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "point",
                             "connector": -1,
                             "selected": False,
@@ -624,7 +641,7 @@ class EditTool(ToolWidget):
                             "next": next_seg,
                             "point": segment.end,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "point",
                             "connector": -1,
                             "selected": False,
@@ -641,7 +658,7 @@ class EditTool(ToolWidget):
                             "next": next_seg,
                             "point": segment.end,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "point",
                             "connector": -1,
                             "selected": False,
@@ -657,7 +674,7 @@ class EditTool(ToolWidget):
                             "next": None,
                             "point": segment.control,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "control",
                             "connector": nidx,
                             "selected": False,
@@ -673,7 +690,7 @@ class EditTool(ToolWidget):
                             "next": next_seg,
                             "point": segment.end,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "point",
                             "connector": -1,
                             "selected": False,
@@ -689,7 +706,7 @@ class EditTool(ToolWidget):
                             "next": None,
                             "point": segment.control1,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "control",
                             "connector": l_idx,
                             "selected": False,
@@ -704,7 +721,7 @@ class EditTool(ToolWidget):
                             "next": None,
                             "point": segment.control2,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "control",
                             "connector": nidx,
                             "selected": False,
@@ -721,7 +738,7 @@ class EditTool(ToolWidget):
                             "next": None,
                             "point": midp,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "midpoint",
                             "connector": -1,
                             "selected": False,
@@ -737,7 +754,7 @@ class EditTool(ToolWidget):
                             "next": next_seg,
                             "point": segment.end,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "point",
                             "connector": -1,
                             "selected": False,
@@ -753,7 +770,7 @@ class EditTool(ToolWidget):
                             "next": None,
                             "point": segment.center,
                             "segment": segment,
-                            "path": path,
+                            "path": self.path,
                             "type": "control",
                             "connector": nidx,
                             "selected": False,
@@ -839,7 +856,7 @@ class EditTool(ToolWidget):
                 else:
                     p.AddLineToPoint(ptx, pty)
         else:
-            path = node.path
+            path = self.path
             init = False
             for idx, entry in enumerate(self.nodes):
                 if not entry["type"] == "point":
@@ -970,10 +987,14 @@ class EditTool(ToolWidget):
         Central routine that tells the system that the node was
         changed, if 'reload' is set to True then it requires
         reload/recalculation of the properties (e.g. after the
-        segement structure of a path was changed)
+        segment structure of a path was changed)
         """
         if self.element is None:
             return
+        if self.shape is not None:
+            self.element.geometry = Geomstr.svg(Path(self.shape))
+        elif self.path is not None:
+            self.element.geometry = Geomstr.svg(self.path)
         self.element.altered()
         try:
             __ = self.element.bbox()
@@ -996,12 +1017,13 @@ class EditTool(ToolWidget):
 
     def first_segment_in_subpath(self, index):
         """
-        Provides the first non-move/close segment in the subpath to which the segment at location index belongs to
+        Provides the first non-move/close segment in the subpath
+        to which the segment at location index belongs to
         """
         result = None
         if not self.element is None and hasattr(self.element, "path"):
             for idx in range(index, -1, -1):
-                seg = self.element.path[idx]
+                seg = self.path[idx]
                 if isinstance(seg, (Move, Close)):
                     break
                 result = seg
@@ -1009,12 +1031,13 @@ class EditTool(ToolWidget):
 
     def last_segment_in_subpath(self, index):
         """
-        Provides the last non-move/close segment in the subpath to which the segment at location index belongs to
+        Provides the last non-move/close segment in the subpath
+        to which the segment at location index belongs to
         """
         result = None
         if not self.element is None and hasattr(self.element, "path"):
-            for idx in range(index, len(self.element.path)):
-                seg = self.element.path[idx]
+            for idx in range(index, len(self.path)):
+                seg = self.path[idx]
                 if isinstance(seg, (Move, Close)):
                     break
                 result = seg
@@ -1022,12 +1045,13 @@ class EditTool(ToolWidget):
 
     def is_closed_subpath(self, index):
         """
-        Provides the last segment in the subpath to which the segment at location index belongs to
+        Provides the last segment in the subpath
+        to which the segment at location index belongs to
         """
         result = False
         if not self.element is None and hasattr(self.element, "path"):
-            for idx in range(index, len(self.element.path)):
-                seg = self.element.path[idx]
+            for idx in range(index, len(self.path)):
+                seg = self.path[idx]
                 if isinstance(seg, Move):
                     break
                 if isinstance(seg, Close):
@@ -1062,6 +1086,8 @@ class EditTool(ToolWidget):
             setattr(newnode, item[0], item[1])
         newnode.altered()
         self.element = newnode
+        self.shape = None
+        self.path = path
         self.modify_element(reload=True)
 
     def toggle_close(self):
@@ -1074,7 +1100,7 @@ class EditTool(ToolWidget):
                 newshape = Polyline(self.element.shape)
             else:
                 newshape = Polygon(self.element.shape)
-            self.element.shape = newshape
+            self.shape = newshape
             modified = True
         else:
             dealt_with = []
@@ -1103,8 +1129,8 @@ class EditTool(ToolWidget):
                     # Let's establish the last segment in the path
                     prevseg = None
                     is_closed = False
-                    for sidx in range(segstart, len(self.element.path), 1):
-                        seg = self.element.path[sidx]
+                    for sidx in range(segstart, len(self.path), 1):
+                        seg = self.path[sidx]
                         if isinstance(seg, Move) and prevseg is None:
                             # Not the one at the very beginning!
                             continue
@@ -1119,7 +1145,7 @@ class EditTool(ToolWidget):
                         prevseg = seg
                     if is_closed:
                         # it's enough just to delete it...
-                        del self.element.path[lastidx + 1]
+                        del self.path[lastidx + 1]
                         modified = True
                     else:
                         # Need to insert a Close segment
@@ -1127,7 +1153,7 @@ class EditTool(ToolWidget):
                             start=Point(prevseg.end.x, prevseg.end.y),
                             end=Point(prevseg.end.x, prevseg.end.y),
                         )
-                        self.element.path.insert(lastidx + 1, newseg)
+                        self.path.insert(lastidx + 1, newseg)
                         modified = True
 
         if modified:
@@ -1296,7 +1322,7 @@ class EditTool(ToolWidget):
             # Not valid for a polyline Could make a path now but that might be more than the user expected...
             return
         # Pass 1 - make all lines a cubic bezier
-        for idx, segment in enumerate(self.element.path):
+        for idx, segment in enumerate(self.path):
             if isinstance(segment, Line):
                 startpt = copy(segment.start)
                 endpt = copy(segment.end)
@@ -1311,7 +1337,7 @@ class EditTool(ToolWidget):
                 newsegment = CubicBezier(
                     start=startpt, end=endpt, control1=ctrl1pt, control2=ctrl2pt
                 )
-                self.element.path[idx] = newsegment
+                self.path[idx] = newsegment
                 modified = True
             elif isinstance(segment, QuadraticBezier):
                 # The cubic control - points lie on 2/3 of the way of the
@@ -1327,20 +1353,20 @@ class EditTool(ToolWidget):
                 newsegment = CubicBezier(
                     start=startpt, end=endpt, control1=ctrl1pt, control2=ctrl2pt
                 )
-                self.element.path[idx] = newsegment
+                self.path[idx] = newsegment
                 modified = True
             elif isinstance(segment, Arc):
                 for newsegment in list(segment.as_cubic_curves(1)):
-                    self.element.path[idx] = newsegment
+                    self.path[idx] = newsegment
                     break
                 modified = True
         # Pass 2 - make all control lines align
         prevseg = None
-        lastidx = len(self.element.path) - 1
-        for idx, segment in enumerate(self.element.path):
+        lastidx = len(self.path) - 1
+        for idx, segment in enumerate(self.path):
             nextseg = None
             if idx < lastidx:
-                nextseg = self.element.path[idx + 1]
+                nextseg = self.path[idx + 1]
                 if isinstance(nextseg, (Move, Close)):
                     nextseg = None
             if isinstance(segment, CubicBezier):
@@ -1447,27 +1473,27 @@ class EditTool(ToolWidget):
             entry = self.nodes[idx]
             if entry["selected"] and entry["type"] == "point":
                 if self.node_type == "polyline":
-                    if len(self.element.shape.points) > 2:
+                    if len(self.shape.points) > 2:
                         modified = True
-                        self.element.shape.points.pop(idx)
+                        self.shape.points.pop(idx)
                     else:
                         break
                 else:
                     idx = entry["pathindex"]
                     prevseg = None
                     nextseg = None
-                    seg = self.element.path[idx]
+                    seg = self.path[idx]
                     if idx > 0:
-                        prevseg = self.element.path[idx - 1]
-                    if idx < len(self.element.path) - 1:
-                        nextseg = self.element.path[idx + 1]
+                        prevseg = self.path[idx - 1]
+                    if idx < len(self.path) - 1:
+                        nextseg = self.path[idx + 1]
                     if nextseg is None:
                         # Last point of the path
                         # Can just be deleted, provided we have something
                         # in front...
                         if prevseg is None or isinstance(prevseg, (Move, Close)):
                             continue
-                        del self.element.path[idx]
+                        del self.path[idx]
                         modified = True
                     elif isinstance(nextseg, (Move, Close)):
                         # last point of the subsegment...
@@ -1481,7 +1507,7 @@ class EditTool(ToolWidget):
                             nextseg.end.x = seg.start.x
                             nextseg.end.y = seg.start.y
 
-                        del self.element.path[idx]
+                        del self.path[idx]
                         modified = True
                     else:
                         # Could be the first point...
@@ -1491,16 +1517,16 @@ class EditTool(ToolWidget):
                             continue
                         if prevseg is None:  # # Move
                             seg.end = Point(nextseg.end.x, nextseg.end.y)
-                            del self.element.path[idx + 1]
+                            del self.path[idx + 1]
                             modified = True
                         elif isinstance(seg, Move):  # # Move
                             seg.end = Point(nextseg.end.x, nextseg.end.y)
-                            del self.element.path[idx + 1]
+                            del self.path[idx + 1]
                             modified = True
                         else:
                             nextseg.start.x = prevseg.end.x
                             nextseg.start.y = prevseg.end.y
-                            del self.element.path[idx]
+                            del self.path[idx]
                             modified = True
 
         if modified:
@@ -1524,7 +1550,7 @@ class EditTool(ToolWidget):
                 if entry["segtype"] not in ("C", "Q", "A"):
                     continue
                 newsegment = Line(start=startpt, end=endpt)
-                self.element.path[idx] = newsegment
+                self.path[idx] = newsegment
                 modified = True
         if modified:
             self.modify_element(True)
@@ -1537,13 +1563,13 @@ class EditTool(ToolWidget):
         if self.node_type == "polyline":
             # Not valid for a polyline Could make a path now but that might be more than the user expected...
             return
-        for idx, segment in enumerate(self.element.path):
+        for idx, segment in enumerate(self.path):
             if isinstance(segment, (Close, Move, Line)):
                 continue
             startpt = Point(segment.start.x, segment.start.y)
             endpt = Point(segment.end.x, segment.end.y)
             newsegment = Line(start=startpt, end=endpt)
-            self.element.path[idx] = newsegment
+            self.path[idx] = newsegment
             modified = True
 
         if modified:
@@ -1593,7 +1619,7 @@ class EditTool(ToolWidget):
                 newsegment = CubicBezier(
                     start=startpt, end=endpt, control1=ctrl1pt, control2=ctrl2pt
                 )
-                self.element.path[idx] = newsegment
+                self.path[idx] = newsegment
                 modified = True
         if modified:
             self.modify_element(True)
@@ -1616,14 +1642,14 @@ class EditTool(ToolWidget):
                     continue
                 # Is this the last point? Then no use to break the path
                 nextseg = None
-                if idx in (0, len(self.element.path) - 1):
+                if idx in (0, len(self.path) - 1):
                     # Don't break at the first or last point
                     continue
-                nextseg = self.element.path[idx + 1]
+                nextseg = self.path[idx + 1]
                 if isinstance(nextseg, (Move, Close)):
                     # Not at end of subpath
                     continue
-                prevseg = self.element.path[idx - 1]
+                prevseg = self.path[idx - 1]
                 if isinstance(prevseg, (Move, Close)):
                     # We could still be at the end point of the first segment...
                     if entry["point"] == seg.start:
@@ -1633,14 +1659,14 @@ class EditTool(ToolWidget):
                     start=Point(seg.end.x, seg.end.y),
                     end=Point(nextseg.start.x, nextseg.start.y),
                 )
-                self.element.path.insert(idx + 1, newseg)
+                self.path.insert(idx + 1, newseg)
                 # Now let's validate whether the 'right' path still has a
                 # close segment at its end. That will be removed as this would
                 # create an unwanted behaviour
                 prevseg = None
                 is_closed = False
-                for sidx in range(idx + 1, len(self.element.path), 1):
-                    seg = self.element.path[sidx]
+                for sidx in range(idx + 1, len(self.path), 1):
+                    seg = self.path[sidx]
                     if isinstance(seg, Move) and prevseg is None:
                         # Not the one at the very beginning!
                         continue
@@ -1655,7 +1681,7 @@ class EditTool(ToolWidget):
                     prevseg = seg
                 if is_closed:
                     # it's enough just to delete it...
-                    del self.element.path[lastidx + 1]
+                    del self.path[lastidx + 1]
 
                 modified = True
         if modified:
@@ -1677,9 +1703,9 @@ class EditTool(ToolWidget):
                 prevseg = None
                 nextseg = None
                 if idx > 0:
-                    prevseg = self.element.path[idx - 1]
-                if idx < len(self.element.path) - 1:
-                    nextseg = self.element.path[idx + 1]
+                    prevseg = self.path[idx - 1]
+                if idx < len(self.path) - 1:
+                    nextseg = self.path[idx + 1]
                 if isinstance(seg, (Move, Close)):
                     # Beginning of path
                     if prevseg is None:
@@ -1692,7 +1718,7 @@ class EditTool(ToolWidget):
                         continue
                     nextseg.start.x = seg.start.x
                     nextseg.start.y = seg.start.y
-                    del self.element.path[idx]
+                    del self.path[idx]
                     modified = True
                 else:
                     # Let's look at the next segment
@@ -1702,7 +1728,7 @@ class EditTool(ToolWidget):
                         continue
                     seg.end.x = nextseg.end.x
                     seg.end.y = nextseg.end.y
-                    del self.element.path[idx + 1]
+                    del self.path[idx + 1]
                     modified = True
 
         if modified:
@@ -1718,27 +1744,27 @@ class EditTool(ToolWidget):
             entry = self.nodes[idx]
             if entry["selected"] and entry["type"] == "point":
                 if self.node_type == "polyline":
-                    pt1 = self.element.shape.points[idx]
+                    pt1 = self.shape.points[idx]
                     if idx == 0:
                         # Very first point? Mirror first segment and take midpoint
                         pt2 = Point(
-                            self.element.shape.points[idx + 1].x,
-                            self.element.shape.points[idx + 1].y,
+                            self.shape.points[idx + 1].x,
+                            self.shape.points[idx + 1].y,
                         )
                         pt2.x = pt1.x - (pt2.x - pt1.x)
                         pt2.y = pt1.y - (pt2.y - pt1.y)
                         pt2.x = (pt1.x + pt2.x) / 2
                         pt2.y = (pt1.y + pt2.y) / 2
-                        self.element.shape.points.insert(0, pt2)
+                        self.shape.points.insert(0, pt2)
                     else:
                         pt2 = Point(
-                            self.element.shape.points[idx - 1].x,
-                            self.element.shape.points[idx - 1].y,
+                            self.shape.points[idx - 1].x,
+                            self.shape.points[idx - 1].y,
                         )
                         pt2.x = (pt1.x + pt2.x) / 2
                         pt2.y = (pt1.y + pt2.y) / 2
                         # Mid point
-                        self.element.shape.points.insert(idx, pt2)
+                        self.shape.points.insert(idx, pt2)
                     modified = True
                 else:
                     # Path
@@ -1754,7 +1780,7 @@ class EditTool(ToolWidget):
                             start=Point(mid_x, mid_y),
                             end=Point(segment.end.x, segment.end.y),
                         )
-                        self.element.path.insert(idx + 1, newsegment)
+                        self.path.insert(idx + 1, newsegment)
                         segment.end.x = mid_x
                         segment.end.y = mid_y
                         modified = True
@@ -1768,7 +1794,7 @@ class EditTool(ToolWidget):
                             control1=Point(mid_x, mid_y),
                             control2=Point(segment.control2.x, segment.control2.y),
                         )
-                        self.element.path.insert(idx + 1, newsegment)
+                        self.path.insert(idx + 1, newsegment)
                         segment.end.x = mid_x
                         segment.end.y = mid_y
                         segment.control2.x = mid_x
@@ -1786,7 +1812,7 @@ class EditTool(ToolWidget):
                         newsegment = copy(segment)
                         newsegment.start.x = mid_x
                         newsegment.start.y = mid_y
-                        self.element.path.insert(idx + 1, newsegment)
+                        self.path.insert(idx + 1, newsegment)
                         segment.end.x = mid_x
                         segment.end.y = mid_y
                         modified = True
@@ -1799,7 +1825,7 @@ class EditTool(ToolWidget):
                             end=Point(segment.end.x, segment.end.y),
                             control=Point(segment.control.x, segment.control.y),
                         )
-                        self.element.path.insert(idx + 1, newsegment)
+                        self.path.insert(idx + 1, newsegment)
                         segment.end.x = mid_x
                         segment.end.y = mid_y
                         segment.control.x = mid_x
@@ -1819,16 +1845,16 @@ class EditTool(ToolWidget):
                         pt1 = Point((p1x + p2x) / 2, (p1y + p2y) / 2)
                         pt2 = copy(nextseg.start)
                         newsegment = Line(start=pt1, end=pt2)
-                        self.element.path.insert(idx + 1, newsegment)
+                        self.path.insert(idx + 1, newsegment)
                         segment.end = pt1
                         # We need to step forward to assess whether there is a close segment
-                        for idx2 in range(idx + 1, len(self.element.path)):
-                            if isinstance(self.element.path[idx2], Move):
+                        for idx2 in range(idx + 1, len(self.path)):
+                            if isinstance(self.path[idx2], Move):
                                 break
-                            if isinstance(self.element.path[idx2], Close):
+                            if isinstance(self.path[idx2], Close):
                                 # Adjust the close segment to that it points again
                                 # to the first move end
-                                self.element.path[idx2].end = Point(pt1.x, pt1.y)
+                                self.path[idx2].end = Point(pt1.x, pt1.y)
                                 break
 
                         modified = True
@@ -1842,40 +1868,35 @@ class EditTool(ToolWidget):
         """
         modified = False
         if self.node_type == "polyline":
-            idx = len(self.element.shape.points) - 1
-            pt1 = self.element.shape.points[idx - 1]
-            pt2 = self.element.shape.points[idx]
+            idx = len(self.shape.points) - 1
+            pt1 = self.shape.points[idx - 1]
+            pt2 = self.shape.points[idx]
             newpt = Point(pt2.x + (pt2.x - pt1.x), pt2.y + (pt2.y - pt1.y))
-            self.element.shape.points.append(newpt)
+            self.shape.points.append(newpt)
             modified = True
         else:
             # path
             try:
-                valididx = len(self.element.path) - 1
+                valididx = len(self.path) - 1
             except AttributeError:
                 # Shape
                 return
-            while valididx >= 0 and isinstance(
-                self.element.path[valididx], (Close, Move)
-            ):
+            while valididx >= 0 and isinstance(self.path[valididx], (Close, Move)):
                 valididx -= 1
             if valididx >= 0:
-                seg = self.element.path[valididx]
+                seg = self.path[valididx]
                 pt1 = seg.start
                 pt2 = seg.end
                 newpt = Point(pt2.x + (pt2.x - pt1.x), pt2.y + (pt2.y - pt1.y))
                 newsegment = Line(start=Point(seg.end.x, seg.end.y), end=newpt)
-                if valididx < len(self.element.path) - 1:
-                    if (
-                        self.element.path[valididx + 1].end
-                        == self.element.path[valididx + 1].start
-                    ):
-                        self.element.path[valididx + 1].end.x = newpt.x
-                        self.element.path[valididx + 1].end.y = newpt.y
-                    self.element.path[valididx + 1].start.x = newpt.x
-                    self.element.path[valididx + 1].start.y = newpt.y
+                if valididx < len(self.path) - 1:
+                    if self.path[valididx + 1].end == self.path[valididx + 1].start:
+                        self.path[valididx + 1].end.x = newpt.x
+                        self.path[valididx + 1].end.y = newpt.y
+                    self.path[valididx + 1].start.x = newpt.x
+                    self.path[valididx + 1].start.y = newpt.y
 
-                self.element.path.insert(valididx + 1, newsegment)
+                self.path.insert(valididx + 1, newsegment)
                 modified = True
 
         if modified:
@@ -2049,10 +2070,8 @@ class EditTool(ToolWidget):
                     if current["segtype"] == "M":
                         # We changed the end, let's check whether the last segment in
                         # the subpath is a Close then we need to change this .end as well
-                        for nidx in range(
-                            self.selected_index + 1, len(self.element.path), 1
-                        ):
-                            nextseg = self.element.path[nidx]
+                        for nidx in range(self.selected_index + 1, len(self.path), 1):
+                            nextseg = self.path[nidx]
                             if isinstance(nextseg, Move):
                                 break
                             if isinstance(nextseg, Close):

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -3,8 +3,6 @@ from copy import copy
 
 import wx
 
-from meerk40t.tools.geomstr import Geomstr
-
 from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.mwindow import MWindow
@@ -27,6 +25,7 @@ from meerk40t.svgelements import (
     Polyline,
     QuadraticBezier,
 )
+from meerk40t.tools.geomstr import Geomstr
 
 _ = wx.GetTranslation
 

--- a/meerk40t/gui/toolwidgets/toolpolygon.py
+++ b/meerk40t/gui/toolwidgets/toolpolygon.py
@@ -1,8 +1,9 @@
-from math import sqrt, tau, sin, tan
+from math import sin, sqrt, tan, tau
 
 import wx
 
 from meerk40t.core.units import Length
+from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage, icons8_polygon_50
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.scene.sceneconst import (
     RESPONSE_ABORT,
@@ -10,9 +11,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.svgelements import Point, Polygon, Angle
-from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage, icons8_polygon_50
-from meerk40t.tools.geomstr import Geomstr
+from meerk40t.svgelements import Point, Polygon
 
 
 class PolygonTool(ToolWidget):
@@ -107,7 +106,7 @@ class PolygonTool(ToolWidget):
         )
 
         self.scene.context.kernel.register(
-            f"button/tool_polygon/tool_freehand",
+            "button/tool_polygon/tool_freehand",
             {
                 "label": "Freehand",
                 "icon": icons8_polygon_50,
@@ -118,7 +117,7 @@ class PolygonTool(ToolWidget):
         )
 
         self.scene.context.kernel.register(
-            f"button/tool_polygon/tool_polygon",
+            "button/tool_polygon/tool_polygon",
             {
                 "label": "Regular",
                 "icon": icon_polygon,
@@ -129,7 +128,7 @@ class PolygonTool(ToolWidget):
         )
 
         self.scene.context.kernel.register(
-            f"button/tool_polygon/tool_star1",
+            "button/tool_polygon/tool_star1",
             {
                 "label": "Star 1",
                 "icon": icon_regular_star,
@@ -140,7 +139,7 @@ class PolygonTool(ToolWidget):
         )
 
         self.scene.context.kernel.register(
-            f"button/tool_polygon/tool_star2",
+            "button/tool_polygon/tool_star2",
             {
                 "label": "Star 2",
                 "icon": icon_crossing_star,
@@ -205,7 +204,6 @@ class PolygonTool(ToolWidget):
         tx = 0
         ty = 0
         tc = 0
-        radius = 0
         for pt in points:
             tc += 1
             tx += pt[0]
@@ -213,7 +211,6 @@ class PolygonTool(ToolWidget):
         if tc > 0:
             cx = tx / tc
             cy = ty / tc
-            radius = sqrt((cx - points[0][0]) ** 2 + (cy - points[0][1]) ** 2)
         if self.design_mode == 0:
             pass
         elif self.design_mode == 1:
@@ -497,10 +494,10 @@ class PolygonTool(ToolWidget):
             elif keycode == "r":
                 # Regular
                 self.set_designmode(1)
-            elif keycode == "1" or keycode == "s":
+            elif keycode in ("1", "s"):
                 # Star 1
                 self.set_designmode(2)
-            elif keycode == "2" or keycode == "p":
+            elif keycode in ("2", "p"):
                 # Star 2 / Pentagram
                 self.set_designmode(3)
 

--- a/meerk40t/gui/toolwidgets/toolpolygon.py
+++ b/meerk40t/gui/toolwidgets/toolpolygon.py
@@ -1,4 +1,4 @@
-from math import sqrt, tau
+from math import sqrt, tau, sin, tan
 
 import wx
 
@@ -10,7 +10,9 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.svgelements import Point, Polygon
+from meerk40t.svgelements import Point, Polygon, Angle
+from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage, icons8_polygon_50
+from meerk40t.tools.geomstr import Geomstr
 
 
 class PolygonTool(ToolWidget):
@@ -28,6 +30,125 @@ class PolygonTool(ToolWidget):
         # angle_snap indicates whether a line should be angle snapping
         # False anything goes, True snaps to next 45° angle
         self.angle_snap = False
+        # design_mode
+        # 0 - freehand polygon
+        # 1 - regular polygon
+        # 2 - star polygon
+        # 3 - crossing star polygon
+        self.design_mode = 0
+        self.design_param = 0
+        self.define_buttons()
+
+    def set_designmode(self, mode):
+        if mode < 0 or mode > 3:
+            mode = 0
+        # print(f"Designmode set to {mode}")
+        if mode != self.design_mode:
+            self.design_mode = mode
+            self.design_param = 0
+            self.scene.refresh_scene()
+        else:
+            self.design_param += 1
+
+    def define_buttons(self):
+        icon_size = STD_ICON_SIZE
+        icon_regular_star = PyEmbeddedImage(
+            b"iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwY"
+            b"AAAD5klEQVR4nO2ZaahNaxjHf8c5uAfXlEPGpMzDByGzW265fCDXUPcDMuSTWfKB4pshlClj"
+            b"XVxdRd2MR9dMXeEDkumQFNec46Acw3G2Hv1Xve32OXvtY6119opfrdq969nP87zvWut9hhd+"
+            b"4IsawFngjH7Hll+BhK6hxJg9zkT+JqY0BkqBMl2lGosds/QkCoGj+j2TGHJFzo8Bxur3NWJG"
+            b"bzn+AqgN1AKeaawXMWKznF7ljK3W2CZiQj7wSk53ccY7aawEqEMMmCSH/0tx77zuTSQGnJOz"
+            b"U1Lcm6p7Fu2zmg5AOfAW+DnF/XrAG03GXrWsZbmc3FaJzHbJLCNLyQMey8m+lcj1k8xToCZZ"
+            b"yCg5eMuH7A3JjiQLOSjn5vmQnS/ZA1RDbCgA2gE9gcHAcGAcMB1YAHwCPkguHQWS/aT/Tpeu"
+            b"4dLdU7YKZNsXE4A/gX3AceACcB24DxQrc034vPZmsDh7M9BbJl/uy7cL8nWffLc58NyHolLl"
+            b"TfeAy4oVhXJmK7AGWAI0z2AiLfSfNdJhugql+7JsvZDtdP7ZHPhNaUNCe/x4oBvQFmgE5FL9"
+            b"5MqXtvJtvBOPSjSHr7QHbjoZ6y9kL/2BJ/L1blI+95X6zs5jH+EMso9p2iTMx3/1lCp8hF50"
+            b"tmtLlgStvBR+2Vha/gDe6U/28TWl+mgMnJAv74HJmSqwvfyBFNzTRxY1HYHb8uFxmtQn7RZ5"
+            b"UYosox1NdIxwdlPbjtt8q0KruXdIYbne1TC7hjnAQuCzbO4JuqKc7UR5C151CZ6fgL+cRVuq"
+            b"iYX6uK3d0zpA3abLayGVyFaoWGVXJIOW5wSF9/oWRVk9rpdRy5WCwl4j07mOCPHSmQEB6hwo"
+            b"nVZ0RUILJ8EMMupbpH4t3a2IsG91KATdh6Pse+2SsTkh6J4r3TuJgIcyFkbK0l26HxEynWXo"
+            b"ic9A1UlnI0d9bqk5Tq1htkJjpoxY9E334S5MKlM/Kr2xI4bK2C35UOuh/TJSWSrdRwc6Xpqx"
+            b"XVe5c9hjMhUxWXJmKxRyneOCVKlJvla8zEn97VTXY5CadwklhFvUC06mlZOm+CqeMsVrdVp9"
+            b"kMwQ4I5TJq+tIKnMVwT3ylVr7wxLIVfko/VaZRZL+QZnrKFW1nttrurYLR09gEtJ/bAmzv2N"
+            b"Gl8Uwjw4LeVecTXOORd8p5XOJNLnqTR4Kx0v1XE0ftfYqaAnUUf1sr3/XYF/nNU8p5K0qlhr"
+            b"9Jij74ieWJlewUDrnmHOynuNsWKdSgVR+ORIV7GTx3nNj1TfUJVZmdSitDyrJcHTzEmBvGtF"
+            b"kAZOSun/OgcJm1GylZDtwBiiXasB0dFANs3298MXw0hXuTS4jKMAAAAASUVORK5CYII="
+        )
+        icon_crossing_star = PyEmbeddedImage(
+            b"iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAABnRSTlMA/wD/AP83WBt9AAAA"
+            b"CXBIWXMAAA7EAAAOxAGVKw4bAAACbUlEQVRYhd2YO08CQRDHZw/LCw0tHb3PgoJeOv08+gV8"
+            b"ND4a/QAajYaHET8CCT0JoaAlAZUooiWsxSXruXc7O8tsjLkJ1e3M3H/3tzO7h5BSwv+zwFsi"
+            b"kQtEzls2X4n8WqZlKXy+OGZ6tQBgIecLOfeVzYMsDZwXjpmGqPD54siVlYqMzzG7EDVwXjiy"
+            b"ZCGwmBwzCjEVGZ/j8rJywQrTAbHlZVnvj5wLJgtiuVw2DVUqFU5mIf7nrpdSCggEBCcnp5Js"
+            b"UQjfJ25HR8cqBOIp6FkEBLs7u7hPdbvqlDAuANRAvd4gKqNPwClhrVb/eSJ/14vqzkjviXwo"
+            b"zcnqaXqdvt/VMH56FAoFqyYAyOfzyCiyBCllqK6/gcj1ej1t9ObmFgBeXp8pst6nbwDQaj1p"
+            b"z7vdrlrI1LXUIf6SnDYbOkGTP2mfIBlNQEulElETABSLxaRKXBMAgLE8EpVyd3c/HA6dWpEK"
+            b"n0wmV1fXDiWMQEydpX2iPmKpJ89Czi8uL5zUaHZ2fuYwHzqLfr+verFTO41+g8GA/i4qRIjV"
+            b"FHHbxt2c65foF7d4YxuPx0mH0WiEtyW7EVe13W4nwaUCNVEWEHQ6Hc8QTRQ0oNh54sJx+eu2"
+            b"pobaJ2lG2luPjy3++5zCSRDx9Y9G9/f3pJQHB4dWT4o+lizkLEf8SRc1qwf+juQQcmPz2beQ"
+            b"v4qaD03TV3Wj2cBjcbND1FbeqeKSzkSOJIha0jAMiTgWch6GYao+liyVbm11XU30YzalpI7s"
+            b"YzZVvW1zY0tLazILRC2e07qcUlEr8fNrxm+nn18zorPzJwbfuJ8Y1uDlzFuX/3v7BikOKD82"
+            b"lTxEAAAAAElFTkSuQmCC"
+        )
+        icon_polygon = PyEmbeddedImage(
+            b"iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwY"
+            b"AAACZUlEQVR4nO2aT0sVURjGf7qo0EVIEUUYiYFCFLRIsEViGXTzC1hgfYeSbFVt0o1pu3Kj"
+            b"req61BbZoqCWldEHUFKvtJBKKPpH6Y0DT3AW/rn3zJxzz8j9wV3NnOd5z9yZOe/7noEqVaKh"
+            b"G1gCZoGzKeoaLaNZAHIEwBgVPf8WQ0xkLsBEZn1PYjewbJmleWt1WRdpWV7eGJTRS48ez+Ux"
+            b"4MvgIPAdWAPafZkAJ+XxEzjkw+ChrtQj/PNYXuNpCx8HVoHfQDP+OQz8kueJNIWf6QoNEY67"
+            b"8pxOS7BTgl+APYSjAfgk73NJxWqBGYldJTzX5P1esThzRUIfgJ2EZ4fWKxPDZVeRXcCCRHqo"
+            b"HBcVg8nv6lwEbkjgXdK/NSE1wGvF0u/yoH3W4DNUntOKZQXYW87Aexo4STxMKaaRUgc0aTH6"
+            b"CxwlHlqAP1qUj5QyYEIzv098PFBs+a1ObFPC9g3YT3zsA74qxlObnfhCM75JvNxSjK/WO3hB"
+            b"72lzwkegnnipV4zF9er7Quh6OSGFjeLN8kQW7AM562DWbq3zm9XL5oGKldul9A3s1+8B4n79"
+            b"tm91cl4zNotPbIwqNlPTZzZFaS03RUGJWVGJWiw8UUzDrml8mt1EVzqsNL7svkF/RIXVG8Vy"
+            b"3bXUnZeAKTcrxSVrzXAqdVHBH0vzoTeJkLml3krItGZC05dWO8hu0Dk9aAlosF44iRt0/5mW"
+            b"oGljhmJYnk/TFD2mBTJUE7vJVxMbtfhLTg8SkpfXWJY3etrk8QNo9GUyEHDr7U6ozdC5LG+G"
+            b"bpvt6W31wUBOk/H1CcfiRnV4lSqE5x+0Tyg887i34gAAAABJRU5ErkJggg=="
+        )
+
+        self.scene.context.kernel.register(
+            f"button/tool_polygon/tool_freehand",
+            {
+                "label": "Freehand",
+                "icon": icons8_polygon_50,
+                "tip": "Draw a freehand polygon (f)",
+                "action": lambda v: self.set_designmode(0),
+                "size": icon_size,
+            },
+        )
+
+        self.scene.context.kernel.register(
+            f"button/tool_polygon/tool_polygon",
+            {
+                "label": "Regular",
+                "icon": icon_polygon,
+                "tip": "Draw a regular polygon (r)",
+                "action": lambda v: self.set_designmode(1),
+                "size": icon_size,
+            },
+        )
+
+        self.scene.context.kernel.register(
+            f"button/tool_polygon/tool_star1",
+            {
+                "label": "Star 1",
+                "icon": icon_regular_star,
+                "tip": "Draw a regular star (1)",
+                "action": lambda v: self.set_designmode(2),
+                "size": icon_size,
+            },
+        )
+
+        self.scene.context.kernel.register(
+            f"button/tool_polygon/tool_star2",
+            {
+                "label": "Star 2",
+                "icon": icon_crossing_star,
+                "tip": "Draw a crossing star (2)",
+                "action": lambda v: self.set_designmode(3),
+                "size": icon_size,
+            },
+        )
 
     def angled(self, pos):
         points = list(self.point_series)
@@ -59,11 +180,8 @@ class PolygonTool(ToolWidget):
                         wx.BRUSHSTYLE_SOLID,
                     )
                 )
-            points = list(self.point_series)
-            if self.mouse_position is not None:
-                pos = self.angled(self.mouse_position)
-                points.append(pos)
-            points.append(points[0])
+            points = self.calculated_points(True)
+
             gc.StrokeLines(points)
             total_len = 0
             for idx in range(1, len(points)):
@@ -79,6 +197,203 @@ class PolygonTool(ToolWidget):
                 )
             self.scene.context.signal("statusmsg", s)
 
+    def calculated_points(self, closeit):
+        points = list(self.point_series)
+        if self.mouse_position is not None:
+            pos = self.angled(self.mouse_position)
+            points.append(pos)
+        tx = 0
+        ty = 0
+        tc = 0
+        radius = 0
+        for pt in points:
+            tc += 1
+            tx += pt[0]
+            ty += pt[1]
+        if tc > 0:
+            cx = tx / tc
+            cy = ty / tc
+            radius = sqrt((cx - points[0][0]) ** 2 + (cy - points[0][1]) ** 2)
+        if self.design_mode == 0:
+            pass
+        elif self.design_mode == 1:
+            number_points = tc
+            if number_points > 2:
+                point0 = Point(points[0])
+                pcenter = Point(points[-1])
+                radius = pcenter.distance_to(point0)
+                if radius < 5000:
+                    pcenter = Point(cx, cy)
+                    radius = pcenter.distance_to(point0)
+                angle = pcenter.angle_to(point0) + tau / number_points
+                point1 = pcenter.polar(pcenter, angle, radius)
+                points[1] = [point1.x, point1.y]
+                dx = points[1][0] - points[0][0]
+                dy = points[1][1] - points[0][1]
+                baseline = sqrt(dx * dx + dy * dy)
+                apothem = baseline / (2 * tan(tau / (2 * number_points)))
+                circumradius = baseline / (2 * sin(tau / (2 * number_points)))
+                midpoint = Point(points[0][0] + 0.5 * dx, points[0][1] + 0.5 * dy)
+                ax = 0
+                ay = 0
+                for pt in points:
+                    ax += pt[0]
+                    ay += pt[1]
+                ax /= number_points
+                ay /= number_points
+                # The arithmetic center (ax, ay) indicates to which
+                # 'side' of the baseline the polygon needs to be constructed
+                arithmetic_center = Point(ax, ay)
+                # mk_debug_point(ax, ay, "green")
+                angle = point0.angle_to(points[1])
+                midangle = midpoint.angle_to(arithmetic_center)
+                angle += tau / 4
+                first_point = Point.polar(midpoint, angle, apothem)
+                second_point = Point.polar(midpoint, angle + tau / 2, apothem)
+                deltaangle = tau / number_points
+                d1 = arithmetic_center.distance_to(first_point)
+                d2 = arithmetic_center.distance_to(second_point)
+                if d1 < d2:
+                    center_point = Point(first_point)
+                else:
+                    center_point = Point(second_point)
+                # mk_debug_point(center_point.x, center_point.y, "red")
+
+                if center_point.angle_to(point0) > center_point.angle_to(point1):
+                    deltaangle *= -1
+                angle = center_point.angle_to(point0)
+                for idx in range(number_points):
+                    # if idx > 1:
+                    pt = Point.polar(center_point, angle, circumradius)
+                    points[idx] = (pt.x, pt.y)
+                    angle += deltaangle
+        elif self.design_mode == 2:
+            number_points = tc
+            if number_points > 2:
+                point0 = Point(points[0])
+                pcenter = Point(points[-1])
+                pinner = Point(points[-2])
+                radius_inner = pcenter.distance_to(pinner)
+                radius = pcenter.distance_to(point0)
+                if radius < 5000:
+                    pcenter = Point(cx, cy)
+                    radius = pcenter.distance_to(point0)
+                angle = pcenter.angle_to(point0) + tau / number_points
+                point1 = pcenter.polar(pcenter, angle, radius)
+                points[1] = [point1.x, point1.y]
+                dx = points[1][0] - points[0][0]
+                dy = points[1][1] - points[0][1]
+                baseline = sqrt(dx * dx + dy * dy)
+                apothem = baseline / (2 * tan(tau / (2 * number_points)))
+                circumradius = baseline / (2 * sin(tau / (2 * number_points)))
+                midpoint = Point(points[0][0] + 0.5 * dx, points[0][1] + 0.5 * dy)
+                ax = 0
+                ay = 0
+                for pt in points:
+                    ax += pt[0]
+                    ay += pt[1]
+                ax /= number_points
+                ay /= number_points
+                # The arithmetic center (ax, ay) indicates to which
+                # 'side' of the baseline the polygon needs to be constructed
+                arithmetic_center = Point(ax, ay)
+                # mk_debug_point(ax, ay, "green")
+                angle = point0.angle_to(points[1])
+                midangle = midpoint.angle_to(arithmetic_center)
+                angle += tau / 4
+                first_point = Point.polar(midpoint, angle, apothem)
+                second_point = Point.polar(midpoint, angle + tau / 2, apothem)
+                deltaangle = tau / (2 * number_points)
+                d1 = arithmetic_center.distance_to(first_point)
+                d2 = arithmetic_center.distance_to(second_point)
+                if d1 < d2:
+                    center_point = Point(first_point)
+                else:
+                    center_point = Point(second_point)
+                # mk_debug_point(center_point.x, center_point.y, "red")
+
+                if center_point.angle_to(point0) > center_point.angle_to(point1):
+                    deltaangle *= -1
+                angle = center_point.angle_to(point0)
+                points = []
+                for idx in range(2 * number_points):
+                    if idx % 2 == 0:
+                        radius = circumradius
+                    else:
+                        radius = radius_inner
+                    # if idx > 1:
+                    pt = Point.polar(center_point, angle, radius)
+                    points.append((pt.x, pt.y))
+                    angle += deltaangle
+        elif self.design_mode == 3:
+            number_points = tc
+            if number_points > 1:
+                point0 = Point(points[0])
+                pcenter = Point(points[-1])
+                radius = pcenter.distance_to(point0)
+                if radius < 5000:
+                    pcenter = Point(cx, cy)
+                    radius = pcenter.distance_to(point0)
+                angle = pcenter.angle_to(point0) + tau / number_points
+                point1 = pcenter.polar(pcenter, angle, radius)
+                points[1] = [point1.x, point1.y]
+                dx = points[1][0] - points[0][0]
+                dy = points[1][1] - points[0][1]
+                baseline = sqrt(dx * dx + dy * dy)
+                apothem = baseline / (2 * tan(tau / (2 * number_points)))
+                circumradius = baseline / (2 * sin(tau / (2 * number_points)))
+                midpoint = Point(points[0][0] + 0.5 * dx, points[0][1] + 0.5 * dy)
+                ax = 0
+                ay = 0
+                for pt in points:
+                    ax += pt[0]
+                    ay += pt[1]
+                ax /= number_points
+                ay /= number_points
+                # The arithmetic center (ax, ay) indicates to which
+                # 'side' of the baseline the polygon needs to be constructed
+                arithmetic_center = Point(ax, ay)
+                # mk_debug_point(ax, ay, "green")
+                angle = point0.angle_to(points[1])
+                midangle = midpoint.angle_to(arithmetic_center)
+                angle += tau / 4
+                first_point = Point.polar(midpoint, angle, apothem)
+                second_point = Point.polar(midpoint, angle + tau / 2, apothem)
+                targetlen = 2 * number_points + 1
+                deltaangle = tau / targetlen
+                d1 = arithmetic_center.distance_to(first_point)
+                d2 = arithmetic_center.distance_to(second_point)
+                if d1 < d2:
+                    center_point = Point(first_point)
+                else:
+                    center_point = Point(second_point)
+                # mk_debug_point(center_point.x, center_point.y, "red")
+
+                if center_point.angle_to(point0) > center_point.angle_to(point1):
+                    deltaangle *= -1
+                angle = center_point.angle_to(point0)
+                midpoints = []
+                for idx in range(targetlen):
+                    radius = circumradius
+                    pt = Point.polar(center_point, angle, radius)
+                    midpoints.append((pt.x, pt.y))
+                    angle += deltaangle
+                points = []
+                mid_idx = 0
+                delta = int(targetlen / 2 - self.design_param)
+                while delta < 0:
+                    delta += targetlen
+
+                for idx in range(targetlen):
+                    points.append(midpoints[mid_idx])
+                    mid_idx += delta
+                    while mid_idx >= targetlen:
+                        mid_idx -= targetlen
+        # Close the polygon
+        if closeit:
+            points.append(points[0])
+        return points
+
     def event(
         self,
         window_pos=None,
@@ -86,6 +401,7 @@ class PolygonTool(ToolWidget):
         event_type=None,
         nearest_snap=None,
         modifiers=None,
+        keycode=None,
         **kwargs,
     ):
         response = RESPONSE_CHAIN
@@ -125,6 +441,7 @@ class PolygonTool(ToolWidget):
                     complex(*self.point_series[-2]) - complex(*self.point_series[-1])
                 )
                 < 5000
+                and self.design_mode == 0
             ):
                 self.end_tool()
                 response = RESPONSE_ABORT
@@ -165,6 +482,29 @@ class PolygonTool(ToolWidget):
                 response = RESPONSE_CHAIN
             self.point_series = []
             self.mouse_position = None
+        elif event_type == "key_up" and modifiers == "return":
+            self.end_tool()
+            response = RESPONSE_ABORT
+        elif event_type == "key_up":
+            if not self.scene.pane.tool_active:
+                return RESPONSE_CHAIN
+            # print(
+            #     f"key-up: {event_type}, modifiers: '{modifiers}', keycode: '{keycode}'"
+            # )
+            if keycode == "f":
+                # Freehand
+                self.set_designmode(0)
+            elif keycode == "r":
+                # Regular
+                self.set_designmode(1)
+            elif keycode == "1" or keycode == "s":
+                # Star 1
+                self.set_designmode(2)
+            elif keycode == "2" or keycode == "p":
+                # Star 2 / Pentagram
+                self.set_designmode(3)
+
+            return RESPONSE_CONSUME
         elif update_required:
             self.scene.request_refresh()
             response = RESPONSE_CONSUME
@@ -172,7 +512,8 @@ class PolygonTool(ToolWidget):
 
     def end_tool(self):
         if len(self.point_series) > 2:
-            polyline = Polygon(*self.point_series)
+            lines = self.calculated_points(False)
+            polyline = Polygon(*lines)
             elements = self.scene.context.elements
             node = elements.elem_branch.add(
                 shape=polyline,

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -77,7 +77,6 @@ from .propertypanels.textproperty import TextPropertyPanel
 from .propertypanels.waitproperty import WaitPropertyPanel
 from .simpleui import SimpleUI
 from .simulation import Simulation
-from .toolwidgets.toolnodeedit import NodeEditToolbar
 from .wordlisteditor import WordlistEditor
 from .wxmmain import MeerK40t
 
@@ -324,6 +323,7 @@ class wxMeerK40t(wx.App, Module):
         # Monkey patch for pycharm excepthook override issue. https://youtrack.jetbrains.com/issue/PY-39723
         try:
             import importlib
+
             pydevd = importlib.import_module("_pydevd_bundle.pydevd_breakpoints")
         except ImportError:
             pass
@@ -731,13 +731,11 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("window/Alignment", Alignment)
         kernel.register("window/HersheyFontManager", HersheyFontManager)
         kernel.register("window/HersheyFontSelector", HersheyFontSelector)
-        kernel.register("window/NodeEditIcons", NodeEditToolbar)
         kernel.register("window/SplitImage", RenderSplit)
         kernel.register("window/OperationInfo", OperationInformation)
         kernel.register("window/Lasertool", LaserTool)
         kernel.register("window/Templatetool", TemplateTool)
         kernel.register("window/Hingetool", LivingHingeTool)
-        kernel.register("window/NodeEditToolbar", NodeEditToolbar)
         kernel.register("window/Kerftest", KerfTool)
         kernel.register("window/SimpleUI", SimpleUI)
         # Hershey Manager stuff

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1026,16 +1026,29 @@ class MeerK40t(MWindow):
                 "identifier": "none",
             },
         )
+        # kernel.register(
+        #     "button/tools/Nodeeditor",
+        #     {
+        #         "label": _("Node Edit"),
+        #         "icon": icons8_node_edit_50,
+        #         "tip": _("Edit nodes of a polyline/path-object"),
+        #         "action": lambda v: kernel.elements("tool nodemove\n"),
+        #         "group": "tool",
+        #         "size": bsize_normal,
+        #         "identifier": "nodemove",
+        #     },
+        # )
         kernel.register(
             "button/tools/Nodeeditor",
             {
                 "label": _("Node Edit"),
                 "icon": icons8_node_edit_50,
                 "tip": _("Edit nodes of a polyline/path-object"),
-                "action": lambda v: kernel.elements("tool nodemove\n"),
+                "action": lambda v: kernel.elements("tool edit\n"),
                 "group": "tool",
                 "size": bsize_normal,
-                "identifier": "nodemove",
+                "identifier": "nodeedit",
+                "rule_enabled": lambda cond: contains_a_path(),
             },
         )
 

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -61,6 +61,7 @@ def register_panel_ribbon(window, context):
 
     window.on_pane_create(pane_ribbon)
     context.register("pane/ribbon", pane_ribbon)
+    context.register("ribbonbar/primary", ribbon)
 
     minh = int(1.5 * iconsize)
     pane_tool = (
@@ -86,6 +87,7 @@ def register_panel_ribbon(window, context):
 
     window.on_pane_create(pane_tool)
     context.register("pane/tools", pane_tool)
+    context.register("ribbonbar/tools", ribbon)
 
     choices = [
         {

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -139,7 +139,8 @@ class MKRibbonBarPanel(RibbonBarPanel):
         self.storage.read_configuration()
 
         # Layout properties.
-        self.toggle_show_labels(context.setting(bool, "ribbon_show_labels", True))
+        if show_labels is None or show_labels:
+            self.toggle_show_labels(context.setting(bool, "ribbon_show_labels", True))
 
         self._pages = []
         self.set_default_pages()

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -372,11 +372,66 @@ class MeerK40tScenePanel(wx.Panel):
                     channel(t)
                 channel(_("-------"))
                 return
+            toolbar = context.lookup("ribbonbar/tools")
+
             try:
                 if tool == "none":
                     self.tool_container.set_tool(None)
+                    # Reset the edit toolbar
+                    if toolbar is not None:
+                        toolbar.remove_page("toolcontainer")
+                        for pages in toolbar.pages:
+                            pages.visible = True
+                        toolbar.validate_current_page()
+                        toolbar.apply_enable_rules()
+                        toolbar.modified()
                 else:
                     self.tool_container.set_tool(tool.lower())
+                    # Reset the edit toolbar
+                    if toolbar is not None:
+                        toolbar.remove_page("toolcontainer")
+                        tool_values = list(context.find(f"button/tool_{tool}/.*"))
+                        # print(f"button/tool_{tool}/.*\n{tool_values}")
+                        if tool_values is not None and len(tool_values) > 0:
+                            for pages in toolbar.pages:
+                                pages.visible = False
+                            newpage = toolbar.add_page(
+                                "toolcontainer",
+                                "toolcontainer",
+                                "Select",
+                                None,
+                            )
+
+                            select_panel = toolbar.add_panel(
+                                "toolback",
+                                newpage,
+                                "toolback",
+                                "Select",
+                                None,
+                            )
+                            select_values = (
+                                (
+                                    context.lookup("button/tools/Scene"),
+                                    "button/tools/Scene",
+                                    "Select",
+                                ),
+                            )
+                            select_panel.set_buttons(select_values)
+
+                            tool_panel = toolbar.add_panel(
+                                "toolutil",
+                                newpage,
+                                "toolutil",
+                                "Tools",
+                                None,
+                            )
+                            tool_panel.set_buttons(tool_values)
+                            newpage.visible = True
+                            toolbar.validate_current_page()
+                            toolbar.apply_enable_rules()
+
+                        toolbar.modified()
+
             except (KeyError, AttributeError):
                 raise CommandSyntaxError
 


### PR DESCRIPTION
# Node-Editor
The Node-Editor got reestablished. The corresponding tool is using ``tool edit`` again (``tool nodemove`` is still around but no longer exposed in the GUI)
# Secondary toolwidgets
The toolwidget uses a newly established functionality to use the secondary tool ribbonbar. This is usable for all toolwidgets if they register some buttons. As an example - more a proof of concept than the intent to create something really useful - the polygon tool got some subtools to play with.

![tool](https://github.com/meerk40t/meerk40t/assets/2670784/5a3674fd-afa1-413d-99e1-8e128875e722)
