### PR TITLE
Plain svg loader

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1713,12 +1713,13 @@ class Elemental(Service):
         if fast:
             self.signal("rebuild_tree")
 
-    def clear_all(self):
+    def clear_all(self, ops_too=True):
         fast = True
         self.set_start_time("clear_all")
         with self.static("clear_all"):
             self.clear_elements(fast=fast)
-            self.clear_operations(fast=fast)
+            if ops_too:
+                self.clear_operations(fast=fast)
             self.clear_files()
             self.clear_note()
             self.clear_regmarks(fast=fast)
@@ -3325,7 +3326,9 @@ class Elemental(Service):
         # which aren't supported by mk yet, we could ask a program
         # to convert these elements into supported artifacts
         # This may change the fileformat (and filename)
-
+        preferred_loader = None
+        if "preferred_loader" in kwargs:
+            preferred_loader = kwargs["preferred_loader"]
         fn_name, fn_extension = os.path.splitext(filename_to_process)
         if fn_extension:
             preproc = self.lookup(f"preprocessor/{fn_extension}")
@@ -3335,7 +3338,11 @@ class Elemental(Service):
                 # print (f"Gave: {pathname}, received: {filename_to_process}")
         for loader, loader_name, sname in kernel.find("load"):
             for description, extensions, mimetype in loader.load_types():
+                valid = False
                 if str(filename_to_process).lower().endswith(extensions):
+                    if preferred_loader is None or (preferred_loader == loader_name):
+                        valid = True
+                if valid:
                     self.set_start_time("load")
                     self.set_start_time("full_load")
                     with self.static("load elements"):

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -109,6 +109,9 @@ def plugin(kernel, lifecycle=None):
             },
         ]
         kernel.register_choices("preferences", choices)
+        # The order is relevant as both loaders support SVG
+        # By definition the very first matching loader is used as a default
+        # so that needs to be the full loader
         kernel.register("load/SVGLoader", SVGLoader)
         kernel.register("load/SVGPlainLoader", SVGLoaderPlain)
         kernel.register("save/SVGWriter", SVGWriter)
@@ -1215,6 +1218,10 @@ class SVGProcessor:
 
 
 class SVGLoader:
+    """
+    SVG loader - loading elements, regmarks and operations
+    """
+
     @staticmethod
     def load_types():
         yield "Scalable Vector Graphics", ("svg", "svgz"), "image/svg+xml"
@@ -1258,6 +1265,10 @@ class SVGLoader:
 
 
 class SVGLoaderPlain:
+    """
+    SVG loader but without loading the operations branch
+    """
+
     @staticmethod
     def load_types():
         yield "SVG (elements only)", ("svg", "svgz"), "image/svg+xml"

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1908,8 +1908,17 @@ class MeerK40t(MWindow):
             ) as fileDialog:
                 if fileDialog.ShowModal() == wx.ID_CANCEL:
                     return  # the user changed their mind
+                idx = fileDialog.GetFilterIndex()
+                preferred_loader = None
+                if idx > 0:
+                    lidx = 0
+                    for loader, loader_name, sname in context.kernel.find("load"):
+                        lidx += 1
+                        if lidx == idx:
+                            preferred_loader = loader_name
+                            break
                 pathname = fileDialog.GetPath()
-                gui.clear_and_open(pathname)
+                gui.clear_and_open(pathname, preferred_loader=preferred_loader)
 
         @context.console_command("dialog_import", hidden=True)
         def import_dialog(**kwargs):
@@ -1922,8 +1931,17 @@ class MeerK40t(MWindow):
             ) as fileDialog:
                 if fileDialog.ShowModal() == wx.ID_CANCEL:
                     return  # the user changed their mind
+                idx = fileDialog.GetFilterIndex()
+                preferred_loader = None
+                if idx > 0:
+                    lidx = 0
+                    for loader, loader_name, sname in context.kernel.find("load"):
+                        lidx += 1
+                        if lidx == idx:
+                            preferred_loader = loader_name
+                            break
                 pathname = fileDialog.GetPath()
-                gui.load(pathname)
+                gui.load(pathname, preferred_loader)
 
         @context.console_option("quit", "q", action="store_true", type=bool)
         @context.console_command("dialog_save_as", hidden=True)
@@ -3561,8 +3579,17 @@ class MeerK40t(MWindow):
             fileDialog.SetFilename(default_file)
             if fileDialog.ShowModal() == wx.ID_CANCEL:
                 return  # the user changed their mind
+            idx = fileDialog.GetFilterIndex()
+            preferred_loader = None
+            if idx > 0:
+                lidx = 0
+                for loader, loader_name, sname in context.kernel.find("load"):
+                    lidx += 1
+                    if lidx == idx:
+                        preferred_loader = loader_name
+                        break
             pathname = fileDialog.GetPath()
-            self.load(pathname)
+            self.load(pathname, preferred_loader)
 
     def populate_recent_menu(self):
         if not hasattr(self, "recent_file_menu"):
@@ -3640,20 +3667,20 @@ class MeerK40t(MWindow):
                 break
         self.populate_recent_menu()
 
-    def clear_project(self):
+    def clear_project(self, ops_too=True):
         context = self.context
         kernel = context.kernel
         kernel.busyinfo.start(msg=_("Cleaning up..."))
         self.working_file = None
-        context.elements.clear_all()
+        context.elements.clear_all(ops_too=ops_too)
         self.context(".laserpath_clear\n")
         self.validate_save()
         kernel.busyinfo.end()
         self.context("tool none\n")
 
-    def clear_and_open(self, pathname):
-        self.clear_project()
-        if self.load(pathname):
+    def clear_and_open(self, pathname, preferred_loader=None):
+        self.clear_project(ops_too=False)
+        if self.load(pathname, preferred_loader):
             try:
                 if self.context.uniform_svg and pathname.lower().endswith("svg"):
                     # or (len(elements) > 0 and "meerK40t" in elements[0].values):
@@ -3663,7 +3690,7 @@ class MeerK40t(MWindow):
             except AttributeError:
                 pass
 
-    def load(self, pathname):
+    def load(self, pathname, preferred_loader=None):
         def unescaped(filename):
             OS_NAME = platform.system()
             if OS_NAME == "Windows":
@@ -3683,6 +3710,7 @@ class MeerK40t(MWindow):
                 pathname,
                 channel=self.context.channel("load"),
                 svg_ppi=self.context.elements.svg_ppi,
+                preferred_loader=preferred_loader,
             )
             kernel.busyinfo.end()
         except BadFileError as e:
@@ -3815,13 +3843,15 @@ class MeerK40t(MWindow):
                 amount=bbox[0] - x_delta, relative_length=self.context.device.view.width
             ).length_mm
             y0 = Length(
-                amount=bbox[1] - y_delta, relative_length=self.context.device.view.height
+                amount=bbox[1] - y_delta,
+                relative_length=self.context.device.view.height,
             ).length_mm
             x1 = Length(
                 amount=bbox[2] + x_delta, relative_length=self.context.device.view.width
             ).length_mm
             y1 = Length(
-                amount=bbox[3] + y_delta, relative_length=self.context.device.view.height
+                amount=bbox[3] + y_delta,
+                relative_length=self.context.device.view.height,
             ).length_mm
             self.context(f"scene focus -a {x0} {y0} {x1} {y1}\n")
 


### PR DESCRIPTION
Allow loading of svg files without the operations branch (uses a custom loader)
That required = introduces the opportunity to overrid the default = first loader that would fit the file extension. If you have selected a certain wildcard (corresponding to a loader) that will be honored.