### PR TITLE
Allow dragging of an operation node onto an element

### DIFF
--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -253,6 +253,10 @@ class HatchEffectNode(Node, Stroked):
             if modify:
                 self.append_child(drag_node.node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def copy_children(self, obj):

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -208,6 +208,10 @@ class EllipseNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -172,6 +172,10 @@ class ImageNode(Node):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -180,6 +180,10 @@ class LineNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -166,6 +166,10 @@ class PathNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -79,6 +79,10 @@ class PointNode(Node):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -191,6 +191,10 @@ class PolylineNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -195,6 +195,10 @@ class RectNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -189,6 +189,10 @@ class TextNode(Node, Stroked):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -61,6 +61,10 @@ class GroupNode(Node):
             if modify:
                 self.append_child(drag_node)
             return True
+        elif drag_node.type.startswith("op"):
+            # If we drag an operation to this node,
+            # then we will reverse the game
+            return drag_node.drop(self, modify=modify)
         return False
 
     @property


### PR DESCRIPTION
If you drag e.g. a Cut operation onto an element then that element will be added to the operation (drag = dropped element to be adopted, reverse drag = dropped operation will be assigned)