### PR TITLE
Subdivide the Mixins for the Element nodes

### DIFF
--- a/meerk40t/balormk/balor_params.py
+++ b/meerk40t/balormk/balor_params.py
@@ -30,6 +30,9 @@ STRING_PARAMETERS = ("wobble_type", "wobble_radius", "wobble_interval")
 
 class Parameters:
     def __init__(self, settings: Dict = None, **kwargs):
+        if hasattr(self, "settings"):
+            # already initialized.
+            return
         self.settings = settings
         if self.settings is None:
             self.settings = dict()

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -1,7 +1,7 @@
 from copy import copy
 from math import cos, sin, tau, sqrt
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Fillrule, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -13,7 +13,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class EllipseNode(Node, Stroked):
+class EllipseNode(Node, Stroked, FunctionalParameter):
     """
     EllipseNode is the bootstrapped node type for the 'elem ellipse' type.
     """

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -12,7 +12,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class LineNode(Node, Stroked):
+class LineNode(Node, Stroked, FunctionalParameter):
     """
     LineNode is the bootstrapped node type for the 'elem line' type.
     """

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -10,7 +10,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PathNode(Node, Stroked):
+class PathNode(Node, Stroked, FunctionalParameter):
     """
     PathNode is the bootstrapped node type for the 'elem path' type.
     """

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -1,11 +1,12 @@
 from copy import copy
 
+from meerk40t.core.node.mixins import FunctionalParameter
 from meerk40t.core.node.node import Node
 from meerk40t.svgelements import Matrix, Point
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PointNode(Node):
+class PointNode(Node, FunctionalParameter):
     """
     PointNode is the bootstrapped node type for the 'elem point' type.
     """

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -13,7 +13,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PolylineNode(Node, Stroked):
+class PolylineNode(Node, Stroked, FunctionalParameter):
     """
     PolylineNode is the bootstrapped node type for the 'elem polyline' type.
     """

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -1,7 +1,7 @@
 import math
 from copy import copy
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Fillrule, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -13,7 +13,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class RectNode(Node, Stroked):
+class RectNode(Node, Stroked, FunctionalParameter):
     """
     RectNode is the bootstrapped node type for the 'elem rect' type.
     """

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -2,7 +2,7 @@ import re
 from copy import copy
 from math import tau
 
-from meerk40t.core.node.mixins import Stroked
+from meerk40t.core.node.mixins import Stroked, FunctionalParameter
 from meerk40t.core.node.node import Node
 from meerk40t.core.units import UNITS_PER_POINT, Length
 from meerk40t.svgelements import (
@@ -40,7 +40,7 @@ REGEX_CSS_FONT_FAMILY = re.compile(
 )
 
 
-class TextNode(Node, Stroked):
+class TextNode(Node, Stroked, FunctionalParameter):
     """
     TextNode is the bootstrapped node type for the 'elem text' type.
     """

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -1,8 +1,21 @@
+"""
+Mixins for nodes are aspects of code which can and should be used between multiple different nodes which convey some
+basic functionality.
+
+The use of ABC allows @abstractmethod decorators which require any subclass to implement the required method.
+"""
+
 from abc import ABC
 from math import sqrt
 
 
 class Stroked(ABC):
+    """
+    Stroked nodes provide a stroke_scaled matrix controlled stroke mixin. Such that the stroke scaling can be enabled
+    and disabled, and it will increase or decrease the implied_stroke_width. If stroke scaling is disabled then the
+    stroke_width is independent to the scaling of the node (dictated by the .matrix attribute).
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__()
 
@@ -76,6 +89,9 @@ class Stroked(ABC):
 
 
 class FunctionalParameter(ABC):
+    """
+    Functional Parameters mixin allows the use and utility of functional parameters for this node type.
+    """
     def __init__(self, *args, **kwargs):
         self.mkparam = None
         super().__init__()

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -4,7 +4,6 @@ from math import sqrt
 
 class Stroked(ABC):
     def __init__(self, *args, **kwargs):
-        print("Stroked called.")
         super().__init__()
 
     @property
@@ -78,7 +77,6 @@ class Stroked(ABC):
 
 class FunctionalParameter(ABC):
     def __init__(self, *args, **kwargs):
-        print("FunctionalParameter called.")
         self.mkparam = None
         super().__init__()
 

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -4,7 +4,8 @@ from math import sqrt
 
 class Stroked(ABC):
     def __init__(self, *args, **kwargs):
-        self.mkparam = None
+        print("Stroked called.")
+        super().__init__()
 
     @property
     def stroke_scaled(self):
@@ -73,6 +74,13 @@ class Stroked(ABC):
         """
         matrix = self.matrix
         self._stroke_zero = sqrt(abs(matrix.determinant))
+
+
+class FunctionalParameter(ABC):
+    def __init__(self, *args, **kwargs):
+        print("FunctionalParameter called.")
+        self.mkparam = None
+        super().__init__()
 
     @property
     def functional_parameter(self):

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -131,6 +131,7 @@ class Node:
 
         self._item = None
         self._cache = None
+        super().__init__()
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"

--- a/meerk40t/core/parameters.py
+++ b/meerk40t/core/parameters.py
@@ -81,6 +81,9 @@ class Parameters:
     """
 
     def __init__(self, settings: Dict = None, **kwargs):
+        if hasattr(self, "settings"):
+            # already initialized.
+            return
         self.settings = settings
         if self.settings is None:
             self.settings = dict()


### PR DESCRIPTION
The Stroked mixin is different and implies different things than the FunctionalParameter mixin. This makes sure that `super()` is correctly called by Node, Stroke, and FunctionalParameter (needed to traverse the class tree init commands).

This also ensures that .mkparam is always initialized correctly.

Point is not a `Stroked` but is `FunctionalParameter` since you could have a point with a functional parameter but not one with a stroke.