### PR TITLE
Propagate node notify_modifiers through parents rather than directly through roots for extensibility.

### DIFF
--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -627,52 +627,52 @@ class Node:
         return True
 
     def notify_created(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_created(node=node, **kwargs)
+            self._parent.notify_created(node=node, **kwargs)
 
     def notify_destroyed(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_destroyed(node=node, **kwargs)
+            self._parent.notify_destroyed(node=node, **kwargs)
 
     def notify_attached(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_attached(node=node, **kwargs)
+            self._parent.notify_attached(node=node, **kwargs)
 
     def notify_detached(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_detached(node=node, **kwargs)
+            self._parent.notify_detached(node=node, **kwargs)
 
     def notify_changed(self, node, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_changed(node=node, **kwargs)
+            self._parent.notify_changed(node=node, **kwargs)
 
     def notify_selected(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_selected(node=node, **kwargs)
+            self._parent.notify_selected(node=node, **kwargs)
 
     def notify_emphasized(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_emphasized(node=node, **kwargs)
+            self._parent.notify_emphasized(node=node, **kwargs)
 
     def notify_targeted(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_targeted(node=node, **kwargs)
+            self._parent.notify_targeted(node=node, **kwargs)
 
     def notify_highlighted(self, node=None, **kwargs):
         if self._root is not None:
@@ -681,58 +681,58 @@ class Node:
             self._root.notify_highlighted(node=node, **kwargs)
 
     def notify_modified(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_modified(node=node, **kwargs)
+            self._parent.notify_modified(node=node, **kwargs)
 
     def notify_translated(self, node=None, dx=0, dy=0, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_translated(node=node, dx=dx, dy=dy, **kwargs)
+            self._parent.notify_translated(node=node, dx=dx, dy=dy, **kwargs)
 
     def notify_scaled(self, node=None, sx=1, sy=1, ox=0, oy=0, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_scaled(node=node, sx=sx, sy=sy, ox=ox, oy=oy, **kwargs)
+            self._parent.notify_scaled(node=node, sx=sx, sy=sy, ox=ox, oy=oy, **kwargs)
 
     def notify_altered(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_altered(node=node, **kwargs)
+            self._parent.notify_altered(node=node, **kwargs)
 
     def notify_expand(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_expand(node=node, **kwargs)
+            self._parent.notify_expand(node=node, **kwargs)
 
     def notify_collapse(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_collapse(node=node, **kwargs)
+            self._parent.notify_collapse(node=node, **kwargs)
 
     def notify_reorder(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_reorder(node=node, **kwargs)
+            self._parent.notify_reorder(node=node, **kwargs)
 
     def notify_update(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_update(node=node, **kwargs)
+            self._parent.notify_update(node=node, **kwargs)
 
     def notify_focus(self, node=None, **kwargs):
-        if self._root is not None:
+        if self._parent is not None:
             if node is None:
                 node = self
-            self._root.notify_focus(node=node, **kwargs)
+            self._parent.notify_focus(node=node, **kwargs)
 
     def focus(self):
         self.notify_focus(self)


### PR DESCRIPTION
Root is always there. Sometimes notification might not occur from nodes which are not part of the active tree. But rather than directly contact the root, it will filter the notifications up from the child to parent until reaching the root. The distinction being that parents can override the notification to receive the notice.