### PR TITLE
Crash reporter couldn't handle commits only identified by hashes. Fix…

### DIFF
--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -27,6 +27,9 @@ if not getattr(sys, "frozen", False):
                 if ref.startswith(ref_prefix):
                     branch = ref[len(ref_prefix) :].strip("\n")
                     APPLICATION_VERSION += " " + branch
+                else:
+                    branch = ref.strip("\n")
+                    APPLICATION_VERSION += " " + branch
         except Exception:
             # Entirely optional, also this code segment may run in python2
             pass


### PR DESCRIPTION
…es that.
![image](https://github.com/meerk40t/meerk40t/assets/1036922/c94fdd53-c38f-4140-8f44-a0f51cecf1c6)
