### PR TITLE
Improved snap behaviour for first point

### DIFF
--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -7,7 +7,6 @@ from math import sqrt
 
 import wx
 
-from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.gui.scene.sceneconst import HITCHAIN_PRIORITY_HIT, RESPONSE_CHAIN
 from meerk40t.gui.scene.widget import Widget
 
@@ -30,7 +29,7 @@ class AttractionWidget(Widget):
         # We want to be unrecognized
         self.transparent = True
         self.context = self.scene.context
-        self.attraction_points = None  # Clear all
+        self.snap_attraction_points = None  # Clear all
         self.my_x = None
         self.my_y = None
         self.visible_pen = wx.Pen()
@@ -39,7 +38,6 @@ class AttractionWidget(Widget):
         self.closeup_pen.SetWidth(1)
         self.load_colors()
         self.symbol_size = 1  # Will be replaced anyway
-        self.display_points = []
 
         # Should already be covered in wxmain choice panel, but are used here and thus set here.
         self.context.setting(int, "show_attract_len", 45)
@@ -48,8 +46,6 @@ class AttractionWidget(Widget):
         self.context.setting(bool, "snap_grid", True)
         self.context.setting(bool, "snap_points", False)
         self._show_snap_points = False
-        self._snap_grid = False
-        self._snap_points = False
 
     def load_colors(self):
         self.visible_pen.SetColour(self.scene.colors.color_snap_visible)
@@ -87,15 +83,18 @@ class AttractionWidget(Widget):
         self.my_y = space_pos[1]
         ctx = self.context
 
-        self._snap_grid = ctx.snap_grid
-        self._snap_points = ctx.snap_points
+        snap_grid = ctx.snap_grid
+        snap_points = ctx.snap_points
         self._show_snap_points = False
         if "shift" in modifiers:
-            # Shift inverts the on/off of snaps.
-            self._snap_grid = not self._snap_grid
-            self._snap_points = not self._snap_points
+            # Shift inverts the on/off of snaps,
+            snap_grid = not snap_grid
+            snap_points = not snap_points
+            # but we just do that for the grid
+            if snap_points:
+                snap_points = False
 
-        if not self._snap_points and not self._snap_grid:
+        if not snap_points and not snap_grid:
             # We are not going to snap.
             return RESPONSE_CHAIN
 
@@ -107,9 +106,9 @@ class AttractionWidget(Widget):
 
         # Inform profiler
         ctx.elements.set_start_time("attr_calc_disp")
-        self._calculate_display_points()
+        self.scene.calculate_display_points(self.my_x, self.my_y, snap_points, snap_grid)
         ctx.elements.set_end_time(
-            "attr_calc_disp", message=f"points added={len(self.display_points)}"
+            "attr_calc_disp", message=f"points added={len(self.scene.snap_display_points)}"
         )
 
         if event_type in (
@@ -126,28 +125,11 @@ class AttractionWidget(Widget):
             # (but we needed the calculation)
             self._show_snap_points = False
 
-        # Loop through display points, find closest.
-        if self.display_points and self.my_x is not None:
-            # Has to be lower than the action threshold
-            min_delta = float("inf")
-            new_x = None
-            new_y = None
-            for pt in self.display_points:
-                dx = pt[0] - self.my_x
-                dy = pt[1] - self.my_y
-                delta = dx * dx + dy * dy
-                if delta < min_delta:
-                    new_x = pt[0]
-                    new_y = pt[1]
-                    min_delta = delta
-            if new_x is None:
-                return RESPONSE_CHAIN
-            matrix = self.parent.matrix
-            pixel = self.context.action_attract_len / matrix.value_scale_x()
-            if abs(new_x - self.my_x) <= pixel and abs(new_y - self.my_y) <= pixel:
-                # If the distance small enough, snap.
-                return RESPONSE_CHAIN, new_x, new_y
-        return RESPONSE_CHAIN
+        res_x, res_y = self.scene.calculate_snap(self.my_x, self.my_y)
+        if res_x is None:
+            return RESPONSE_CHAIN
+        else:
+            return RESPONSE_CHAIN, res_x, res_y
 
     def _draw_caret(self, gc, x, y, closeup):
         if closeup == 2:  # closest
@@ -265,7 +247,7 @@ class AttractionWidget(Widget):
         min_x = None
         min_y = None
         min_type = None
-        for pts in self.display_points:
+        for pts in self.scene.snap_display_points:
             if (
                 abs(pts[0] - self.my_x) <= local_attract_len
                 and abs(pts[1] - self.my_y) <= local_attract_len
@@ -314,95 +296,11 @@ class AttractionWidget(Widget):
             elif min_type == TYPE_GRID:
                 self._draw_gridpoint(gc, min_x, min_y, closeup)
 
-    def _calculate_attraction_points(self):
-        """
-        Looks at all elements (all_points=True) or at non-selected elements (all_points=False) and identifies all
-        attraction points (center, corners, sides)
-        """
-        self.context.elements.set_start_time("attr_calc_points")
-        self.attraction_points = []  # Clear all
-        translation_table = {
-            "bounds top_left": TYPE_BOUND,
-            "bounds top_right": TYPE_BOUND,
-            "bounds bottom_left": TYPE_BOUND,
-            "bounds bottom_right": TYPE_BOUND,
-            "bounds center_center": TYPE_CENTER,
-            "bounds top_center": TYPE_MIDDLE,
-            "bounds bottom_center": TYPE_MIDDLE,
-            "bounds center_left": TYPE_MIDDLE,
-            "bounds center_right": TYPE_MIDDLE,
-            "endpoint": TYPE_POINT,
-            "point": TYPE_POINT,
-            "midpoint": TYPE_MIDDLE_SMALL,
-        }
-
-        for e in self.scene.context.elements.flat(types=elem_nodes):
-            emph = e.emphasized
-            if hasattr(e, "points"):
-                for pt in e.points:
-                    try:
-                        pt_type = translation_table[pt[2]]
-                    except:
-                        print(f"Unknown type: {pt[2]}")
-                        pt_type = TYPE_POINT
-                    self.attraction_points.append([pt[0], pt[1], pt_type, emph])
-
-        self.context.elements.set_end_time(
-            "attr_calc_points", message=f"points added={len(self.attraction_points)}"
-        )
-
-    def _calculate_snap_points(self, length):
-        """
-        Recalculate the snap element attraction points
-
-        @param length:
-        @return:
-        """
-        for pts in self.attraction_points:
-            if self.scene.pane.modif_active:
-                if pts[3]:
-                    # No snap points for emphasized objects.
-                    continue
-            if abs(pts[0] - self.my_x) <= length and abs(pts[1] - self.my_y) <= length:
-                self.display_points.append([pts[0], pts[1], pts[2]])
-
-    def _calculate_grid_points(self, length):
-        """
-        Recalculate the local grid points
-
-        @param length:
-        @return:
-        """
-        for pts in self.scene.pane.grid.grid_points:
-            if abs(pts[0] - self.my_x) <= length and abs(pts[1] - self.my_y) <= length:
-                self.display_points.append([pts[0], pts[1], TYPE_GRID])
-
-    def _calculate_display_points(self):
-        """
-        Recalcuate the points that need to be displayed for the user.
-
-        @return:
-        """
-        self.display_points = []
-        if self.my_x is None:
-            return
-        if self.attraction_points is None and self._snap_points:
-            self._calculate_attraction_points()
-
-        matrix = self.parent.matrix
-        length = self.context.show_attract_len / matrix.value_scale_x()
-
-        if self._snap_points and self.attraction_points:
-            self._calculate_snap_points(length)
-
-        if self._snap_grid and self.scene.pane.grid.grid_points:
-            self._calculate_grid_points(length)
-
     def signal(self, signal, *args, **kwargs):
         """
         Signal commands which indicate that we need to refresh / discard some data
         """
         if signal in ("modified", "emphasized", "element_added", "tool_modified"):
-            self.attraction_points = None
+            self.scene.reset_snap_attraction()
         elif signal == "theme":
             self.load_colors()

--- a/meerk40t/gui/statusbarwidgets/selectionwidget.py
+++ b/meerk40t/gui/statusbarwidgets/selectionwidget.py
@@ -5,7 +5,7 @@ from .statusbarwidget import StatusBarWidget
 _ = wx.GetTranslation
 
 
-class SelectionWidget(StatusBarWidget):
+class SelectionOptionWidget(StatusBarWidget):
     """
     Panel to set some of the options for the selection rectangle
     around an emphasized element
@@ -101,3 +101,66 @@ class SelectionWidget(StatusBarWidget):
             value = self.cb_skew.GetValue()
             self.context.enable_sel_skew = value
             self.context.signal("refresh_scene", "Scene")
+
+class SnapOptionsWidget(StatusBarWidget):
+    """
+    Panel to set some of the options for mouse snapping
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def GenerateControls(self, parent, panelidx, identifier, context):
+        super().GenerateControls(parent, panelidx, identifier, context)
+
+        FONT_SIZE = 7
+
+        # These will fall into the last field
+        self.cb_grid = wx.CheckBox(self.parent, id=wx.ID_ANY, label=_("Snap to Grid"))
+        self.cb_points = wx.CheckBox(self.parent, id=wx.ID_ANY, label=_("Snap to Element"))
+        self.cb_grid.SetFont(
+            wx.Font(
+                FONT_SIZE,
+                wx.FONTFAMILY_DEFAULT,
+                wx.FONTSTYLE_NORMAL,
+                wx.FONTWEIGHT_NORMAL,
+            )
+        )
+        self.cb_points.SetFont(
+            wx.Font(
+                FONT_SIZE,
+                wx.FONTFAMILY_DEFAULT,
+                wx.FONTSTYLE_NORMAL,
+                wx.FONTWEIGHT_NORMAL,
+            )
+        )
+
+        self.parent.Bind(wx.EVT_CHECKBOX, self.on_toggle_grid, self.cb_grid)
+        self.parent.Bind(wx.EVT_CHECKBOX, self.on_toggle_points, self.cb_points)
+        self.StartPopulation()
+        self.cb_grid.SetValue(self.context.snap_grid)
+        self.cb_points.SetValue(self.context.snap_points)
+        self.EndPopulation()
+        self.cb_grid.SetToolTip(_("Shall the cursor snap to the next grid intersection?"))
+        self.cb_points.SetToolTip(_("Shall the cursor snap to the next element point?"))
+        self.PrependSpacer(5)
+        self.Add(self.cb_grid, 1, 0, 0)
+        self.Add(self.cb_points, 1, 0, 0)
+
+    # the checkbox was clicked
+    def on_toggle_grid(self, event):
+        if not self.startup:
+            state = self.cb_grid.GetValue()
+            self.context.snap_grid = state
+            self.context.signal("snap_grid", state)
+
+    def on_toggle_points(self, event):
+        if not self.startup:
+            state = self.cb_points.GetValue()
+            self.context.snap_points = state
+            self.context.signal("snap_points", state)
+
+    def Signal(self, signal, *args):
+        if signal in ("snap_grid", "snap_points"):
+            self.cb_grid.SetValue(self.context.snap_grid)
+            self.cb_points.SetValue(self.context.snap_points)

--- a/meerk40t/gui/statusbarwidgets/statusbar.py
+++ b/meerk40t/gui/statusbarwidgets/statusbar.py
@@ -81,7 +81,7 @@ class CustomStatusBar(wx.StatusBar):
         widget.active = visible
         self.widgets[identifier] = widget
 
-    def activate_panel(self, identifier, newflag):
+    def activate_panel(self, identifier, newflag, force=False):
         # Activate Panel will make the indicated panel become choosable
         # print ("Activate Panel: %s -> %s" % (identifier, newflag))
         try:
@@ -93,7 +93,7 @@ class CustomStatusBar(wx.StatusBar):
 
             # Choosable
             self.widgets[identifier].active = newflag
-            if newflag and self.activesizer[panelidx] is None:
+            if newflag and (self.activesizer[panelidx] is None or force):
                 self.activesizer[panelidx] = identifier
             elif not newflag and self.activesizer[panelidx] == identifier:
                 # Was the active one, so look for an alternative

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -117,7 +117,8 @@ class EllipseTool(ToolWidget):
         if event_type == "leftdown":
             self.scene.pane.tool_active = True
             if nearest_snap is None:
-                self.p1 = complex(space_pos[0], space_pos[1])
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                self.p1 = complex(sx, sy)
             else:
                 self.p1 = complex(nearest_snap[0], nearest_snap[1])
             response = RESPONSE_CONSUME

--- a/meerk40t/gui/toolwidgets/toollinetext.py
+++ b/meerk40t/gui/toolwidgets/toollinetext.py
@@ -116,7 +116,8 @@ class LineTextTool(ToolWidget):
                 else:
                     self.color = elements.default_stroke
                 if nearest_snap is None:
-                    self.p1 = complex(space_pos[0], space_pos[1])
+                    sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                    self.p1 = complex(sx, sy)
                 else:
                     self.p1 = complex(nearest_snap[0], nearest_snap[1])
                 x = self.p1.real

--- a/meerk40t/gui/toolwidgets/toolplacement.py
+++ b/meerk40t/gui/toolwidgets/toolplacement.py
@@ -71,7 +71,8 @@ class PlacementTool(ToolWidget):
             #     f"Ctrl={self.has_ctrl}, alt={self.has_alt}, shift={self.has_shift}, point={space_pos}, snap={nearest_snap}"
             # )
             if nearest_snap is None:
-                point = Point(space_pos[0], space_pos[1])
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                point = Point(sx, sy)
             else:
                 point = Point(nearest_snap[0], nearest_snap[1])
             if self.has_ctrl:

--- a/meerk40t/gui/toolwidgets/toolpoint.py
+++ b/meerk40t/gui/toolwidgets/toolpoint.py
@@ -30,7 +30,8 @@ class PointTool(ToolWidget):
         response = RESPONSE_CHAIN
         if event_type == "leftclick":
             if nearest_snap is None:
-                point = Point(space_pos[0], space_pos[1])
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                point = Point(sx, sx)
             else:
                 point = Point(nearest_snap[0], nearest_snap[1])
             elements = self.scene.context.elements

--- a/meerk40t/gui/toolwidgets/toolpolygon.py
+++ b/meerk40t/gui/toolwidgets/toolpolygon.py
@@ -335,7 +335,8 @@ class PolygonTool(ToolWidget):
                 update_required = True
         if event_type == "leftclick":
             if nearest_snap is None:
-                pos = [space_pos[0], space_pos[1]]
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                pos = [sx, sy]
             else:
                 pos = [nearest_snap[0], nearest_snap[1]]
             pos = self.angled(pos)

--- a/meerk40t/gui/toolwidgets/toolpolyline.py
+++ b/meerk40t/gui/toolwidgets/toolpolyline.py
@@ -108,7 +108,8 @@ class PolylineTool(ToolWidget):
         if event_type == "leftclick":
             self.scene.pane.tool_active = True
             if nearest_snap is None:
-                pos = [space_pos[0], space_pos[1]]
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                pos = [sx, sy]
             else:
                 pos = [nearest_snap[0], nearest_snap[1]]
             pos = self.angled(pos)

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -114,7 +114,8 @@ class RectTool(ToolWidget):
         if event_type == "leftdown":
             self.scene.pane.tool_active = True
             if nearest_snap is None:
-                self.p1 = complex(space_pos[0], space_pos[1])
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                self.p1 = complex(sx, sy)
             else:
                 self.p1 = complex(nearest_snap[0], nearest_snap[1])
             response = RESPONSE_CONSUME

--- a/meerk40t/gui/toolwidgets/tooltext.py
+++ b/meerk40t/gui/toolwidgets/tooltext.py
@@ -45,8 +45,7 @@ class TextTool(ToolWidget):
         self.scene.cursor("text")
         if event_type == "leftdown":
             if nearest_snap is None:
-                x = space_pos[0]
-                y = space_pos[1]
+                x, y = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
             else:
                 x = nearest_snap[0]
                 y = nearest_snap[1]

--- a/meerk40t/gui/toolwidgets/toolvector.py
+++ b/meerk40t/gui/toolwidgets/toolvector.py
@@ -102,7 +102,8 @@ class VectorTool(ToolWidget):
                     self.pen.SetWidth(int(elements.default_strokewidth))
                 self.path = Path()
                 if nearest_snap is None:
-                    self.path.move((space_pos[0], space_pos[1]))
+                    sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                    self.path.move((sx, sy))
                 else:
                     self.path.move((nearest_snap[0], nearest_snap[1]))
             else:
@@ -126,7 +127,8 @@ class VectorTool(ToolWidget):
         elif event_type == "leftdown":
             self.scene.pane.tool_active = True
             if nearest_snap is None:
-                pos = (space_pos[0], space_pos[1])
+                sx, sy = self.scene.get_snap_point(space_pos[0], space_pos[1], modifiers)
+                pos = (sx, sy)
             else:
                 pos = (nearest_snap[0], nearest_snap[1])
             pos = self.angled(pos)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -20,7 +20,7 @@ from meerk40t.gui.statusbarwidgets.infowidget import (
 #     OperationAssignWidget,
 # )
 from meerk40t.gui.statusbarwidgets.defaultoperations import DefaultOperationWidget
-from meerk40t.gui.statusbarwidgets.selectionwidget import SelectionWidget
+from meerk40t.gui.statusbarwidgets.selectionwidget import SelectionOptionWidget, SnapOptionsWidget
 from meerk40t.gui.statusbarwidgets.shapepropwidget import (
     FillruleWidget,
     LinecapWidget,
@@ -253,10 +253,14 @@ class MeerK40t(MWindow):
 
         self.main_statusbar.add_panel_widget(self.status_panel, 0, "status", True)
 
-        self.select_panel = SelectionWidget()
+        self.select_panel = SelectionOptionWidget()
+        self.snap_panel = SnapOptionsWidget()
         self.info_panel = InformationWidget()
         self.main_statusbar.add_panel_widget(
             self.select_panel, self.idx_selection, "selection", False
+        )
+        self.main_statusbar.add_panel_widget(
+            self.snap_panel, self.idx_selection, "snap", False
         )
         self.main_statusbar.add_panel_widget(
             self.info_panel, self.idx_selection, "infos", False
@@ -295,7 +299,7 @@ class MeerK40t(MWindow):
         self.main_statusbar.add_panel_widget(
             self.burn_panel, self.idx_selection, "burninfo", False
         )
-
+        self.main_statusbar.activate_panel("snap", True)
         self.assign_button_panel.show_stuff(False)
 
     def _setup_edit_menu_choice(self):
@@ -599,7 +603,7 @@ class MeerK40t(MWindow):
         # First enable/disable the controls in the statusbar
 
         self.assign_button_panel.show_stuff(value)
-        self.main_statusbar.activate_panel("selection", value)
+        self.main_statusbar.activate_panel("selection", value, force=True)
         self.main_statusbar.activate_panel("infos", value)
         self.main_statusbar.activate_panel("color", value)
         self.main_statusbar.activate_panel("stroke", value)
@@ -3505,6 +3509,12 @@ class MeerK40t(MWindow):
     @signal_listener("default_operations")
     def on_def_ops(self, origin, *args):
         self.main_statusbar.Signal("default_operations")
+
+    @signal_listener("snap_grid")
+    @signal_listener("snap_points")
+    def on_sig_snap(self, origin, *args):
+        # will be used for both
+        self.main_statusbar.Signal("snap_grid")
 
     @signal_listener("activate;device")
     def on_device_active(self, origin, *args):


### PR DESCRIPTION
If you had snap to grid or elements active the very first point was still unaware of snapping. That has been fixed.
Old:
![snap_old](https://github.com/meerk40t/meerk40t/assets/2670784/382e4f9c-f56e-4c37-be97-3e12653e08f6)

New:
![snap_new](https://github.com/meerk40t/meerk40t/assets/2670784/e1bac887-8a34-43a6-a8b3-29fe0b0ab43e)
