### PR TITLE
Introduce break subpaths when parsing a svg path

### DIFF
--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -3474,7 +3474,6 @@ class Geomstr:
                     isinstance(seg, Line)
                     and seg.start.x == seg.end.x
                     and seg.start.y == seg.end.y
-                    and seg.start.y == seg.end.y
                 ):
                     obj._segments.pop(idx)
                     removed += 1

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -818,18 +818,22 @@ class Geomstr:
         return g
 
     @classmethod
-    def svg(cls, path_d, break_subpaths=False):
+    def svg(cls, path_d):
         obj = cls()
         if isinstance(path_d, str):
             path = Path(path_d)
         else:
             path = path_d
-        first_move = True
+        last_point = None
         for seg in path:
             if isinstance(seg, Move):
-                if first_move and break_subpaths:
-                    first_move = False
-                else:
+                # If the move destination is identical to destination of the
+                # last point then we need to introduce a subpath break
+                if (
+                    last_point is not None
+                    and last_point.x == seg.end.x
+                    and last_point.y == seg.end.y
+                ):
                     # This is a deliberate subpath break
                     obj.new_subpath()
             elif isinstance(seg, (Line, Close)):
@@ -852,6 +856,7 @@ class Geomstr:
                     quads = seg.as_quad_curves(4)
                     for q in quads:
                         obj.quad(complex(q.start), complex(q.control), complex(q.end))
+            last_point = seg.end
         return obj
 
     @classmethod

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -835,7 +835,7 @@ class Geomstr:
                     and last_point.y == seg.end.y
                 ):
                     # This is a deliberate subpath break
-                    obj.new_subpath()
+                    obj.end()
             elif isinstance(seg, (Line, Close)):
                 obj.line(complex(seg.start), complex(seg.end))
             elif isinstance(seg, QuadraticBezier):
@@ -1210,17 +1210,6 @@ class Geomstr:
     #######################
     # Geometric Primitives
     #######################
-    def new_subpath(self, settings=-1):
-        # Will add an end primitive = break subpath
-        self._ensure_capacity(self.index + 1)
-        self.segments[self.index] = (
-            np.nan,
-            np.nan,
-            complex(TYPE_END, settings),
-            np.nan,
-            np.nan,
-        )
-        self.index += 1
 
     def line(self, start, end, settings=0, a=None, b=None):
         """

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1210,15 +1210,15 @@ class Geomstr:
     #######################
     # Geometric Primitives
     #######################
-    def new_subpath(self, settings=0):
+    def new_subpath(self, settings=-1):
         # Will add an end primitive = break subpath
         self._ensure_capacity(self.index + 1)
         self.segments[self.index] = (
-            0,
-            0,
+            np.nan,
+            np.nan,
             complex(TYPE_END, settings),
-            0,
-            0,
+            np.nan,
+            np.nan,
         )
         self.index += 1
 


### PR DESCRIPTION
geomstr did not recognise intentional moves inside a path if the point before and after the move had the same coordinates. 