### PR TITLE
Correct issues for the 0.9.3 merges

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -2689,6 +2689,16 @@ def init_tree(kernel):
     def image_save_processed(node, **kwargs):
         self("image save output.png --processed\n")
 
+    @tree_conditional(lambda node: not node.lock)
+    @tree_submenu(_("Convert"))
+    @tree_operation(_("Raw Image"), node_type="elem image", help="")
+    def image_convert_raw(node, **kwargs):
+        node.replace_node(
+            image=node.image,
+            matrix=node.matrix,
+            type="image raster",
+        )
+
     @tree_conditional(lambda node: len(node.children) > 0)
     @tree_separator_before()
     @tree_operation(

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -2614,12 +2614,6 @@ def init_tree(kernel):
             return
         self.signal("magnet_gen", ("center", node))
 
-    # @tree_conditional(lambda node: not node.lock)
-    # @tree_conditional_try(lambda node: not node.lock)
-    # @tree_operation(_("Actualize pixels"), node_type="elem image", help="")
-    # def image_actualize_pixels(node, **kwargs):
-    #     self("image resample\n")
-
     @tree_conditional(lambda node: not node.lock)
     @tree_submenu(_("Z-depth divide"))
     @tree_iterate("divide", 2, 10)

--- a/meerk40t/core/elements/element_types.py
+++ b/meerk40t/core/elements/element_types.py
@@ -64,6 +64,7 @@ place_nodes = (
     "place current",
 )
 effect_nodes = ("effect hatch", "effect wobble")
+image_nodes = ("image raster", "image processed", "elem image")
 elem_nodes = (
     "elem ellipse",
     "elem image",
@@ -73,8 +74,6 @@ elem_nodes = (
     "elem rect",
     "elem line",
     "elem text",
-    "image raster",
-    "effect hatch",
 )
 elem_group_nodes = (
     "elem ellipse",

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -141,6 +141,9 @@ class ImageNode(Node):
         self.set_dirty_bounds()
         self.process_image(self.step_x, self.step_y, not self.prevent_crop)
 
+    def as_image(self):
+        return self.active_image, self.bbox()
+
     def bbox(self, transformed=True, with_stroke=False):
         image_width, image_height = self.active_image.size
         matrix = self.active_matrix

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -40,7 +40,6 @@ class RasterOpNode(Node, Parameters):
             "elem rect",
             "elem line",
             "elem text",
-            #            "elem image",
         )
 
         # self.allowed_attributes.append("fill")

--- a/meerk40t/image/imagetools.py
+++ b/meerk40t/image/imagetools.py
@@ -1830,7 +1830,8 @@ class ImageLoader:
         n = file_node.add(
             image=image,
             matrix=matrix,
-            type="image raster",
+            type="elem image",
+            dpi=_dpi,
         )
         if context.create_image_group:
             file_node.focus()


### PR DESCRIPTION
* Restore default image load class is `elem image`
* Fix display of `elem image`
* Permit creation of `image raster` from `elem image`.
