### PR TITLE
Experimental Test of Translation Switch

### DIFF
--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -6,9 +6,7 @@ from meerk40t.device.gui.warningpanel import WarningPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class BalorConfiguration(MWindow):

--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -5,9 +5,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class BalorControllerPanel(wx.ScrolledWindow):

--- a/meerk40t/balormk/gui/baloroperationproperties.py
+++ b/meerk40t/balormk/gui/baloroperationproperties.py
@@ -2,11 +2,10 @@ import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.kernel import _
 
 from ...core.units import Length
 from ..balor_params import Parameters
-
-_ = wx.GetTranslation
 
 
 class BalorOperationPanel(ScrolledPanel):

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -18,10 +18,8 @@ from meerk40t.gui.scene.sceneconst import (
 )
 from meerk40t.gui.scene.scenepanel import ScenePanel
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.kernel import Job, signal_listener
+from meerk40t.kernel import Job, _, signal_listener
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 CORNER_SIZE = 25
 

--- a/meerk40t/device/gui/defaultactions.py
+++ b/meerk40t/device/gui/defaultactions.py
@@ -16,8 +16,7 @@ from meerk40t.gui.icons import (
     icons8_up,
 )
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class DefaultActionPanel(wx.Panel):

--- a/meerk40t/device/gui/formatterpanel.py
+++ b/meerk40t/device/gui/formatterpanel.py
@@ -26,8 +26,7 @@ from meerk40t.gui.icons import (
     icons8_vector,
 )
 from meerk40t.gui.wxutils import dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class FormatterPanel(wx.Panel):

--- a/meerk40t/device/gui/warningpanel.py
+++ b/meerk40t/device/gui/warningpanel.py
@@ -9,8 +9,7 @@ from meerk40t.gui.icons import (
     icons8_laserbeam_weak,
 )
 from meerk40t.gui.wxutils import TextCtrl, dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class WarningPanel(wx.Panel):

--- a/meerk40t/grbl/gui/grblconfiguration.py
+++ b/meerk40t/grbl/gui/grblconfiguration.py
@@ -9,9 +9,7 @@ from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 DOLLAR_INFO = re.compile(r"\$([0-9]+)=(.*)")
 

--- a/meerk40t/grbl/gui/grblcontroller.py
+++ b/meerk40t/grbl/gui/grblcontroller.py
@@ -9,9 +9,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 realtime_commands = (
     "!",  # pause

--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -2,12 +2,12 @@ import datetime
 
 import wx
 
+from meerk40t.kernel import _
+
 from ..main import APPLICATION_NAME, APPLICATION_VERSION
 from .icons import icon_about, icon_meerk40t
 from .mwindow import MWindow
 from .wxutils import ScrolledPanel, StaticBoxSizer
-
-_ = wx.GetTranslation
 
 HEADER_TEXT = (
     "MeerK40t is a free MIT Licensed open source project\n"

--- a/meerk40t/gui/alignment.py
+++ b/meerk40t/gui/alignment.py
@@ -5,6 +5,7 @@ import wx
 
 from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.node.node import Node
+from meerk40t.kernel import _
 from meerk40t.svgelements import (
     Arc,
     Close,
@@ -23,8 +24,6 @@ from ..gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
 from ..kernel import signal_listener
 from .icons import STD_ICON_SIZE, icons8_arrange
 from .mwindow import MWindow
-
-_ = wx.GetTranslation
 
 
 class InfoPanel(wx.Panel):

--- a/meerk40t/gui/basicops.py
+++ b/meerk40t/gui/basicops.py
@@ -8,6 +8,7 @@ import wx
 
 from meerk40t.core.elements.element_types import elem_nodes, op_nodes
 from meerk40t.gui.laserrender import swizzlecolor
+from meerk40t.kernel import _
 
 from ..kernel import Job, lookup_listener, signal_listener
 from ..svgelements import Color
@@ -19,8 +20,6 @@ from .icons import (
     icons8_laserbeam_weak,
 )
 from .wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, create_menu, dip_size
-
-_ = wx.GetTranslation
 
 BUTTONSIZE = 20
 

--- a/meerk40t/gui/bufferview.py
+++ b/meerk40t/gui/bufferview.py
@@ -1,10 +1,10 @@
 import wx
 
+from meerk40t.kernel import _
+
 from .icons import icons8_comments
 from .mwindow import MWindow
 from .wxutils import dip_size
-
-_ = wx.GetTranslation
 
 
 class BufferViewPanel(wx.Panel):

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -10,10 +10,8 @@ from meerk40t.gui.wxutils import (
     TextCtrl,
     dip_size,
 )
-from meerk40t.kernel import Context
+from meerk40t.kernel import Context, _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class ChoicePropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -6,7 +6,7 @@ from wx import aui
 
 from meerk40t.gui.icons import STD_ICON_SIZE, icons8_console
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.kernel import get_safe_path, signal_listener
+from meerk40t.kernel import _, get_safe_path, signal_listener
 
 #
 # try:
@@ -15,7 +15,6 @@ from meerk40t.kernel import get_safe_path, signal_listener
 #     print("import of wx.richtext for console failed, using default console window")
 
 
-_ = wx.GetTranslation
 
 
 def background_color(colour):

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -4,9 +4,7 @@ from wx import aui
 from meerk40t.gui.icons import icons8_manager
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-from meerk40t.kernel import lookup_listener, signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, lookup_listener, signal_listener
 
 
 def register_panel(window, context):

--- a/meerk40t/gui/dialogoptions.py
+++ b/meerk40t/gui/dialogoptions.py
@@ -6,8 +6,7 @@ for a GRBL import / blob conversion
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class DialogOptions:

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -1,13 +1,11 @@
 import wx
 
-from meerk40t.kernel import signal_listener
+from meerk40t.kernel import _, signal_listener
 
 from .choicepropertypanel import ChoicePropertyPanel
 from .icons import STD_ICON_SIZE, icons8_laser_beam
 from .mwindow import MWindow
 from .wxutils import disable_window
-
-_ = wx.GetTranslation
 
 
 class PlannerPanel(wx.Panel):

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -15,9 +15,7 @@ from meerk40t.extra.hershey import (
 from meerk40t.gui.icons import STD_ICON_SIZE, icons8_choose_font
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-from meerk40t.kernel import get_safe_path
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, get_safe_path
 
 
 def create_preview_image(context, fontfile):

--- a/meerk40t/gui/imagesplitter.py
+++ b/meerk40t/gui/imagesplitter.py
@@ -3,10 +3,8 @@ import wx
 from meerk40t.gui.icons import STD_ICON_SIZE, icon_keyhole, icon_split_image
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import signal_listener
+from meerk40t.kernel import _, signal_listener
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class InfoPanel(wx.Panel):

--- a/meerk40t/gui/keymap.py
+++ b/meerk40t/gui/keymap.py
@@ -2,11 +2,11 @@ import platform
 
 import wx
 
+from meerk40t.kernel import _
+
 from .icons import icons8_keyboard
 from .mwindow import MWindow
 from .wxutils import get_key_name
-
-_ = wx.GetTranslation
 
 
 class KeymapPanel(wx.Panel):

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -24,9 +24,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     disable_window,
 )
-from meerk40t.kernel import lookup_listener, signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, lookup_listener, signal_listener
 
 
 def register_panel_laser(window, context):

--- a/meerk40t/gui/lasertoolpanel.py
+++ b/meerk40t/gui/lasertoolpanel.py
@@ -10,10 +10,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
-
+from meerk40t.kernel import _, signal_listener
 
 DEFAULT_LEN = "5cm"
 

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -13,10 +13,8 @@ from meerk40t.core.units import UNITS_PER_PIXEL, Angle, Length
 from meerk40t.gui.icons import STD_ICON_SIZE, icons8_detective
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import Settings, lookup_listener, signal_listener
+from meerk40t.kernel import Settings, _, lookup_listener, signal_listener
 from meerk40t.svgelements import Color, Matrix
-
-_ = wx.GetTranslation
 
 
 class SaveLoadPanel(wx.Panel):

--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -10,8 +10,7 @@ from wx import aui
 
 import meerk40t.gui.icons as mkicons
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 def register_panel_debugger(window, context):

--- a/meerk40t/gui/mwindow.py
+++ b/meerk40t/gui/mwindow.py
@@ -1,8 +1,6 @@
 import wx
 
-from meerk40t.kernel import Module
-
-_ = wx.GetTranslation
+from meerk40t.kernel import Module, _
 
 
 class MWindow(wx.Frame, Module):

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -49,10 +49,8 @@ from meerk40t.gui.icons import (
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.position import PositionPanel
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import signal_listener
+from meerk40t.kernel import _, signal_listener
 from meerk40t.svgelements import Angle
-
-_ = wx.GetTranslation
 
 
 def register_panel_navigation(window, context):

--- a/meerk40t/gui/notes.py
+++ b/meerk40t/gui/notes.py
@@ -1,10 +1,10 @@
 import wx
 from wx import aui
 
+from meerk40t.kernel import _
+
 from .icons import STD_ICON_SIZE, icons8_comments
 from .mwindow import MWindow
-
-_ = wx.GetTranslation
 
 
 def register_panel(window, context):

--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -12,11 +12,10 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.wxutils import dip_size
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
 
 from ..kernel import signal_listener
-
-_ = wx.GetTranslation
 
 
 def register_panel_operation_assign(window, context):

--- a/meerk40t/gui/operation_info.py
+++ b/meerk40t/gui/operation_info.py
@@ -11,9 +11,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class OpInfoPanel(ScrolledPanel):

--- a/meerk40t/gui/position.py
+++ b/meerk40t/gui/position.py
@@ -5,9 +5,7 @@ from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.units import UNITS_PER_PIXEL, Length
 from meerk40t.gui.icons import icons8_compress
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 def register_panel_position(window, context):

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -5,6 +5,7 @@ import platform
 
 import wx
 
+from meerk40t.kernel import _
 from meerk40t.kernel.kernel import signal_listener
 
 from .choicepropertypanel import ChoicePropertyPanel
@@ -12,8 +13,6 @@ from .icons import icons8_administrative_tools
 from .mwindow import MWindow
 from .wxmribbon import RibbonEditor
 from .wxutils import StaticBoxSizer, TextCtrl
-
-_ = wx.GetTranslation
 
 
 class PreferencesUnitsPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -6,9 +6,8 @@ import meerk40t.gui.icons as mkicons
 from meerk40t.core.units import Length
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.wxutils import CheckBox, StaticBoxSizer, TextCtrl, dip_size
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class ColorPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/blobproperty.py
+++ b/meerk40t/gui/propertypanels/blobproperty.py
@@ -1,13 +1,12 @@
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.kernel import _
 
 from ...core.node.blobnode import BlobNode
 from ..icons import icons8_vector
 from ..mwindow import MWindow
 from .attributes import IdPanel
-
-_ = wx.GetTranslation
 
 
 class BlobPropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/propertypanels/consoleproperty.py
+++ b/meerk40t/gui/propertypanels/consoleproperty.py
@@ -1,9 +1,9 @@
 import wx
 
+from meerk40t.kernel import _
+
 from ..icons import icons8_comments
 from ..mwindow import MWindow
-
-_ = wx.GetTranslation
 
 
 class ConsoleProperty(MWindow):

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -4,14 +4,13 @@ import time
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.kernel import _
 
 # from ...svgelements import SVG_ATTR_ID
 from ..icons import icons8_group_objects
 from ..mwindow import MWindow
 from ..wxutils import StaticBoxSizer
 from .attributes import IdPanel
-
-_ = wx.GetTranslation
 
 
 class ElemcountPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/hatchproperty.py
+++ b/meerk40t/gui/propertypanels/hatchproperty.py
@@ -1,13 +1,12 @@
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
+from meerk40t.kernel import _
 
 from ...core.units import Angle, Length
 from ...svgelements import Matrix
 from ..wxutils import TextCtrl, set_ctrl_value
 from .attributes import ColorPanel, IdPanel
-
-_ = wx.GetTranslation
 
 
 class HatchPropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -13,9 +13,8 @@ from meerk40t.gui.propertypanels.attributes import (
     PreventChangePanel,
 )
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, dip_size
+from meerk40t.kernel import _
 from meerk40t.svgelements import Matrix
-
-_ = wx.GetTranslation
 
 # The default value needs to be true, as the static method will be called before init happened...
 HAS_VECTOR_ENGINE = True

--- a/meerk40t/gui/propertypanels/inputproperty.py
+++ b/meerk40t/gui/propertypanels/inputproperty.py
@@ -1,9 +1,7 @@
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class InputPropertyPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/opbranchproperties.py
+++ b/meerk40t/gui/propertypanels/opbranchproperties.py
@@ -1,9 +1,7 @@
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class OpBranchPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -1,15 +1,13 @@
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, dip_size
-from meerk40t.kernel import lookup_listener, signal_listener
+from meerk40t.kernel import _, lookup_listener, signal_listener
 
 from ...core.units import UNITS_PER_MM, Length
 from ...svgelements import Angle, Color, Matrix
 from ..laserrender import swizzlecolor
 from ..wxutils import TextCtrl, set_ctrl_value
 from .attributes import IdPanel
-
-_ = wx.GetTranslation
 
 # OPERATION_TYPE_TOOLTIP = _(
 #     """Operation Type

--- a/meerk40t/gui/propertypanels/outputproperty.py
+++ b/meerk40t/gui/propertypanels/outputproperty.py
@@ -1,9 +1,7 @@
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class OutputPropertyPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -16,9 +16,8 @@ from meerk40t.gui.propertypanels.attributes import (
     StrokeWidthPanel,
 )
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class PathPropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/propertypanels/placementproperty.py
+++ b/meerk40t/gui/propertypanels/placementproperty.py
@@ -7,9 +7,7 @@ import wx
 from meerk40t.core.units import Angle, Length
 from meerk40t.gui.propertypanels.attributes import IdPanel
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, set_ctrl_value
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class PlacementPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/pointproperty.py
+++ b/meerk40t/gui/propertypanels/pointproperty.py
@@ -1,12 +1,11 @@
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.kernel import _
 
 from ..icons import icons8_vector
 from ..mwindow import MWindow
 from .attributes import ColorPanel, IdPanel, PositionSizePanel, PreventChangePanel
-
-_ = wx.GetTranslation
 
 
 class PointPropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -1,11 +1,11 @@
 import wx
 from wx import aui
 
+from meerk40t.kernel import _
+
 from ...kernel import signal_listener
 from ..icons import icons8_computer_support
 from ..mwindow import MWindow
-
-_ = wx.GetTranslation
 
 
 class PropertyWindow(MWindow):

--- a/meerk40t/gui/propertypanels/rasterwizardpanels.py
+++ b/meerk40t/gui/propertypanels/rasterwizardpanels.py
@@ -4,8 +4,7 @@ import wx
 
 from meerk40t.core.node.elem_image import ImageNode
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class ContrastPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -5,14 +5,13 @@ import wx
 from meerk40t.gui.fonts import wxfont_to_svg
 from meerk40t.gui.laserrender import LaserRender
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, dip_size
+from meerk40t.kernel import _
 
 from ...svgelements import Color
 from ..icons import STD_ICON_SIZE, icons8_choose_font, icons8_text
 from ..laserrender import swizzlecolor
 from ..mwindow import MWindow
 from .attributes import ColorPanel, IdPanel, PositionSizePanel, PreventChangePanel
-
-_ = wx.GetTranslation
 
 
 class PromptingComboBox(wx.ComboBox):

--- a/meerk40t/gui/propertypanels/waitproperty.py
+++ b/meerk40t/gui/propertypanels/waitproperty.py
@@ -1,9 +1,7 @@
 import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class WaitPropertyPanel(wx.Panel):

--- a/meerk40t/gui/propertypanels/wobbleproperty.py
+++ b/meerk40t/gui/propertypanels/wobbleproperty.py
@@ -1,12 +1,11 @@
 import wx
 
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
+from meerk40t.kernel import _
 
 from ...core.units import Length
 from ..wxutils import TextCtrl, set_ctrl_value
 from .attributes import ColorPanel, IdPanel
-
-_ = wx.GetTranslation
 
 
 class WobblePropertyPanel(ScrolledPanel):

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -48,10 +48,8 @@ import threading
 import wx
 
 from meerk40t.gui.icons import STD_ICON_SIZE, PyEmbeddedImage
-from meerk40t.kernel import Job
+from meerk40t.kernel import Job, _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 SMALL_RESIZE_FACTOR = 2 / 3
 TINY_RESIZE_FACTOR = 0.5

--- a/meerk40t/gui/scenewidgets/guidewidget.py
+++ b/meerk40t/gui/scenewidgets/guidewidget.py
@@ -6,8 +6,7 @@ from meerk40t.core.units import Length
 from meerk40t.gui.laserrender import DRAW_MODE_GUIDES
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.scene.widget import Widget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class GuideWidget(Widget):

--- a/meerk40t/gui/simpleui.py
+++ b/meerk40t/gui/simpleui.py
@@ -10,13 +10,13 @@ https://github.com/meerk40t/meerk40t/discussions/1944
 import wx
 from wx import aui
 
+from meerk40t.kernel import _
+
 from ..core.exceptions import BadFileError
 from .icons import icons8_computer_support, icons8_opened_folder
 from .mwindow import MWindow
 from .navigationpanels import Drag, Jog
 from .wxutils import StaticBoxSizer
-
-_ = wx.GetTranslation
 
 
 class JogMovePanel(wx.Panel):

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -3,7 +3,7 @@ import platform
 
 import wx
 
-from meerk40t.kernel import Job, signal_listener
+from meerk40t.kernel import Job, _, signal_listener
 
 from ..core.cutcode.cubiccut import CubicCut
 from ..core.cutcode.cutcode import CutCode
@@ -49,8 +49,6 @@ from .scenewidgets.bedwidget import BedWidget
 from .scenewidgets.gridwidget import GridWidget
 from .wxutils import StaticBoxSizer, dip_size
 from .zmatrix import ZMatrix
-
-_ = wx.GetTranslation
 
 
 class OperationsPanel(wx.Panel):

--- a/meerk40t/gui/snapoptions.py
+++ b/meerk40t/gui/snapoptions.py
@@ -1,9 +1,7 @@
 import wx
 from wx import aui
 
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 def register_panel_snapoptions(window, context):

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -14,9 +14,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import HoverButton
-from meerk40t.kernel import get_safe_path, signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, get_safe_path, signal_listener
 
 JC_INDEX = 0
 JC_DEVICE = 1

--- a/meerk40t/gui/statusbarwidgets/defaultoperations.py
+++ b/meerk40t/gui/statusbarwidgets/defaultoperations.py
@@ -6,10 +6,9 @@ from meerk40t.core.node.op_image import ImageOpNode
 from meerk40t.core.node.op_raster import RasterOpNode
 from meerk40t.gui.icons import EmptyIcon
 from meerk40t.gui.laserrender import swizzlecolor
+from meerk40t.kernel import _
 
 from .statusbarwidget import StatusBarWidget
-
-_ = wx.GetTranslation
 
 
 class DefaultOperationWidget(StatusBarWidget):

--- a/meerk40t/gui/statusbarwidgets/infowidget.py
+++ b/meerk40t/gui/statusbarwidgets/infowidget.py
@@ -10,9 +10,8 @@ from meerk40t.core.node.node import Node
 from meerk40t.core.units import UNITS_PER_INCH, Length
 from meerk40t.gui.icons import icons8_up
 from meerk40t.gui.statusbarwidgets.statusbarwidget import StatusBarWidget
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class SimpleInfoWidget(StatusBarWidget):

--- a/meerk40t/gui/statusbarwidgets/opassignwidget.py
+++ b/meerk40t/gui/statusbarwidgets/opassignwidget.py
@@ -10,11 +10,10 @@ from meerk40t.gui.icons import (
     icons8_laserbeam_weak,
 )
 from meerk40t.gui.laserrender import swizzlecolor
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
 
 from .statusbarwidget import StatusBarWidget
-
-_ = wx.GetTranslation
 
 
 class OperationAssignOptionWidget(StatusBarWidget):

--- a/meerk40t/gui/statusbarwidgets/selectionwidget.py
+++ b/meerk40t/gui/statusbarwidgets/selectionwidget.py
@@ -1,8 +1,8 @@
 import wx
 
-from .statusbarwidget import StatusBarWidget
+from meerk40t.kernel import _
 
-_ = wx.GetTranslation
+from .statusbarwidget import StatusBarWidget
 
 
 class SelectionOptionWidget(StatusBarWidget):

--- a/meerk40t/gui/statusbarwidgets/shapepropwidget.py
+++ b/meerk40t/gui/statusbarwidgets/shapepropwidget.py
@@ -10,10 +10,9 @@ from meerk40t.gui.icons import (
     icon_join_miter,
     icon_join_round,
 )
+from meerk40t.kernel import _
 
 from .statusbarwidget import StatusBarWidget
-
-_ = wx.GetTranslation
 
 
 class LinecapWidget(StatusBarWidget):

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -1,11 +1,10 @@
 import wx
 
 from meerk40t.core.elements.element_types import elem_nodes
+from meerk40t.kernel import _
 
 from ...core.units import Length
 from .statusbarwidget import StatusBarWidget
-
-_ = wx.GetTranslation
 
 
 class ColorWidget(StatusBarWidget):

--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -10,9 +10,8 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.svgelements import Ellipse
-
-_ = wx.GetTranslation
 
 
 class CircleTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -8,8 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class EllipseTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolimagecut.py
+++ b/meerk40t/gui/toolwidgets/toolimagecut.py
@@ -9,9 +9,8 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.tools.geomstr import Geomstr
-
-_ = wx.GetTranslation
 
 
 class ImageCutTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolline.py
+++ b/meerk40t/gui/toolwidgets/toolline.py
@@ -9,9 +9,8 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.tools.geomstr import Geomstr
-
-_ = wx.GetTranslation
 
 
 class LineTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toollinetext.py
+++ b/meerk40t/gui/toolwidgets/toollinetext.py
@@ -7,9 +7,8 @@ from meerk40t.extra.hershey import create_linetext_node, update_linetext
 from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color
-
-_ = wx.GetTranslation
 
 
 class LineTextTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -9,8 +9,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class MeasureTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -26,7 +26,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.kernel import signal_listener
+from meerk40t.kernel import _, signal_listener
 from meerk40t.svgelements import (
     Arc,
     Close,
@@ -40,8 +40,6 @@ from meerk40t.svgelements import (
     QuadraticBezier,
 )
 from meerk40t.tools.geomstr import Geomstr
-
-_ = wx.GetTranslation
 
 
 class EditTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolparameter.py
+++ b/meerk40t/gui/toolwidgets/toolparameter.py
@@ -4,8 +4,7 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class SimpleCheckbox:

--- a/meerk40t/gui/toolwidgets/toolplacement.py
+++ b/meerk40t/gui/toolwidgets/toolplacement.py
@@ -2,9 +2,8 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.svgelements import Point
-
-_ = wx.GetTranslation
 
 
 class PlacementTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolpolygon.py
+++ b/meerk40t/gui/toolwidgets/toolpolygon.py
@@ -17,10 +17,9 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.kernel.kernel import Job
 from meerk40t.svgelements import Point, Polygon
-
-_ = wx.GetTranslation
 
 
 class PolygonTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -8,8 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class RectTool(ToolWidget):

--- a/meerk40t/gui/toolwidgets/tooltext.py
+++ b/meerk40t/gui/toolwidgets/tooltext.py
@@ -5,9 +5,8 @@ from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 
 # from meerk40t.gui.toolwidgets.textentry import TextEntry
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.kernel import _
 from meerk40t.svgelements import Color, Matrix
-
-_ = wx.GetTranslation
 
 
 class TextTool(ToolWidget):

--- a/meerk40t/gui/usbconnect.py
+++ b/meerk40t/gui/usbconnect.py
@@ -2,8 +2,7 @@ import wx
 
 from meerk40t.gui.icons import icons8_usb_connector
 from meerk40t.gui.mwindow import MWindow
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class UsbConnectPanel(wx.Panel):

--- a/meerk40t/gui/utilitywidgets/openclosewidget.py
+++ b/meerk40t/gui/utilitywidgets/openclosewidget.py
@@ -6,8 +6,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_ABORT,
 )
 from meerk40t.gui.scene.widget import Widget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class OpenCloseWidget(Widget):

--- a/meerk40t/gui/utilitywidgets/togglewidget.py
+++ b/meerk40t/gui/utilitywidgets/togglewidget.py
@@ -8,8 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
 )
 from meerk40t.gui.scene.widget import Widget
 from meerk40t.gui.utilitywidgets.buttonwidget import ButtonWidget
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class ToggleWidget(Widget):

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -4,6 +4,8 @@ import re
 import wx
 from wx import aui
 
+from meerk40t.kernel import _
+
 from ..kernel import signal_listener
 from .icons import (
     STD_ICON_SIZE,
@@ -17,8 +19,6 @@ from .icons import (
 )
 from .mwindow import MWindow
 from .wxutils import StaticBoxSizer, dip_size
-
-_ = wx.GetTranslation
 
 
 def register_panel_wordlist(window, context):

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -753,16 +753,15 @@ class wxMeerK40t(wx.App, Module):
 
         context.app = self  # Registers self as kernel.app
 
-        context.setting(int, "language", None)
-        language = context.language
+        context.setting(str, "i18n", "en")
+        language = context.i18n
         from meerk40t.gui.help_assets.help_assets import asset
 
         def get_asset(asset_name):
             return asset(context, asset_name)
 
         context.asset = get_asset
-        if language is not None and language != 0:
-            self.update_language(language)
+        self.update_language(language)
 
         kernel.register("window/MeerK40t", MeerK40t)
 
@@ -905,27 +904,27 @@ class wxMeerK40t(wx.App, Module):
                     'Argument "sure" is required. Requires typing: "nuke_settings yes"'
                 )
 
-    def update_language(self, lang):
+    def update_language(self, lang_code):
         """
         Update language to the requested language.
         """
         context = self.context
-        try:
-            language_code, language_name, language_index = supported_languages[lang]
-        except (IndexError, ValueError):
-            return
-        context.language = lang
-        self.context.kernel.set_language(language_code)
-        if self.locale:
-            assert sys.getrefcount(self.locale) <= 2
-            del self.locale
-        self.locale = wx.Locale(language_index)
-        # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
-        if self.locale.IsOk() or platform.system() == "Linux":
-            self.locale.AddCatalog("meerk40t")
-        else:
-            self.locale = None
-        context.signal("language", (lang, language_code, language_name, language_index))
+        for i, suplang in enumerate(supported_languages):
+            language_code, language_name, language_index = suplang
+            if language_code != lang_code:
+                continue
+            context.i18n = language_code
+            self.context.kernel.set_language(language_code)
+            if self.locale:
+                assert sys.getrefcount(self.locale) <= 2
+                del self.locale
+            self.locale = wx.Locale(language_index)
+            # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
+            if self.locale.IsOk() or platform.system() == "Linux":
+                self.locale.AddCatalog("meerk40t")
+            else:
+                self.locale = None
+            context.signal("language", (i, language_code, language_name, language_index))
 
 
 # end of class MeerK40tGui

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -916,15 +916,15 @@ class wxMeerK40t(wx.App, Module):
             return
         context.language = lang
         self.context.kernel.set_language(language_code)
-        # if self.locale:
-        #     assert sys.getrefcount(self.locale) <= 2
-        #     del self.locale
-        # self.locale = wx.Locale(language_index)
-        # # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
-        # if self.locale.IsOk() or platform.system() == "Linux":
-        #     self.locale.AddCatalog("meerk40t")
-        # else:
-        #     self.locale = None
+        if self.locale:
+            assert sys.getrefcount(self.locale) <= 2
+            del self.locale
+        self.locale = wx.Locale(language_index)
+        # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
+        if self.locale.IsOk() or platform.system() == "Linux":
+            self.locale.AddCatalog("meerk40t")
+        else:
+            self.locale = None
         context.signal("language", (lang, language_code, language_name, language_index))
 
 

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -751,26 +751,6 @@ class wxMeerK40t(wx.App, Module):
         context = self.context
         kernel = context.kernel
 
-        try:  # pyinstaller internal location
-            # pylint: disable=no-member
-            _resource_path = os.path.join(sys._MEIPASS, "locale")
-            wx.Locale.AddCatalogLookupPathPrefix(_resource_path)
-        except Exception:
-            pass
-
-        try:  # Mac py2app resource
-            _resource_path = os.path.join(os.environ["RESOURCEPATH"], "locale")
-            wx.Locale.AddCatalogLookupPathPrefix(_resource_path)
-        except Exception:
-            pass
-
-        wx.Locale.AddCatalogLookupPathPrefix("locale")
-
-        # Default Locale, prepended. Check this first.
-        basepath = os.path.abspath(os.path.dirname(sys.argv[0]))
-        localedir = os.path.join(basepath, "locale")
-        wx.Locale.AddCatalogLookupPathPrefix(localedir)
-
         context.app = self  # Registers self as kernel.app
 
         context.setting(int, "language", None)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -95,7 +95,7 @@ The Transformations work in Windows/OSX/Linux for wxPython 4.0+ (and likely befo
 
 """
 
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class ActionPanel(wx.Panel):

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -771,8 +771,6 @@ class wxMeerK40t(wx.App, Module):
         localedir = os.path.join(basepath, "locale")
         wx.Locale.AddCatalogLookupPathPrefix(localedir)
 
-        kernel.translation = wx.GetTranslation
-
         context.app = self  # Registers self as kernel.app
 
         context.setting(int, "language", None)
@@ -937,16 +935,16 @@ class wxMeerK40t(wx.App, Module):
         except (IndexError, ValueError):
             return
         context.language = lang
-
-        if self.locale:
-            assert sys.getrefcount(self.locale) <= 2
-            del self.locale
-        self.locale = wx.Locale(language_index)
-        # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
-        if self.locale.IsOk() or platform.system() == "Linux":
-            self.locale.AddCatalog("meerk40t")
-        else:
-            self.locale = None
+        self.context.kernel.set_language(language_code)
+        # if self.locale:
+        #     assert sys.getrefcount(self.locale) <= 2
+        #     del self.locale
+        # self.locale = wx.Locale(language_index)
+        # # wxWidgets is broken. IsOk()==false and pops up error dialog, but it translates fine!
+        # if self.locale.IsOk() or platform.system() == "Linux":
+        #     self.locale.AddCatalog("meerk40t")
+        # else:
+        #     self.locale = None
         context.signal("language", (lang, language_code, language_name, language_index))
 
 

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -3366,36 +3366,36 @@ class MeerK40t(MWindow):
         self.SetMenuBar(self.main_menubar)
 
     def add_language_menu(self):
-        tl = wx.FileTranslationsLoader()
-        trans = tl.GetAvailableTranslations("meerk40t")
+        from ..kernel import _gettext_language
 
-        if trans:
-            wxglade_tmp_menu = wx.Menu()
-            i = 0
-            for lang in self.context.app.supported_languages:
-                language_code, language_name, language_index = lang
-                m = wxglade_tmp_menu.Append(
-                    wx.ID_ANY, language_name, language_name, wx.ITEM_RADIO
-                )
-                if i == self.context.language:
-                    m.Check(True)
+        trans = _gettext_language
+        if not trans:
+            trans = "en"
 
-                def language_update(q):
-                    def check(event):
-                        self.context.app.update_language(q)
-                        # Intentionally no translation...
-                        wx.MessageBox(
-                            message="This requires a program restart before the language change will kick in!",
-                            caption="Language changed",
-                        )
+        wxglade_tmp_menu = wx.Menu()
+        for lang in self.context.app.supported_languages:
+            language_code, language_name, language_index = lang
+            m = wxglade_tmp_menu.Append(
+                wx.ID_ANY, language_name, language_name, wx.ITEM_RADIO
+            )
+            if trans == language_code:
+                m.Check(True)
 
-                    return check
+            def language_update(q):
+                def check(event):
+                    self.context.app.update_language(q)
+                    # Intentionally no translation...
+                    wx.MessageBox(
+                        message="This requires a program restart before the language change will kick in!",
+                        caption="Language changed",
+                    )
 
-                self.Bind(wx.EVT_MENU, language_update(i), id=m.GetId())
-                if language_code not in trans and i != 0:
-                    m.Enable(False)
-                i += 1
-            self.main_menubar.Append(wxglade_tmp_menu, _("Languages"))
+                return check
+
+            self.Bind(wx.EVT_MENU, language_update(language_code), id=m.GetId())
+            # if language_code not in trans and i != 0:
+            #     m.Enable(False)
+        self.main_menubar.Append(wxglade_tmp_menu, _("Languages"))
 
     @signal_listener("file;loaded")
     @signal_listener("file;saved")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -26,7 +26,7 @@ from meerk40t.gui.statusbarwidgets.shapepropwidget import (
 )
 from meerk40t.gui.statusbarwidgets.statusbar import CustomStatusBar
 from meerk40t.gui.statusbarwidgets.strokewidget import ColorWidget, StrokeWidget
-from meerk40t.kernel import lookup_listener, signal_listener
+from meerk40t.kernel import _, lookup_listener, signal_listener
 
 from ..core.units import UNITS_PER_INCH, UNITS_PER_PIXEL, Length
 from ..svgelements import Color, Matrix, Path
@@ -106,8 +106,6 @@ from .laserrender import (
     swizzlecolor,
 )
 from .mwindow import MWindow
-
-_ = wx.GetTranslation
 
 
 class MeerK40t(MWindow):

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -37,9 +37,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.ribbon import RibbonBarPanel
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-from meerk40t.kernel import Settings, lookup_listener, signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import Settings, _, lookup_listener, signal_listener
 
 
 def register_panel_ribbon(window, context):

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -56,10 +56,8 @@ from meerk40t.gui.utilitywidgets.harmonograph import HarmonographWidget
 from meerk40t.gui.utilitywidgets.seekbarwidget import SeekbarWidget
 from meerk40t.gui.utilitywidgets.togglewidget import ToggleWidget
 from meerk40t.gui.wxutils import get_key_name, is_navigation_key
-from meerk40t.kernel import CommandSyntaxError, signal_listener
+from meerk40t.kernel import CommandSyntaxError, _, signal_listener
 from meerk40t.svgelements import Angle, Color
-
-_ = wx.GetTranslation
 
 
 def register_panel_scene(window, context):

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -2,6 +2,7 @@ import wx
 from wx import aui
 
 from meerk40t.core.elements.element_types import op_nodes
+from meerk40t.kernel import _
 
 from ..core.units import Length
 from ..kernel import signal_listener
@@ -51,8 +52,6 @@ from .wxutils import (
     get_key_name,
     is_navigation_key,
 )
-
-_ = wx.GetTranslation
 
 
 def register_panel_tree(window, context):

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -9,9 +9,7 @@ import wx.lib.mixins.listctrl as listmix
 from wx.lib.scrolledpanel import ScrolledPanel as SP
 
 from meerk40t.core.units import ACCEPTED_UNITS, Angle, Length
-
-_ = wx.GetTranslation
-
+from meerk40t.kernel import _
 
 ##############
 # DYNAMIC CHOICE

--- a/meerk40t/kernel/__init__.py
+++ b/meerk40t/kernel/__init__.py
@@ -20,7 +20,7 @@ def _(message):
 
 
 def set_language(domain, localedir, language):
-    el = gettext.translation(domain, localedir=localedir, languages=[language])
+    el = gettext.translation(domain, localedir=localedir, languages=[language], fallback=True)
     el.install()
     global _gettext
     _gettext = el.gettext

--- a/meerk40t/kernel/__init__.py
+++ b/meerk40t/kernel/__init__.py
@@ -12,7 +12,7 @@ from .module import *
 from .service import *
 from .settings import *
 
-_gettext = None
+_gettext = lambda e: e
 
 
 def _(message):

--- a/meerk40t/kernel/__init__.py
+++ b/meerk40t/kernel/__init__.py
@@ -13,6 +13,7 @@ from .service import *
 from .settings import *
 
 _gettext = lambda e: e
+_gettext_language = None
 
 
 def _(message):
@@ -43,10 +44,17 @@ def set_language(domain, localedir, language):
     working_dir = os.path.join(basepath, localedir)
     localedirs.append(working_dir)
 
+    localedirs.append(None)
+
     for localedir in localedirs:
-        el = gettext.translation(
-            domain, localedir=localedir, languages=[language]
-        )
+        try:
+            el = gettext.translation(
+                domain, localedir=localedir, languages=[language], fallback=localedir is None
+            )
+        except FileNotFoundError:
+            continue
         el.install()
-        global _gettext
+        global _gettext, _gettext_language
         _gettext = el.gettext
+        _gettext_language = language
+        break

--- a/meerk40t/kernel/__init__.py
+++ b/meerk40t/kernel/__init__.py
@@ -1,4 +1,5 @@
 """Standalone kernel enabling sophisticated console / UI applications."""
+import gettext
 
 from .channel import *
 from .context import *
@@ -10,3 +11,16 @@ from .lifecycles import *
 from .module import *
 from .service import *
 from .settings import *
+
+_gettext = None
+
+
+def _(message):
+    return _gettext(message)
+
+
+def set_language(domain, localedir, language):
+    el = gettext.translation(domain, localedir=localedir, languages=[language])
+    el.install()
+    global _gettext
+    _gettext = el.gettext

--- a/meerk40t/kernel/__init__.py
+++ b/meerk40t/kernel/__init__.py
@@ -20,7 +20,33 @@ def _(message):
 
 
 def set_language(domain, localedir, language):
-    el = gettext.translation(domain, localedir=localedir, languages=[language], fallback=True)
-    el.install()
-    global _gettext
-    _gettext = el.gettext
+    import sys
+
+    localedirs = list()
+    try:  # pyinstaller internal location
+        # pylint: disable=no-member
+        _resource_path = os.path.join(sys._MEIPASS, localedir)
+        localedirs.append(_resource_path)
+    except Exception:
+        pass
+
+    try:  # Mac py2app resource
+        _resource_path = os.path.join(os.environ["RESOURCEPATH"], localedir)
+        localedirs.append(_resource_path)
+    except Exception:
+        pass
+
+    localedirs.append(localedir)
+
+    # Default Locale, prepended. Check this first.
+    basepath = os.path.abspath(os.path.dirname(sys.argv[0]))
+    working_dir = os.path.join(basepath, localedir)
+    localedirs.append(working_dir)
+
+    for localedir in localedirs:
+        el = gettext.translation(
+            domain, localedir=localedir, languages=[language]
+        )
+        el.install()
+        global _gettext
+        _gettext = el.gettext

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -131,6 +131,8 @@ class Kernel(Settings):
         # define translation
         from . import _
         self.translation = _
+        if language is not None:
+            self.set_language(language)
 
         # The function used to process the signals. This is useful if signals should be kept to a single thread.
         self.scheduler_handles_main_thread_jobs = True

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -74,6 +74,7 @@ class Kernel(Settings):
         ansi: bool = True,
         ignore_settings: bool = False,
         delay: float = 0.05,  # 20 ticks per second
+        language: str = None,
     ):
         """
         Initialize the Kernel. This sets core attributes of the ecosystem that are accessible to all modules.

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -127,8 +127,9 @@ class Kernel(Settings):
         self._dirty_paths = []
         self._lookup_lock = threading.Lock()
 
-        # The translation object to be overridden by any valid translation functions
-        self.translation = lambda e: e
+        # define translation
+        from . import _
+        self.translation = _
 
         # The function used to process the signals. This is useful if signals should be kept to a single thread.
         self.scheduler_handles_main_thread_jobs = True
@@ -170,6 +171,10 @@ class Kernel(Settings):
 
     def __str__(self):
         return "Kernel()"
+
+    def set_language(self, language, localedir="locale"):
+        from . import set_language
+        set_language(self.name, localedir=localedir, language=language)
 
     def open_safe(self, filename, *args):
         """

--- a/meerk40t/lihuiyu/gui/lhyaccelgui.py
+++ b/meerk40t/lihuiyu/gui/lhyaccelgui.py
@@ -3,8 +3,7 @@ import wx
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class LihuiyuAccelerationChartPanel(ScrolledPanel):

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -15,9 +15,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 _simple_width = 500
 _advanced_width = 952

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -7,9 +7,7 @@ from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 FIX_SPEEDS_RATIO = 0.9195
 

--- a/meerk40t/lihuiyu/gui/lhyoperationproperties.py
+++ b/meerk40t/lihuiyu/gui/lhyoperationproperties.py
@@ -1,8 +1,7 @@
 import wx
 
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class LhyAdvancedPanel(wx.Panel):

--- a/meerk40t/lihuiyu/gui/tcpcontroller.py
+++ b/meerk40t/lihuiyu/gui/tcpcontroller.py
@@ -3,9 +3,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import TextCtrl, dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class TCPController(MWindow):

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -112,6 +112,13 @@ parser.add_argument(
     default=False,
     help="Don't load config file at startup",
 )
+parser.add_argument(
+    "-L",
+    "--language",
+    type=str,
+    default=None,
+    help="force default language",
+)
 
 
 def run():
@@ -153,6 +160,7 @@ def run():
         APPLICATION_NAME,
         ansi=not args.disable_ansi,
         ignore_settings=args.nuke_settings,
+        language=args.language
     )
     kernel.args = args
     kernel.add_plugin(internal_plugins)

--- a/meerk40t/moshi/gui/moshicontrollergui.py
+++ b/meerk40t/moshi/gui/moshicontrollergui.py
@@ -5,9 +5,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 _simple_width = 500
 _advanced_width = 855

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -6,8 +6,7 @@ from meerk40t.device.gui.warningpanel import WarningPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class MoshiDriverGui(MWindow):

--- a/meerk40t/newly/gui/newlyconfig.py
+++ b/meerk40t/newly/gui/newlyconfig.py
@@ -6,8 +6,7 @@ from meerk40t.device.gui.warningpanel import WarningPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class NewlyConfiguration(MWindow):

--- a/meerk40t/newly/gui/newlycontroller.py
+++ b/meerk40t/newly/gui/newlycontroller.py
@@ -5,9 +5,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class NewlyControllerPanel(wx.ScrolledWindow):

--- a/meerk40t/newly/gui/operationproperties.py
+++ b/meerk40t/newly/gui/operationproperties.py
@@ -5,7 +5,7 @@
 #
 # from ..newly_params import Parameters
 #
-# _ = wx.GetTranslation
+# from meerk40t.kernel import _
 #
 #
 # class NewlyOperationPanel(ScrolledPanel):

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -8,8 +8,7 @@ import wx
 from meerk40t.gui.icons import icon_rotary
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, dip_size
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class RotarySettingsPanel(ScrolledPanel):

--- a/meerk40t/ruida/gui/ruidaconfig.py
+++ b/meerk40t/ruida/gui/ruidaconfig.py
@@ -6,8 +6,7 @@ from meerk40t.device.gui.warningpanel import WarningPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class RuidaConfiguration(MWindow):

--- a/meerk40t/ruida/gui/ruidacontroller.py
+++ b/meerk40t/ruida/gui/ruidacontroller.py
@@ -5,9 +5,7 @@ import wx
 from meerk40t.gui.icons import icons8_connected, icons8_disconnected
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import dip_size
-from meerk40t.kernel import signal_listener
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _, signal_listener
 
 
 class RuidaControllerPanel(wx.ScrolledWindow):

--- a/meerk40t/ruida/gui/ruidaoperationproperties.py
+++ b/meerk40t/ruida/gui/ruidaoperationproperties.py
@@ -2,8 +2,7 @@ import wx
 
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.wxutils import ScrolledPanel
-
-_ = wx.GetTranslation
+from meerk40t.kernel import _
 
 
 class RuidaOperationPanel(ScrolledPanel):

--- a/meerk40t/tools/kerftest.py
+++ b/meerk40t/tools/kerftest.py
@@ -12,10 +12,8 @@ from meerk40t.core.units import UNITS_PER_PIXEL, Length
 from meerk40t.gui.icons import STD_ICON_SIZE, icon_kerf, icons8_detective
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
-from meerk40t.kernel import lookup_listener, signal_listener
+from meerk40t.kernel import _, lookup_listener, signal_listener
 from meerk40t.svgelements import Color, Matrix, Polyline
-
-_ = wx.GetTranslation
 
 
 class KerfPanel(wx.Panel):

--- a/meerk40t/tools/livinghinges.py
+++ b/meerk40t/tools/livinghinges.py
@@ -8,13 +8,12 @@ from meerk40t.gui.icons import STD_ICON_SIZE, icon_hinges
 from meerk40t.gui.laserrender import LaserRender
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import StaticBoxSizer, dip_size
-from meerk40t.kernel import signal_listener
+from meerk40t.kernel import _, signal_listener
 from meerk40t.svgelements import Color, Matrix, Path
 
 # from meerk40t.fill.patternfill import LivingHinges
 
 
-_ = wx.GetTranslation
 
 """
 TODO:


### PR DESCRIPTION
Test implementation of #2103

gettext translation routines are built into python standardly, and we can use the translation routines outside of wxPython and the gui and even as early as the CLI if we use the python standard gettext implementation rather than the wxPython version.

* Still requires setting the language for wxPython since it has a few things like dates which are relevant based on region.
* Should be much easier to integrate different catalogs to divide up the needed translations better.
* Previously untranslated text that was outside the GUI needs to be flagged as needing translation.
* Needs to be tested with builds to see whether the included .mo files are correctly found in their _MEIPASS directory
* Needs a better understanding of how to add translations to already existing translations so as to permit plugins, even non-gui plugins to use their own translations.
* Needs a better understanding of how things could potentially be better organized into multiple files, though that could be done with the .po files to build a single primary .mo file.