### PR TITLE
Selection fixes

### DIFF
--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -160,7 +160,8 @@ class CircleTool(ToolWidget):
             self.p2 = None
             self.scene.pane.tool_active = False
             self.scene.request_refresh()
-            response = RESPONSE_ABORT
+            # Allow other widgets (like the selection widget to take over)
+            response = RESPONSE_CHAIN
         elif event_type == "leftup":
             self.scene.pane.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -138,7 +138,8 @@ class EllipseTool(ToolWidget):
             self.p2 = None
             self.scene.pane.tool_active = False
             self.scene.request_refresh()
-            response = RESPONSE_ABORT
+            # Allow other widgets (like the selection widget to take over)
+            response = RESPONSE_CHAIN
         elif event_type == "leftup":
             self.scene.pane.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolimagecut.py
+++ b/meerk40t/gui/toolwidgets/toolimagecut.py
@@ -96,7 +96,8 @@ class ImageCutTool(ToolWidget):
             self.p2 = None
             self.scene.pane.tool_active = False
             self.scene.request_refresh()
-            response = RESPONSE_ABORT
+            # Allow other widgets (like the selection widget to take over)
+            response = RESPONSE_CHAIN
         elif event_type == "leftup":
             self.scene.pane.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolline.py
+++ b/meerk40t/gui/toolwidgets/toolline.py
@@ -96,7 +96,8 @@ class LineTool(ToolWidget):
             self.p2 = None
             self.scene.pane.tool_active = False
             self.scene.request_refresh()
-            response = RESPONSE_ABORT
+            # Allow other widgets (like the selection widget to take over)
+            response = RESPONSE_CHAIN
         elif event_type == "leftup":
             self.scene.pane.tool_active = False
             try:

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -135,7 +135,8 @@ class RectTool(ToolWidget):
             self.p2 = None
             self.scene.pane.tool_active = False
             self.scene.request_refresh()
-            response = RESPONSE_ABORT
+            # Allow other widgets (like the selection widget to take over)
+            response = RESPONSE_CHAIN
         elif event_type == "leftup":
             self.scene.pane.tool_active = False
             try:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -3838,7 +3838,7 @@ class MeerK40t(MWindow):
         self.context(".laserpath_clear\n")
         self.validate_save()
         kernel.busyinfo.end()
-        self.context("tool none\n")
+        self.context(".tool none\n")
 
     def clear_and_open(self, pathname, preferred_loader=None):
         self.clear_project(ops_too=False)
@@ -3939,9 +3939,11 @@ class MeerK40t(MWindow):
 
     def on_click_open(self, event=None):  # wxGlade: MeerK40t.<event_handler>
         self.context(".dialog_load\n")
+        self.context(".tool none\n")
 
     def on_click_import(self, event=None):  # wxGlade: MeerK40t.<event_handler>
         self.context(".dialog_import\n")
+        self.context(".tool none\n")
 
     def on_click_stop(self, event=None):
         self.context("estop\n")
@@ -3951,9 +3953,11 @@ class MeerK40t(MWindow):
 
     def on_click_save(self, event):
         self.context(".dialog_save\n")
+        self.context(".tool none\n")
 
     def on_click_save_as(self, event=None):
         self.context(".dialog_save_as\n")
+        self.context(".tool none\n")
 
     def on_click_close(self, event=None):
         try:


### PR DESCRIPTION
- File operations reset the tool to ``tool none``
- Singleclicks could not generate element primitives (circle, ellipse, rect etc.) but weren't passed along either