### PR TITLE
Make m2nano controller window a bit more compact

### DIFF
--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -10388,7 +10388,7 @@ msgstr "Verbindungsstatus"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:237
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "IP/Hostname des Servers"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/es/LC_MESSAGES/meerk40t.po
+++ b/locale/es/LC_MESSAGES/meerk40t.po
@@ -12657,7 +12657,7 @@ msgstr "Estado de la conección"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr ""
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/fr/LC_MESSAGES/meerk40t.po
+++ b/locale/fr/LC_MESSAGES/meerk40t.po
@@ -12650,7 +12650,7 @@ msgstr ""
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr ""
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/hu/LC_MESSAGES/meerk40t.po
+++ b/locale/hu/LC_MESSAGES/meerk40t.po
@@ -12724,7 +12724,7 @@ msgstr "Kapcsolat állapota"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "IP/Host, ha ez a szerver"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/it/LC_MESSAGES/meerk40t.po
+++ b/locale/it/LC_MESSAGES/meerk40t.po
@@ -12863,7 +12863,7 @@ msgstr "Stato della connessione"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "IP/Host del computer server"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/ja/LC_MESSAGES/meerk40t.po
+++ b/locale/ja/LC_MESSAGES/meerk40t.po
@@ -12706,7 +12706,7 @@ msgstr "接続状態"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "サーバーコンピュータの場合はIP /ホスト"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/messages.po
+++ b/locale/messages.po
@@ -12650,7 +12650,7 @@ msgstr ""
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr ""
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/nl/LC_MESSAGES/meerk40t.po
+++ b/locale/nl/LC_MESSAGES/meerk40t.po
@@ -12765,7 +12765,7 @@ msgstr "Verbindingsstatus"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "IP/Host van de servercomputer"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/pt_BR/LC_MESSAGES/meerk40t.po
+++ b/locale/pt_BR/LC_MESSAGES/meerk40t.po
@@ -12650,7 +12650,7 @@ msgstr ""
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr ""
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/pt_PT/LC_MESSAGES/meerk40t.po
+++ b/locale/pt_PT/LC_MESSAGES/meerk40t.po
@@ -12772,7 +12772,7 @@ msgstr "Estado da ligação"
 #: meerk40t/grbl/gui/tcpcontroller.py:70
 #: meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "IP/Hospedeiro se o computador servidor"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71

--- a/locale/zh/LC_MESSAGES/meerk40t.po
+++ b/locale/zh/LC_MESSAGES/meerk40t.po
@@ -12612,7 +12612,7 @@ msgstr "连接状态"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:70 meerk40t/lihuiyu/gui/lhydrivergui.py:228
 #: meerk40t/lihuiyu/gui/tcpcontroller.py:73
-msgid "IP/Host if the server computer"
+msgid "IP/hostname of the server computer"
 msgstr "服务器计算机的 IP/主机"
 
 #: meerk40t/grbl/gui/tcpcontroller.py:71 meerk40t/lihuiyu/gui/lhydrivergui.py:242

--- a/meerk40t/grbl/gui/grblcontroller.py
+++ b/meerk40t/grbl/gui/grblcontroller.py
@@ -34,7 +34,7 @@ class GRBLControllerPanel(wx.Panel):
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
 
         self.state = None
-        self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
+        self.button_device_connect = wx.Button(self, wx.ID_ANY, self.button_connect_string("Connection"))
         self.button_device_connect.SetBackgroundColour(wx.Colour(102, 255, 102))
         self.button_device_connect.SetFont(
             wx.Font(
@@ -120,6 +120,21 @@ class GRBLControllerPanel(wx.Panel):
         self._buffer_lock = threading.Lock()
         # end wxGlade
 
+
+    def button_connect_string(self, pattern):
+        res = _(pattern)
+        context = self.service
+        if context.permit_serial and context.interface == "serial":
+            iface = "?" if context.serial_port is None else context.serial_port
+        elif context.permit_tcp and context.interface == "tcp":
+            iface = f"{context.address}:{context.port}"
+        else:
+            # Mock
+            iface = "Mock"
+
+        res += f" ({iface})"
+        return res
+    
     def on_clear_log(self, event):
         self.data_exchange.SetValue("")
 
@@ -186,7 +201,7 @@ class GRBLControllerPanel(wx.Panel):
         self.state = state
         if state == "uninitialized" or state == "disconnected":
             self.button_device_connect.SetBackgroundColour("#ffff00")
-            self.button_device_connect.SetLabel(_("Connect"))
+            self.button_device_connect.SetLabel(self.button_connect_string("Connect"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
                     use_theme=False, resize=get_default_icon_size()
@@ -195,7 +210,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.Enable()
         elif state == "connected":
             self.button_device_connect.SetBackgroundColour("#00ff00")
-            self.button_device_connect.SetLabel(_("Disconnect"))
+            self.button_device_connect.SetLabel(self.button_connect_string("Disconnect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
                     use_theme=False, resize=get_default_icon_size()
@@ -210,7 +225,7 @@ class GRBLControllerPanel(wx.Panel):
             or self.state == "disconnected"
         ):
             self.button_device_connect.SetBackgroundColour("#ffff00")
-            self.button_device_connect.SetLabel(_("Connect"))
+            self.button_device_connect.SetLabel(self.button_connect_string("Connect"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
                     use_theme=False, resize=get_default_icon_size()
@@ -219,7 +234,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.Enable()
         elif self.state == "connected":
             self.button_device_connect.SetBackgroundColour("#00ff00")
-            self.button_device_connect.SetLabel(_("Disconnect"))
+            self.button_device_connect.SetLabel(self.button_connect_string("Disconnect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
                     use_theme=False, resize=get_default_icon_size()

--- a/meerk40t/grbl/gui/grblcontroller.py
+++ b/meerk40t/grbl/gui/grblcontroller.py
@@ -32,7 +32,7 @@ class GRBLControllerPanel(wx.Panel):
         kwds["style"] = kwds.get("style", 0)
         wx.Panel.__init__(self, *args, **kwds)
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
-
+        self.iconsize = 0.75 * get_default_icon_size()
         self.state = None
         self.button_device_connect = wx.Button(self, wx.ID_ANY, self.button_connect_string("Connection"))
         self.button_device_connect.SetBackgroundColour(wx.Colour(102, 255, 102))
@@ -50,7 +50,7 @@ class GRBLControllerPanel(wx.Panel):
             _("Force connection/disconnection from the device.")
         )
         self.button_device_connect.SetBitmap(
-            icons8_connected.GetBitmap(use_theme=False, resize=get_default_icon_size())
+            icons8_connected.GetBitmap(use_theme=False, resize=self.iconsize)
         )
         sizer_1.Add(self.button_device_connect, 0, wx.EXPAND, 0)
 
@@ -204,7 +204,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.SetLabel(self.button_connect_string("Connect"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=self.iconsize
                 )
             )
             self.button_device_connect.Enable()
@@ -213,7 +213,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.SetLabel(self.button_connect_string("Disconnect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=self.iconsize
                 )
             )
             self.button_device_connect.Enable()
@@ -228,7 +228,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.SetLabel(self.button_connect_string("Connect"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=self.iconsize
                 )
             )
             self.button_device_connect.Enable()
@@ -237,7 +237,7 @@ class GRBLControllerPanel(wx.Panel):
             self.button_device_connect.SetLabel(self.button_connect_string("Disconnect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=self.iconsize
                 )
             )
             self.button_device_connect.Enable()

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -20,9 +20,9 @@ from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
-_simple_width = 500
+_simple_width = 565
 _advanced_width = 952
-_default_height = 584
+_default_height = 570
 
 
 class LihuiyuControllerPanel(ScrolledPanel):
@@ -46,7 +46,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.rejected_packet_count_text = wx.TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.packet_text_text = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_packet_info = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.text_byte_0 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.text_byte_1 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.text_desc = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
@@ -96,7 +96,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.button_device_connect.SetForegroundColour(wx.BLACK)
         self.button_device_connect.SetFont(
             wx.Font(
-                12,
+                11,
                 wx.FONTFAMILY_DEFAULT,
                 wx.FONTSTYLE_NORMAL,
                 wx.FONTWEIGHT_NORMAL,
@@ -113,7 +113,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.button_controller_control.SetForegroundColour(wx.BLACK)
         self.button_controller_control.SetFont(
             wx.Font(
-                12,
+                11,
                 wx.FONTFAMILY_DEFAULT,
                 wx.FONTSTYLE_NORMAL,
                 wx.FONTWEIGHT_NORMAL,
@@ -127,30 +127,30 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.text_controller_status.SetToolTip(
             _("Displays the controller's current process.")
         )
-        self.packet_count_text.SetMinSize(dip_size(self, 77, 23))
+        self.packet_count_text.SetMinSize(dip_size(self, 35, -1))
         self.packet_count_text.SetToolTip(_("Total number of packets sent"))
-        self.rejected_packet_count_text.SetMinSize(dip_size(self, 77, 23))
+        self.rejected_packet_count_text.SetMinSize(dip_size(self, 35, -1))
         self.rejected_packet_count_text.SetToolTip(
             _("Total number of packets rejected")
         )
-        self.packet_text_text.SetToolTip(_("Last packet information sent"))
-        self.text_byte_0.SetMinSize(dip_size(self, 77, 23))
-        self.text_byte_1.SetMinSize(dip_size(self, 77, 23))
-        self.text_desc.SetMinSize(dip_size(self, 75, 23))
+        self.text_packet_info.SetToolTip(_("Last packet information sent"))
+        self.text_byte_0.SetMinSize(dip_size(self, 35, -1))
+        self.text_byte_1.SetMinSize(dip_size(self, 35, -1))
+        self.text_desc.SetMinSize(dip_size(self, 35, -1))
         self.text_desc.SetToolTip(_("The meaning of Byte 1"))
-        self.text_byte_2.SetMinSize(dip_size(self, 77, 23))
-        self.text_byte_3.SetMinSize(dip_size(self, 77, 23))
-        self.text_byte_4.SetMinSize(dip_size(self, 77, 23))
-        self.text_byte_5.SetMinSize(dip_size(self, 77, 23))
+        self.text_byte_2.SetMinSize(dip_size(self, 35, -1))
+        self.text_byte_3.SetMinSize(dip_size(self, 35, -1))
+        self.text_byte_4.SetMinSize(dip_size(self, 35, -1))
+        self.text_byte_5.SetMinSize(dip_size(self, 35, -1))
         self.checkbox_show_usb_log.SetValue(1)
         self.button_device_connect.SetBitmap(
             icons8_disconnected.GetBitmap(
-                use_theme=False, resize=get_default_icon_size()
+                use_theme=False, resize=0.75 * get_default_icon_size()
             )
         )
         self.button_controller_control.SetBitmap(
             icons8_circled_play.GetBitmap(
-                use_theme=False, resize=get_default_icon_size()
+                use_theme=False, resize=0.75 * get_default_icon_size()
             )
         )
         # end wxGlade
@@ -186,22 +186,27 @@ class LihuiyuControllerPanel(ScrolledPanel):
         sizer_11 = StaticBoxSizer(self, wx.ID_ANY, _("Device Bus:"), wx.HORIZONTAL)
         sizer_10 = StaticBoxSizer(self, wx.ID_ANY, _("Device Address:"), wx.HORIZONTAL)
         sizer_3 = StaticBoxSizer(self, wx.ID_ANY, _("Device Index:"), wx.HORIZONTAL)
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer_usb_connect = StaticBoxSizer(
             self, wx.ID_ANY, _("USB Connection"), wx.VERTICAL
         )
         sizer_usb_connect.Add(self.button_device_connect, 0, wx.EXPAND, 0)
         sizer_usb_connect.Add(self.text_connection_status, 0, wx.EXPAND, 0)
-        sizer_main_vertical.Add(sizer_usb_connect, 0, wx.EXPAND, 0)
+        button_sizer.Add(sizer_usb_connect, 1, wx.EXPAND, 0)
+
         sizer_controller.Add(self.button_controller_control, 0, wx.EXPAND, 0)
         sizer_controller.Add(self.text_controller_status, 0, wx.EXPAND, 0)
-        sizer_main_vertical.Add(sizer_controller, 0, wx.EXPAND, 0)
+        button_sizer.Add(sizer_controller, 1, wx.EXPAND, 0)
+
+        sizer_main_vertical.Add(button_sizer, 0, wx.EXPAND, 0)
+
         sizer_count_packets.Add(self.packet_count_text, 0, wx.EXPAND, 0)
         sizer_statistics.Add(sizer_count_packets, 1, wx.EXPAND, 0)
         sizer_count_rejected.Add(self.rejected_packet_count_text, 0, wx.EXPAND, 0)
         sizer_statistics.Add(sizer_count_rejected, 1, wx.EXPAND, 0)
         sizer_statistics.Add(self.button_clear_stats, 0, wx.EXPAND, 0)
         packet_count.Add(sizer_statistics, 1, wx.EXPAND, 0)
-        packet_info.Add(self.packet_text_text, 11, wx.EXPAND, 0)
+        packet_info.Add(self.text_packet_info, 11, wx.EXPAND, 0)
         packet_count.Add(packet_info, 0, wx.EXPAND, 0)
         byte0sizer.Add(self.text_byte_0, 0, 0, 0)
         label_1 = wx.StaticText(self, wx.ID_ANY, _("Byte 0"))
@@ -235,7 +240,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
         sizer_show_usb_log.Add(self.checkbox_show_usb_log, 0, 0, 0)
         sizer_main_vertical.Add(sizer_show_usb_log, 1, wx.EXPAND, 0)
         sizer_main.Add(sizer_main_vertical, 1, 0, 0)
-        sizer_main.Add(self.text_usb_log, 2, wx.EXPAND, 0)
+        sizer_main.Add(self.text_usb_log, 1, wx.EXPAND, 0)
         self.SetSizer(sizer_main)
         self.Layout()
         # end wxGlade
@@ -335,7 +340,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
         if origin != self.context._path:
             return
         if string_data is not None and len(string_data) != 0:
-            self.packet_text_text.SetValue(str(string_data))
+            self.text_packet_info.SetValue(str(string_data))
 
     @signal_listener("pipe;usb_status")
     def on_connection_status_change(self, origin, status):
@@ -356,7 +361,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Connect failed"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -366,7 +371,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Retrying..."))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -376,7 +381,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Suspended Retrying"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -386,7 +391,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("No Backend"))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -395,7 +400,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Connect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -404,7 +409,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Disconnecting..."))
             self.button_device_connect.SetBitmap(
                 icons8_disconnected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Disable()
@@ -413,7 +418,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Disconnect"))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Enable()
@@ -422,7 +427,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             self.button_device_connect.SetLabel(_("Connecting..."))
             self.button_device_connect.SetBitmap(
                 icons8_connected.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             self.button_device_connect.Disable()
@@ -482,7 +487,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetLabel(_("Hold Controller"))
             button.SetBitmap(
                 icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             button.Enable(True)
@@ -491,7 +496,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetLabel(_("LOCKED"))
             button.SetBitmap(
                 icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             button.Enable(False)
@@ -505,7 +510,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetLabel(_("Force Continue"))
             button.SetBitmap(
                 icons8_laser_beam_hazard.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             button.Enable(True)
@@ -519,7 +524,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetLabel(_("Resume Controller"))
             button.SetBitmap(
                 icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             button.Enable(True)
@@ -532,7 +537,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetBackgroundColour("#00ff00")
             button.SetLabel(_("Pause Controller"))
             button.SetBitmap(
-                icons8_pause.GetBitmap(use_theme=False, resize=get_default_icon_size())
+                icons8_pause.GetBitmap(use_theme=False, resize=0.75 * get_default_icon_size())
             )
             button.Enable(True)
         elif state == "terminate":
@@ -545,7 +550,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
             button.SetLabel(_("Manual Reset"))
             button.SetBitmap(
                 icons8_emergency_stop_button.GetBitmap(
-                    use_theme=False, resize=get_default_icon_size()
+                    use_theme=False, resize=0.75 * get_default_icon_size()
                 )
             )
             button.Enable(True)
@@ -584,13 +589,16 @@ class LihuiyuControllerGui(MWindow):
         # ==========
         # MENUBAR END
         # ==========
-
         self.panel = LihuiyuControllerPanel(self, wx.ID_ANY, context=self.context)
         self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected.GetBitmap())
         self.SetIcon(_icon)
         self.SetTitle(_("Lihuiyu-Controller"))
+        mainsizer = wx.BoxSizer(wx.VERTICAL)
+        mainsizer.Add(self.panel, 1, wx.EXPAND, 0)
+        self.SetSizer(mainsizer)
+        self.Layout()
 
     def create_menu(self, append):
         wxglade_tmp_menu = wx.Menu()

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -41,13 +41,13 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.text_connection_status = wx.TextCtrl(
             self, wx.ID_ANY, connectivity, style=wx.TE_READONLY
         )
-        self.button_controller_control = wx.Button(
-            self, wx.ID_ANY, _("Start Controller")
-        )
-        self.button_controller_control.function = lambda: self.context("start\n")
-        self.text_controller_status = wx.TextCtrl(
-            self, wx.ID_ANY, "", style=wx.TE_READONLY
-        )
+        # self.button_controller_control = wx.Button(
+        #     self, wx.ID_ANY, _("Start Controller")
+        # )
+        # self.button_controller_control.function = lambda: self.context("start\n")
+        # self.text_controller_status = wx.TextCtrl(
+        #     self, wx.ID_ANY, "", style=wx.TE_READONLY
+        # )
         self.packet_count_text = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.rejected_packet_count_text = wx.TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
@@ -71,11 +71,11 @@ class LihuiyuControllerPanel(ScrolledPanel):
 
         self.Bind(wx.EVT_BUTTON, self.on_button_start_usb, self.button_device_connect)
         self.Bind(wx.EVT_BUTTON, self.on_button_reset_stats, self.button_clear_stats)
-        self.Bind(
-            wx.EVT_BUTTON,
-            self.on_button_start_controller,
-            self.button_controller_control,
-        )
+        # self.Bind(
+        #     wx.EVT_BUTTON,
+        #     self.on_button_start_controller,
+        #     self.button_controller_control,
+        # )
         self.Bind(
             wx.EVT_CHECKBOX, self.on_check_show_usb_log, self.checkbox_show_usb_log
         )
@@ -115,24 +115,24 @@ class LihuiyuControllerPanel(ScrolledPanel):
         )
         self.text_connection_status.SetToolTip(_("Connection status"))
 
-        self.button_controller_control.SetBackgroundColour(wx.Colour(102, 255, 102))
-        self.button_controller_control.SetForegroundColour(wx.BLACK)
-        self.button_controller_control.SetFont(
-            wx.Font(
-                11,
-                wx.FONTFAMILY_DEFAULT,
-                wx.FONTSTYLE_NORMAL,
-                wx.FONTWEIGHT_NORMAL,
-                0,
-                "Segoe UI",
-            )
-        )
-        self.button_controller_control.SetToolTip(
-            _("Change the currently performed operation.")
-        )
-        self.text_controller_status.SetToolTip(
-            _("Displays the controller's current process.")
-        )
+        # self.button_controller_control.SetBackgroundColour(wx.Colour(102, 255, 102))
+        # self.button_controller_control.SetForegroundColour(wx.BLACK)
+        # self.button_controller_control.SetFont(
+        #     wx.Font(
+        #         11,
+        #         wx.FONTFAMILY_DEFAULT,
+        #         wx.FONTSTYLE_NORMAL,
+        #         wx.FONTWEIGHT_NORMAL,
+        #         0,
+        #         "Segoe UI",
+        #     )
+        # )
+        # self.button_controller_control.SetToolTip(
+        #     _("Change the currently performed operation.")
+        # )
+        # self.text_controller_status.SetToolTip(
+        #     _("Displays the controller's current process.")
+        # )
         self.packet_count_text.SetMinSize(dip_size(self, 35, -1))
         self.packet_count_text.SetToolTip(_("Total number of packets sent"))
         self.rejected_packet_count_text.SetMinSize(dip_size(self, 35, -1))
@@ -154,11 +154,11 @@ class LihuiyuControllerPanel(ScrolledPanel):
                 use_theme=False, resize=0.75 * get_default_icon_size()
             )
         )
-        self.button_controller_control.SetBitmap(
-            icons8_circled_play.GetBitmap(
-                use_theme=False, resize=0.75 * get_default_icon_size()
-            )
-        )
+        # self.button_controller_control.SetBitmap(
+        #     icons8_circled_play.GetBitmap(
+        #         use_theme=False, resize=0.75 * get_default_icon_size()
+        #     )
+        # )
         # end wxGlade
 
     def __do_layout(self):
@@ -200,9 +200,9 @@ class LihuiyuControllerPanel(ScrolledPanel):
         sizer_usb_connect.Add(self.text_connection_status, 0, wx.EXPAND, 0)
         button_sizer.Add(sizer_usb_connect, 1, wx.EXPAND, 0)
 
-        sizer_controller.Add(self.button_controller_control, 0, wx.EXPAND, 0)
-        sizer_controller.Add(self.text_controller_status, 0, wx.EXPAND, 0)
-        button_sizer.Add(sizer_controller, 1, wx.EXPAND, 0)
+        # sizer_controller.Add(self.button_controller_control, 0, wx.EXPAND, 0)
+        # sizer_controller.Add(self.text_controller_status, 0, wx.EXPAND, 0)
+        # button_sizer.Add(sizer_controller, 1, wx.EXPAND, 0)
 
         sizer_main_vertical.Add(button_sizer, 0, wx.EXPAND, 0)
 
@@ -469,105 +469,105 @@ class LihuiyuControllerPanel(ScrolledPanel):
         elif state in ("STATE_CONNECTED", "STATE_USB_CONNECTED"):
             self.context("usb_disconnect\n")
 
-    @signal_listener("pipe;thread")
-    def on_control_state(self, origin, state):
-        if origin != self.context._path:
-            return
-
-        if self.last_control_state == state:
-            return
-        self.last_control_state = state
-        button = self.button_controller_control
-        if self.text_controller_status is None:
-            return
-        value = self.context.kernel.get_text_thread_state(state)
-        self.text_controller_status.SetValue(str(value))
-        if state in ("init", "end", "idle"):
-
-            def f(event=None):
-                self.context("start\n")
-                self.context("hold\n")
-
-            button.function = f
-            button.SetBackgroundColour("#009900")
-            button.SetLabel(_("Hold Controller"))
-            button.SetBitmap(
-                icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=0.75 * get_default_icon_size()
-                )
-            )
-            button.Enable(True)
-        elif state == "busy":
-            button.SetBackgroundColour("#00dd00")
-            button.SetLabel(_("LOCKED"))
-            button.SetBitmap(
-                icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=0.75 * get_default_icon_size()
-                )
-            )
-            button.Enable(False)
-        elif state == "wait":
-
-            def f(event=None):
-                self.context("continue\n")
-
-            button.function = f
-            button.SetBackgroundColour("#dddd00")
-            button.SetLabel(_("Force Continue"))
-            button.SetBitmap(
-                icons8_laser_beam_hazard.GetBitmap(
-                    use_theme=False, resize=0.75 * get_default_icon_size()
-                )
-            )
-            button.Enable(True)
-        elif state == "pause":
-
-            def f(event=None):
-                self.context("resume\n")
-
-            button.function = f
-            button.SetBackgroundColour("#00dd00")
-            button.SetLabel(_("Resume Controller"))
-            button.SetBitmap(
-                icons8_circled_play.GetBitmap(
-                    use_theme=False, resize=0.75 * get_default_icon_size()
-                )
-            )
-            button.Enable(True)
-        elif state == "active":
-
-            def f(event=None):
-                self.context("hold\n")
-
-            button.function = f
-            button.SetBackgroundColour("#00ff00")
-            button.SetLabel(_("Pause Controller"))
-            button.SetBitmap(
-                icons8_pause.GetBitmap(use_theme=False, resize=0.75 * get_default_icon_size())
-            )
-            button.Enable(True)
-        elif state == "terminate":
-
-            def f(event=None):
-                self.context("abort\n")
-
-            button.function = f
-            button.SetBackgroundColour("#00ffff")
-            button.SetLabel(_("Manual Reset"))
-            button.SetBitmap(
-                icons8_emergency_stop_button.GetBitmap(
-                    use_theme=False, resize=0.75 * get_default_icon_size()
-                )
-            )
-            button.Enable(True)
+    # @signal_listener("pipe;thread")
+    # def on_control_state(self, origin, state):
+    #     if origin != self.context._path:
+    #         return
+    #
+    #     if self.last_control_state == state:
+    #         return
+    #     self.last_control_state = state
+    #     button = self.button_controller_control
+    #     if self.text_controller_status is None:
+    #         return
+    #     value = self.context.kernel.get_text_thread_state(state)
+    #     self.text_controller_status.SetValue(str(value))
+    #     if state in ("init", "end", "idle"):
+    #
+    #         def f(event=None):
+    #             self.context("start\n")
+    #             self.context("hold\n")
+    #
+    #         button.function = f
+    #         button.SetBackgroundColour("#009900")
+    #         button.SetLabel(_("Hold Controller"))
+    #         button.SetBitmap(
+    #             icons8_circled_play.GetBitmap(
+    #                 use_theme=False, resize=0.75 * get_default_icon_size()
+    #             )
+    #         )
+    #         button.Enable(True)
+    #     elif state == "busy":
+    #         button.SetBackgroundColour("#00dd00")
+    #         button.SetLabel(_("LOCKED"))
+    #         button.SetBitmap(
+    #             icons8_circled_play.GetBitmap(
+    #                 use_theme=False, resize=0.75 * get_default_icon_size()
+    #             )
+    #         )
+    #         button.Enable(False)
+    #     elif state == "wait":
+    #
+    #         def f(event=None):
+    #             self.context("continue\n")
+    #
+    #         button.function = f
+    #         button.SetBackgroundColour("#dddd00")
+    #         button.SetLabel(_("Force Continue"))
+    #         button.SetBitmap(
+    #             icons8_laser_beam_hazard.GetBitmap(
+    #                 use_theme=False, resize=0.75 * get_default_icon_size()
+    #             )
+    #         )
+    #         button.Enable(True)
+    #     elif state == "pause":
+    #
+    #         def f(event=None):
+    #             self.context("resume\n")
+    #
+    #         button.function = f
+    #         button.SetBackgroundColour("#00dd00")
+    #         button.SetLabel(_("Resume Controller"))
+    #         button.SetBitmap(
+    #             icons8_circled_play.GetBitmap(
+    #                 use_theme=False, resize=0.75 * get_default_icon_size()
+    #             )
+    #         )
+    #         button.Enable(True)
+    #     elif state == "active":
+    #
+    #         def f(event=None):
+    #             self.context("hold\n")
+    #
+    #         button.function = f
+    #         button.SetBackgroundColour("#00ff00")
+    #         button.SetLabel(_("Pause Controller"))
+    #         button.SetBitmap(
+    #             icons8_pause.GetBitmap(use_theme=False, resize=0.75 * get_default_icon_size())
+    #         )
+    #         button.Enable(True)
+    #     elif state == "terminate":
+    #
+    #         def f(event=None):
+    #             self.context("abort\n")
+    #
+    #         button.function = f
+    #         button.SetBackgroundColour("#00ffff")
+    #         button.SetLabel(_("Manual Reset"))
+    #         button.SetBitmap(
+    #             icons8_emergency_stop_button.GetBitmap(
+    #                 use_theme=False, resize=0.75 * get_default_icon_size()
+    #             )
+    #         )
+    #         button.Enable(True)
 
     @signal_listener("pipe;failing")
     def on_usb_failing(self, origin, count):
         self.retries = count
 
-    def on_button_start_controller(self, event=None):
-        event.Skip()
-        self.button_controller_control.function()
+    # def on_button_start_controller(self, event=None):
+    #     event.Skip()
+    #     self.button_controller_control.function()
 
     def on_check_show_usb_log(self, event=None):
         on = self.checkbox_show_usb_log.GetValue()

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -32,8 +32,14 @@ class LihuiyuControllerPanel(ScrolledPanel):
         self.context = context.device
 
         self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
+        if self.context.mock:
+            connectivity = "Mock-Device"
+        elif self.context.networked:
+            connectivity = f"Network: {self.context.address}:{self.context.port}"
+        else:
+            connectivity = "USB"
         self.text_connection_status = wx.TextCtrl(
-            self, wx.ID_ANY, "", style=wx.TE_READONLY
+            self, wx.ID_ANY, connectivity, style=wx.TE_READONLY
         )
         self.button_controller_control = wx.Button(
             self, wx.ID_ANY, _("Start Controller")
@@ -616,6 +622,10 @@ class LihuiyuControllerGui(MWindow):
         self.Bind(wx.EVT_MENU, self.on_menu_pause, id=item.GetId())
         item = wxglade_tmp_menu.Append(wx.ID_ANY, _("Stop"), "")
         self.Bind(wx.EVT_MENU, self.on_menu_stop, id=item.GetId())
+        wxglade_tmp_menu.AppendSeparator()
+        item = wxglade_tmp_menu.Append(wx.ID_ANY, _("Configuration"), "")
+        self.Bind(wx.EVT_MENU, self.on_menu_config, id=item.GetId())
+
         append(wxglade_tmp_menu, _("Commands"))
         wxglade_tmp_menu = wx.Menu()
         item = wxglade_tmp_menu.Append(
@@ -626,6 +636,9 @@ class LihuiyuControllerGui(MWindow):
 
     def window_preserve(self):
         return False
+
+    def on_menu_config(self, event):
+        self.context("window open Configuration\n")
 
     def on_menu_usb_reset(self, event):
         try:

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -223,7 +223,7 @@ class ConfigurationTcp(wx.Panel):
 
         self.text_address = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_address.SetMinSize(dip_size(self, 75, -1))
-        self.text_address.SetToolTip(_("IP/Host if the server computer"))
+        self.text_address.SetToolTip(_("IP/hostname of the server computer"))
         h_sizer_y1.Add(self.text_address, 1, wx.EXPAND, 0)
 
         sizer_port = StaticBoxSizer(self, wx.ID_ANY, _("Port"), wx.VERTICAL)

--- a/meerk40t/lihuiyu/gui/tcpcontroller.py
+++ b/meerk40t/lihuiyu/gui/tcpcontroller.py
@@ -6,7 +6,7 @@ from meerk40t.gui.icons import (
     icons8_disconnected,
 )
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import TextCtrl, dip_size
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size
 from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
@@ -14,19 +14,19 @@ _ = wx.GetTranslation
 
 class TCPController(MWindow):
     def __init__(self, *args, **kwds):
-        super().__init__(499, 170, *args, **kwds)
+        super().__init__(500, 200, *args, **kwds)
         self.button_device_connect = wx.Button(self, wx.ID_ANY, _("Connection"))
         self.service = self.context.device
-        self.text_status = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_status = wx.TextCtrl(self, wx.ID_ANY, "",  style=wx.TE_PROCESS_ENTER)
         self.text_ip_host = TextCtrl(
-            self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER, check="empty"
+            self, wx.ID_ANY, "", limited=True, style=wx.TE_PROCESS_ENTER, check="empty"
         )
         self.text_port = TextCtrl(
-            self, wx.ID_ANY, "", check="float", style=wx.TE_PROCESS_ENTER
+            self, wx.ID_ANY, "", check="int", limited=True, style=wx.TE_PROCESS_ENTER
         )
         self.gauge_buffer = wx.Gauge(self, wx.ID_ANY, 10)
-        self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
 
         self.__set_properties()
         self.__do_layout()
@@ -39,6 +39,7 @@ class TCPController(MWindow):
         # end wxGlade
         self.max = 0
         self.state = None
+        # self.on_tcp_buffer(None, 20)
 
     def on_port_change(self):
         try:
@@ -55,6 +56,7 @@ class TCPController(MWindow):
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icons8_connected.GetBitmap())
         self.SetIcon(_icon)
+        self.SetBackgroundColour(None)
         self.button_device_connect.SetBackgroundColour(wx.Colour(102, 255, 102))
         self.button_device_connect.SetForegroundColour(wx.BLACK)
         self.button_device_connect.SetFont(
@@ -76,53 +78,63 @@ class TCPController(MWindow):
             )
         )
         self.text_status.SetToolTip(_("Connection status"))
-        self.text_ip_host.SetToolTip(_("IP/Host if the server computer"))
+        self.text_ip_host.SetToolTip(_("IP/hostname of the server computer"))
         self.text_port.SetToolTip(_("Port for tcp connection on the server computer"))
-        self.text_buffer_length.SetMinSize(dip_size(self, 165, -1))
+        self.text_buffer_length.SetMinSize(dip_size(self, 45, -1))
+        self.text_buffer_length.SetMaxSize(dip_size(self, 75, -1))
         self.text_buffer_length.SetToolTip(
             _("Current number of bytes in the write buffer.")
         )
-        self.text_buffer_max.SetMinSize(dip_size(self, 165, -1))
+        self.text_buffer_max.SetMinSize(dip_size(self, 45, -1))
+        self.text_buffer_max.SetMaxSize(dip_size(self, 75, -1))
         self.text_buffer_max.SetToolTip(
-            _("Current number of bytes in the write buffer.")
+            _("Highest number of bytes in the write buffer.")
         )
         # end wxGlade
 
     def __do_layout(self):
         # begin wxGlade: Controller.__do_layout
-        sizer_1 = wx.BoxSizer(wx.VERTICAL)
-        write_buffer = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_main = wx.BoxSizer(wx.VERTICAL)
         connection_controller = wx.BoxSizer(wx.VERTICAL)
-        sizer_15 = wx.BoxSizer(wx.HORIZONTAL)
         connection_controller.Add(self.button_device_connect, 0, wx.EXPAND, 0)
-        label_7 = wx.StaticText(self, wx.ID_ANY, _("Status"))
+
+        sizer_connection = wx.BoxSizer(wx.HORIZONTAL)
+        info_left = StaticBoxSizer(self, wx.ID_ANY, label=_("Status"), orientation=wx.HORIZONTAL)
+        info_left.Add(self.text_status, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        sizer_connection.Add(info_left, 1, wx.EXPAND, 0)
+
+        info_right = StaticBoxSizer(self, wx.ID_ANY, label=_("Connection"), orientation=wx.HORIZONTAL)
         label_8 = wx.StaticText(self, wx.ID_ANY, _("Address"))
+        info_right.Add(label_8, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        info_right.Add(self.text_ip_host, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        info_right.AddSpacer(20)
         label_9 = wx.StaticText(self, wx.ID_ANY, _("Port"))
+        info_right.Add(label_9, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        info_right.Add(self.text_port, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        sizer_15.Add(label_7, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_15.Add(self.text_status, 11, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_15.Add(label_8, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_15.Add(self.text_ip_host, 11, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_15.Add((20, 20), 0, 0, 0)
-        sizer_15.Add(label_9, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_15.Add(self.text_port, 11, wx.ALIGN_CENTER_VERTICAL, 0)
+        sizer_connection.Add(info_right, 2, wx.EXPAND, 0)
+        connection_controller.Add(sizer_connection, 0, wx.EXPAND, 0)
 
-        connection_controller.Add(sizer_15, 0, 0, 0)
+        sizer_main.Add(connection_controller, 0, wx.EXPAND, 0)
+        buffer_sizer = StaticBoxSizer(self, wx.ID_ANY, label=_("Buffer"), orientation=wx.VERTICAL)
+        buffer_sizer.Add(self.gauge_buffer, 0, wx.EXPAND, 0)
 
-        sizer_1.Add(connection_controller, 0, wx.EXPAND, 0)
-        static_line_2 = wx.StaticLine(self, wx.ID_ANY)
-        static_line_2.SetMinSize(dip_size(self, 483, 5))
-        sizer_1.Add(static_line_2, 0, wx.EXPAND, 0)
-        sizer_1.Add(self.gauge_buffer, 0, wx.EXPAND, 0)
         label_12 = wx.StaticText(self, wx.ID_ANY, _("Buffer Size: "))
-        write_buffer.Add(label_12, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        write_buffer.Add(self.text_buffer_length, 10, wx.ALIGN_CENTER_VERTICAL, 0)
-        write_buffer.Add((20, 20), 0, 0, 0)
+        total_write_buffer = wx.BoxSizer(wx.HORIZONTAL)
+        left_buffer = wx.BoxSizer(wx.HORIZONTAL)
+        right_buffer = wx.BoxSizer(wx.HORIZONTAL)
+        left_buffer.Add(label_12, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        left_buffer.Add(self.text_buffer_length, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        total_write_buffer.Add(left_buffer, 1, wx.EXPAND, 0)
+
         label_13 = wx.StaticText(self, wx.ID_ANY, _("Max Buffer Size:"))
-        write_buffer.Add(label_13, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        write_buffer.Add(self.text_buffer_max, 10, wx.ALIGN_CENTER_VERTICAL, 0)
-        sizer_1.Add(write_buffer, 0, 0, 0)
-        self.SetSizer(sizer_1)
+        right_buffer.Add(label_13, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        right_buffer.Add(self.text_buffer_max, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        total_write_buffer.Add(right_buffer, 1, wx.EXPAND, 0)
+        buffer_sizer.Add(total_write_buffer, 0, wx.EXPAND, 0)
+
+        sizer_main.Add(buffer_sizer, 0, wx.EXPAND, 0)
+        self.SetSizer(sizer_main)
         self.Layout()
         # end wxGlade
 


### PR DESCRIPTION
Made control sizes a bit more compact for Lihuiyu controller:

![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/7378af78-eeff-4357-bcec-d61add0b2840)


Added device info to controll button for GRBL + reduced bitmap size a bit

![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/157fd870-48e8-40d8-af11-414518de65dd)
