### PR TITLE
Add in GRBL Interpolation tweaks.

### DIFF
--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1459,6 +1459,72 @@ class Geomstr:
             yield end
             at_start = False
 
+    def as_equal_interpolated_segments(self, distance=100):
+        """
+        Interpolated segments gives interpolated points as a generator of lists.
+
+        At points of disjoint, the list is yielded.
+        @param distance:
+        @return:
+        """
+        segments = list()
+        for point in self.as_equal_interpolated_points(distance=distance):
+            if point is None:
+                if segments:
+                    yield segments
+                    segments = list()
+            else:
+                segments.append(point)
+        if segments:
+            yield segments
+
+    def as_equal_interpolated_points(self, distance=100):
+        at_start = True
+        end = None
+        for e in self.segments[: self.index]:
+            seg_type = int(e[2].real)
+            start = e[0]
+            if end != start and not at_start:
+                # Start point does not equal previous end point.
+                yield None
+                at_start = True
+                if seg_type == TYPE_END:
+                    # End segments, flag new start but should not be returned.
+                    continue
+            end = e[4]
+            if at_start:
+                yield start
+            at_start = False
+            if seg_type == TYPE_LINE:
+                yield end
+                continue
+            if seg_type == TYPE_QUAD:
+                quads = self._quad_position(e, np.linspace(0, 1, 1000))
+                last = quads[0]
+                for d in quads[1:-1]:
+                    if abs(last - d) > distance:
+                        yield d
+                        last = d
+                yield quads[-1]
+            elif seg_type == TYPE_CUBIC:
+                cubics = self._cubic_position(e, np.linspace(0, 1, 1000))
+                last = cubics[0]
+                for d in cubics[1:-1]:
+                    if abs(last - d) > distance:
+                        yield d
+                        last = d
+                yield cubics[-1]
+            elif seg_type == TYPE_ARC:
+                arcs = self._arc_position(e, np.linspace(0, 1, 1000))
+                last = arcs[0]
+                for d in arcs[1:-1]:
+                    if abs(last - d) > distance:
+                        yield d
+                        last = d
+                yield arcs[-1]
+            elif seg_type == TYPE_END:
+                at_start = True
+
     def as_interpolated_segments(self, interpolate=100):
         """
         Interpolated segments gives interpolated points as a generator of lists.

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1499,29 +1499,35 @@ class Geomstr:
                 yield end
                 continue
             if seg_type == TYPE_QUAD:
-                quads = self._quad_position(e, np.linspace(0, 1, 1000))
-                last = quads[0]
-                for d in quads[1:-1]:
-                    if abs(last - d) > distance:
-                        yield d
-                        last = d
-                yield quads[-1]
+                ts = np.linspace(0, 1, 1000)
+                pts = self._quad_position(e, ts)
+                distances = np.abs(pts[:-1] - pts[1:])
+                distances = np.cumsum(distances)
+                max_distance = distances[-1]
+                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                near_t = np.searchsorted(distances, dist_values, side="right")
+                pts = pts[near_t]
+                yield from pts
             elif seg_type == TYPE_CUBIC:
-                cubics = self._cubic_position(e, np.linspace(0, 1, 1000))
-                last = cubics[0]
-                for d in cubics[1:-1]:
-                    if abs(last - d) > distance:
-                        yield d
-                        last = d
-                yield cubics[-1]
+                ts = np.linspace(0, 1, 1000)
+                pts = self._cubic_position(e, ts)
+                distances = np.abs(pts[:-1] - pts[1:])
+                distances = np.cumsum(distances)
+                max_distance = distances[-1]
+                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                near_t = np.searchsorted(distances, dist_values, side="right")
+                pts = pts[near_t]
+                yield from pts
             elif seg_type == TYPE_ARC:
-                arcs = self._arc_position(e, np.linspace(0, 1, 1000))
-                last = arcs[0]
-                for d in arcs[1:-1]:
-                    if abs(last - d) > distance:
-                        yield d
-                        last = d
-                yield arcs[-1]
+                ts = np.linspace(0, 1, 1000)
+                pts = self._arc_position(e, ts)
+                distances = np.abs(pts[:-1] - pts[1:])
+                distances = np.cumsum(distances)
+                max_distance = distances[-1]
+                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                near_t = np.searchsorted(distances, dist_values, side="right")
+                pts = pts[near_t]
+                yield from pts
             elif seg_type == TYPE_END:
                 at_start = True
 

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1504,7 +1504,9 @@ class Geomstr:
                 distances = np.abs(pts[:-1] - pts[1:])
                 distances = np.cumsum(distances)
                 max_distance = distances[-1]
-                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                dist_values = np.linspace(
+                    0, max_distance, int(np.ceil(max_distance / distance))
+                )[1:]
                 near_t = np.searchsorted(distances, dist_values, side="right")
                 pts = pts[near_t]
                 yield from pts
@@ -1514,7 +1516,9 @@ class Geomstr:
                 distances = np.abs(pts[:-1] - pts[1:])
                 distances = np.cumsum(distances)
                 max_distance = distances[-1]
-                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                dist_values = np.linspace(
+                    0, max_distance, int(np.ceil(max_distance / distance))
+                )[1:]
                 near_t = np.searchsorted(distances, dist_values, side="right")
                 pts = pts[near_t]
                 yield from pts
@@ -1524,7 +1528,9 @@ class Geomstr:
                 distances = np.abs(pts[:-1] - pts[1:])
                 distances = np.cumsum(distances)
                 max_distance = distances[-1]
-                dist_values = np.linspace(0, max_distance, int(np.ceil(max_distance / distance)))[1:]
+                dist_values = np.linspace(
+                    0, max_distance, int(np.ceil(max_distance / distance))
+                )[1:]
                 near_t = np.searchsorted(distances, dist_values, side="right")
                 pts = pts[near_t]
                 yield from pts

--- a/test/test_geomstr.py
+++ b/test/test_geomstr.py
@@ -562,12 +562,16 @@ class TestGeomstr(unittest.TestCase):
         @return:
         """
         path = Geomstr()
-        path.cubic((77.46150486344618+8.372252124023593j), (99.5707686371264+1.7675099427501895j), (48.146907914727855+48.97717310792103j), (26.350415653100136+77.5272640600043j))
+        path.cubic(
+            (77.46150486344618 + 8.372252124023593j),
+            (99.5707686371264 + 1.7675099427501895j),
+            (48.146907914727855 + 48.97717310792103j),
+            (26.350415653100136 + 77.5272640600043j),
+        )
         p = np.array(list(path.as_equal_interpolated_points(5)))
         distances = np.abs(p[:-1] - p[1:])
         for d in distances:
             self.assertAlmostEqual(d, 5, delta=1)
-
 
     # def test_geomstr_cubic_equal_distances(self):
     #     for i in range(5):

--- a/test/test_geomstr.py
+++ b/test/test_geomstr.py
@@ -538,6 +538,54 @@ class TestGeomstr(unittest.TestCase):
             t = random.random()
             self.assertEqual(c.point(t), path.position(0, t))
 
+    def test_geomstr_quad_equal_distances(self):
+        """
+        Ballpark estimate that the lines are 5 units apart. Really due to speed and curvature they could be less.
+        Also with distribution of the remaining length it could be more.
+        @return:
+        """
+        path = Geomstr()
+        path.quad(
+            (2.4597240004342713 + 51.217173195366975j),
+            (58.07775791133034 + 9.86075895321774j),
+            (58.09621943136784 + 98.90335897241886j),
+        )
+        p = np.array(list(path.as_equal_interpolated_points(5)))
+        distances = np.abs(p[:-1] - p[1:])
+        for d in distances:
+            self.assertAlmostEqual(d, 5, delta=1)
+
+    def test_geomstr_cubic_equal_distances(self):
+        """
+        Ballpark estimate that the lines are 5 units apart. Really due to speed and curvature they could be less.
+        Also with distribution of the remaining length it could be more.
+        @return:
+        """
+        path = Geomstr()
+        path.cubic((77.46150486344618+8.372252124023593j), (99.5707686371264+1.7675099427501895j), (48.146907914727855+48.97717310792103j), (26.350415653100136+77.5272640600043j))
+        p = np.array(list(path.as_equal_interpolated_points(5)))
+        distances = np.abs(p[:-1] - p[1:])
+        for d in distances:
+            self.assertAlmostEqual(d, 5, delta=1)
+
+
+    # def test_geomstr_cubic_equal_distances(self):
+    #     for i in range(5):
+    #         start = random_point()
+    #         c1 = random_point()
+    #         c2 = random_point()
+    #         end = random_point()
+    #         path = Geomstr()
+    #         path.cubic(start, c1, c2, end)
+    #         print(f"curve: {start}, {c1}, {c2}, {end}")
+    #         p = np.array(list(path.as_equal_interpolated_points(5)))
+    #         distances = np.abs(p[:-1] - p[1:])
+    #         print(p)
+    #         print(distances)
+    #         for d in distances:
+    #             self.assertAlmostEqual(d, 5, delta=1)
+    #         print("\n")
+
     def test_geomstr_cubic_length(self):
         """
         This test is too time-consuming without scipy installed


### PR DESCRIPTION
See Discord discussion (11-21-2023 11:29 PM PST). The GRBL code interpolates a curve into 50 subpoints regardless how intricate the curve is. This means small fragments of curve are made more fragmented and does not account for the speed change within bezier curves ( https://youtu.be/aVwxzDHniEw?si=nUytSTNjguAWS1nn&t=907 ).

The algorithm around this is usually to use a lookup table of distance and slice into that lookup table. Here I did a bit of a different thing but it mostly would work slightly inferior.