### PR TITLE
Simplify geometric calls in wxmtree.

### DIFF
--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -189,6 +189,20 @@ class EllipseNode(Node, Stroked, FunctionalParameter):
             )
         return xmin, ymin, xmax, ymax
 
+    def length(self):
+        """
+        The calculation of the length of an ellipse using the Ramanujan approximation
+        @return:
+        """
+        a = abs(complex(*self.matrix.transform_vector([self.rx, 0])))
+        b = abs(complex(*self.matrix.transform_vector([0,self.ry])))
+        if a == b:
+            return tau * self.rx
+        if b > a:
+            a, b = b, a
+        h = ((a - b) * (a - b)) / ((a + b) * (a + b))
+        return tau / 2 * (a + b) * (1 + (3 * h / (10 + sqrt(4 - 3 * h))))
+
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = False
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -180,6 +180,9 @@ class LineNode(Node, Stroked, FunctionalParameter):
             )
         return xmin, ymin, xmax, ymax
 
+    def length(self):
+        return abs(self.p1 - self.p2)
+
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = False
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -96,6 +96,14 @@ class LineNode(Node, Stroked, FunctionalParameter):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"
 
     @property
+    def p1(self):
+        return complex(*self.matrix.point_in_matrix_space((self.x1, self.y1)))
+
+    @property
+    def p2(self):
+        return complex(*self.matrix.point_in_matrix_space((self.x2, self.y2)))
+
+    @property
     def shape(self):
         return SimpleLine(
             x1=self.x1,

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -147,6 +147,10 @@ class PathNode(Node, Stroked, FunctionalParameter):
             )
         return xmin, ymin, xmax, ymax
 
+    def length(self):
+        g = self.as_geometry()
+        return g.length()
+
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = False
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -63,6 +63,9 @@ class PointNode(Node, FunctionalParameter):
         p = self.matrix.point_in_matrix_space((x, y))
         return p[0], p[1], p[0], p[1]
 
+    def length(self):
+        return 0
+
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Point"

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -172,6 +172,11 @@ class PolylineNode(Node, Stroked, FunctionalParameter):
             )
         return xmin, ymin, xmax, ymax
 
+    def length(self):
+        geometry = self.as_geometry()
+        # Polylines have length === raw_length
+        return geometry.raw_length()
+
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = False
         self.stroke_scaled = True

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -91,6 +91,9 @@ class PolylineNode(Node, Stroked, FunctionalParameter):
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"
 
+    def __len__(self):
+        return len(self.geometry)
+
     @property
     def shape(self):
         if self.closed:

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -176,6 +176,9 @@ class RectNode(Node, Stroked, FunctionalParameter):
             )
         return xmin, ymin, xmax, ymax
 
+    def length(self):
+        return self.width + self.width + self.height + self.height
+
     def preprocess(self, context, matrix, plan):
         self.stroke_scaled = False
         self.stroke_scaled = True

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1949,7 +1949,7 @@ class ShadowTree:
                             hh = Length(amount=bb[3] - bb[1], digits=1)
                             ll = Length(amount=node.length(), digits=1)
                             ttip = f"{ww.length_mm} x {hh.length_mm}, L={ll.length_mm}"
-                            ttip += f"\n{len(node.shape.points)} pts"
+                            ttip += f"\n{len(node)} pts"
                     elif node.type == "elem ellipse":
                         bb = node.bounds
                         if bb is not None:

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1933,21 +1933,21 @@ class ShadowTree:
                         if bb is not None:
                             ww = Length(amount=bb[2] - bb[0], digits=1)
                             hh = Length(amount=bb[3] - bb[1], digits=1)
-                            ll = Length(amount=node.shape.length(), digits=1)
+                            ll = Length(amount=node.length(), digits=1)
                             ttip = f"{ww.length_mm} x {hh.length_mm}, L={ll.length_mm}"
                     elif node.type == "elem rect":
                         bb = node.bounds
                         if bb is not None:
                             ww = Length(amount=bb[2] - bb[0], digits=1)
                             hh = Length(amount=bb[3] - bb[1], digits=1)
-                            ll = Length(amount=node.shape.length(), digits=1)
+                            ll = Length(amount=node.length(), digits=1)
                             ttip = f"{ww.length_mm} x {hh.length_mm}, L={ll.length_mm}"
                     elif node.type == "elem polyline":
                         bb = node.bounds
                         if bb is not None:
                             ww = Length(amount=bb[2] - bb[0], digits=1)
                             hh = Length(amount=bb[3] - bb[1], digits=1)
-                            ll = Length(amount=node.shape.length(), digits=1)
+                            ll = Length(amount=node.length(), digits=1)
                             ttip = f"{ww.length_mm} x {hh.length_mm}, L={ll.length_mm}"
                             ttip += f"\n{len(node.shape.points)} pts"
                     elif node.type == "elem ellipse":

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -4649,7 +4649,7 @@ class Geomstr:
     def raw_length(self):
         """
         Determines the raw length of the geoms. Where length is taken as the distance
-        from start to end (ignoring any curving), real length would be greater than this
+        from start to end (ignoring any curving), real length could be greater than this
         but never less.
 
         @return:

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -2551,13 +2551,19 @@ class Geomstr:
         ).all(axis=2)
         yield from candidates[q[0]]
 
-    def length(self, e):
+    def length(self, e=None):
         """
         Returns the length of geom e.
 
         @param e:
         @return:
         """
+        if e is None:
+            total = 0
+            for i in range(self.index):
+                total += self.length(i)
+            return total
+
         line = self.segments[e]
         start, control1, info, control2, end = line
         if info.real == TYPE_LINE:


### PR DESCRIPTION
Some wxmtree calls delegated to the `.shape.` call, these were slower.

In the case of rect with rounded corners calling `node.shape.length` was actually prohibitively expensive because calculating the length of an arc without scipy is non-trivial