### PR TITLE
Different restart mechanism

### DIFF
--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -228,13 +228,15 @@ class MeerK40t(MWindow):
 
         # Look at window elements we are hovering over
         # to establish the online help functionality
-        self.timer = wx.Timer(self, id=wx.ID_ANY)
-        self.Bind(wx.EVT_TIMER, self.mouse_query, self.timer)
-        self.timer.Start(500, wx.TIMER_CONTINUOUS)
+        self.context.kernel.add_job(run=self.mouse_query, name="helper-check", interval=0.5)
+        # Switched to kernel to avoid 0xC0000005 crash in windows.
+        # self.timer = wx.Timer(self, id=wx.ID_ANY)
+        # self.Bind(wx.EVT_TIMER, self.mouse_query, self.timer)
+        # self.timer.Start(500, wx.TIMER_CONTINUOUS)
         self._last_help_info = ""
         self._last_help_section = ""
 
-    def mouse_query(self, event):
+    def mouse_query(self, event=None):
         """
             This routine looks periodically (every 0.5 seconds)
             at the window ie control under the mouse cursor.

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -149,15 +149,23 @@ def run():
     ###################
     # END Old Python Code.
     ###################
-    while _exe(args):
-        pass
+    restart = _exe(args)
+    if restart:
+        cmd = sys.argv[0]
+        args = sys.argv
+        if cmd == "meerk40t.py":
+            cmd = sys.executable
+            args = (sys.executable, 'meerk40t.py')
+        try:
+            os.execvp(cmd, args)
+        except (PermissionError, FileNotFoundError) as e:
+            print (f"Sorry, can't restart '{cmd} {args}': {e}")
 
 
 def _exe(args):
     from meerk40t.external_plugins import plugin as external_plugins
     from meerk40t.internal_plugins import plugin as internal_plugins
     from meerk40t.kernel import Kernel
-
     kernel = Kernel(
         APPLICATION_NAME,
         APPLICATION_VERSION,
@@ -170,4 +178,5 @@ def _exe(args):
     kernel.add_plugin(internal_plugins)
     kernel.add_plugin(external_plugins)
     kernel()
-    return hasattr(kernel, "restart") and kernel.restart
+    flag = hasattr(kernel, "restart") and kernel.restart
+    return flag

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -153,12 +153,13 @@ def run():
     if restart:
         cmd = sys.argv[0]
         args = sys.argv
-        if cmd == "meerk40t.py":
+        if cmd.endswith("meerk40t.py"):
+            args = (sys.executable, cmd)
             cmd = sys.executable
-            args = (sys.executable, 'meerk40t.py')
+        # print(f"Trying {cmd}, {args} ({sys.executable})")
         try:
             os.execvp(cmd, args)
-        except (PermissionError, FileNotFoundError) as e:
+        except (PermissionError, FileNotFoundError, OSError) as e:
             print (f"Sorry, can't restart '{cmd} {args}': {e}")
 
 


### PR DESCRIPTION
The current loop approach crashes under Linux all the time. Different approach with ``os.execvp`` - works both under Linux and Windows - might not work in the compiled executable - requires testing.