### PR TITLE
MKernel: Improve Signal Swap

### DIFF
--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -1142,7 +1142,7 @@ class Kernel(Settings):
             name="kernel.signals",
             interval=self.delay,
             run_main=True,
-            conditional=lambda: not self._message_queue and not self._processing,
+            conditional=lambda: not self._processing,
         )
         self._booted = True
 

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -148,13 +148,14 @@ class Kernel(Settings):
         # Signal Listener
         self.signal_job = None
         self.listeners = {}
+        self._add_lock = threading.Lock()
         self._adding_listeners = []
+        self._remove_lock = threading.Lock()
         self._removing_listeners = []
         self._last_message = {}
-        self._signal_lock = threading.Lock()
-        self._add_lock = threading.Lock()
-        self._remove_lock = threading.Lock()
+        self._message_queue_lock = threading.Lock()
         self._message_queue = {}
+        self._process_lock = threading.Lock()
         self._processing = {}
 
         # Channels
@@ -1141,7 +1142,7 @@ class Kernel(Settings):
             name="kernel.signals",
             interval=self.delay,
             run_main=True,
-            conditional=lambda: not self._processing,
+            conditional=lambda: not self._message_queue and not self._processing,
         )
         self._booted = True
 
@@ -1295,7 +1296,7 @@ class Kernel(Settings):
                         channel(_("Suspended Command: {c}").format(c=c))
 
         # pylint: disable=method-hidden
-        self.console = console  # redefine console signal, hidden by design
+        self.console = console  # redefine console function, hidden by design
 
         self.process_queue()  # Process last events.
 
@@ -1958,67 +1959,82 @@ class Kernel(Settings):
         """
         Signals add the latest message to the message queue.
 
+        This merely writes the signal to the signal queue.
+
         @param code: Signal code
         @param path: Path of signal
         @param message: Message to send.
         """
-        with self._signal_lock:
+        with self._message_queue_lock:
             self._message_queue[code] = path, message
 
     def _process_add_listeners(self):
-        # Process any adding listeners.
+        """
+        Any add listeners are applied to update listeners.
+        Process any adding listeners.
+        @return:
+        """
         if not self._adding_listeners:
             return
         with self._add_lock:
             add = self._adding_listeners
             self._adding_listeners = []
+        if not add:
+            return
 
-        if add is not None:
-            for signal, funct, lso in add:
-                if signal in self.listeners:
-                    listeners = self.listeners[signal]
-                    listeners.append((funct, lso))
-                else:
-                    self.listeners[signal] = [(funct, lso)]
-                if signal in self._last_message:
-                    origin, message = self._last_message[signal]
-                    funct(origin, *message)
+        for signal, funct, lso in add:
+            if signal in self.listeners:
+                listeners = self.listeners[signal]
+                listeners.append((funct, lso))
+            else:
+                self.listeners[signal] = [(funct, lso)]
+            if signal in self._last_message:
+                origin, message = self._last_message[signal]
+                funct(origin, *message)
 
     def _process_remove_listeners(self):
-        # Process any removing listeners.
+        """
+        Any remove listeners are used to update the current listeners.
+        Process any removing listeners.
+        @return:
+        """
         if not self._removing_listeners:
             return
         with self._remove_lock:
             remove = self._removing_listeners
             self._removing_listeners = []
+        if not remove:
+            return
+        for signal, remove_funct, remove_lso in remove:
+            if signal in self.listeners:
+                listeners = self.listeners[signal]
+                removed = False
+                for i, listen in enumerate(listeners):
+                    listen_funct, listen_lso = listen
+                    if (listen_funct == remove_funct or remove_funct is None) and (
+                        listen_lso is remove_lso or remove_lso is None
+                    ):
+                        del listeners[i]
+                        removed = True
+                        break
+                if not removed:
+                    # This occurs if we attempt to remove a listener which does not exist.
+                    # This is not a useless error but rather a symptom of another bug.
+                    # This should not occur, if it does, something is desynced attempting
+                    # to double remove. Which could also mean listeners are stuck listening
+                    # to places they should not which can cause other errors.
+                    print(
+                        f"Error in {signal}, no {str(remove_funct)} matching {str(remove_lso)}"
+                    )
+                    for index, listener in enumerate(listeners):
+                        print(f"{index}: {str(listener)}")
 
-        if remove is not None:
-            for signal, remove_funct, remove_lso in remove:
-                if signal in self.listeners:
-                    listeners = self.listeners[signal]
-                    removed = False
-                    for i, listen in enumerate(listeners):
-                        listen_funct, listen_lso = listen
-                        if (listen_funct == remove_funct or remove_funct is None) and (
-                            listen_lso is remove_lso or remove_lso is None
-                        ):
-                            del listeners[i]
-                            removed = True
-                            break
-                    if not removed:
-                        # This occurs if we attempt to remove a listener which does not exist.
-                        # This is not a useless error but rather a symptom of another bug.
-                        # This should not occur, if it does, something is desynced attempting
-                        # to double remove. Which could also mean listeners are stuck listening
-                        # to places they should not which can cause other errors.
-                        print(
-                            f"Error in {signal}, no {str(remove_funct)} matching {str(remove_lso)}"
-                        )
-                        for index, listener in enumerate(listeners):
-                            print(f"{index}: {str(listener)}")
-
-    def _process_signal_queue(self, queue):
-        # Process signals.
+    def _process_signal_queue(self):
+        """
+        Process signals in the processing queue.
+        @return:
+        """
+        queue = self._processing
         signal_channel = self.channel("signals")
         for signal, payload in queue.items():
             origin, message = payload
@@ -2035,8 +2051,6 @@ class Kernel(Settings):
 
     def process_queue(self, *args) -> None:
         """
-        Performed in the run_later thread. Signal groups. Threadsafe.
-
         Process the signals queued up. Inserting any attaching listeners, removing any removing listeners. And
         providing the newly attached listeners the last message known from that signal.
         @param args: None
@@ -2048,16 +2062,14 @@ class Kernel(Settings):
             and len(self._removing_listeners) == 0
         ):
             return
-        with self._signal_lock:
-            self._message_queue, self._processing = (
-                self._processing,
-                self._message_queue,
-            )
-        self._process_add_listeners()
-        self._process_remove_listeners()
-
-        self._process_signal_queue(self._processing)
-        self._processing.clear()
+        with self._process_lock:
+            with self._message_queue_lock:
+                self._processing.update(self._message_queue)
+                self._message_queue.clear()
+            self._process_add_listeners()
+            self._process_remove_listeners()
+            self._process_signal_queue()
+            self._processing.clear()
 
     def last_signal(self, signal: str) -> Optional[Tuple]:
         """
@@ -2144,18 +2156,17 @@ class Kernel(Settings):
         @param cookie: cookie used to bind this listener.
         @return:
         """
-        with self._signal_lock:
-            with self._remove_lock:
-                for signal in self.listeners:
-                    listens = self.listeners[signal]
-                    for listener, lso in listens:
-                        if lso is cookie:
-                            self._removing_listeners.append((signal, listener, cookie))
-            with self._add_lock:
-                for i in range(len(self._adding_listeners) - 1, -1, -1):
-                    sl, func, lso = self._adding_listeners[i]
+        with self._remove_lock:
+            for signal in self.listeners:
+                listens = self.listeners[signal]
+                for listener, lso in listens:
                     if lso is cookie:
-                        del self._adding_listeners[i]
+                        self._removing_listeners.append((signal, listener, cookie))
+        with self._add_lock:
+            for i in range(len(self._adding_listeners) - 1, -1, -1):
+                sl, func, lso = self._adding_listeners[i]
+                if lso is cookie:
+                    del self._adding_listeners[i]
 
         # if len(self._removing_listeners) != len(set(self._removing_listeners)):
         #     print("Warning duplicate listener removing.")


### PR DESCRIPTION
A rare edge case could occur during shutdown where if the signal job `MainThread` processing could occur at the same time as the shutdown `run` and both called `process_signals()` the previous mechanism was using a double-buffer where the `message_queue` used to store new messages and the `processing` would swap the two. So the messages to be processed would be put into processing, and messaging would be the empty dictionary (after processing). This allowed for additional `signals` to be added to the messaging queue while the processing queue was processing the process data.

However, this would end very poorly during shutdown which explicitly calls `process_signals()` before preventing any additional signals to get added, and then processing anything that got added during that gap. Because the function was double-buffered it would double-flip here and processing would be the same as the queuing. So a `signal` could well modify the processing queue dictionary causing a crash.

* We no longer double buffer.
* During `process_signals()` we update all the values in the processing with the values in the `process_signals()`.
* We add in an additional gate for `process_lock`.
* Ensure that nothing can touch the `adding_listeners` list without acquiring the `add_lock`. 
* Ensure that nothing can touch the `removing_listeners` list without acquiring the `remove_lock`.
* Ensure that nothing can touch the `message_queue` without the `message_queue_lock`.
* Ensure that nothing can touch the `processing` without the `processing_lock`.

```python
MeerK40t crash log. Version: 0.9.3002 git dae117b6520165810570a7117c39385c606a59a7 on Windows: Python 3.11.1: AMD64 - wxPython: 4.2.1 msw (phoenix) wxWidgets 3.2.2.1
Traceback (most recent call last):
  File "C:\Users\David\PycharmProjects\meerk40t\meerk40t\kernel\kernel.py", line 1834, in schedule_run
    job.process(*job.args)
  File "C:\Users\David\PycharmProjects\meerk40t\meerk40t\kernel\kernel.py", line 2050, in process_queue
    self._process_signal_queue(self._processing)
  File "C:\Users\David\PycharmProjects\meerk40t\meerk40t\kernel\kernel.py", line 2014, in _process_signal_queue
    for signal, payload in queue.items():
RuntimeError: dictionary changed size during iteration
```