### PR TITLE
Recognize device rename in device manager

### DIFF
--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -290,7 +290,6 @@ class DevicePanel(wx.Panel):
             item = self.devices_list.GetItem(idx)
             dev_index = item.GetData()
             service = self.devices[dev_index]
-            service = self.devices[dev_index]
             if self.context.device is service:
                 self.devices_list.SetItemTextColour(idx, wx.RED)
             else:


### PR DESCRIPTION
The device manager window did neither recognize outside changes to a device's label nor did a proper announcement of a label change