### PR TITLE
Update check

### DIFF
--- a/locale/de/LC_MESSAGES/meerk40t.po
+++ b/locale/de/LC_MESSAGES/meerk40t.po
@@ -16049,13 +16049,13 @@ msgid "Enable all operations of this type"
 msgstr "Aktiviere alle Arbeitsabläufe des gleichen Typs"
 
 msgid "Disable all operations of this type"
-msgstr "Dektiviere alle Arbeitsabläufe des gleichen Typs"
+msgstr "Deaktiviere alle Arbeitsabläufe des gleichen Typs"
 
 msgid "Check for Updates"
 msgstr "Prüfe auf Updates"
 
-msgid  "A new {type} release is available:"
-msgstr "Es ist eine neue {type}-Version verfügbar:"
+msgid  "A new {type} release is available ({system}):"
+msgstr "Es ist eine neue {type}-Version für {system} verfügbar:"
 
 msgid ""
 "Version: {name} v{version} ({label})\n"
@@ -16064,8 +16064,8 @@ msgstr ""
 "Version: {name} v{version} ({label})\n"
 "Url: {url}"
 
-msgid "You seem to have the latest version."
-msgstr "Dies scheint die aktuelle Version von MeerK40t zu sein."
+msgid "You seem to have the latest {system} version."
+msgstr "Dies scheint die aktuelle {system}-Version von MeerK40t zu sein."
 
 msgid ""
 "Latest version on github: {name} v{version} ({label})\n"

--- a/locale/es/LC_MESSAGES/meerk40t.po
+++ b/locale/es/LC_MESSAGES/meerk40t.po
@@ -2091,7 +2091,7 @@ msgid "return paths around image"
 msgstr ""
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2100,7 +2100,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/fr/LC_MESSAGES/meerk40t.po
+++ b/locale/fr/LC_MESSAGES/meerk40t.po
@@ -2089,7 +2089,7 @@ msgid "return paths around image"
 msgstr ""
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2098,7 +2098,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/hu/LC_MESSAGES/meerk40t.po
+++ b/locale/hu/LC_MESSAGES/meerk40t.po
@@ -2101,7 +2101,7 @@ msgid "return paths around image"
 msgstr "visszatérési utak a kép körül"
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2110,7 +2110,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/it/LC_MESSAGES/meerk40t.po
+++ b/locale/it/LC_MESSAGES/meerk40t.po
@@ -2156,7 +2156,7 @@ msgid "return paths around image"
 msgstr "restituisci percorsi attorno all'immagine"
 
 #: meerk40t/extra/updater.py:21
-msgid "A new {type} release is available:"
+msgid "A new {type} release is available ({system}):"
 msgstr "È disponibile una nuova versione di {type}:"
 
 msgid ""
@@ -2167,7 +2167,7 @@ msgstr ""
 "URL: {url}"
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr "Sembra che tu abbia l'ultima versione."
 
 msgid ""

--- a/locale/ja/LC_MESSAGES/meerk40t.po
+++ b/locale/ja/LC_MESSAGES/meerk40t.po
@@ -2096,7 +2096,7 @@ msgid "return paths around image"
 msgstr "画像周辺のパスを返す"
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2105,7 +2105,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/messages.po
+++ b/locale/messages.po
@@ -2089,7 +2089,7 @@ msgid "return paths around image"
 msgstr ""
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2098,7 +2098,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/nl/LC_MESSAGES/meerk40t.po
+++ b/locale/nl/LC_MESSAGES/meerk40t.po
@@ -2104,7 +2104,7 @@ msgid "return paths around image"
 msgstr "paden rond afbeelding terug"
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2113,7 +2113,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/pt_BR/LC_MESSAGES/meerk40t.po
+++ b/locale/pt_BR/LC_MESSAGES/meerk40t.po
@@ -2089,7 +2089,7 @@ msgid "return paths around image"
 msgstr ""
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2098,7 +2098,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/pt_PT/LC_MESSAGES/meerk40t.po
+++ b/locale/pt_PT/LC_MESSAGES/meerk40t.po
@@ -2110,7 +2110,7 @@ msgid "return paths around image"
 msgstr "caminhos de retorno em torno da imagem"
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr ""
 
 msgid ""
@@ -2119,7 +2119,7 @@ msgid ""
 msgstr ""
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr ""
 
 msgid ""

--- a/locale/zh/LC_MESSAGES/meerk40t.po
+++ b/locale/zh/LC_MESSAGES/meerk40t.po
@@ -2070,7 +2070,7 @@ msgid "return paths around image"
 msgstr "返回围绕图像的路径"
 
 #: meerk40t/extra/updater.py:21
-msgid  "A new {type} release is available:"
+msgid  "A new {type} release is available ({system}):"
 msgstr "有一个新的 {type} 发布可用:"
 
 msgid ""
@@ -2081,7 +2081,7 @@ msgstr ""
 "网址：{url}"
 
 #: meerk40t/extra/updater.py:26
-msgid "You seem to have the latest version."
+msgid "You seem to have the latest {system} version."
 msgstr "您似乎已经有了最新版本。"
 
 msgid ""


### PR DESCRIPTION
Will only show an update message, if the release contains a matching asset.
Test:
- ``check_for_updates -s 4`` reports 0.9.2 (the ``-s``-parameter forces a system to look for: 0=Auto, 1=Source, 2=Windows, 3=Linux, 4=Darwin, 5=RPI)
- ``check_for_updates`` reports 0.9.3.1

Criteria for the match: the ``name`` tag of the asset-list must contain a known entry:
```
                    if default_system == 2:
                        # Windows:
                        asset_requirement = ("meerk40t.exe", "wx-meerk40t.exe", )
                        system_type = "Windows"
                        is_source = False
                    elif default_system == 3:
                        # Linux:
                        asset_requirement = ("meerk40t-Linux", )
                        system_type = "Linux"
                        is_source = False
                    elif default_system == 4:
                        # Darwin:
                        asset_requirement = ("meerk40t.dmg", "meerk40t-m1.dmg", "MeerK40t_PyInst_11.dmg", "MeerK40t_unsigned.dmg", )
                        system_type = "Mac-OSX"
                        is_source = False
                    elif default_system == 5:
                        # Raspberry-Pi:
                        asset_requirement = ("meerk40t_pi.tar", "meerk40t_pi64.tar", "meerk40t_pi_slow.tar")
                        system_type = "Raspberry Pi"
                        is_source = False
                    else:
                        # Source
                        asset_requirement = None
                        system_type = "Source"
                        is_source = True
```