### PR TITLE
Rotary Corrections

### DIFF
--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -459,11 +459,7 @@ class LihuiyuDevice(Service, Status):
             flip_y=self.flip_y,
             swap_xy=self.swap_xy,
         )
-        # rotary_active = self.rotary_active,
-        # rotary_scale_x = self.rotary_scale_x,
-        # rotary_scale_y = self.rotary_scale_y,
-        # rotary_flip_x = self.rotary_flip_x,
-        # rotary_flip_y = self.rotary_flip_y,
+        self.realize_rotary()
         self.setting(int, "buffer_max", 900)
         self.setting(bool, "buffer_limit", True)
 
@@ -1000,6 +996,8 @@ class LihuiyuDevice(Service, Status):
     @signal_listener("rotary_scale_x")
     @signal_listener("rotary_scale_y")
     @signal_listener("rotary_active")
+    @signal_listener("rotary_flip_x")
+    @signal_listener("rotary_flip_y")
     @signal_listener("user_scale_x")
     @signal_listener("user_scale_y")
     @signal_listener("bedsize")
@@ -1015,7 +1013,17 @@ class LihuiyuDevice(Service, Status):
             flip_y=self.flip_y,
             swap_xy=self.swap_xy,
         )
+        self.realize_rotary(origin, *args)
         self.space.update_bounds(0, 0, self.bedwidth, self.bedheight)
+
+    def realize_rotary(self, origin=None, *args):
+        if not self.rotary_active:
+            return
+        self.view.scale(self.rotary_scale_x, self.rotary_scale_y)
+        if self.rotary_flip_x:
+            self.view.flip_x()
+        if self.rotary_flip_y:
+            self.view.flip_y()
 
     def outline_move_relative(self, dx, dy):
         x, y = self.native

--- a/test/bootstrap.py
+++ b/test/bootstrap.py
@@ -1,8 +1,8 @@
 from meerk40t.kernel import Kernel
 
 
-def bootstrap(profile="MeerK40t_TEST"):
-    kernel = Kernel("MeerK40t", "0.0.0-testing", profile, ansi=False)
+def bootstrap(profile="MeerK40t_TEST", ignore_settings=True):
+    kernel = Kernel("MeerK40t", "0.0.0-testing", profile, ansi=False, ignore_settings=ignore_settings)
 
     from meerk40t.network import kernelserver
 

--- a/test/test_drivers_grbl.py
+++ b/test/test_drivers_grbl.py
@@ -38,7 +38,7 @@ class TestDriverGRBL(unittest.TestCase):
         finally:
             kernel.shutdown()
 
-        kernel = bootstrap.bootstrap(profile="MeerK40t_GRBL")
+        kernel = bootstrap.bootstrap(profile="MeerK40t_GRBL", ignore_settings=False)
         try:
             devs = [name for name in kernel.contexts if name.startswith("grbl")]
             self.assertGreater(len(devs), 1)

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -36,6 +36,16 @@ Creator-Software: MeerK40t v0.0.0-testing
 %0%0%0%0%
 """
 
+egv_rect_y2_rotary = """Document type : LHYMICRO-GL file
+File version: 1.0.01
+Copyright: Unknown
+Creator-Software: MeerK40t v0.0.0-testing
+
+%0%0%0%0%
+IBzzzvRzzzzzz|tS1P
+ICV2490731016000027CNLBS1EDz139RzzzvTz139LzzzvFNSE-
+"""
+
 egv_override_speed_1_rect = """Document type : LHYMICRO-GL file
 File version: 1.0.01
 Copyright: Unknown
@@ -198,6 +208,8 @@ class TestDriverLihuiyuRotary(unittest.TestCase):
             path = kernel.device.path
             device(f"set -p {path} rotary_active True")
             device(f"set -p {path} rotary_scale_y 2.0")
+            device.signal("rotary_active", True)
+            device.realize()  # In case signal doesn't update the device settings quickly enough.
             kernel.console(
                 f"rect 2cm 2cm 1cm 1cm engrave -s 15 plan copy-selected preprocess validate blob preopt optimize save_job {file1}\n"
             )
@@ -205,8 +217,7 @@ class TestDriverLihuiyuRotary(unittest.TestCase):
             kernel.shutdown()
         with open(file1) as f:
             data = f.read()
-        print(data)
-        # self.assertEqual(egv_rect_y2_rotary, data)
+        self.assertEqual(egv_rect_y2_rotary, data)
 
 
 class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -181,6 +181,34 @@ class TestDriverLihuiyu(unittest.TestCase):
         self.assertEqual(data, egv_image)
 
 
+class TestDriverLihuiyuRotary(unittest.TestCase):
+    def test_driver_rotary_engrave(self):
+        """
+        This test creates a lihuiyu device, with a rotary.
+        @return:
+        """
+        file1 = "test_rotary.egv"
+        self.addCleanup(os.remove, file1)
+
+        kernel = bootstrap.bootstrap(profile="MeerK40t_TEST_rotary")
+        try:
+            kernel.console("service device start -i lhystudios 0\n")
+            kernel.console("operation* delete\n")
+            device = kernel.device
+            path = kernel.device.path
+            device(f"set -p {path} rotary_active True")
+            device(f"set -p {path} rotary_scale_y 2.0")
+            kernel.console(
+                f"rect 2cm 2cm 1cm 1cm engrave -s 15 plan copy-selected preprocess validate blob preopt optimize save_job {file1}\n"
+            )
+        finally:
+            kernel.shutdown()
+        with open(file1) as f:
+            data = f.read()
+        print(data)
+        # self.assertEqual(egv_rect_y2_rotary, data)
+
+
 class TestDriverLihuiyuOverrideSpeed(unittest.TestCase):
     def test_driver_override_speed_engrave(self):
         """

--- a/test/test_drivers_lihuiyu.py
+++ b/test/test_drivers_lihuiyu.py
@@ -89,7 +89,7 @@ class TestDriverLihuiyu(unittest.TestCase):
         finally:
             kernel.shutdown()
 
-        kernel = bootstrap.bootstrap(profile="MeerK40t_LHY")
+        kernel = bootstrap.bootstrap(profile="MeerK40t_LHY", ignore_settings=False)
         try:
             devs = [name for name in kernel.contexts if name.startswith("lhystudios")]
             self.assertGreater(len(devs), 1)


### PR DESCRIPTION
Fix rotary commands for after the 0.9.2 coordinate system update.

The coordinate system was switched to 4-to-4 point mapping system since its significantly easier to use consistently and covers things like rotation clockwise, etc. This however, broke the older system which was used for the rotary system and setup. This corrects that oversight.