### PR TITLE
Settings backup

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -526,7 +526,7 @@ class Elemental(Service):
         self.setting(float, "svg_ppi", 96.0)
         self.setting(bool, "operation_default_empty", True)
 
-        self.op_data = Settings(self.kernel.name, "operations.cfg", create_backup=2) # keep backup (max 1 / hour)
+        self.op_data = Settings(self.kernel.name, "operations.cfg", create_backup=True) # keep backup
 
         self.wordlists = {"version": [1, self.kernel.version]}
 

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -526,7 +526,7 @@ class Elemental(Service):
         self.setting(float, "svg_ppi", 96.0)
         self.setting(bool, "operation_default_empty", True)
 
-        self.op_data = Settings(self.kernel.name, "operations.cfg")
+        self.op_data = Settings(self.kernel.name, "operations.cfg", create_backup=2) # keep backup (max 1 / hour)
 
         self.wordlists = {"version": [1, self.kernel.version]}
 

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -138,7 +138,7 @@ class MKRibbonBarPanel(RibbonBarPanel):
             self.context._ribbons = dict()
         self.context._ribbons[self.identifier] = self
 
-        self.storage = Settings(self.context.kernel.name, f"ribbon_{identifier}.cfg")
+        self.storage = Settings(self.context.kernel.name, f"ribbon_{identifier}.cfg", create_backup=1) # keep backup (max 1 / day)
         self.storage.read_configuration()
 
         self.allow_labels = bool(show_labels is None or show_labels)

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -138,7 +138,7 @@ class MKRibbonBarPanel(RibbonBarPanel):
             self.context._ribbons = dict()
         self.context._ribbons[self.identifier] = self
 
-        self.storage = Settings(self.context.kernel.name, f"ribbon_{identifier}.cfg", create_backup=1) # keep backup (max 1 / day)
+        self.storage = Settings(self.context.kernel.name, f"ribbon_{identifier}.cfg", create_backup=True) # keep backup
         self.storage.read_configuration()
 
         self.allow_labels = bool(show_labels is None or show_labels)

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -89,7 +89,7 @@ class Kernel(Settings):
 
         # Persistent Settings
         Settings.__init__(
-            self, self.name, f"{profile}.cfg", ignore_settings=ignore_settings
+            self, self.name, f"{profile}.cfg", ignore_settings=ignore_settings, create_backup=3
         )
         self.settings = self
         self.delay = delay

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -89,7 +89,7 @@ class Kernel(Settings):
 
         # Persistent Settings
         Settings.__init__(
-            self, self.name, f"{profile}.cfg", ignore_settings=ignore_settings, create_backup=3
+            self, self.name, f"{profile}.cfg", ignore_settings=ignore_settings, create_backup=True
         )
         self.settings = self
         self.delay = delay

--- a/meerk40t/kernel/settings.py
+++ b/meerk40t/kernel/settings.py
@@ -1,5 +1,4 @@
 import ast
-import datetime
 import os
 from configparser import ConfigParser, MissingSectionHeaderError, NoSectionError
 from pathlib import Path
@@ -21,12 +20,11 @@ class Settings:
     `write_configuration` is called.
     """
 
-    def __init__(self, directory, filename, ignore_settings=False, create_backup=0):
+    def __init__(self, directory, filename, ignore_settings=False, create_backup=False):
         self._config_file = Path(get_safe_path(directory, create=True)).joinpath(
             filename
         )
         self._config_dict = {}
-        # 0 = No backup, 1 = keep daily, 2 = keep hourly, 3 = keep every minute
         self.create_backup = create_backup
         if not ignore_settings:
             self.read_configuration()
@@ -85,21 +83,28 @@ class Settings:
                     except NoSectionError:
                         parser.add_section(section_key)
                         parser.set(section_key, key, value)
-            if self.create_backup > 0:
+            if self.create_backup:
+                VERSIONS = 5
                 try:
                     if os.path.exists(targetfile):
-                        modified_time = os.path.getmtime(targetfile)
-                        if self.create_backup == 1:
-                            pattern = "%y-%m-%d"
-                        elif self.create_backup == 2:
-                            pattern = "%y-%m-%d-%H"
-                        else: # 3:
-                            pattern = "%y-%m-%d-%H-%M"
-                        timestamp = datetime.datetime.fromtimestamp(modified_time).strftime(pattern)
-                        backupfile = str(targetfile) + "." + timestamp
-                        if not os.path.exists(backupfile):
-                            os.rename(targetfile, backupfile)
+                        base_name, base_ext = os.path.splitext(targetfile)
+                        for history in range(VERSIONS - 1, -1, -1):
+                            if history == 0:
+                                v0 = ".bak"
+                            else:
+                                v0 = f".ba{history}"
+                            v1 = f".ba{history + 1}"
+                            v0_file = base_name + v0
+                            v1_file = base_name + v1
+                            if os.path.exists(v0_file):
+                                if os.path.exists(v1_file):
+                                    os.remove(v1_file)
+                                os.rename(v0_file, v1_file)
+
+                        v1_file = base_name + ".bak"
+                        os.rename(targetfile, v1_file)
                 except (PermissionError, OSError, RuntimeError, FileExistsError, FileNotFoundError) as e:
+                    # print (f"Error happened: {e}")
                     pass
             with open(targetfile, "w", encoding="utf-8") as fp:
                 parser.write(fp)


### PR DESCRIPTION
if you use the ``create_backup`` parameter when instantiating a Settings object then it will maintain copies of the old config file before writing the new version: it will generate up to 6 previous versions of the file
``.bak``, ``.ba1`` .. ``.ba5`` - ``.bak`` the most recent one, ``.ba5`` the oldest
