### PR TITLE
Device.safe_label + Bug Fixes

### DIFF
--- a/meerk40t/balormk/controller.py
+++ b/meerk40t/balormk/controller.py
@@ -239,9 +239,7 @@ class GalvoController:
         self.force_mock = force_mock
         self.is_shutdown = False  # Shutdown finished.
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)
+        self.usb_log = service.channel(f"{self.service.safe_label}/usb", buffer_size=500)
         self.usb_log.watch(lambda e: service.signal("pipe;usb_status", e))
 
         self.connection = None
@@ -354,8 +352,7 @@ class GalvoController:
         if self.connection is None:
             if self.service.setting(bool, "mock", False) or self.force_mock:
                 self.connection = MockConnection(self.usb_log)
-                name = self.service.label.replace(" ", "-")
-                name = name.replace("/", "-")
+                name = self.service.safe_label
                 self.connection.send = self.service.channel(f"{name}/send")
                 self.connection.recv = self.service.channel(f"{name}/recv")
             else:

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -691,6 +691,17 @@ class BalorDevice(Service, Status):
         self.viewbuffer = ""
         self._simulate = False
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     def service_attach(self, *args, **kwargs):
         self.realize()
 

--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -147,9 +147,7 @@ class BalorControllerPanel(wx.ScrolledWindow):
             self.context("usb_connect\n")
 
     def pane_show(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.context.channel(f"{name}/usb").watch(self.update_text)
+        self.context.channel(f"{self.service.safe_label}/usb").watch(self.update_text)
         try:
             connected = self.service.driver.connected
             if connected:
@@ -160,9 +158,7 @@ class BalorControllerPanel(wx.ScrolledWindow):
             pass
 
     def pane_hide(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.context.channel(f"{name}/usb").unwatch(self.update_text)
+        self.context.channel(f"{self.service.safe_label}/usb").unwatch(self.update_text)
 
 
 class BalorController(MWindow):

--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -147,7 +147,8 @@ class BalorControllerPanel(wx.ScrolledWindow):
             self.context("usb_connect\n")
 
     def pane_show(self):
-        self.context.channel(f"{self.service.safe_label}/usb").watch(self.update_text)
+        self._channel_watching = f"{self.context.safe_label}/usb"
+        self.context.channel(self._channel_watching).watch(self.update_text)
         try:
             connected = self.service.driver.connected
             if connected:
@@ -158,7 +159,7 @@ class BalorControllerPanel(wx.ScrolledWindow):
             pass
 
     def pane_hide(self):
-        self.context.channel(f"{self.service.safe_label}/usb").unwatch(self.update_text)
+        self.context.channel(self._channel_watching).unwatch(self.update_text)
 
 
 class BalorController(MWindow):

--- a/meerk40t/device/dummydevice.py
+++ b/meerk40t/device/dummydevice.py
@@ -113,6 +113,17 @@ class DummyDevice(Service, Status):
         )
         self.view = View(self.bedwidth, self.bedheight)
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     @signal_listener("bedwidth")
     @signal_listener("bedheight")
     @signal_listener("scale_x")

--- a/meerk40t/grbl/controller.py
+++ b/meerk40t/grbl/controller.py
@@ -334,8 +334,7 @@ class GrblController:
             w(data, type=type)
 
     def _channel_log(self, data, type=None):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         if type == "send":
             if not hasattr(self, "_grbl_send"):
                 self._grbl_send = self.service.channel(f"send-{name}", pure=True)
@@ -463,8 +462,7 @@ class GrblController:
             delay = self.service.connect_delay / 1000
         else:
             delay = 0
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         if delay:
             self.service(f".timer 1 {delay} .gcode_realtime {cmd}")
             self.service(
@@ -475,8 +473,7 @@ class GrblController:
             self.service(f".timer-{name}{cmd} 0 1 gcode_realtime {cmd}")
 
     def validate_stop(self, cmd):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         if cmd == "*":
             self.service(f".timer-{name}* -q --off")
             return

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -743,6 +743,17 @@ class GRBLDevice(Service, Status):
                 channel(_("Interpreter cannot be attached to any device."))
             return
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     def _register_console_serial(self):
         _ = self.kernel.translation
 

--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -140,8 +140,8 @@ class LihuiyuController:
     log, providing information about the connecting and error status of the USB device.
     """
 
-    def __init__(self, context, *args, **kwargs):
-        self.context = context
+    def __init__(self, service, *args, **kwargs):
+        self.context = service
         self.state = "unknown"
         self.is_shutdown = False
         self.serial_confirmed = None
@@ -176,12 +176,12 @@ class LihuiyuController:
 
         self.abort_waiting = False
 
-        name = self.context.label
-        self.pipe_channel = context.channel(f"{name}/events")
-        self.usb_log = context.channel(f"{name}/usb", buffer_size=500)
-        self.usb_send_channel = context.channel(f"{name}/usb_send")
-        self.recv_channel = context.channel(f"{name}/recv")
-        self.usb_log.watch(lambda e: context.signal("pipe;usb_status", e))
+        name = service.safe_label
+        self.pipe_channel = service.channel(f"{name}/events")
+        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)
+        self.usb_send_channel = service.channel(f"{name}/usb_send")
+        self.recv_channel = service.channel(f"{name}/recv")
+        self.usb_log.watch(lambda e: service.signal("pipe;usb_status", e))
         self.reset()
 
     @property

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -899,6 +899,17 @@ class LihuiyuDevice(Service, Status):
                     channel(_("Intepreter cannot be attached to any device."))
                 return
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     def service_attach(self, *args, **kwargs):
         self.realize()
 

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -260,7 +260,7 @@ class LihuiyuControllerPanel(ScrolledPanel):
 
     def pane_show(self):
         # Channel watching is to make sure we unwatch the channel we watched even if label changes.
-        self._channel_watching = f"{self.context.label}/usb"
+        self._channel_watching = f"{self.context.safe_label}/usb"
         self.context.channel(self._channel_watching, buffer_size=500).watch(
             self.update_text
         )

--- a/meerk40t/moshi/controller.py
+++ b/meerk40t/moshi/controller.py
@@ -58,8 +58,8 @@ class MoshiController:
     Checks done before the Epilogue will have 205 state.
     """
 
-    def __init__(self, context, channel=None, force_mock=False, *args, **kwargs):
-        self.context = context
+    def __init__(self, service, channel=None, force_mock=False, *args, **kwargs):
+        self.context = service
         self.state = "unknown"
 
         self._programs = []  # Programs to execute.
@@ -83,13 +83,13 @@ class MoshiController:
         self.count = 0
         self.abort_waiting = False
 
-        name = self.context.label
-        self.pipe_channel = context.channel(f"{name}/events")
-        self.usb_log = context.channel(f"{name}/usb", buffer_size=500)
-        self.usb_send_channel = context.channel(f"{name}/usb_send")
-        self.recv_channel = context.channel(f"{name}/recv")
+        name = service.safe_label
+        self.pipe_channel = service.channel(f"{name}/events")
+        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)
+        self.usb_send_channel = service.channel(f"{name}/usb_send")
+        self.recv_channel = service.channel(f"{name}/recv")
 
-        self.usb_log.watch(lambda e: context.signal("pipe;usb_status", e))
+        self.usb_log.watch(lambda e: service.signal("pipe;usb_status", e))
 
     def viewbuffer(self):
         """

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -318,6 +318,17 @@ class MoshiDevice(Service, Status):
             except (PermissionError, OSError):
                 channel(_("Could not save: {filename}").format(filename=filename))
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     def service_attach(self, *args, **kwargs):
         self.realize()
 

--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -64,9 +64,7 @@ class MoshiDriver(Parameters):
         self.preferred_offset_x = 0
         self.preferred_offset_y = 0
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.pipe_channel = service.channel(f"{name}/events")
+        self.pipe_channel = service.channel(f"{service.safe_label}/events")
         self.program.channel = self.pipe_channel
 
         self.out_pipe = None

--- a/meerk40t/moshi/gui/moshicontrollergui.py
+++ b/meerk40t/moshi/gui/moshicontrollergui.py
@@ -247,16 +247,15 @@ class MoshiControllerPanel(wx.Panel):
         # end wxGlade
 
     def pane_show(self):
-        active = self.context.path.split("/")[-1]
-        self.context.channel(f"{active}/usb", buffer_size=500).watch(self.update_text)
+        self._channel_watch = f"{self.context.safe_label}/usb"
+        self.context.channel(self._channel_watch, buffer_size=500).watch(self.update_text)
         self.context.listen("pipe;status", self.update_status)
         self.context.listen("pipe;usb_status", self.on_connection_status_change)
         self.context.listen("pipe;state", self.on_connection_state_change)
         self.context.listen("active", self.on_active_change)
 
     def pane_hide(self):
-        active = self.context.path.split("/")[-1]
-        self.context.channel(f"{active}/usb").unwatch(self.update_text)
+        self.context.channel(self._channel_watch).unwatch(self.update_text)
         self.context.unlisten("pipe;status", self.update_status)
         self.context.unlisten("pipe;usb_status", self.on_connection_status_change)
         self.context.unlisten("pipe;state", self.on_connection_state_change)

--- a/meerk40t/newly/controller.py
+++ b/meerk40t/newly/controller.py
@@ -27,10 +27,7 @@ class NewlyController:
         self.force_mock = force_mock
         self.is_shutdown = False  # Shutdown finished.
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-
-        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)
+        self.usb_log = service.channel(f"{service.safe_label}/usb", buffer_size=500)
         self.usb_log.watch(lambda e: service.signal("pipe;usb_status", e))
 
         # Load Primary Pens
@@ -149,8 +146,7 @@ class NewlyController:
         if self.connection is None:
             if self.service.setting(bool, "mock", False) or self.force_mock:
                 self.connection = MockConnection(self.usb_log)
-                name = self.service.label.replace(" ", "-")
-                name = name.replace("/", "-")
+                name = self.service.safe_label
                 self.connection.send = self.service.channel(f"{name}/send")
                 self.connection.recv = self.service.channel(f"{name}/recv")
             else:

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -687,6 +687,17 @@ class NewlyDevice(Service, Status):
                     _("Not Connected"),
                 )
 
+    @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
     def service_attach(self, *args, **kwargs):
         self.realize()
 

--- a/meerk40t/newly/gui/newlycontroller.py
+++ b/meerk40t/newly/gui/newlycontroller.py
@@ -149,7 +149,8 @@ class NewlyControllerPanel(wx.ScrolledWindow):
             self.context("usb_connect\n")
 
     def pane_show(self):
-        self.context.channel(f"{self.service.safe_label}/usb").watch(self.update_text)
+        self._channel_watching = f"{self.service.safe_label}/usb"
+        self.context.channel(self._channel_watching).watch(self.update_text)
         try:
             connected = self.service.driver.connected
             if connected:
@@ -160,7 +161,7 @@ class NewlyControllerPanel(wx.ScrolledWindow):
             pass
 
     def pane_hide(self):
-        self.context.channel(f"{self.service.safe_label}/usb").unwatch(self.update_text)
+        self.context.channel(self._channel_watching).unwatch(self.update_text)
 
 
 class NewlyController(MWindow):

--- a/meerk40t/newly/gui/newlycontroller.py
+++ b/meerk40t/newly/gui/newlycontroller.py
@@ -149,9 +149,7 @@ class NewlyControllerPanel(wx.ScrolledWindow):
             self.context("usb_connect\n")
 
     def pane_show(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.context.channel(f"{name}/usb").watch(self.update_text)
+        self.context.channel(f"{self.service.safe_label}/usb").watch(self.update_text)
         try:
             connected = self.service.driver.connected
             if connected:
@@ -162,9 +160,7 @@ class NewlyControllerPanel(wx.ScrolledWindow):
             pass
 
     def pane_hide(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.context.channel(f"{name}/usb").unwatch(self.update_text)
+        self.context.channel(f"{self.service.safe_label}/usb").unwatch(self.update_text)
 
 
 class NewlyController(MWindow):

--- a/meerk40t/ruida/controller.py
+++ b/meerk40t/ruida/controller.py
@@ -24,9 +24,7 @@ class RuidaController:
         self._send_queue = []
         self._send_lock = threading.Condition()
         self._send_thread = None
-        name = service.label.replace(" ", "-")
-        name = name.replace("/", "-")
-        self.events = service.channel(f"{name}/events")
+        self.events = service.channel(f"{service.safe_label}/events")
 
     def start_sending(self):
         self._send_thread = threading.Thread(target=self._data_sender, daemon=True)

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -355,6 +355,17 @@ class RuidaDevice(Service):
                 channel(_("Could not save: {filename}").format(filename=filename))
 
     @property
+    def safe_label(self):
+        """
+        Provides a safe label without spaces or / which could cause issues when used in timer or other names.
+        @return:
+        """
+        if not hasattr(self, "label"):
+            return self.name
+        name = self.label.replace(" ", "-")
+        return name.replace("/", "-")
+
+    @property
     def has_endstops(self):
         return True
 

--- a/meerk40t/ruida/driver.py
+++ b/meerk40t/ruida/driver.py
@@ -30,8 +30,7 @@ class RuidaDriver(Parameters):
         self.native_y = 0
         self.name = str(self.service)
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         send = service.channel(f"{name}/send")
         self.controller = RuidaController(self.service, send)
         self.controller.job.set_magic(service.magic)

--- a/meerk40t/ruida/gui/ruidacontroller.py
+++ b/meerk40t/ruida/gui/ruidacontroller.py
@@ -139,8 +139,7 @@ class RuidaControllerPanel(wx.ScrolledWindow):
             self.context("ruida_connect\n")
 
     def pane_show(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.context.channel(f"{name}/recv", pure=True).watch(self.update_text)
         self.context.channel(f"{name}/send", pure=True).watch(self.update_text)
         self.context.channel(f"{name}/real", pure=True).watch(self.update_text)
@@ -153,8 +152,7 @@ class RuidaControllerPanel(wx.ScrolledWindow):
             self.set_button_disconnected()
 
     def pane_hide(self):
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.context.channel(f"{name}/recv").unwatch(self.update_text)
         self.context.channel(f"{name}/send").unwatch(self.update_text)
         self.context.channel(f"{name}/real").unwatch(self.update_text)

--- a/meerk40t/ruida/gui/ruidacontroller.py
+++ b/meerk40t/ruida/gui/ruidacontroller.py
@@ -139,11 +139,11 @@ class RuidaControllerPanel(wx.ScrolledWindow):
             self.context("ruida_connect\n")
 
     def pane_show(self):
-        name = self.service.safe_label
-        self.context.channel(f"{name}/recv", pure=True).watch(self.update_text)
-        self.context.channel(f"{name}/send", pure=True).watch(self.update_text)
-        self.context.channel(f"{name}/real", pure=True).watch(self.update_text)
-        self.context.channel(f"{name}/events").watch(self.update_text)
+        self._name = self.service.safe_label
+        self.context.channel(f"{self._name}/recv", pure=True).watch(self.update_text)
+        self.context.channel(f"{self._name}/send", pure=True).watch(self.update_text)
+        self.context.channel(f"{self._name}/real", pure=True).watch(self.update_text)
+        self.context.channel(f"{self._name}/events").watch(self.update_text)
 
         connected = self.service.connected
         if connected:
@@ -152,11 +152,10 @@ class RuidaControllerPanel(wx.ScrolledWindow):
             self.set_button_disconnected()
 
     def pane_hide(self):
-        name = self.service.safe_label
-        self.context.channel(f"{name}/recv").unwatch(self.update_text)
-        self.context.channel(f"{name}/send").unwatch(self.update_text)
-        self.context.channel(f"{name}/real").unwatch(self.update_text)
-        self.context.channel(f"{name}/events").unwatch(self.update_text)
+        self.context.channel(f"{self._name}/recv").unwatch(self.update_text)
+        self.context.channel(f"{self._name}/send").unwatch(self.update_text)
+        self.context.channel(f"{self._name}/real").unwatch(self.update_text)
+        self.context.channel(f"{self._name}/events").unwatch(self.update_text)
 
 
 class RuidaController(MWindow):

--- a/meerk40t/ruida/mock_connection.py
+++ b/meerk40t/ruida/mock_connection.py
@@ -12,8 +12,7 @@ import struct
 class MockConnection:
     def __init__(self, service):
         self.service = service
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.channel = service.channel(f"{name}/mock")
         self.send = service.channel(f"{name}/send")
         self.recv = service.channel(f"{name}/recv", pure=True)

--- a/meerk40t/ruida/serial_connection.py
+++ b/meerk40t/ruida/serial_connection.py
@@ -15,8 +15,7 @@ class SerialConnection:
         self.laser = None
         self.read_buffer = bytearray()
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.recv = service.channel(f"{name}/recv", pure=True)
         self.send = service.channel(f"{name}/send", pure=True)
         self.events = service.channel(f"{name}/events", pure=True)
@@ -51,10 +50,8 @@ class SerialConnection:
             )
             self.events("Connected")
 
-            name = self.service.label.replace(" ", "-")
-            name = name.replace("/", "-")
             self.service.threaded(
-                self._run_serial_listener, thread_name=f"thread-{name}", daemon=True
+                self._run_serial_listener, thread_name=f"thread-{self.service.safe_label}", daemon=True
             )
             self.service.signal("pipe;usb_status", "connected")
             self.events("Connected")

--- a/meerk40t/ruida/udp_connection.py
+++ b/meerk40t/ruida/udp_connection.py
@@ -9,8 +9,7 @@ import struct
 class UDPConnection:
     def __init__(self, service):
         self.service = service
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.recv = service.channel(f"{name}/recv", pure=True)
         self.send = service.channel(f"{name}/send", pure=True)
         self.events = service.channel(f"{name}/events", pure=True)
@@ -28,8 +27,7 @@ class UDPConnection:
         self.socket.settimeout(4)
         self.socket.bind(("", 40200))
 
-        name = self.service.label.replace(" ", "-")
-        name = name.replace("/", "-")
+        name = self.service.safe_label
         self.service.threaded(
             self._run_udp_listener, thread_name=f"thread-{name}", daemon=True
         )


### PR DESCRIPTION
* Add in `device.safe_label` property universally to all drivers.
* Replace code-level safe_label with property
* Fix several controller open (listens) vs close (unlisten) where the label could have changed and thus crashed.