### PR TITLE
Extended snap logic

### DIFF
--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1566,16 +1566,31 @@ class MoveWidget(Widget):
             c) Regular snap-check
             d) Use magnet lines
             """
+
+            def shortest_distance(p1, p2):
+                """
+                Calculates the shortest distance between two arrays of 2-dimensional points.
+                """
+                # Calculate the Euclidean distance between each point in p1 and p2
+                dist = np.sqrt(np.sum((p1[:, np.newaxis] - p2) ** 2, axis=2))
+
+                # Find the minimum distance and its corresponding indices
+                min_dist = np.min(dist)
+                min_indices = np.argwhere(dist == min_dist)
+
+                # Return the coordinates of the two points
+                return min_dist, p1[min_indices[0][0]], p2[min_indices[0][1]]
+
             b = elements._emphasized_bounds
             if b is None:
                 b = elements.selected_area()
+            matrix = self.scene.widget_root.scene_widget.matrix
             did_snap_to_point = False
             if (
                 self.scene.context.snap_points
                 and not "shift" in modifiers
                 and b is not None
             ):
-                matrix = self.scene.widget_root.scene_widget.matrix
                 gap = self.scene.context.action_attract_len / matrix.value_scale_x()
                 # We gather all points of non-selected elements,
                 # but only those that lie within the boundaries
@@ -1585,19 +1600,6 @@ class MoveWidget(Widget):
                 # lie within the selection area plus boundary) and look for
                 # the closest distance.
 
-                def shortest_distance(p1, p2):
-                    """
-                    Calculates the shortest distance between two arrays of 2-dimensional points.
-                    """
-                    # Calculate the Euclidean distance between each point in p1 and p2
-                    dist = np.sqrt(np.sum((p1[:, np.newaxis] - p2) ** 2, axis=2))
-
-                    # Find the minimum distance and its corresponding indices
-                    min_dist = np.min(dist)
-                    min_indices = np.argwhere(dist == min_dist)
-
-                    # Return the coordinates of the two points
-                    return min_dist, p1[min_indices[0][0]], p2[min_indices[0][1]]
                 t1 = perf_counter()
                 other_points = []
                 selected_points = []

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1685,6 +1685,9 @@ class MoveWidget(Widget):
 
                 t2 = perf_counter()
                 # print (f"Corner-points, compared {len(selected_points)} pts to {len(other_points)} pts. Total time: {t2-t1:.2f}sec")
+                if did_snap_to_point:
+                    # Even then magnets win!
+                    self.check_for_magnets()
 
             if not did_snap_to_point:
                 if nearest_snap is None:

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -33,7 +33,7 @@ from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT_AND_DELEGATE
 from meerk40t.gui.scene.widget import Widget
 from meerk40t.gui.wxutils import StaticBoxSizer, create_menu_for_node
 from meerk40t.svgelements import Point
-from meerk40t.tools.geomstr import TYPE_END, Geomstr
+from meerk40t.tools.geomstr import TYPE_END
 
 NEARLY_ZERO = 1.0e-6
 
@@ -1559,13 +1559,11 @@ class MoveWidget(Widget):
             # )
 
         if event == 1:  # end
-            """
-            Cleanup - we check for:
-            a) Would a point of the selection snap to a point of the non-selected elements? If yes we are done
-            b) Use the distance of the 4 corners and the center to a grid point -> take smallest distance
-            c) Regular snap-check
-            d) Use magnet lines
-            """
+            # Cleanup - we check for:
+            # a) Would a point of the selection snap to a point of the non-selected elements? If yes we are done
+            # b) Use the distance of the 4 corners and the center to a grid point -> take smallest distance
+            # c) Regular snap-check
+            # d) Use magnet lines
 
             def shortest_distance(p1, p2):
                 """

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -15,10 +15,10 @@ LockWidget: Widget to lock and unlock the given object.
 
 
 import math
+from time import perf_counter
 
 import numpy as np
 import wx
-from time import perf_counter
 
 from meerk40t.core.elements.element_types import *
 from meerk40t.core.units import Length
@@ -1643,9 +1643,7 @@ class MoveWidget(Widget):
                 if len(other_points) > 0:
                     np_other = np.asarray(other_points)
                     np_selected = np.asarray(selected_points)
-                    dist, pt1, pt2 = shortest_distance(
-                        np_other, np_selected
-                    )
+                    dist, pt1, pt2 = shortest_distance(np_other, np_selected)
 
                     if dist < gap:
                         did_snap_to_point = True
@@ -1670,15 +1668,13 @@ class MoveWidget(Widget):
                     (b[2], b[1]),
                     (b[0], b[3]),
                     (b[2], b[3]),
-                    ((b[0] + b[2]) / 2, (b[1] + b[3])/2),
+                    ((b[0] + b[2]) / 2, (b[1] + b[3]) / 2),
                 )
                 other_points = self.scene.pane.grid.grid_points
                 if len(other_points) > 0:
                     np_other = np.asarray(other_points)
                     np_selected = np.asarray(selected_points)
-                    dist, pt1, pt2 = shortest_distance(
-                        np_other, np_selected
-                    )
+                    dist, pt1, pt2 = shortest_distance(np_other, np_selected)
                     if dist < gap:
                         did_snap_to_point = True
                         dx = pt1[0] - pt2[0]


### PR DESCRIPTION
Moving a selection will be a bit smarter - until now it tried to snap the center of the selection to either grid or element points.
Now it will check (in hierarchical order)
1. would any point of the selected elements (=start + end points of geomstr segments) snap to a point of the non-selected elements (needs flag ``snap to element`` active) 
2. would any of the 4 corners + center of the selection snap to a grid point (needs flag ``snap to grid`` active)
3. would the center of the selection snap to a point (old logic)
4. both 2. and 3. are followed by a magnetline attraction (if any)

![snapper](https://github.com/meerk40t/meerk40t/assets/2670784/f0af0171-9aa6-45d0-bf08-46b13fc3f115)
