### PR TITLE
Add service/kernel console command applied to lifecycle objects

### DIFF
--- a/meerk40t/kernel/functions.py
+++ b/meerk40t/kernel/functions.py
@@ -328,7 +328,7 @@ def console_command(
                     inner.object = obj
                     reg.register(p, inner)
 
-        def unregister(reg):
+        def unregister(reg, obj=None):
             if force_kernel and hasattr(reg, "kernel"):
                 reg = reg.kernel
             console_command_remove(reg, path, input_type)

--- a/meerk40t/kernel/functions.py
+++ b/meerk40t/kernel/functions.py
@@ -318,19 +318,27 @@ def console_command(
         inner.options = list()
         inner.object = None
 
-        def register(registration, obj=None):
+        # Process registration.
+        def register(reg, obj=None):
+            if force_kernel and hasattr(reg, "kernel"):
+                reg = reg.kernel
             for cmd in cmds:
                 for i in ins:
                     p = f"command/{i}/{cmd}"
                     inner.object = obj
-                    if force_kernel and hasattr(registration, "kernel"):
-                        registration = registration.kernel
-                    registration.register(p, inner)
+                    reg.register(p, inner)
+
+        def unregister(reg):
+            if force_kernel and hasattr(reg, "kernel"):
+                reg = reg.kernel
+            console_command_remove(reg, path, input_type)
+
+        inner.unreg = unregister
+        inner.reg = register
 
         if registration:
-            register(registration)
-        else:
-            inner.reg = register
+            inner.reg(registration)
+
         return inner
 
     return decorator

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2274,11 +2274,13 @@ class Kernel(Settings):
             except UnicodeDecodeError:
                 return
         self._console_buffer += data
+        data_out = None
         while "\n" in self._console_buffer:
             pos = self._console_buffer.find("\n")
             command = self._console_buffer[0:pos].strip("\r")
             self._console_buffer = self._console_buffer[pos + 1 :]
-            self._console_parse(command, channel=self._console_channel)
+            data_out = self._console_parse(command, channel=self._console_channel)
+        return data_out
 
     def _console_interface(self, command: str):
         pass

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -705,6 +705,7 @@ class Kernel(Settings):
             for plugin in self._kernel_plugins:
                 plugin(kernel, "register")
 
+        objects = self.get_linked_objects(kernel)
         for k in objects:
             if klp(k) < LIFECYCLE_KERNEL_CONFIGURE <= end:
                 k._kernel_lifecycle = LIFECYCLE_KERNEL_CONFIGURE
@@ -890,7 +891,6 @@ class Kernel(Settings):
                 k._kernel_lifecycle = LIFECYCLE_KERNEL_SHUTDOWN
                 if channel:
                     channel(f"kernel-shutdown: {str(k)}")
-                self._command_detach(kernel, k)
                 self._signal_detach(k)
                 self._lookup_detach(k)
                 if hasattr(k, "shutdown"):

--- a/test/bootstrap.py
+++ b/test/bootstrap.py
@@ -1,7 +1,7 @@
 from meerk40t.kernel import Kernel
 
 
-def bootstrap(profile="MeerK40t_TEST", ignore_settings=True):
+def bootstrap(profile="MeerK40t_TEST", ignore_settings=True, plugins=None):
     kernel = Kernel(
         "MeerK40t",
         "0.0.0-testing",
@@ -65,6 +65,10 @@ def bootstrap(profile="MeerK40t_TEST", ignore_settings=True):
     from meerk40t.rotary import rotary
 
     kernel.add_plugin(rotary.plugin)
+
+    if plugins:
+        for plugin in plugins:
+            kernel.add_plugin(plugin)
 
     kernel(partial=True)
     kernel.console("channel print console\n")

--- a/test/test_kernel.py
+++ b/test/test_kernel.py
@@ -1,8 +1,60 @@
 import unittest
+
+from meerk40t.kernel import (
+    service_console_command,
+    kernel_console_command,
+)
 from test import bootstrap
 
 
+def test_plugin_service(kernel, lifecycle):
+    if lifecycle == "register":
+        service = kernel.elements
+        service.add_service_delegate(TestObject())
+
+
+def test_plugin_kernel(kernel, lifecycle):
+    if lifecycle == "register":
+        kernel.add_delegate(TestObject(), kernel)
+
+
+class TestObject:
+    """
+    Object flagged with service and kernel console commands.
+    """
+
+    @service_console_command("hello")
+    def service_console_command(self, command, channel, **kwargs):
+        return "elements", "hello"
+
+    @kernel_console_command("hello")
+    def kernel_console_command2(self, command, channel, **kwargs):
+        return "elements", 1
+
+
 class TestKernel(unittest.TestCase):
+    def test_object_service_commands(self):
+        """
+        Test registration of service command via classbased decorator
+        """
+        kernel = bootstrap.bootstrap(plugins=[test_plugin_service])
+        try:
+            n = kernel.root("hello")
+            self.assertEqual(n, "hello")
+        finally:
+            kernel()
+
+    def test_object_kernel_commands(self):
+        """
+        Test registration of kernel command via classbased decorator
+        """
+        kernel = bootstrap.bootstrap(plugins=[test_plugin_kernel])
+        try:
+            n = kernel.root("hello")
+            self.assertEqual(n, 1)
+        finally:
+            kernel()
+
     def test_kernel_commands(self):
         """
         Tests all commands with no arguments to test for crashes...


### PR DESCRIPTION
* Correct return for `kernel.console` call
* Testing.bootstrap now allows adding test plugins
* added _command_attach/_command_detach
* Hooked to lifecycle: kernel.boot`, `service.added`.
* Removed from lifecycle `remove_delegate`, `kernel.preshutdown`, `service.shutdown`.

The chief purpose of this PR is to allow kernel to use `@service_console_command` and `@kernel_console_command` decorators in the kernel (or delegate thereof) or in a service or delegate thereof.

The _() command is usually located in the kernel and so it's decidedly much harder to get this to work correctly if they are class methods.