### PR TITLE
Vectorfont - fixes and poor man's kerning

### DIFF
--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -135,6 +135,17 @@ class LineTextPropertyPanel(wx.Panel):
         self.btn_smaller.SetToolTip(_("Decrease the font-size"))
         sizer_text.Add(self.btn_smaller, 0, wx.EXPAND, 0)
 
+        self.btn_bigger_spacing = wx.Button(self, wx.ID_ANY, "+")
+        self.btn_bigger_spacing.SetToolTip(_("Increase the character-gap"))
+        sizer_text.Add(self.btn_bigger_spacing, 0, wx.EXPAND, 0)
+
+        self.btn_smaller_spacing = wx.Button(self, wx.ID_ANY, "-")
+        self.btn_smaller_spacing.SetToolTip(_("Decrease the character-gap"))
+        sizer_text.Add(self.btn_smaller_spacing, 0, wx.EXPAND, 0)
+
+        for btn in (self.btn_bigger, self.btn_smaller, self.btn_bigger_spacing, self.btn_smaller_spacing):
+            btn.SetMinSize(dip_size(self,35, -1))
+
         sizer_fonts = StaticBoxSizer(
             self, wx.ID_ANY, _("Fonts (double-click to use)"), wx.VERTICAL
         )
@@ -156,6 +167,12 @@ class LineTextPropertyPanel(wx.Panel):
         self.Layout()
         self.btn_bigger.Bind(wx.EVT_BUTTON, self.on_button_bigger)
         self.btn_smaller.Bind(wx.EVT_BUTTON, self.on_button_smaller)
+
+        self.btn_bigger_spacing.Bind(wx.EVT_BUTTON, self.on_button_bigger_spacing)
+        self.btn_smaller_spacing.Bind(wx.EVT_BUTTON, self.on_button_smaller_spacing)
+        self.btn_bigger_spacing.Bind(wx.EVT_RIGHT_DOWN, self.on_button_reset_spacing)
+        self.btn_smaller_spacing.Bind(wx.EVT_RIGHT_DOWN, self.on_button_reset_spacing)
+
         self.text_text.Bind(wx.EVT_TEXT, self.on_text_change)
         self.list_fonts.Bind(wx.EVT_LISTBOX, self.on_list_font)
         self.list_fonts.Bind(wx.EVT_LISTBOX_DCLICK, self.on_list_font_dclick)
@@ -185,6 +202,8 @@ class LineTextPropertyPanel(wx.Panel):
         if self.node is None or not self.accepts(node):
             self.Hide()
             return
+        if not hasattr(self.node, "mkfontspacing") or self.node.mkfontspacing is None:
+            self.node.mkfontspacing = 1.0
         fontdir = fontdirectory(self.context)
         self.load_directory(fontdir)
         self.text_text.SetValue(str(node.mktext))
@@ -226,6 +245,23 @@ class LineTextPropertyPanel(wx.Panel):
         if self.node is None:
             return
         self.node.mkfontsize /= 1.2
+        self.update_node()
+
+    def on_button_reset_spacing(self, event):
+        print ("Reset")
+        self.node.mkfontspacing = 1.0
+        self.update_node()
+
+    def on_button_bigger_spacing(self, event):
+        if self.node is None:
+            return
+        self.node.mkfontspacing += 0.01
+        self.update_node()
+
+    def on_button_smaller_spacing(self, event):
+        if self.node is None:
+            return
+        self.node.mkfontspacing -= 0.01
         self.update_node()
 
     def on_text_change(self, event):
@@ -519,8 +555,8 @@ class PanelFontManager(wx.Panel):
         sizer_buttons.Add(self.combo_webget, 0, wx.EXPAND, 0)
 
         self.SetSizer(mainsizer)
-
         self.Layout()
+        mainsizer.Fit(self)
 
         self.Bind(wx.EVT_TEXT, self.on_text_directory, self.text_fontdir)
         self.Bind(wx.EVT_BUTTON, self.on_btn_directory, self.btn_dirselect)

--- a/meerk40t/tools/jhfparser.py
+++ b/meerk40t/tools/jhfparser.py
@@ -170,7 +170,7 @@ class JhfFont:
                     self.bottom = struct["bottom"]
             cidx += 1
 
-    def render(self, path, text, horizontal=True, font_size=12.0):
+    def render(self, path, text, horizontal=True, font_size=12.0, spacing=1.0):
         """
         From https://emergent.unpythonic.net/software/hershey
         The structure is basically as follows: each character consists of a number 1->4000 (not all used) in column 0:4,
@@ -260,7 +260,7 @@ class JhfFont:
                 struct = self.glyphs[tchar]
                 nverts = struct["nverts"]
                 vertices = struct["vertices"]
-                offsetx += abs(struct["left"])
+                offsetx += abs(struct["left"]) * spacing
                 # offsetx += abs(struct["realleft"] - 1)
                 idx = 0
                 penup = True
@@ -284,7 +284,7 @@ class JhfFont:
                         lasty = rightval
                     idx += 1
                 cidx += 1
-                offsetx += struct["right"]
+                offsetx += struct["right"] * spacing
                 # offsetx += struct["realright"] + 1
             else:
                 # print(f"Char '{tchar}' (ord={ord(tchar)}) not in font...")

--- a/meerk40t/tools/shxparser.py
+++ b/meerk40t/tools/shxparser.py
@@ -347,12 +347,16 @@ class ShxFont:
         except IndexError as e:
             raise ShxFontParseError("No codes to pop()") from e
 
-    def render(self, path, text, horizontal=True, font_size=12.0):
+    def render(self, path, text, horizontal=True, font_size=12.0, spacing=1.0):
         if self.above is None:
             self.above = 1
         self._scale = font_size / self.above
         self._horizontal = horizontal
         self._path = path
+        self._x = 0
+        self._y = 0
+        self._last_x = 0
+        self._last_y = 0
         replacer = []
         for tchar in text:
             to_replace = None
@@ -378,6 +382,8 @@ class ShxFont:
             # print (f"Replace all '{to_replace[0]}' with '{to_replace[1]}'")
             text = text.replace(to_replace[0], to_replace[1])
         for letter in text:
+            last_letter_x = self._last_x
+            last_letter_y = self._last_y
             self._letter = letter
             try:
                 self._code = bytearray(reversed(self.glyphs[ord(letter)]))
@@ -391,6 +397,10 @@ class ShxFont:
                 except IndexError as e:
                     raise ShxFontParseError("Stack Error during render.") from e
             self._skip = False
+            if spacing != 1.0:
+                dx = (spacing - 1) * (self._last_x - last_letter_x)
+                self._last_x += dx
+                self._x += dx
         if self._debug:
             print(f"Render Complete.\n\n\n")
 

--- a/meerk40t/tools/ttfparser.py
+++ b/meerk40t/tools/ttfparser.py
@@ -59,13 +59,14 @@ class TrueTypeFont:
         self.parse_cmap()
         self.glyphs = list(self.parse_glyf())
 
-    def render(self, path, text, horizontal=True, font_size=12.0):
+    def render(self, path, text, horizontal=True, font_size=12.0, spacing=1.0):
+        # Letter spacing
         scale = font_size / self.units_per_em
         offset_x = 0
         offset_y = 0
         for c in text:
             index = self._character_map.get(c, 0)
-            advance_x = self.horizontal_metrics[index][0]
+            advance_x = self.horizontal_metrics[index][0] * spacing
             advance_y = 0
             glyph = self.glyphs[index]
             path.new_path()


### PR DESCRIPTION
- Autocad fonts were no longer rendered correctly (did not reset the internal position)
- Added support for a poor man kerning ie character gap adjustment