### PR TITLE
Effect Drag-and-Drop treatment correction.

### DIFF
--- a/meerk40t/core/node/branch_elems.py
+++ b/meerk40t/core/node/branch_elems.py
@@ -17,7 +17,7 @@ class BranchElementsNode(Node):
         return default_map
 
     def drop(self, drag_node, modify=True):
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.append_child(drag_node)
             return True

--- a/meerk40t/core/node/branch_regmark.py
+++ b/meerk40t/core/node/branch_regmark.py
@@ -25,7 +25,7 @@ class BranchRegmarkNode(Node):
             self.remove_references(ref)
 
     def drop(self, drag_node, modify=True):
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.remove_references(drag_node)
                 self.append_child(drag_node)

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -218,7 +218,7 @@ class EllipseNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -171,7 +171,7 @@ class ImageNode(Node):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -199,7 +199,7 @@ class LineNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -166,7 +166,7 @@ class PathNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -79,7 +79,7 @@ class PointNode(Node, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -195,7 +195,7 @@ class PolylineNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -194,7 +194,7 @@ class RectNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -185,7 +185,7 @@ class TextNode(Node, Stroked, FunctionalParameter):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -51,7 +51,7 @@ class GroupNode(Node):
         return default_map
 
     def drop(self, drag_node, modify=True):
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             # Dragging element onto a group moves it to the group node.
             if modify:
                 self.append_child(drag_node)

--- a/meerk40t/core/node/image_processed.py
+++ b/meerk40t/core/node/image_processed.py
@@ -164,7 +164,7 @@ class ImageProcessedNode(Node):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/image_raster.py
+++ b/meerk40t/core/node/image_raster.py
@@ -93,7 +93,7 @@ class ImageRasterNode(Node):
 
     def drop(self, drag_node, modify=True):
         # Dragging element into element.
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -116,7 +116,7 @@ class CutOpNode(Node, Parameters):
 
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
-        if drag_node.type.startswith("elem") or drag_node.type.startswith("effect"):
+        if hasattr(drag_node, "as_geometry"):
             if (
                 drag_node.type not in self._allowed_elements_dnd
                 or drag_node._parent.type == "branch reg"

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -72,7 +72,7 @@ class DotsOpNode(Node, Parameters):
 
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry"):
             if (
                 drag_node.type not in self._allowed_elements_dnd
                 or drag_node._parent.type == "branch reg"

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -102,7 +102,7 @@ class EngraveOpNode(Node, Parameters):
 
     def drop(self, drag_node, modify=True):
         # Default routine for drag + drop for an op node - irrelevant for others...
-        if drag_node.type.startswith("elem") or drag_node.type.startswith("effect"):
+        if hasattr(drag_node, "as_geometry"):
             if (
                 drag_node.type not in self._allowed_elements_dnd
                 or drag_node._parent.type == "branch reg"

--- a/meerk40t/core/node/refnode.py
+++ b/meerk40t/core/node/refnode.py
@@ -30,7 +30,7 @@ class ReferenceNode(Node):
         return default_map
 
     def drop(self, drag_node, modify=True):
-        if drag_node.type.startswith("elem"):
+        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             op = self.parent
             drop_index = op.children.index(self)
             if modify:


### PR DESCRIPTION
Most nodes check for `type.startswith("elem")` rather than whether they give geometry and as such would not accept an effect which has geometry but is not an an `elem` type.