### PR TITLE
Advanced Ribbon Tool, Tool Modes

### DIFF
--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -22,7 +22,7 @@ class CircleTool(ToolWidget):
     Adds Circle with click and drag.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.p1 = None

--- a/meerk40t/gui/toolwidgets/toolcontainer.py
+++ b/meerk40t/gui/toolwidgets/toolcontainer.py
@@ -13,6 +13,7 @@ class ToolContainer(Widget):
     def __init__(self, scene):
         Widget.__init__(self, scene, all=False)
         self._active_tool = "unset"
+        self._tool_mode = "unset"
         # Selection/Manipulation widget.
         self.mode = "selection"
         self.selection_widgets = {
@@ -33,13 +34,17 @@ class ToolContainer(Widget):
     def signal(self, signal, *args, **kwargs):
         if signal == "tool":
             tool = args[0]
-            self.set_tool(tool)
+            if len(args) > 1:
+                mode = args[1]
+            else:
+                mode = None
+            self.set_tool(tool, mode=mode)
 
-    def set_tool(self, tool):
-        response = ""
-        if self._active_tool == tool:
+    def set_tool(self, tool, mode=None):
+        if self._active_tool == tool and self._tool_mode == mode:
             return True, f"Tool {tool} was already active"
         self._active_tool = tool
+        self._tool_mode = mode
         self.scene.pane.tool_active = False
         self.scene.pane.modif_active = False
         self.scene.pane.suppress_selection = False
@@ -59,7 +64,7 @@ class ToolContainer(Widget):
 
         self.add_widget(widget=self.selection_widgets.get(self.mode))
         if new_tool is not None:
-            self.add_widget(widget=new_tool(self.scene))
+            self.add_widget(widget=new_tool(self.scene, mode=mode))
 
         self.scene.cursor("arrow")
 

--- a/meerk40t/gui/toolwidgets/tooldraw.py
+++ b/meerk40t/gui/toolwidgets/tooldraw.py
@@ -15,7 +15,7 @@ class DrawTool(ToolWidget):
     Draw Tool adds paths that are clicked and drawn within the scene.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.preferred_length = 50
         self.series = None

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -19,7 +19,7 @@ class EllipseTool(ToolWidget):
     Adds Circle with click and drag.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.p1 = None

--- a/meerk40t/gui/toolwidgets/toolimagecut.py
+++ b/meerk40t/gui/toolwidgets/toolimagecut.py
@@ -8,8 +8,8 @@ class ImageCutTool(PointListTool):
     Draws a line with click and drag, uses that line to slice an image.
     """
 
-    def __init__(self, scene):
-        PointListTool.__init__(self, scene)
+    def __init__(self, scene, mode=None):
+        PointListTool.__init__(self, scene, mode=mode)
 
     def create_node(self):
         if len(self.point_series) > 1:

--- a/meerk40t/gui/toolwidgets/toolline.py
+++ b/meerk40t/gui/toolwidgets/toolline.py
@@ -8,8 +8,8 @@ class LineTool(PointListTool):
     Adds Line with two clicks.
     """
 
-    def __init__(self, scene):
-        PointListTool.__init__(self, scene)
+    def __init__(self, scene, mode=None):
+        PointListTool.__init__(self, scene, mode=mode)
 
     def create_node(self):
         if len(self.point_series) > 1:

--- a/meerk40t/gui/toolwidgets/toollinetext.py
+++ b/meerk40t/gui/toolwidgets/toollinetext.py
@@ -19,7 +19,7 @@ class LineTextTool(ToolWidget):
     Adds a linetext, first point click then Text-Entry
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.p1 = None

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -17,8 +17,8 @@ class MeasureTool(PointListTool):
     and after 3 points the covered area as well
     """
 
-    def __init__(self, scene):
-        PointListTool.__init__(self, scene)
+    def __init__(self, scene, mode=None):
+        PointListTool.__init__(self, scene, mode=mode)
         self.line_pen = wx.Pen()
         self.line_pen.SetColour(self.scene.colors.color_measure_line)
         self.line_pen.SetStyle(wx.PENSTYLE_DOT)

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -51,7 +51,7 @@ class EditTool(ToolWidget):
     polylines / polygons and paths.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self._listener_active = False
         self.nodes = []

--- a/meerk40t/gui/toolwidgets/toolnodemove.py
+++ b/meerk40t/gui/toolwidgets/toolnodemove.py
@@ -15,7 +15,7 @@ class NodeMoveTool(ToolWidget):
 
     select_mode = "vertex"
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
 
     def event(

--- a/meerk40t/gui/toolwidgets/toolparameter.py
+++ b/meerk40t/gui/toolwidgets/toolparameter.py
@@ -235,7 +235,7 @@ class ParameterTool(ToolWidget):
     and allows to change them visually.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.element = None
         self.params = []

--- a/meerk40t/gui/toolwidgets/toolplacement.py
+++ b/meerk40t/gui/toolwidgets/toolplacement.py
@@ -14,7 +14,7 @@ class PlacementTool(ToolWidget):
     Adds a placement with clicks.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.has_ctrl = False
         self.has_alt = False

--- a/meerk40t/gui/toolwidgets/toolpoint.py
+++ b/meerk40t/gui/toolwidgets/toolpoint.py
@@ -12,7 +12,7 @@ class PointTool(ToolWidget):
     Adds points with clicks.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
 
     def process_draw(self, gc: wx.GraphicsContext):

--- a/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
+++ b/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
@@ -28,7 +28,7 @@ class PointListTool(ToolWidget):
 
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.point_series = []

--- a/meerk40t/gui/toolwidgets/toolpointmove.py
+++ b/meerk40t/gui/toolwidgets/toolpointmove.py
@@ -15,7 +15,7 @@ class PointMoveTool(ToolWidget):
     Node Move Tool allows clicking and dragging of nodes to new locations.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.points = list()
         self.pt_offset = 5

--- a/meerk40t/gui/toolwidgets/toolpolygon.py
+++ b/meerk40t/gui/toolwidgets/toolpolygon.py
@@ -25,8 +25,8 @@ class PolygonTool(PointListTool):
     Adds polygon with clicks.
     """
 
-    def __init__(self, scene):
-        PointListTool.__init__(self, scene)
+    def __init__(self, scene, mode=None):
+        PointListTool.__init__(self, scene, mode=mode)
 
         # design_mode
         # 0 - freehand polygon

--- a/meerk40t/gui/toolwidgets/toolpolyline.py
+++ b/meerk40t/gui/toolwidgets/toolpolyline.py
@@ -10,8 +10,8 @@ class PolylineTool(PointListTool):
     Adds a polyline with two or more clicks.
     """
 
-    def __init__(self, scene):
-        PointListTool.__init__(self, scene)
+    def __init__(self, scene, mode=None):
+        PointListTool.__init__(self, scene, mode=mode)
 
     def create_node(self):
         if len(self.point_series) > 1:

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -19,7 +19,7 @@ class RectTool(ToolWidget):
     Adds Rectangles with click and drag.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.p1 = None

--- a/meerk40t/gui/toolwidgets/toolrelocate.py
+++ b/meerk40t/gui/toolwidgets/toolrelocate.py
@@ -13,7 +13,7 @@ class RelocateTool(ToolWidget):
     Adds Circle with click and drag.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.p1 = None

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -14,6 +14,10 @@ from meerk40t.tools.geomstr import Geomstr
 
 
 class RibbonNode:
+    """
+    Base RibbonNode class.
+    """
+
     def __init__(self, ribbon):
         self.brush = wx.Brush(wx.RED)
         self.pen = wx.Pen(wx.BLUE)
@@ -38,6 +42,10 @@ class RibbonNode:
 
 
 class RetroNode(RibbonNode):
+    """
+    Position of node is the referenced nodes position <count> ticks ago. Or the average of the last <count> ticks.
+    """
+
     def __init__(self, ribbon, retro_node, count, average=False):
         super().__init__(ribbon)
         self.retro_node = retro_node
@@ -67,7 +75,7 @@ class RetroNode(RibbonNode):
 
 class MidpointNode(RibbonNode):
     """
-    Position node is simply the ribbon's last identified position as a node.
+    Node's position is the average of the provided nodes positions.
     """
 
     def __init__(self, ribbon, nodes):
@@ -97,7 +105,7 @@ class MidpointNode(RibbonNode):
 
 class OffsetNode(RibbonNode):
     """
-    Position node is simply the ribbon's last identified position as a node.
+    Position is the referenced node's position plus a static offset.
     """
 
     def __init__(self, ribbon, offset_node, dx=0.0, dy=0.0):
@@ -120,6 +128,9 @@ class OffsetNode(RibbonNode):
 class OrientationNode(RibbonNode):
     """
     Orientation node is a 5 node positional. It is located at the reference node. At some angle and some distance away.
+    If a0, a1 are not given the angle is static at offset_angle.
+    if d0, d1 are not given the radius is static at offset_radius.
+    dx, dy are static offsets.
     """
 
     def __init__(

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -2,10 +2,155 @@ import math
 
 import wx
 
-from meerk40t.gui.laserrender import swizzlecolor
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.svgelements import Path, Point
+from meerk40t.tools.geomstr import Geomstr
+
+
+class GravityNode:
+    def __init__(self, ribbon, attract_node=0):
+        self.ribbon = ribbon
+        self.friction = 0.05
+        self.distance = 50
+        self.attraction = 1000
+        self.position = None
+        self.velocity = [0, 0]
+        self.brush = wx.Brush(wx.RED)
+        self.pen = wx.Pen(wx.BLUE)
+        self.diameter = 5000
+        self.attract_node = attract_node
+
+    def tick(self):
+        towards_pos = self.ribbon.nodes[self.attract_node].position
+        if self.position is None:
+            self.position = list(self.ribbon.position)
+        vx = self.velocity[0] * (1 - self.friction)
+        vy = self.velocity[1] * (1 - self.friction)
+        angle = Geomstr.angle(
+            None, complex(*towards_pos), complex(*self.position)
+        )
+        vx -= self.attraction * math.cos(angle)
+        vy -= self.attraction * math.sin(angle)
+
+        self.velocity[0] = vx
+        self.velocity[1] = vy
+        self.position[0] += vx
+        self.position[1] += vy
+
+    def process_draw(self, gc: wx.GraphicsContext):
+        if not self.position:
+            return
+        gc.PushState()
+        gc.SetPen(self.pen)
+        gc.SetBrush(self.brush)
+        gc.DrawEllipse(self.position[0], self.position[1], self.diameter, self.diameter)
+        gc.PopState()
+
+
+class PositionNode:
+    def __init__(self, ribbon):
+        self.ribbon = ribbon
+        self.brush = wx.Brush(wx.RED)
+        self.pen = wx.Pen(wx.BLUE)
+
+    @property
+    def position(self):
+        return self.ribbon.position
+
+    def tick(self):
+        pass
+
+    def process_draw(self, gc: wx.GraphicsContext):
+        if not self.position:
+            return
+        gc.SetPen(self.pen)
+        gc.SetBrush(self.brush)
+        gc.DrawEllipse(self.position[0], self.position[1], 5000, 5000)
+
+
+class DrawSequence:
+    def __init__(self, ribbon, sequences):
+        self.series = {}
+        self.tick_index = 0
+        self.ribbon = ribbon
+        self.pen = wx.Pen(wx.BLUE)
+        self.sequences = sequences
+
+    @classmethod
+    def zig(cls, ribbon):
+        return cls(ribbon, sequences=[[[0], [0], [1], [1]]])
+
+    @classmethod
+    def bounce(cls, ribbon, *args):
+        return cls(ribbon, sequences=[[list(args)]])
+
+    def tick(self):
+        self.tick_index += 1
+        for s, sequence in enumerate(self.sequences):
+            series = self.series.get(s)
+            if series is None:
+                # Add series if not init
+                series = []
+                self.series[s] = series
+
+            q = self.tick_index % len(sequence)
+            seq = sequence[q]
+            for i in seq:
+                x, y = self.ribbon.nodes[i].position
+                series.append((x, y))
+
+    def process_draw(self, gc: wx.GraphicsContext):
+        gc.SetPen(self.pen)
+        for q in self.series:
+            series = self.series[q]
+            gc.StrokeLines(series)
+
+    def get_path(self):
+        g = Geomstr()
+        for q in self.series:
+            series = self.series[q]
+            g.polyline(points=[complex(x, y) for x, y in series])
+        return g
+
+
+class Ribbon:
+    def __init__(self):
+        self.nodes = []
+        self.sequence = DrawSequence.zig(self)
+        self.position = None
+
+    @classmethod
+    def gravity_tool(cls):
+        obj = cls()
+        obj.nodes.append(PositionNode(obj))
+        obj.nodes.append(GravityNode(obj, 0))
+        obj.sequence = DrawSequence.zig(obj)
+        return obj
+
+    @classmethod
+    def bezier_gravity_tool(cls):
+        obj = cls()
+        obj.nodes.append(PositionNode(obj))
+        obj.nodes.append(GravityNode(obj, 0))
+        obj.nodes.append(GravityNode(obj, 1))
+        obj.sequence = DrawSequence.bounce(obj, 1, 2)
+        return obj
+
+    def tick(self):
+        for node in self.nodes:
+            node.tick()
+        self.sequence.tick()
+
+    def process_draw(self, gc: wx.GraphicsContext):
+        for node in self.nodes:
+            node.process_draw(gc)
+        self.sequence.process_draw(gc)
+
+    def get_path(self):
+        return self.sequence.get_path()
+
+    def clear(self):
+        self.sequence.series.clear()
 
 
 class RibbonTool(ToolWidget):
@@ -15,57 +160,18 @@ class RibbonTool(ToolWidget):
 
     def __init__(self, scene):
         ToolWidget.__init__(self, scene)
-        self.preferred_length = 50
-        self.last_position = None
-        self.track_object = [0, 0]
-        self.velocity = [0, 0]
-        self.series = []
         self.stop = False
-        self.pos = 0
+        self.ribbon = Ribbon.gravity_tool()
 
     def process_draw(self, gc: wx.GraphicsContext):
-        elements = self.scene.context.elements
-        if elements.default_stroke is None:
-            self.pen.SetColour(wx.BLUE)
-        else:
-            self.pen.SetColour(wx.Colour(swizzlecolor(elements.default_stroke)))
-        gc.SetPen(self.pen)
-        gc.SetBrush(wx.RED_BRUSH)
-        gc.DrawEllipse(self.track_object[0], self.track_object[1], 5000, 5000)
-        if self.last_position:
-            gc.DrawEllipse(self.last_position[0], self.last_position[1], 5000, 5000)
-
-        if self.series is not None and len(self.series) > 1:
-            gc.SetPen(self.pen)
-            gc.StrokeLines(self.series)
+        self.ribbon.process_draw(gc)
 
     def tick(self):
-        if self.last_position is None:
-            return
-        friction = 0.05
-        attraction = 500
-        vx = self.velocity[0] * (1 - friction)
-        vy = self.velocity[1] * (1 - friction)
-        angle = Point.angle(self.last_position, self.track_object)
-        vx -= attraction * math.cos(angle)
-        vy -= attraction * math.sin(angle)
-
-        self.velocity[0] = vx
-        self.velocity[1] = vy
-        self.track_object[0] += vx
-        self.track_object[1] += vy
-        self.pos += 1
-        if self.pos & 2:
-            self.series.append((self.last_position[0], self.last_position[1]))
-        else:
-            self.series.append((self.track_object[0], self.track_object[1]))
+        self.ribbon.tick()
         self.scene.request_refresh()
         if self.stop:
             return False
-        return (
-            abs(self.last_position[0] - self.track_object[0]) > 1000
-            or abs(self.last_position[1] - self.track_object[1]) > 1000
-        )
+        return True
 
     def event(
         self, window_pos=None, space_pos=None, event_type=None, modifiers=None, **kwargs
@@ -75,15 +181,15 @@ class RibbonTool(ToolWidget):
         response = RESPONSE_CHAIN
         if event_type == "leftdown":
             self.stop = False
-            self.last_position = space_pos[:2]
+            self.ribbon.position = space_pos[:2]
             self.scene.animate(self)
             response = RESPONSE_CONSUME
         elif event_type == "move" or event_type == "hover":
-            self.last_position = space_pos[:2]
+            self.ribbon.position = space_pos[:2]
             response = RESPONSE_CONSUME
         elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
             self.stop = True
-            self.series.clear()
+            self.ribbon.clear()
             if self.scene.pane.tool_active:
                 self.scene.pane.tool_active = False
                 self.scene.request_refresh()
@@ -92,14 +198,11 @@ class RibbonTool(ToolWidget):
                 return RESPONSE_CHAIN
         elif event_type == "leftup":
             self.stop = True
-            if self.series:
-                t = Path()
-                t.move(self.series[0])
-                for m in self.series:
-                    t.line(m)
+            t = self.ribbon.get_path()
+            if t:
                 elements = self.scene.context.elements
                 node = elements.elem_branch.add(
-                    path=t,
+                    geometry=t,
                     type="elem path",
                     stroke_width=elements.default_strokewidth,
                     stroke=elements.default_stroke,
@@ -107,7 +210,6 @@ class RibbonTool(ToolWidget):
                 )
                 if elements.classify_new:
                     elements.classify([node])
-                self.notify_created(node)
-                self.series.clear()
+                self.ribbon.clear()
             response = RESPONSE_CONSUME
         return response

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -377,14 +377,28 @@ class Ribbon:
         return obj
 
     @classmethod
-    def nudge_loop(cls):
+    def bendy_calligraphy_tool(cls):
+        """
+        B5,5B2,10kO5,3,4vvl100,100f0"
+        @return:
+        """
+        obj = cls()
+        obj.nodes.append(PositionNode(obj))
+        obj.nodes.append(OffsetNode(obj, 0, 10000, 10000))
+        obj.nodes.append(RetroNode(obj, 0, 5, average=True))
+        obj.nodes.append(RetroNode(obj, 1, 10, average=True))
+        obj.sequence = DrawSequence.bounce_back(obj, 2, 3)
+
+        return obj
+
+    @classmethod
+    def nudge_loop_tool(cls):
         obj = cls()
         obj.nodes.append(PositionNode(obj))
         obj.nodes.append(GravityNode(obj, 2))
         obj.nodes.append(GravityNode(obj, 3))
         obj.nodes.append(GravityNode(obj, 4))
         obj.nodes.append(MidpointNode(obj, [0, 1]))
-        obj.nodes.append(OffsetNode(obj, 0, 10000, 10000))
         obj.sequence = DrawSequence.bounce_back(obj, 1, 2, 3)
         return obj
 
@@ -438,7 +452,9 @@ class RibbonTool(ToolWidget):
         elif mode == "calligraphy":
             self.ribbon = Ribbon.calligraphy_tool()
         elif mode == "nudge":
-            self.ribbon = Ribbon.nudge_loop()
+            self.ribbon = Ribbon.nudge_loop_tool()
+        elif mode == "bendy_calligraphy":
+            self.ribbon = Ribbon.bendy_calligraphy_tool()
         else:
             self.ribbon = Ribbon.gravity_tool()
 

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -37,13 +37,48 @@ class RibbonNode:
         gc.PopState()
 
 
+class RetroNode(RibbonNode):
+    def __init__(self, ribbon, retro_node, count, average=False):
+        super().__init__(ribbon)
+        self.retro_node = retro_node
+        self.count = count
+        self.average = average
+        self._xs = []
+        self._ys = []
+
+    def tick(self):
+        tracking_pos = self.get(self.retro_node)
+        self._xs.append(tracking_pos[0])
+        self._ys.append(tracking_pos[1])
+        if self.average:
+            xs = sum(self._xs) / len(self._xs)
+            ys = sum(self._ys) / len(self._ys)
+            self.position = [xs, ys]
+            if len(self._xs) >= self.count:
+                self._xs.pop(0)
+                self._ys.pop(0)
+        else:
+            self.position = None
+            if len(self._xs) >= self.count:
+                self.position = self._xs.pop(0), self._ys.pop(0)
+
+
 class OrientationNode(RibbonNode):
     """
     Orientation node is a 5 node positional. It is located at the reference node. At some angle and some distance away.
     """
 
     def __init__(
-        self, ribbon, ref_node=0, a0=None, a1=None, d0=None, d1=None, dx=0., dy=0., d_theta=0.
+        self,
+        ribbon,
+        ref_node=0,
+        a0=None,
+        a1=None,
+        d0=None,
+        d1=None,
+        dx=0.0,
+        dy=0.0,
+        d_theta=0.0,
     ):
         super().__init__(ribbon)
         self.ref_node = ref_node

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -170,14 +170,14 @@ class DrawSequence:
         self.sequences = sequences
 
     @classmethod
-    def zig(cls, ribbon):
+    def zig(cls, ribbon, zig=0, zag=1):
         """
         This is one path, [] and each is in a 4 tick sequence. The first sequence is 0 the second 0, third 1 and then 1
         So this draws between element 0, then element 0, then element 1, then element 1. Performing a zig-zag.
         @param ribbon:
         @return:
         """
-        return cls(ribbon, sequences=[[[0], [0], [1], [1]]])
+        return cls(ribbon, sequences=[[[zig], [zig], [zag], [zag]]])
 
     @classmethod
     def bounce(cls, ribbon, *args):
@@ -248,6 +248,20 @@ class Ribbon:
         return obj
 
     @classmethod
+    def smooth_gravity_tool(cls):
+        """
+        Gravity tool is a position node and a single gravity node that moves towards it.
+        @return:
+        """
+        obj = cls()
+        obj.nodes.append(PositionNode(obj))
+        obj.nodes.append(RetroNode(obj, 0, 25, average=True))
+        obj.nodes.append(GravityNode(obj, 1))
+
+        obj.sequence = DrawSequence.zig(obj, 1, 2)
+        return obj
+
+    @classmethod
     def line_gravity_tool(cls):
         """
         Gravity line tool is a position node, being tracked by a gravity node, which in turn is tracked by another such
@@ -303,6 +317,8 @@ class RibbonTool(ToolWidget):
             self.ribbon = Ribbon.gravity_tool()
         elif mode == "line":
             self.ribbon = Ribbon.line_gravity_tool()
+        elif mode == "smooth":
+            self.ribbon = Ribbon.smooth_gravity_tool()
         else:
             self.ribbon = Ribbon.gravity_tool()
 

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -96,7 +96,12 @@ class OrientationNode(RibbonNode):
         angle_end = self.get(self.a1)
         distance_start = self.get(self.d0)
         distance_end = self.get(self.d1)
-        if angle_start is None or angle_end is None or distance_start is None or distance_end is None:
+        if (
+            angle_start is None
+            or angle_end is None
+            or distance_start is None
+            or distance_end is None
+        ):
             # Not engaged.
             self.position = None
             return
@@ -282,6 +287,16 @@ class Ribbon:
         return obj
 
     @classmethod
+    def reverb_tool(cls):
+        """
+        @return:
+        """
+        obj = cls()
+        obj.nodes.append(PositionNode(obj))
+        obj.nodes.append(RetroNode(obj, 0, 20))
+        return obj
+
+    @classmethod
     def line_gravity_tool(cls):
         """
         Gravity line tool is a position node, being tracked by a gravity node, which in turn is tracked by another such
@@ -341,6 +356,8 @@ class RibbonTool(ToolWidget):
             self.ribbon = Ribbon.smooth_gravity_tool()
         elif mode == "speedzig":
             self.ribbon = Ribbon.speed_zig_tool()
+        elif mode == "reverb":
+            self.ribbon = Ribbon.reverb_tool()
         else:
             self.ribbon = Ribbon.gravity_tool()
 

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -26,9 +26,7 @@ class GravityNode:
             self.position = list(self.ribbon.position)
         vx = self.velocity[0] * (1 - self.friction)
         vy = self.velocity[1] * (1 - self.friction)
-        angle = Geomstr.angle(
-            None, complex(*towards_pos), complex(*self.position)
-        )
+        angle = Geomstr.angle(None, complex(*towards_pos), complex(*self.position))
         vx -= self.attraction * math.cos(angle)
         vy -= self.attraction * math.sin(angle)
 
@@ -128,7 +126,7 @@ class Ribbon:
         return obj
 
     @classmethod
-    def bezier_gravity_tool(cls):
+    def line_gravity_tool(cls):
         obj = cls()
         obj.nodes.append(PositionNode(obj))
         obj.nodes.append(GravityNode(obj, 0))
@@ -158,10 +156,15 @@ class RibbonTool(ToolWidget):
     Ribbon Tool draws new segments by animating some click and press locations.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode="gravity"):
         ToolWidget.__init__(self, scene)
         self.stop = False
-        self.ribbon = Ribbon.gravity_tool()
+        if mode == "gravity":
+            self.ribbon = Ribbon.gravity_tool()
+        elif mode == "line":
+            self.ribbon = Ribbon.line_gravity_tool()
+        else:
+            self.ribbon = Ribbon.line_gravity_tool()
 
     def process_draw(self, gc: wx.GraphicsContext):
         self.ribbon.process_draw(gc)

--- a/meerk40t/gui/toolwidgets/toolribbon.py
+++ b/meerk40t/gui/toolwidgets/toolribbon.py
@@ -48,6 +48,8 @@ class RetroNode(RibbonNode):
 
     def tick(self):
         tracking_pos = self.get(self.retro_node)
+        if tracking_pos is None:
+            return
         self._xs.append(tracking_pos[0])
         self._ys.append(tracking_pos[1])
         if self.average:
@@ -208,6 +210,7 @@ class PositionNode(RibbonNode):
         self.ribbon = ribbon
         self.brush = wx.Brush(wx.RED)
         self.pen = wx.Pen(wx.BLUE)
+        self.position = self.ribbon.position
 
     def tick(self):
         self.position = self.ribbon.position
@@ -399,6 +402,33 @@ class Ribbon:
         return obj
 
     @classmethod
+    def crescent_tool(cls):
+        """
+        o3,4,120,100o3,4,0,100o3,4,-120,100kB5, 10B5,5f0"
+        @return:
+        """
+        obj = cls()
+        obj.nodes.append(
+            OrientationNode(
+                obj, 3, 3, 4, offset_angle=math.tau / 3, offset_radius=10000
+            )
+        )
+        obj.nodes.append(
+            OrientationNode(obj, 3, 3, 4, offset_angle=0, offset_radius=10000)
+        )
+        obj.nodes.append(
+            OrientationNode(
+                obj, 3, 3, 4, offset_angle=-math.tau / 3, offset_radius=10000
+            )
+        )
+        obj.nodes.append(RetroNode(obj, 5, 10, average=True))
+        obj.nodes.append(RetroNode(obj, 5, 5, average=True))
+        obj.nodes.append(PositionNode(obj))
+
+        obj.sequence = DrawSequence.bounce_back(obj, 0, 1, 2)
+        return obj
+
+    @classmethod
     def rake_tool(cls):
         """
         "f0B0,10o1,0,90,100s.3ns.6ns-.3ns-.6D2,3,1,4,5"
@@ -417,14 +447,16 @@ class Ribbon:
             OrientationNode(obj, 1, 0, 1, offset_angle=math.tau / 4, offset_radius=5000)
         )
         obj.nodes.append(
-            OrientationNode(obj, 1, 0, 1, offset_angle=math.tau / 4, offset_radius=-5000)
+            OrientationNode(
+                obj, 1, 0, 1, offset_angle=math.tau / 4, offset_radius=-5000
+            )
         )
         obj.nodes.append(
             OrientationNode(
                 obj, 1, 0, 1, offset_angle=math.tau / 4, offset_radius=-10000
             )
         )
-        obj.sequence = DrawSequence.parallel(obj,  2, 3, 1, 4, 5)
+        obj.sequence = DrawSequence.parallel(obj, 2, 3, 1, 4, 5)
 
         return obj
 
@@ -494,6 +526,8 @@ class RibbonTool(ToolWidget):
             self.ribbon = Ribbon.bendy_calligraphy_tool()
         elif mode == "rake":
             self.ribbon = Ribbon.rake_tool()
+        elif mode == "crescent":
+            self.ribbon = Ribbon.crescent_tool()
         else:
             self.ribbon = Ribbon.gravity_tool()
 

--- a/meerk40t/gui/toolwidgets/tooltext.py
+++ b/meerk40t/gui/toolwidgets/tooltext.py
@@ -17,7 +17,7 @@ class TextTool(ToolWidget):
     Adds Text at set location.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.last_node_created = None

--- a/meerk40t/gui/toolwidgets/toolvector.py
+++ b/meerk40t/gui/toolwidgets/toolvector.py
@@ -16,7 +16,7 @@ class VectorTool(ToolWidget):
     Adds Path with click and drag.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, mode=None):
         ToolWidget.__init__(self, scene)
         self.start_position = None
         self.path = None

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -374,7 +374,7 @@ class MeerK40tScenePanel(wx.Panel):
 
         @context.console_argument("tool", help=_("tool to use."))
         @context.console_command("tool", help=_("sets a particular tool for the scene"))
-        def tool_base(command, channel, _, tool=None, **kwgs):
+        def tool_base(command, channel, _, tool=None, remainder=None, **kwgs):
             if tool is None:
                 channel(_("Tools:"))
                 channel("none")
@@ -393,12 +393,12 @@ class MeerK40tScenePanel(wx.Panel):
                 toolbar.modified()
             try:
                 if tool == "none":
-                    success, response = self.tool_container.set_tool(None)
+                    success, response = self.tool_container.set_tool(None, remainder)
                     channel(response)
                     if not success:
                         return
                 else:
-                    success, response = self.tool_container.set_tool(tool.lower())
+                    success, response = self.tool_container.set_tool(tool.lower(), remainder)
                     channel(response)
                     if not success:
                         return


### PR DESCRIPTION
* Add in a small alteration to the tools api. Rather than just the tool name, the `tool <tool> <extra>` data is sent to the tool to process additional modal information.
* Rewrite's ribbon to allow for more advanced and different mode ribbons.
* Default ribbon made ribbon `gravity`.

Ribbon Variants Added:
* gravity
* line
* smooth
* speedzig
* reverb
* calligraphy
* nudge
* bendy_calligraphy
* rake
* crescent