### PR TITLE
lock/unlock of the helper pane updates 

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -245,6 +245,7 @@ DEFAULT_KEYMAP = {
         "reset_bind_alias",
     ),
     "ctrl+alt+shift+home": ("bind default;alias default",),
+    "ctrl+shift+l": ("signal lock_helper",),
 }
 DEFAULT_ALIAS = {
     "+scale_up": (".timerscale_up 0 0.1 .scale 1.02",),

--- a/meerk40t/gui/helper.py
+++ b/meerk40t/gui/helper.py
@@ -48,9 +48,11 @@ class HelperPanel(wx.Panel):
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
         wx.Panel.__init__(self, *args, **kwds)
         self.context = context
+        self._lock_updates = None
         self.text_info = wx.TextCtrl(
             self, wx.ID_ANY, style=wx.TE_MULTILINE | wx.TE_READONLY
         )
+        self.check_allow = wx.CheckBox(self, wx.ID_ANY, _("Display control-information"))
         # self.button_webhelp = wx.Button(self, wx.ID_ANY, _("Online-Help"))
         # self.button_webhelp.SetBitmap(icons8_info.GetBitmap(resize = 0.5 * get_default_icon_size()))
         self.active = False
@@ -64,6 +66,25 @@ class HelperPanel(wx.Panel):
             interval=0.2,
             run_main=True,
         )
+        self.lock_updates = False
+        self.Bind(wx.EVT_CHECKBOX, self.on_check_allow, self.check_allow)
+
+    @property
+    def lock_updates(self):
+        return self._lock_updates
+
+    @lock_updates.setter
+    def lock_updates(self, value):
+        if self.lock_updates != value:
+            self._lock_updates = value
+            self.check_allow.SetValue(not value)
+            if not value:
+                # Make sure we get an update immediately
+                self.mouse_query(None)
+
+    def on_check_allow(self, event):
+        value = self.check_allow.GetValue()
+        self.lock_updates = not value
 
     def mouse_query(self, event=None):
         """
@@ -76,6 +97,8 @@ class HelperPanel(wx.Panel):
         Wiki page on GitHub to open an associated online help page.
         """
         if self.context.kernel.is_shutdown:
+            return
+        if self._lock_updates:
             return
         try:
             wind, pos = wx.FindWindowAtPointer()
@@ -92,6 +115,10 @@ class HelperPanel(wx.Panel):
         except RuntimeError:
             return
 
+    @signal_listener("lock_helper")
+    def helper_locker(self, origin, *args, **kwargs):
+        self.lock_updates = not self.lock_updates
+
     def pane_show(self, *args):
         self.context.kernel.schedule(self.job)
 
@@ -99,14 +126,18 @@ class HelperPanel(wx.Panel):
         self.context.kernel.unschedule(self.job)
 
     def __set_properties(self):
-        self.text_info.SetToolTip(
-            _("Information about the control the mouse is hovering over")
+        s = ("Information about the control the mouse is hovering over")
+        self.text_info.SetToolTip(s)
+        self.check_allow.SetToolTip(
+            s+ "\n" +
+            _("If inactive then no more updates will happen until you check this checkbox again")
         )
         # self.button_webhelp.SetToolTip(_("Call online help-page"))
 
     def __do_layout(self):
         sizer_main = wx.BoxSizer(wx.VERTICAL)
-        sizer_1 = StaticBoxSizer(self, wx.ID_ANY, _("Information"), wx.VERTICAL)
+        sizer_1 = wx.BoxSizer(wx.VERTICAL)
+        sizer_1.Add(self.check_allow, 0, 0, 0)
         sizer_1.Add(self.text_info, 1, wx.EXPAND, 0)
         # sizer_1.Add(self.button_webhelp, 0, wx.ALIGN_RIGHT, 0)
         sizer_main.Add(sizer_1, 1, wx.EXPAND, 0)

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -3440,6 +3440,35 @@ class Kernel(Settings):
             channel(
                 _("Persistent settings imported from {file}.").format(file=filename)
             )
+        # ==========
+        # SIGNAL
+        # ==========
+        @self.console_argument(
+            "signalname", type=str, help=_("Signal to send")
+        )
+        @self.console_argument(
+            "signalargs", type=str, help=_("Signal content")
+        )
+        @self.console_command(
+            ("signal"), help=_("sends a signal")
+        )
+        def send_signal(channel, _, signalname=None, signalargs=None, **kwargs):
+            if signalname is None:
+                channel(_("Please provide a signal to send, attached listeners:"))
+                signal_keys = list(self.listeners.keys())
+                signal_keys.sort()
+                for idx, key in enumerate(signal_keys):
+                    channel(f"{idx}: {key}")
+                return
+            try:
+                if signalargs is None:
+                    self.root.signal(signalname)
+                else:
+                    self.root.signal(signalname, signalargs)
+                channel(f"Signal {signalname}, {signalargs} successfully sent")
+            except (TypeError, RuntimeError) as e:
+                channel(f"Error while sending {signalname}, {signalargs}: {e}")
+            return
 
         # ==========
         # LIFECYCLE


### PR DESCRIPTION
Allow lock/unlock of the helper pane updates via Ctrl+Shift+l to give the user the opportunity to thoroughly study the displayed text.
(Added a 'signal' command under the hood to allow sending of signals via the console)