### PR TITLE
GotoOperation Corrections

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -200,9 +200,12 @@ class CutPlan:
                 if op.type.startswith("place "):
                     continue
                 self.plan.append(op)
-                if op.type.startswith("op"):
+                if op.type.startswith("op") or op.type.startswith("util"):
+                    # Call preprocess on any op or util ops in our list.
                     if hasattr(op, "preprocess"):
                         op.preprocess(self.context, placement, self)
+
+                if op.type.startswith("op"):
                     for node in op.flat():
                         if node is op:
                             continue

--- a/meerk40t/core/elements/branches.py
+++ b/meerk40t/core/elements/branches.py
@@ -544,12 +544,6 @@ def init_commands(kernel):
                 parent_node = EngraveOpNode()
                 parent_node.add_node(HatchEffectNode())
                 return parent_node
-            elif command == "waitop":
-                return WaitOperation()
-            elif command == "outputop":
-                return OutputOperation()
-            elif command == "inputop":
-                return InputOperation()
             else:
                 raise ValueError
 
@@ -672,6 +666,33 @@ def init_commands(kernel):
             op = self.op_branch.add(
                 type="util output", output_mask=mask, output_value=value
             )
+        return "ops", [op]
+
+    @self.console_argument(
+        "x",
+        type=Length,
+        default=0,
+        help=_("X-Coordinate of Goto?"),
+    )
+    @self.console_argument(
+        "y",
+        type=Length,
+        default=0,
+        help=_("Y-Coordinate of Goto?"),
+    )
+    @self.console_command(
+        "gotoop",
+        help=_("<gotoop> <x> <y> - Create new utility operation"),
+        input_type=None,
+        output_type="ops",
+    )
+    def gotoop(
+        command,
+        x=0,
+        y=0,
+        **kwargs,
+    ):
+        op = self.op_branch.add(type="util goto", x=str(x), y=str(y))
         return "ops", [op]
 
     @self.console_command(

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1682,8 +1682,6 @@ def init_tree(kernel):
             pos=pos,
             x=x,
             y=y,
-            rotation=0,
-            corner=0,
         )
         self.signal("updateop_tree")
 

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1669,6 +1669,25 @@ def init_tree(kernel):
         self.signal("updateop_tree")
 
     @tree_submenu(_("Append special operation(s)"))
+    @tree_prompt("y", _("Y-Coordinate of Goto?"))
+    @tree_prompt("x", _("X-Coordinate of Goto?"))
+    @tree_operation(
+        _("Append Goto Location"),
+        node_type="branch ops",
+        help=_("Send laser to specific location."),
+    )
+    def append_operation_goto_location(node, y, x, pos=None, **kwargs):
+        self.op_branch.add(
+            type="util goto",
+            pos=pos,
+            x=x,
+            y=y,
+            rotation=0,
+            corner=0,
+        )
+        self.signal("updateop_tree")
+
+    @tree_submenu(_("Append special operation(s)"))
     @tree_operation(_("Append Beep"), node_type="branch ops", help="")
     def append_operation_beep(node, pos=None, **kwargs):
         self.op_branch.add(

--- a/meerk40t/core/node/util_goto.py
+++ b/meerk40t/core/node/util_goto.py
@@ -1,6 +1,7 @@
 from meerk40t.core.cutcode.gotocut import GotoCut
 from meerk40t.core.elements.element_types import *
 from meerk40t.core.node.node import Node
+from meerk40t.core.units import Length
 
 
 class GotoOperation(Node):
@@ -48,6 +49,19 @@ class GotoOperation(Node):
                 drop_node.append_child(drag_node)
             return True
         return False
+
+    def preprocess(self, context, matrix, plan):
+        """
+        Preprocess util goto
+
+        @param context:
+        @param matrix:
+        @param plan: Plan value during preprocessor call
+        @return:
+        """
+        self.x = float(Length(self.x))
+        self.y = float(Length(self.y))
+        self.x, self.y = matrix.point_in_matrix_space((self.x, self.y))
 
     def as_cutobjects(self, closed_distance=15, passes=1):
         """

--- a/meerk40t/gui/propertypanels/gotoproperty.py
+++ b/meerk40t/gui/propertypanels/gotoproperty.py
@@ -1,0 +1,65 @@
+import wx
+
+from meerk40t.core.units import Length
+from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
+from meerk40t.kernel import signal_listener
+
+_ = wx.GetTranslation
+
+
+class GotoPropertyPanel(wx.Panel):
+    name = "Goto"
+
+    def __init__(self, *args, context=None, node=None, **kwds):
+        kwds["style"] = kwds.get("style", 0)
+        wx.Panel.__init__(self, *args, **kwds)
+        self.context = context
+        self.operation = node
+
+        self.choices = [
+            {
+                "attr": "x",
+                "object": self.operation,
+                "default": 0,
+                "type": Length,
+                "label": _("X-Coordinate of Goto?"),
+                "tip": _("Set the X-Coordinate of the goto operation."),
+            },
+            {
+                "attr": "y",
+                "object": self.operation,
+                "default": 0,
+                "type": Length,
+                "label": _("Y-Coordinate of Goto?"),
+                "tip": _("Set the Y-Coordinate of the goto operation."),
+            },
+        ]
+        self.panel = ChoicePropertyPanel(
+            self, wx.ID_ANY, context=self.context, choices=self.choices
+        )
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(main_sizer)
+        self.Layout()
+
+    @signal_listener("x")
+    @signal_listener("y")
+    def location_changed(self, *args):
+        self.context.elements.signal("element_property_update", self.operation)
+
+    def pane_hide(self):
+        self.panel.pane_hide()
+        self.context.elements.signal("element_property_update", self.operation)
+
+    def pane_show(self):
+        self.panel.pane_show()
+
+    def set_widgets(self, node):
+        self.operation = node
+        for item in self.choices:
+            try:
+                item_att = item["attr"]
+            except KeyError:
+                continue
+            if hasattr(node, item_att):
+                item_value = getattr(node, item_att)
+                self.context.signal(item_att, item_value, self.operation)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -21,6 +21,7 @@ from meerk40t.gui.spoolerpanel import JobSpooler
 from meerk40t.gui.wxmscene import SceneWindow
 from meerk40t.kernel import CommandSyntaxError, ConsoleFunction, Module, get_safe_path
 from meerk40t.kernel.kernel import Job
+from .propertypanels.gotoproperty import GotoPropertyPanel
 
 from ..main import APPLICATION_NAME, APPLICATION_VERSION
 from ..tools.kerftest import KerfTool
@@ -838,6 +839,7 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("property/TextNode/TextProperty", TextPropertyPanel)
         kernel.register("property/BlobNode/BlobProperty", BlobPropertyPanel)
         kernel.register("property/WaitOperation/WaitProperty", WaitPropertyPanel)
+        kernel.register("property/GotoOperation/GotoProperty", GotoPropertyPanel)
         kernel.register("property/InputOperation/InputProperty", InputPropertyPanel)
         kernel.register("property/BranchOperationsNode/LoopProperty", OpBranchPanel)
         kernel.register("property/OutputOperation/OutputProperty", OutputPropertyPanel)


### PR DESCRIPTION
* Fix use of `Length` by default for GotoOperation.
* Preprocess to native units, allowing default to be converted to correct units.
* Add Tree Operation to add GotoOperation.
* Add GotoProperty window to allow you to modify the properties of a Goto Location operation.