### PR TITLE
Geomstr simplify

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -184,6 +184,8 @@ class CutPlan:
         idx = 0
         self.context.elements.mywordlist.push()
 
+        perform_simplify = self.context.opt_reduce_details and self.context.do_optimization
+        tolerance = self.context.opt_reduce_tolerance
         for placement in placements:
             # Adjust wordlist
             if idx > 0:
@@ -204,11 +206,13 @@ class CutPlan:
                     # Call preprocess on any op or util ops in our list.
                     if hasattr(op, "preprocess"):
                         op.preprocess(self.context, placement, self)
-
                 if op.type.startswith("op"):
                     for node in op.flat():
                         if node is op:
                             continue
+                        if hasattr(node, "geometry") and perform_simplify:
+                            # We are still in scene reolution and not yet at device level
+                            node.geometry.simplify(tolerance=tolerance)
                         if hasattr(node, "mktext") and hasattr(node, "_cache"):
                             newtext = self.context.elements.wordlist_translate(
                                 node.mktext, elemnode=node, increment=False

--- a/meerk40t/core/elements/offset_clpr.py
+++ b/meerk40t/core/elements/offset_clpr.py
@@ -600,7 +600,10 @@ def init_commands(kernel):
         offs.add_path(path)
         offs.process_data(offset_value, jointype="round", separate=False)
         p = None
+        # Attention geometry is already at device resolution, so we need to use a small tolerance
         for g in offs.result_geometry():
+            changed, before, after = g.simplify(tolerance=0.1)
+            # print (before, after)
             if g is not None:
                 p = g.as_path()
                 break

--- a/meerk40t/core/elements/offset_mk.py
+++ b/meerk40t/core/elements/offset_mk.py
@@ -368,8 +368,16 @@ def offset_path(self, path, offset_value=0):
         interpolation=500,
     )
     if p is None:
-        p = path
+        return path
+    g = Geomstr.svg(p)
+    # We are already at device resolution, so we need to reduce tolerance a lot
+    # Standard is 25 tats, so about 1/3 of a mil
+    g.simplify(tolerance=0.1)
+    p = g.as_path()
+    p.stroke = path.stroke
+    p.fill = path.fill
     return p
+
 
 
 def path_offset(

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -255,6 +255,41 @@ def plugin(kernel, lifecycle=None):
                 "section": "_20_Reducing Movements",
                 "hidden": True,
             },
+            {
+                "attr": "opt_reduce_details",
+                "object": context,
+                "default": False,
+                "type": bool,
+                "label": _("Reduce polyline details"),
+                "tip": _(
+                    "Active: reduce the details of polyline elements,\n" +
+                    "so that less information needs to be sent to the laser."
+                    ) + "\n" + _(
+                    "This can reduce the processing and laser time but can as well\n" +
+                    "compromise the quality at higher levels, so use with care and preview in simulation."
+                ),
+                "page": "Optimisations",
+                "section": "_30_Details",
+                "subsection": "_10_",
+            },
+            {
+                "attr": "opt_reduce_tolerance",
+                "object": context,
+                "default": 10,
+                "type": int,
+                "label": _("Level"),
+                "style": "option",
+                "choices": (1, 10, 50, 100),
+                "display": (_("Minimal"), _("Fine"), _("Medium"),_("Coarse")),
+                "tip": _(
+                    "This can reduce the processing and laser time but can as well\n" +
+                    "compromise the quality at higher levels, so use with care and preview in simulation."
+                ),
+                "page": "Optimisations",
+                "section": "_30_Details",
+                "subsection": "_10_",
+                "conditional": (context, "opt_reduce_details")
+            },
         ]
         for c in choices:
             c["help"] = "optimisation"

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -4423,7 +4423,7 @@ class Geomstr:
         @return:
         """
         last = 0
-        for idx, seg in enumerate(self.segments):
+        for idx, seg in enumerate(self.segments[: self.index]):
             segtype = int(seg[2].real)
             if segtype == TYPE_END:
                 yield Geomstr(self.segments[last:idx])
@@ -4528,394 +4528,113 @@ class Geomstr:
             return (x1 + ua * (x2 - x1)), (y1 + ua * (y2 - y1))
         return None
 
-    def simplify(self, tolerance=65.535):  # units per mil.
+
+    def simplify(self, tolerance = 25):
         """
-        This code is derived from the elements.py simplify_node code. And still uses svg.Path objects and simplifies
-        those and returns them to geomstr formats.
-
-        @param tolerance:
-        @return:
+        a)  Removes two or more consecutive ends to avoid the handing back of empty subpaths
+        b)  if tolerance > 1: applies
+            a value of about 25 would reduce the effective resolution to about 1/1000 mm
+            a value of 65 to about 1 mil = 1/1000 inch
         """
-        basically_zero = 1.0e-6
 
-        def my_sign(x):
-            # Returns +1 for positive figures, -1 for negative and 0 for Zero
-            return bool(x > 0) - bool(x < 0)
+        def _compute_distances(points, start, end):
+            """Compute the distances between all points and the line defined by start and end.
 
-        def remove_zero_length_lines(obj):
-            # We remove degenerate line segments ie those of zero length
-            # could be intentional in some cases, but that should be dealt
-            # with in dwell cuts...
-            removed = 0
-            for idx in range(len(obj._segments) - 1, -1, -1):
-                seg = obj._segments[idx]
-                if (
-                    isinstance(seg, Line)
-                    and seg.start.x == seg.end.x
-                    and seg.start.y == seg.end.y
-                ):
-                    obj._segments.pop(idx)
-                    removed += 1
-            return removed
+            :param points: Points to compute distance for.
+            :param start: Starting point of the line
+            :param end: End point of the line
 
-        def remove_superfluous_moves(obj):
-            # Two or more consecutive moves are processed
-            # as well as a move at the very end
-            lastseg = None
-            removed = 0
-            for idx in range(len(obj._segments) - 1, -1, -1):
-                seg = obj._segments[idx]
-                if isinstance(seg, Move):
-                    if lastseg is None:
-                        # Move as the very last segment -> Delete
-                        obj._segments.pop(idx)
-                        removed += 1
-                    else:
-                        if isinstance(lastseg, Move):
-                            # Two consecutive moves? Delete
-                            obj._segments.pop(idx)
-                            removed += 1
-                        else:
-                            lastseg = seg
+            :return: Points distance to the line.
+            """
+            line = end - start
+            if (line_length := np.linalg.norm(line)) == 0:
+                return np.linalg.norm(points - start, axis=-1)
+            if line.size == 2:
+                return abs(np.cross(line, start - points)) / line_length  # 2D case
+            return (
+                abs(np.linalg.norm(np.cross(line, start - points), axis=-1)) / line_length
+            )  # 3D case
+
+        def _mask(points, epsilon: float):
+            stack = [[0, len(points) - 1]]
+            indices = np.ones(len(points), dtype=bool)
+
+            while stack:
+                start_index, last_index = stack.pop()
+
+                local_points = points[indices][start_index + 1 : last_index]
+                if len(local_points) == 0:
+                    continue
+                distances = _compute_distances(
+                    local_points, points[start_index], points[last_index]
+                )
+                dist_max = max(distances)
+                index_max = start_index + 1 + np.argmax(distances)
+
+                if dist_max > epsilon:
+                    stack.append([start_index, index_max])
+                    stack.append([index_max, last_index])
                 else:
-                    lastseg = seg
-            return removed
+                    indices[start_index + 1 : last_index] = False
+            return indices
 
-        def remove_interim_points_on_line(obj):
-            removed = 0
-            last = None
-            for idx in range(len(obj._segments) - 1, -1, -1):
-                seg = obj._segments[idx]
-                if isinstance(seg, Line):
-                    if last is not None:
-                        # Two consecutive line segments (x1,y1)-(x2,y2) and (x3,y3)-(x4,y4)
-                        # denom = (x1-x2)*(y3-y4) - (y1-y2)*(x3-x4)
-                        # denom = (
-                        #     (seg.start.x - seg.end.x) * (last.start.y - last.end.y) -
-                        #     (seg.start.y - seg.end.y) * (last.start.x - last.end.x)
-                        # )
-                        lastdx = last.start.x - last.end.x
-                        lastdy = last.start.y - last.end.y
-                        thisdx = seg.start.x - seg.end.x
-                        thisdy = seg.start.y - seg.end.y
-                        denom = thisdx * lastdy - thisdy * lastdx
 
-                        same = (
-                            abs(denom) < basically_zero
-                            and my_sign(lastdx) == my_sign(thisdx)
-                            and my_sign(lastdy) == my_sign(thisdy)
-                        )
-                        # if thisdx == 0 or lastdx == 0:
-                        #     channel(f"One Vertical line, {thisdx:.1f}, {thisdy:1f} vs {lastdx:1f},{lastdy:.1f}")
-                        # else:
-                        #     channel(f"Compare {idx}, {thisdy / thisdx:.3f} vs {lastdy / lastdx:.3f}")
+        def _rdp(points, epsilon: float):
+            mask = _mask(points, epsilon)
+            return points[mask]
 
-                        if thisdx == 0 or lastdx == 0:
-                            # Vertical line - same direction?
-                            if thisdx == lastdx and my_sign(thisdy) == my_sign(lastdy):
-                                same = True
-                        elif abs(thisdy / thisdx - lastdy / lastdx) < basically_zero:
-                            # TODO Moving from 0,0 to A and A to 0,0 would count as same getting rid of a valid line.
-                            same = True
 
-                        if same:
-                            # We can just merge the two segments
-                            seg.end = last.end
-                            obj._segments.pop(idx + 1)
-                            removed += 1
-                    last = seg
-                else:
-                    last = None
-            return removed
-
-        def combine_overlapping_chains(obj):
-            def list_subpath_bounds(obj):
-                # Return a sorted list of subpaths in the given path (from left to right):
-                # tuples with first index, last index, x-coordinate of first segment, closed
-                result = []
-                start = -1
-                for current, seg in enumerate(obj._segments):
-                    if isinstance(seg, Move):
-                        if start >= 0:
-                            result.append(
-                                (start, current - 1, obj._segments[start].start.x)
-                            )
-                            start = -1
-                    elif isinstance(seg, Close):
-                        if start >= 0:
-                            result.append(
-                                (start, current - 1, obj._segments[start].start.x)
-                            )
-                            start = -1
-                    else:
-                        if start < 0:
-                            start = current
-                if start >= 0:
-                    result.append((start, len(obj) - 1, obj._segments[start].start.x))
-                # Now let's sort the list according to the X-start position
-                result.sort(key=lambda a: a[2])
-                return result
-
-            #  This is not working properly yet, so we skip this for now
-            joined = 0
-            iterations = 0
-            maxiterations = 20
-            redo = True
-            while redo:
-                # Don't do it again unless indicated...
-                redo = False
-                reason = ""
-                results = list_subpath_bounds(obj)
-                if len(results) <= 1:
-                    # only one chain, exit
-                    break
-
-                for idx, entry in enumerate(results):
-                    this_start = entry[0]
-                    this_end = entry[1]
-                    this_endseg = obj._segments[this_end]
-                    this_endline = bool(isinstance(this_endseg, Line))
-
-                    # Look at all subsequent chains, as they are sorted we know we can just look at
-                    # a) the last point and the first point or the two chains, if they are identical
-                    #    the two chains can be joined (regardless of the type of the two path
-                    #    segments at the end / start)
-                    # b) if the last segment of the first chain and the first segment of the second chain
-                    #    are lines, we establish whether they overlap
-                    for idx2 in range(idx + 1, len(results)):
-                        other_entry = results[idx2]
-                        other_start = other_entry[0]
-                        other_end = other_entry[1]
-                        other_startseg = obj._segments[other_start]
-                        other_startline = bool(isinstance(other_startseg, Line))
-                        # Do the lines overlap or have a common end / startpoint together?
-                        if (
-                            abs(this_endseg.end.x - other_startseg.start.x) < tolerance
-                            and abs(this_endseg.end.y - other_startseg.start.y)
-                            < tolerance
-                        ):
-                            for idx3 in range(other_end - other_start + 1):
-                                obj._segments.insert(
-                                    this_end + 1, obj._segments.pop(other_end)
-                                )
-                            joined += 1
-                            redo = True
-                            reason = f"Join segments at endpoints {idx} - {idx2}"
-                            break
-                        else:
-                            if not other_startline or not this_endline:
-                                # incompatible types, need two lines
-                                continue
-                            thisdx = this_endseg.start.x - this_endseg.end.x
-                            thisdy = this_endseg.start.y - this_endseg.end.y
-                            lastdx = other_startseg.start.x - other_startseg.end.x
-                            lastdy = other_startseg.start.y - other_startseg.end.y
-                            denom = thisdx * lastdy - thisdy * lastdx
-
-                            # We have a couple of base cases
-                            # a) end point of first line identical to start point of second line
-                            # -> already covered elsewhere
-
-                            # b) Lines are not parallel -> ignore
-                            if abs(denom) > basically_zero:
-                                continue
-
-                            if abs(thisdx) > basically_zero:
-                                # Non-vertical lines
-                                # c) second segment starts left of the first -> ignore
-                                if other_startseg.start.x < this_endseg.start.x:
-                                    continue
-
-                                # d) second segment fully to the right of the first -> ignore
-                                if other_startseg.start.x > this_endseg.end.x:
-                                    continue
-
-                                # e) They could still be just parallel, so let's establish this...
-                                if (
-                                    abs(lastdx) < basically_zero
-                                    or abs(thisdx) < basically_zero
-                                ):
-                                    # Was coming from zero length lines, now removed earlier
-                                    continue
-                                b1 = (
-                                    this_endseg.start.y
-                                    - thisdy / thisdx * this_endseg.start.x
-                                )
-                                b2 = (
-                                    other_startseg.start.y
-                                    - lastdy / lastdx * other_startseg.start.x
-                                )
-                                if abs(b1 - b2) > tolerance:
-                                    continue
-
-                                # f) Lying completely inside, only if the second chain is a single line we can remove it...
-                                if other_startseg.end.x <= this_endseg.end.x:
-                                    if other_start == other_end:
-                                        # Can be eliminated....
-                                        obj._segments.pop(other_start)
-                                        joined += 1
-                                        redo = True
-                                        reason = (
-                                            f"Removed segment {idx2} fully inside {idx}"
-                                        )
-                                        break
-                                    else:
-                                        continue
-                                # g) the remaining case is an overlap on x, so we can adjust the start to the end and join
-                                other_startseg.start.x = this_endseg.end.x
-                                other_startseg.start.y = this_endseg.end.y
-                                # Now copy the segments together:
-                                # We know that the to be copied segments, ie the source segments, lie behind the target segments
-                                # print (f"We copy [{other_start}:{other_end}] to the end after {this_end}")
-                                for idx3 in range(other_end - other_start + 1):
-                                    # print(f"copy #{idx3}: {obj._segments[this_end + 1]} <- {obj._segments[other_end]}")
-                                    obj._segments.insert(
-                                        this_end + 1, obj._segments.pop(other_end)
-                                    )
-                                joined += 1
-                                redo = True
-                                reason = f"Added overlapping segment {idx2} to {idx}"
-                                break
-                            else:
-                                # vertical lines but still the same logic applies...
-                                # c) second segment starts on top of the first -> ignore
-                                if other_startseg.start.y < this_endseg.start.y:
-                                    continue
-
-                                # d) second segment fully below the first -> ignore
-                                if other_startseg.start.y > this_endseg.end.y:
-                                    continue
-
-                                # e) They could still be just parallel, so let's establish this...
-                                if (
-                                    abs(other_startseg.start.x - this_endseg.start.x)
-                                    > tolerance
-                                ):
-                                    continue
-
-                                # f) Lying completely inside, only if the second chain is a single line we can remove it...
-                                if other_startseg.end.y <= this_endseg.end.y:
-                                    if other_start == other_end:
-                                        # Can be eliminated....
-                                        obj._segments.pop(other_start)
-                                        joined += 1
-                                        redo = True
-                                        reason = f"Removed vertical segment {idx2} fully inside {idx}"
-                                        break
-                                    else:
-                                        continue
-                                # g) the remaining case is an overlap on y, so we can adjust the start to the end and join
-                                other_startseg.start.x = this_endseg.end.x
-                                other_startseg.start.y = this_endseg.end.y
-                                # Now copy the segments together:
-                                # We know that the to be copied segments, ie the source segments,
-                                # lie behind the target segments
-                                for idx3 in range(other_end - other_start + 1):
-                                    obj._segments.insert(
-                                        this_end + 1, obj._segments.pop(other_end)
-                                    )
-                                joined += 1
-                                reason = f"Added overlapping vertical segment {idx2} to {idx}"
-                                redo = True
-                                break
-                    # end of inner loop
-
-                    if redo:
-                        iterations += 1
-                        # print(f"Redo required inner loop #{iterations}: {reason}")
-                        changed = True
-                        if iterations > maxiterations:
-                            redo = False
-                        break
-                # end of outer loop
-            return joined
-
-        def simplify_polyline(obj):
-            removed = 0
-            pt_older = None
-            pt_old = None
-            for idx in range(len(obj.points) - 1, -1, -1):
-                pt = obj.points[idx]
-                if pt_older is not None and pt_old is not None:
-                    # Two consecutive line segments (x1,y1)-(x2,y2) and (x3,y3)-(x4,y4)
-                    # denom = (x1-x2)*(y3-y4) - (y1-y2)*(x3-x4)
-                    # denom = (
-                    #     (pt[0] - pt_old[0]) * (pt_old[1] - pt_older[1]) -
-                    #     (pt[1] - pt_old[1]) * (pt_old[0] - pt_older[0])
-                    # )
-                    lastdx = pt_old[0] - pt_older[0]
-                    lastdy = pt_old[1] - pt_older[1]
-                    thisdx = pt[0] - pt_old[0]
-                    thisdy = pt[1] - pt_old[1]
-                    denom = thisdx * lastdy - thisdy * lastdx
-                    same = (
-                        abs(denom) < basically_zero
-                        and my_sign(lastdx) == my_sign(thisdx)
-                        and my_sign(lastdy) == my_sign(thisdy)
-                    )
-                    # Opposing directions may not happen
-
-                    if same:
-                        # We can just merge the two segments by
-                        # elminating the middle point
-                        obj.points.pop(idx + 1)
-                        removed += 1
-                        # just set the middle point to the last point,
-                        # so that the last point remains
-                        pt_old = pt_older
-
-                pt_older = pt_old
-                pt_old = pt
-            return removed
-
-        # Get self as path object.
-        obj = self.as_path()
-        before = len(obj._segments)
+        before = self.index
         changed = False
+        newgeometry = Geomstr()
+        to_simplify = list()
+        last = None
+        oldcount = 0
+        newcount = 0
+        for seg in self.segments[:self.index]:
+            oldcount += 1
+            start = seg[0]
+            # c1 = seg[1]
+            seg_type = int(seg[2].real)
+            # c2 = seg[3]
+            end = seg[4]
+            if seg_type == TYPE_LINE:
+                if last is None:
+                    to_simplify.append((start.real, start.imag))
+                to_simplify.append((end.real, end.imag))
+                last = end
+            else:
+                last = end
+                if len(to_simplify) > 0:
+                    simplified = _rdp(np.array(to_simplify), tolerance)
+                    if len(simplified) != len(to_simplify):
+                        g = Geomstr.lines(simplified)
+                        newgeometry.append(g)
+                        changed = True
+                        newcount += len(simplified)
+                    to_simplify.clear()
+                    last = None
+                newgeometry._ensure_capacity(newgeometry.index + 1)
+                newgeometry.segments[newgeometry.index] = [ seg[0], seg[1], seg[2], seg[3], seg[4] ]
+                newgeometry.index += 1
 
-        # Pass 1: Dropping zero length line segments
-        eliminated = remove_zero_length_lines(obj)
-        if eliminated > 0:
-            changed = True
-        # print (f"pass 1 for {node.type}-{node.label}: zero_length: {eliminated}")
+                newcount += 1
 
-        # Pass 2: look inside the nodes and bring small line segments back together...
-        eliminated = remove_interim_points_on_line(obj)
-        if eliminated > 0:
-            changed = True
-        # print (f"pass 2 for {node.type}-{node.label}: interim_pts: {eliminated}")
+        if len(to_simplify) > 0:
+            simplified = _rdp(np.array(to_simplify), tolerance)
+            if len(simplified) != len(to_simplify):
+                g = Geomstr.lines(simplified)
+                newgeometry.append(g)
+                changed = True
+                newcount += len(simplified)
+            to_simplify.clear()
+            last = None
 
-        # Pass 3: look at the subpaths....
-        # Commented out as it is not working properly yet
-        # eliminated = combine_overlapping_chains(obj)
-        # if eliminated > 0:
-        #     changed = True
-        # print (f"pass 3 for {node.type}-{node.label}: overlapping: {eliminated}")
+        if changed:
+            self.clear()
+            self.append(newgeometry)
 
-        # pass 4: remove superfluous moves
-        eliminated = remove_superfluous_moves(obj)
-        if eliminated > 0:
-            changed = True
-        # print (f"pass 4 for {node.type}-{node.label}: superfluous moves: {eliminated}")
-
-        after = len(obj._segments)
-        # elif node.type == "elem polyline" and len(node.shape.points) > 2:
-        #     obj = node.shape
-        #     before = len(obj.points)
-        #     eliminated = simplify_polyline(obj)
-        #     if eliminated > 0:
-        #         changed = True
-        #     # print (f"pass 1 for {node.type}-{node.label}: simplify polyline: {eliminated}")
-        #     after = len(obj.points)
-
-        # print (f"Before: {before}, After: {after}")
-
-        # Replace local geometry with modified.
-        new_geom = Geomstr.svg(obj.d())
-        self.segments = new_geom.segments
-        self.index = new_geom.index
-        # TODO: Perform simplification steps directly on geomstr objects.
-
+        after = self.index
         return changed, before, after
 
     #######################

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -4531,10 +4531,13 @@ class Geomstr:
 
     def simplify(self, tolerance = 25):
         """
-        a)  Removes two or more consecutive ends to avoid the handing back of empty subpaths
-        b)  if tolerance > 1: applies
-            a value of about 25 would reduce the effective resolution to about 1/1000 mm
-            a value of 65 to about 1 mil = 1/1000 inch
+            Simplifies polyline sections of a geomstr by applying the Ramer-Douglas-Peucker algorithm.
+            https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+
+            Tolerance is the maximum distance a point might have from a line to still be considered
+            collinear.
+            - a value of about 25 would reduce the effective resolution to about 1/1000 mm
+            - a value of 65 to about 1 mil = 1/1000 inch
         """
 
         def _compute_distances(points, start, end):


### PR DESCRIPTION
- Replace the existing simplify method of geomstr (which was based on the old svg path paradigm anyway) with an implementation of the Ramer-Douglas-Peucker algorithm to reduce the amount of points in a polyline section of the geometry.
- Changing the ``simplify`` command to use this
- Fixing a bug within ``Geomstr.as_contiguous`` 
- Kerf offset calculation will automatically call the simplify method (with minimal tolerance to just reduce the amount of points a bit)
- Added an optimisation option to apply polyline simplification. By default off