### PR TITLE
0.9.4-beta2 Fixes and Checks

### DIFF
--- a/.github/workflows/win/file_version.txt
+++ b/.github/workflows/win/file_version.txt
@@ -6,8 +6,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(0, 9, 3010, 0),
-    prodvers=(0, 9, 3010, 0),
+    filevers=(0, 9, 3020, 0),
+    prodvers=(0, 9, 3020, 0),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'MeerK40t'),
         StringStruct(u'FileDescription', u'MeerK40t Laser Control Software'),
-        StringStruct(u'FileVersion', u'0.9.3010.0'),
+        StringStruct(u'FileVersion', u'0.9.3020.0'),
         StringStruct(u'InternalName', u'MeerK40t.exe'),
         StringStruct(u'LegalCopyright', u'MeerK40t, MIT License'),
         StringStruct(u'OriginalFilename', u'MeerK40t.exe'),
         StringStruct(u'ProductName', u'MeerK40t'),
-        StringStruct(u'ProductVersion', u'0.9.3010')])
+        StringStruct(u'ProductVersion', u'0.9.3020')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1031, 2058])])
   ]

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -187,7 +187,7 @@ class BalorDevice(Service, Status):
                 "subsection": "_10_Axis corrections",
             },
             {
-                "attr": "interpolate",
+                "attr": "interp",
                 "object": self,
                 "default": 50,
                 "type": int,

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -189,7 +189,7 @@ class BalorDevice(Service, Status):
             {
                 "attr": "interp",
                 "object": self,
-                "default": 50,
+                "default": 5,
                 "type": int,
                 "label": _("Curve Interpolation"),
                 "section": "_10_Parameters",

--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -171,7 +171,7 @@ class BalorDriver:
                 x, y = start.real, start.imag
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
 
                 g.clear()
                 g.quad(start, c1, end)
@@ -189,7 +189,7 @@ class BalorDriver:
                 x, y = start.real, start.imag
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
 
                 g.clear()
                 g.cubic(start, c1, c2, end)
@@ -207,7 +207,7 @@ class BalorDriver:
                 x, y = start.real, start.imag
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
 
                 g.clear()
                 g.arc(start, c1, end)
@@ -343,7 +343,7 @@ class BalorDriver:
                 x, y = q.start
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
 
                 g = Geomstr()
                 g.quad(complex(*q.start), complex(*q.c()), complex(*q.end))
@@ -361,7 +361,7 @@ class BalorDriver:
                 x, y = q.start
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
 
                 g = Geomstr()
                 g.cubic(

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -781,8 +781,9 @@ class Elemental(Service):
         #                 element attrib (ie stroke or fill)
         #               - anything else: leave all colors unchanged
         # attrib:       one of 'stroke', 'fill' to establish the source color
-        #               ('auto' is an option too that will pick the color from the
-        #               operation settings)
+        #               ('auto' is an option too, that will pick the color from the
+        #               operation settings) - if we talk about an engrave or cut operation
+        #               and if 'stroke' or 'auto' have been set, 'fill' will be set None
         # similar:      will use attrib (see above) to establish similar elements (having (nearly) the same
         #               color) and assign those as well
         # exclusive:    will delete all other assignments of the source elements in other operations if True
@@ -880,6 +881,7 @@ class Elemental(Service):
                     data.append(n)
 
         needs_refresh = False
+        set_fill_to_none = op_assign.type in ("op engrave", "op cut") and attrib == "stroke"
         for n in data:
             if op_assign.drop(n, modify=False):
                 if exclusive:
@@ -889,6 +891,8 @@ class Elemental(Service):
                 if impose == "to_elem" and target_color is not None:
                     if hasattr(n, attrib):
                         setattr(n, attrib, target_color)
+                        if set_fill_to_none and hasattr(n, "fill"):
+                            n.fill = None
                         needs_refresh = True
         # Refresh the operation so any changes like color materialize...
         self.signal("element_property_reload", op_assign)

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1540,6 +1540,7 @@ class Elemental(Service):
             for e in emph_data:
                 e.emphasized = True
         self.signal("element_property_reload", data)
+        self.signal("warn_state_update")
 
     def remove_unused_default_copies(self):
         # Let's clean non-used operations that come from defaults...

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -881,7 +881,9 @@ class Elemental(Service):
                     data.append(n)
 
         needs_refresh = False
-        set_fill_to_none = op_assign.type in ("op engrave", "op cut") and attrib == "stroke"
+        set_fill_to_none = (
+            op_assign.type in ("op engrave", "op cut") and attrib == "stroke"
+        )
         for n in data:
             if op_assign.drop(n, modify=False):
                 if exclusive:

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -285,9 +285,9 @@ class GRBLDevice(Service, Status):
                 ),
             },
             {
-                "attr": "interpolate",
+                "attr": "interp",
                 "object": self,
-                "default": 50,
+                "default": 5,
                 "type": int,
                 "label": _("Curve Interpolation"),
                 "section": "_5_Config",

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -307,7 +307,7 @@ class GRBLDriver(Parameters):
                 first = False
             elif segment_type == "quad":
                 self.move_mode = 1
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.quad(complex(start), complex(c1), complex(end))
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -316,7 +316,7 @@ class GRBLDriver(Parameters):
                     self._move(p.real, p.imag)
             elif segment_type == "cubic":
                 self.move_mode = 1
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.cubic(
                     complex(start),
@@ -331,7 +331,7 @@ class GRBLDriver(Parameters):
             elif segment_type == "arc":
                 # TODO: Allow arcs to be directly executed by GRBL which can actually use them.
                 self.move_mode = 1
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.arc(
                     complex(start),
@@ -424,7 +424,7 @@ class GRBLDriver(Parameters):
                 self._move(*q.end)
             elif isinstance(q, QuadCut):
                 self.move_mode = 1
-                interp = self.service.interpolate
+                interp = self.service.inter
                 g = Geomstr()
                 g.quad(complex(*q.start), complex(*q.c()), complex(*q.end))
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -433,7 +433,7 @@ class GRBLDriver(Parameters):
                     self._move(p.real, p.imag)
             elif isinstance(q, CubicCut):
                 self.move_mode = 1
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g = Geomstr()
                 g.cubic(
                     complex(*q.start),

--- a/meerk40t/grbl/emulator.py
+++ b/meerk40t/grbl/emulator.py
@@ -509,9 +509,7 @@ class GRBLEmulator:
             return 3  # not yet supported
         elif data == "$X":
             if self.reply:
-                self.reply(
-                    "Alarm status was cleared\r\n"
-                )
+                self.reply("Alarm status was cleared\r\n")
             return 0
         else:
             return 3  # GRBL '$' system command was not recognized or supported.

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -30,7 +30,7 @@ _ = wx.GetTranslation
 
 
 class ImportDialog(wx.Dialog):
-    def __init__(self, *args, context=None, **kwds):
+    def __init__(self, *args, context=None, filename=None, **kwds):
         kwds["style"] = (
             kwds.get("style", 0) | wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         )
@@ -55,6 +55,8 @@ class ImportDialog(wx.Dialog):
         self.on_check(None)
         self.check_consolidate.SetValue(True)
         self._define_logic()
+        if filename is not None:
+            self.txt_filename.SetValue(filename)
 
     def _define_layout(self):
         main_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1491,10 +1493,12 @@ class MaterialPanel(ScrolledPanel):
             self.op_data.write_configuration()
         return added
 
-    def on_import(self, event):
+    def on_import(self, event, filename=None):
         #
         info = None
-        mydlg = ImportDialog(None, id=wx.ID_ANY, context=self.context)
+        mydlg = ImportDialog(
+            None, id=wx.ID_ANY, context=self.context, filename=filename
+        )
         if mydlg.ShowModal() == wx.ID_OK:
             # This returns a Python list of files that were selected.
             info = mydlg.result()
@@ -2268,10 +2272,9 @@ class MaterialManager(MWindow):
         Drop file handler
         Accepts only a single file drop.
         """
-        pass
-        # for pathname in event.GetFiles():
-        #     if self.panel_import.import_csv(pathname):
-        #         break
+        for pathname in event.GetFiles():
+            self.panel_library.on_import(None, filename=pathname)
+            break
 
     def delegates(self):
         yield self.panel_library

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -1757,7 +1757,10 @@ class MaterialPanel(ScrolledPanel):
             if item:
                 listidx = self.tree_library.GetItemData(item)
                 if listidx >= 0:
-                    self.active_material = self.get_nth_material(listidx)
+                    info = self.get_nth_material(listidx)
+                    self.active_material = info
+                else:
+                    self.active_material = None
         except RuntimeError:
             return
 

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -1023,17 +1023,15 @@ class MaterialPanel(ScrolledPanel):
             if newsection not in self.material_list:
                 break
 
-        # print (f"Section={oldsection} -> {newsection}")
-
         oldname = oldsection
-        if "material" in op_info:
-            oldname = op_info["material"]
+        if "title" in op_info:
+            oldname = op_info["title"]
             if oldname.endswith(")"):
                 idx = oldname.rfind("(")
                 if idx >= 0:
                     oldname = oldname[:idx]
         newname = f"{oldname} ({counter})"
-        op_info["material"] = newname
+        op_info["title"] = newname
         self.context.elements.save_persistent_operations_list(
             newsection,
             oplist=op_list,

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -2268,13 +2268,14 @@ class MaterialManager(MWindow):
         Drop file handler
         Accepts only a single file drop.
         """
-        for pathname in event.GetFiles():
-            if self.panel_import.import_csv(pathname):
-                break
+        pass
+        # for pathname in event.GetFiles():
+        #     if self.panel_import.import_csv(pathname):
+        #         break
 
     def delegates(self):
         yield self.panel_library
-        yield self.panel_import
+        # yield self.panel_import
         yield self.panel_about
 
     @staticmethod

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -24,6 +24,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.scene.scenespacewidget import SceneSpaceWidget
+from meerk40t.gui.wxutils import matrix_scale
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point
 
@@ -829,7 +830,7 @@ class Scene(Module, Job):
 
                     sdx = new_x_space - space_pos[0]
                     if current_matrix is not None and not current_matrix.is_identity():
-                        sdx *= current_matrix.value_scale_x()
+                        sdx *= matrix_scale(current_matrix)
                     snap_x = window_pos[0] + sdx
                     sdy = new_y_space - space_pos[1]
                     if current_matrix is not None and not current_matrix.is_identity():
@@ -1008,7 +1009,7 @@ class Scene(Module, Job):
             self._calculate_attraction_points()
 
         matrix = self.widget_root.scene_widget.matrix
-        length = self.context.show_attract_len / matrix.value_scale_x()
+        length = self.context.show_attract_len / matrix_scale(matrix)
 
         if snap_points and self.snap_attraction_points:
             self._calculate_snap_points(my_x, my_y, length)
@@ -1038,7 +1039,7 @@ class Scene(Module, Job):
                     min_delta = delta
             if new_x is not None:
                 matrix = self.widget_root.scene_widget.matrix
-                pixel = self.context.action_attract_len / matrix.value_scale_x()
+                pixel = self.context.action_attract_len / matrix_scale(matrix)
                 if abs(new_x - my_x) <= pixel and abs(new_y - my_y) <= pixel:
                     # If the distance is small enough: snap.
                     res_x = new_x

--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -9,6 +9,7 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import HITCHAIN_PRIORITY_HIT, RESPONSE_CHAIN
 from meerk40t.gui.scene.widget import Widget
+from meerk40t.gui.wxutils import matrix_scale
 
 TYPE_BOUND = 0
 TYPE_POINT = 1
@@ -235,16 +236,16 @@ class AttractionWidget(Widget):
         matrix = self.parent.matrix
         try:
             # Intentionally big to clearly see shape
-            self.symbol_size = 10 / matrix.value_scale_x()
+            self.symbol_size = 10 / matrix_scale(matrix)
         except ZeroDivisionError:
             matrix.reset()
             return
         # Anything within a 15 Pixel Radius will be attracted, anything within a 45 Pixel Radius will be displayed
-        local_attract_len = self.context.show_attract_len / matrix.value_scale_x()
+        local_attract_len = self.context.show_attract_len / matrix_scale(matrix)
         local_action_attract_len = (
-            self.context.action_attract_len / matrix.value_scale_x()
+            self.context.action_attract_len / matrix_scale(matrix)
         )
-        local_grid_attract_len = self.context.grid_attract_len / matrix.value_scale_x()
+        local_grid_attract_len = self.context.grid_attract_len / matrix_scale(matrix)
 
         min_delta = float("inf")
         min_x = None

--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -242,8 +242,8 @@ class AttractionWidget(Widget):
             return
         # Anything within a 15 Pixel Radius will be attracted, anything within a 45 Pixel Radius will be displayed
         local_attract_len = self.context.show_attract_len / matrix_scale(matrix)
-        local_action_attract_len = (
-            self.context.action_attract_len / matrix_scale(matrix)
+        local_action_attract_len = self.context.action_attract_len / matrix_scale(
+            matrix
         )
         local_grid_attract_len = self.context.grid_attract_len / matrix_scale(matrix)
 

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -326,7 +326,7 @@ class RectSelectWidget(Widget):
                                     target.append(end)
                                 last = end
                     # t2 = perf_counter()
-                    if len(other_points) > 0:
+                    if len(other_points) > 0 and len(selected_points) > 0:
                         np_other = np.asarray(other_points)
                         np_selected = np.asarray(selected_points)
                         dist, pt1, pt2 = shortest_distance(np_other, np_selected, False)
@@ -357,7 +357,7 @@ class RectSelectWidget(Widget):
                         ((b[0] + b[2]) / 2, (b[1] + b[3]) / 2),
                     )
                     other_points = self.scene.pane.grid.grid_points
-                    if len(other_points) > 0:
+                    if len(other_points) > 0 and len(selected_points) > 0:
                         np_other = np.asarray(other_points)
                         np_selected = np.asarray(selected_points)
                         dist, pt1, pt2 = shortest_distance(np_other, np_selected, True)

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -16,6 +16,7 @@ from meerk40t.gui.scene.scene import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.scene.widget import Widget
+from meerk40t.gui.wxutils import matrix_scale
 from meerk40t.tools.geomstr import TYPE_END
 
 
@@ -277,7 +278,7 @@ class RectSelectWidget(Widget):
                     and "shift" not in modifiers
                     and b is not None
                 ):
-                    gap = self.scene.context.action_attract_len / matrix.value_scale_x()
+                    gap = self.scene.context.action_attract_len / matrix_scale(matrix)
                     # We gather all points of non-selected elements,
                     # but only those that lie within the boundaries
                     # of the selected area
@@ -347,7 +348,7 @@ class RectSelectWidget(Widget):
                     and not did_snap_to_point
                 ):
                     # t1 = perf_counter()
-                    gap = self.scene.context.grid_attract_len / matrix.value_scale_x()
+                    gap = self.scene.context.grid_attract_len / matrix_scale(matrix)
                     # Check for corner points + center:
                     selected_points = (
                         (b[0], b[1]),
@@ -416,8 +417,7 @@ class RectSelectWidget(Widget):
         self.selection_pen.SetColour(tcolor)
         self.selection_pen.SetStyle(tstyle)
         gc.SetPen(self.selection_pen)
-
-        linewidth = 2.0 / matrix.value_scale_x()
+        linewidth = 2.0 / matrix_scale(matrix)
         if linewidth < 1:
             linewidth = 1
         try:
@@ -435,7 +435,7 @@ class RectSelectWidget(Widget):
         self.selection_pen.SetColour(tcolor)
         self.selection_pen.SetStyle(tstyle)
 
-        linewidth = 2.0 / matrix.value_scale_x()
+        linewidth = 2.0 / matrix_scale(matrix)
         if linewidth < 1:
             linewidth = 1
         try:
@@ -443,8 +443,8 @@ class RectSelectWidget(Widget):
         except TypeError:
             self.selection_pen.SetWidth(int(linewidth))
         gc.SetPen(self.selection_pen)
-        delta_X = 15.0 / matrix.value_scale_x()
-        delta_Y = 15.0 / matrix.value_scale_y()
+        delta_X = 15.0 / matrix_scale(matrix)
+        delta_Y = 15.0 / matrix_scale(matrix)
         if abs(x1 - x0) > delta_X and abs(y1 - y0) > delta_Y:  # Don't draw if too tiny
             # Draw tiny '+' in corner of pointer
             x_signum = +1 * delta_X if x0 < x1 else -1 * delta_X
@@ -455,7 +455,7 @@ class RectSelectWidget(Widget):
             gc.SetPen(self.selection_pen)
             gc.StrokeLine(ax1, y1, ax1, ay1)
             gc.StrokeLine(ax1, ay1, x1, ay1)
-            font_size = 10.0 / matrix.value_scale_x()
+            font_size = 10.0 / matrix_scale(matrix)
             if font_size < 1.0:
                 font_size = 1.0
             try:

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -31,7 +31,7 @@ from meerk40t.gui.scene.scene import (
 )
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT_AND_DELEGATE
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.gui.wxutils import StaticBoxSizer, create_menu_for_node
+from meerk40t.gui.wxutils import StaticBoxSizer, create_menu_for_node, matrix_scale
 from meerk40t.svgelements import Point
 from meerk40t.tools.geomstr import TYPE_END
 
@@ -1593,7 +1593,7 @@ class MoveWidget(Widget):
                 and not "shift" in modifiers
                 and b is not None
             ):
-                gap = self.scene.context.action_attract_len / matrix.value_scale_x()
+                gap = self.scene.context.action_attract_len / matrix_scale(matrix)
                 # We gather all points of non-selected elements,
                 # but only those that lie within the boundaries
                 # of the selected area
@@ -1663,7 +1663,7 @@ class MoveWidget(Widget):
                 and not did_snap_to_point
             ):
                 t1 = perf_counter()
-                gap = self.scene.context.grid_attract_len / matrix.value_scale_x()
+                gap = self.scene.context.grid_attract_len / matrix_scale(matrix)
                 # Check for corner points + center:
                 selected_points = (
                     (b[0], b[1]),

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1642,7 +1642,7 @@ class MoveWidget(Widget):
                                 target.append(end)
                             last = end
                 t2 = perf_counter()
-                if len(other_points) > 0:
+                if len(other_points) > 0 and len(selected_points) > 0:
                     np_other = np.asarray(other_points)
                     np_selected = np.asarray(selected_points)
                     dist, pt1, pt2 = shortest_distance(np_other, np_selected, False)
@@ -1673,7 +1673,7 @@ class MoveWidget(Widget):
                     ((b[0] + b[2]) / 2, (b[1] + b[3]) / 2),
                 )
                 other_points = self.scene.pane.grid.grid_points
-                if len(other_points) > 0:
+                if len(other_points) > 0 and len(selected_points) > 0:
                     np_other = np.asarray(other_points)
                     np_selected = np.asarray(selected_points)
                     dist, pt1, pt2 = shortest_distance(np_other, np_selected, True)

--- a/meerk40t/gui/statusbarwidgets/defaultoperations.py
+++ b/meerk40t/gui/statusbarwidgets/defaultoperations.py
@@ -38,6 +38,7 @@ class DefaultOperationWidget(StatusBarWidget):
             slabel = f"Image ({node.power/10:.0f}%, {node.speed}mm/s)"
         else:
             slabel = ""
+        slabel = _("Assign the selection to:") + "\n" + slabel + "\n" + _("Right click for options")
         return slabel
 
     def GenerateControls(self, parent, panelidx, identifier, context):
@@ -142,10 +143,7 @@ class DefaultOperationWidget(StatusBarWidget):
                 ptsize=fontsize,
             ).GetBitmap(noadjustment=True, use_theme=False)
             btn.SetBitmap(icon)
-            op_label = op.label
-            if op_label is None:
-                op_label = str(op)
-            btn.SetToolTip(op_label)
+            btn.SetToolTip(self.node_label(op))
             size_it(btn, self.buttonsize_x, self.buttonsize_y)
             self.assign_buttons.append(btn)
             self.assign_operations.append(op)
@@ -221,6 +219,39 @@ class DefaultOperationWidget(StatusBarWidget):
 
             stored_mat = matname
             return handler
+
+        # def on_update_button_from_tree(idx, operation):
+        #     def handler(*args):
+        #         self.assign_operations[stored_idx] = self.context.elements.create_usable_copy(stored_op)
+        #
+        #     stored_idx = idx
+        #     stored_op = operation
+        #     return handler
+        #
+        # # Check if the id of this entry is already existing (and the types match too)
+        # button = event.GetEventObject()
+        # node_index = -1
+        # node = None
+        # idx = 0
+        # while idx < len(self.assign_buttons):
+        #     if button is self.assign_buttons[idx]:
+        #         node_index = idx
+        #         node = self.assign_operations[idx]
+        #         break
+        #     idx += 1
+        # foundop = None
+        # if node_index >= 0 and node.id is not None:
+        #     for op in self.context.elements.ops():
+        #         if op.type == node.type and op.id == node.id:
+        #             foundop = op
+        #             break
+        # if node is not None and foundop is not None:
+        #     self.parent.Bind(
+        #         wx.EVT_MENU,
+        #         on_update_button_from_tree(node_index, foundop),
+        #         menu.Append(wx.ID_ANY, _("Use settings from tree for this button"), ""),
+        #     )
+        #     menu.AppendSeparator()
 
         for material in self.context.elements.op_data.section_set():
             if material == "previous":

--- a/meerk40t/gui/statusbarwidgets/defaultoperations.py
+++ b/meerk40t/gui/statusbarwidgets/defaultoperations.py
@@ -38,7 +38,13 @@ class DefaultOperationWidget(StatusBarWidget):
             slabel = f"Image ({node.power/10:.0f}%, {node.speed}mm/s)"
         else:
             slabel = ""
-        slabel = _("Assign the selection to:") + "\n" + slabel + "\n" + _("Right click for options")
+        slabel = (
+            _("Assign the selection to:")
+            + "\n"
+            + slabel
+            + "\n"
+            + _("Right click for options")
+        )
         return slabel
 
     def GenerateControls(self, parent, panelidx, identifier, context):
@@ -271,7 +277,7 @@ class DefaultOperationWidget(StatusBarWidget):
                         material_title = f"Default for {material[9:]}"
                     else:
                         material_title = material.replace("_", " ")
-            entries.append( (material_name, material_thickness, material_title) )
+            entries.append((material_name, material_thickness, material_title))
             matcount += 1
         # Let's sort them
         entries.sort(
@@ -320,7 +326,6 @@ class DefaultOperationWidget(StatusBarWidget):
                     on_menu_material(material),
                     menu_secondary.Append(wx.ID_ANY, mat[2], ""),
                 )
-
 
         self.parent.PopupMenu(menu)
 
@@ -438,6 +443,9 @@ class DefaultOperationWidget(StatusBarWidget):
                         break
 
     def Signal(self, signal, *args):
+        if len(self.context.elements.default_operations) != len(self.assign_buttons):
+            # desync !
+            signal = "default_operations"
         if signal in ("rebuild_tree",):
             self.reset_tooltips()
         elif signal == "element_property_update":

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -3,7 +3,7 @@ from math import atan, cos, sin, sqrt, tau
 import wx
 
 from meerk40t.core.units import Length
-
+from meerk40t.gui.wxutils import matrix_scale
 from .toolpointlistbuilder import PointListTool
 
 _ = wx.GetTranslation
@@ -36,11 +36,14 @@ class MeasureTool(PointListTool):
         if not self.point_series:
             return
         matrix = gc.GetTransform().Get()
+        # mat.a mat.d
+        mat_fact = matrix[0]
         try:
-            font_size = 10.0 / matrix[0]
+            font_size = 10.0 / mat_fact
         except ZeroDivisionError:
             font_size = 5000
-            return
+        if font_size> 1E8:
+            font_size = 5000
         # print ("Fontsize=%.3f, " % self.font_size)
         if font_size < 1.0:
             font_size = 1.0  # Mac does not allow values lower than 1.
@@ -61,7 +64,7 @@ class MeasureTool(PointListTool):
         gc.SetFont(font, self.scene.colors.color_measure_text)
 
         matrix = self.parent.matrix
-        linewidth = 2.0 / matrix.value_scale_x()
+        linewidth = 2.0 / matrix_scale(matrix)
         if linewidth < 1:
             linewidth = 1
         try:

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -4,6 +4,7 @@ import wx
 
 from meerk40t.core.units import Length
 from meerk40t.gui.wxutils import matrix_scale
+
 from .toolpointlistbuilder import PointListTool
 
 _ = wx.GetTranslation
@@ -42,7 +43,7 @@ class MeasureTool(PointListTool):
             font_size = 10.0 / mat_fact
         except ZeroDivisionError:
             font_size = 5000
-        if font_size> 1E8:
+        if font_size > 1e8:
             font_size = 5000
         # print ("Fontsize=%.3f, " % self.font_size)
         if font_size < 1.0:

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -19,13 +19,13 @@ from meerk40t.gui.icons import (
     icon_node_symmetric,
 )
 from meerk40t.gui.laserrender import swizzlecolor
-from meerk40t.gui.wxutils import matrix_scale
 from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CHAIN,
     RESPONSE_CONSUME,
     RESPONSE_DROP,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.gui.wxutils import matrix_scale
 from meerk40t.kernel import signal_listener
 from meerk40t.svgelements import (
     Arc,

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -19,7 +19,7 @@ from meerk40t.gui.icons import (
     icon_node_symmetric,
 )
 from meerk40t.gui.laserrender import swizzlecolor
-from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import matrix_scale
 from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CHAIN,
     RESPONSE_CONSUME,
@@ -332,7 +332,7 @@ class EditTool(ToolWidget):
                 pass  # Exceeds 32 bit signed integer.
 
         matrix = self.scene.widget_root.scene_widget.matrix
-        linewidth = 1.0 / matrix.value_scale_x()
+        linewidth = 1.0 / matrix_scale(matrix)
         if linewidth < 1:
             linewidth = 1
         set_width_pen(self.pen, linewidth)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1313,10 +1313,10 @@ class MeerK40t(MWindow):
             set_icon_appearance(1.0, 0)
 
         self.format_painter = FormatPainter(
-            self.context, "button/basicediting/Paint", "editpaint"
+            self.context, "button/extended_tools/Paint", "editpaint"
         )
         self.context.kernel.register(
-            "button/basicediting/Paint",
+            "button/extended_tools/Paint",
             {
                 "label": _("Paint format"),
                 "icon": icon_paint_brush,

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -892,7 +892,7 @@ class MeerK40tScenePanel(wx.Panel):
                     f.write(f"x={Length(x, preferred_units='mm').preferred_length}\n")
                 for y in self.magnet_y:
                     f.write(f"y={Length(y, preferred_units='mm').preferred_length}\n")
-        except ValueError:  # ( PermissionError, OSError, FileNotFoundError ):
+        except (ValueError, PermissionError, OSError, FileNotFoundError):
             return
 
     def load_magnets(self):

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -18,6 +18,7 @@ _ = wx.GetTranslation
 # NODE MENU
 ##############
 
+
 def matrix_scale(matrix):
     # We usually use the value_scale_x to establish a pixel size
     # by counteracting the scene matrix, linewidth = 1 / matrix.value_scale_x()
@@ -25,12 +26,14 @@ def matrix_scale(matrix):
     # that into consideration, so let's look at the
     # distance from (1, 0) to (0, 0) and call this our scale
     from math import sqrt
+
     x0, y0 = matrix.point_in_matrix_space((0, 0))
     x1, y1 = matrix.point_in_matrix_space((1, 0))
-    res = sqrt((x1 - x0)**2 + (y1 - y0)**2)
-    if res < 1E-8:
+    res = sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2)
+    if res < 1e-8:
         res = 1
     return res
+
 
 def create_menu_for_choices(gui, choices: List[dict]) -> wx.Menu:
     """

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -18,6 +18,19 @@ _ = wx.GetTranslation
 # NODE MENU
 ##############
 
+def matrix_scale(matrix):
+    # We usually use the value_scale_x to establish a pixel size
+    # by counteracting the scene matrix, linewidth = 1 / matrix.value_scale_x()
+    # For a rotated scene this crashes, so we need to take
+    # that into consideration, so let's look at the
+    # distance from (1, 0) to (0, 0) and call this our scale
+    from math import sqrt
+    x0, y0 = matrix.point_in_matrix_space((0, 0))
+    x1, y1 = matrix.point_in_matrix_space((1, 0))
+    res = sqrt((x1 - x0)**2 + (y1 - y0)**2)
+    if res < 1E-8:
+        res = 1
+    return res
 
 def create_menu_for_choices(gui, choices: List[dict]) -> wx.Menu:
     """

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -10,7 +10,7 @@ import os.path
 import sys
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.3010"
+APPLICATION_VERSION = "0.9.3020"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -158,9 +158,9 @@ class MoshiDevice(Service, Status):
                 "subsection": "_30_" + _("Home position"),
             },
             {
-                "attr": "interpolate",
+                "attr": "interp",
                 "object": self,
-                "default": 50,
+                "default": 5,
                 "type": int,
                 "label": _("Curve Interpolation"),
                 "tip": _("Distance of the curve interpolation in mils"),

--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -228,7 +228,7 @@ class MoshiDriver(Parameters):
             elif segment_type == "end":
                 pass
             elif segment_type == "quad":
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.quad(start, c1, end)
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -236,7 +236,7 @@ class MoshiDriver(Parameters):
                         time.sleep(0.05)
                     self._goto_absolute(p.real, p.imag, 1)
             elif segment_type == "cubic":
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.cubic(start, c1, c2, end)
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -244,7 +244,7 @@ class MoshiDriver(Parameters):
                         time.sleep(0.05)
                     self._goto_absolute(p.real, p.imag, 1)
             elif segment_type == "arc":
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.arc(start, c1, end)
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -294,7 +294,7 @@ class MoshiDriver(Parameters):
             if isinstance(q, LineCut):
                 self._goto_absolute(*q.end, 1)
             elif isinstance(q, QuadCut):
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g = Geomstr()
                 g.quad(complex(*q.start), complex(*q.c()), complex(*q.end))
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
@@ -302,7 +302,7 @@ class MoshiDriver(Parameters):
                         time.sleep(0.05)
                     self._goto_absolute(p.real, p.imag, 1)
             elif isinstance(q, CubicCut):
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g = Geomstr()
                 g.cubic(
                     complex(*q.start),

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -188,9 +188,9 @@ class NewlyDevice(Service, Status):
                 "subsection": "_10_Axis corrections",
             },
             {
-                "attr": "interpolate",
+                "attr": "interp",
                 "object": self,
-                "default": 50,
+                "default": 5,
                 "type": int,
                 "label": _("Curve Interpolation"),
                 "section": "_10_Parameters",

--- a/meerk40t/newly/driver.py
+++ b/meerk40t/newly/driver.py
@@ -146,7 +146,7 @@ class NewlyDriver:
                 last_x, last_y = con.get_last_xy()
                 if last_x != start.real or last_y != start.imag:
                     con.goto(start.real, start.imag)
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.quad(start, c1, end)
 
@@ -165,7 +165,7 @@ class NewlyDriver:
                 last_x, last_y = con.get_last_xy()
                 if last_x != start.real or last_y != start.imag:
                     con.goto(start.real, start.imag)
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.cubic(start, c1, c2, end)
 
@@ -184,7 +184,7 @@ class NewlyDriver:
                 last_x, last_y = con.get_last_xy()
                 if last_x != start.real or last_y != start.imag:
                     con.goto(start.real, start.imag)
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g.clear()
                 g.arc(start, c1, end)
 
@@ -263,7 +263,7 @@ class NewlyDriver:
                 x, y = q.start
                 if last_x != x or last_y != y:
                     con.goto(x, y)
-                interp = self.service.interpolate
+                interp = self.service.interp
                 g = Geomstr()
                 if isinstance(q, CubicCut):
                     g.cubic(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = meerk40t
-version = 0.9.3010
+version = 0.9.3020
 description = MeerK40t LaserCutter Software
 long_description_content_type=text/markdown
 long_description = file: README.md


### PR DESCRIPTION
Requires:
- [ ] Numba Check for building @tiger12506 
- [x] Lihuiyu Tiger Test
- [x] Galvo Tiger Test
- [x] GRBL Tiger Test
- [x] Crash Log Audit.
- [ ] Material Manager Full Code audit
- [ ] Discussion feature arranging (`Settings Paint` may be too prominent).

--- Added PRs
## What's Changed
* Recognize device rename in device manager by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2322
* Update check by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2323
* Translations by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2324
* GRBL Connection Robustness. by @tatarize in https://github.com/meerk40t/meerk40t/pull/2321
* Allow suppression of travel path by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2325
* Provide additional feedback by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2326
* 0.10.x+, Geomstr Backend, Phase 1 by @tatarize in https://github.com/meerk40t/meerk40t/pull/2320
* Correct hatches for those lacking count values (#2331) by @tatarize in https://github.com/meerk40t/meerk40t/pull/2334
* Some layout adjustments by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2335
* Add `serial_exchange` command by @tatarize in https://github.com/meerk40t/meerk40t/pull/2333
* Circumvent high userscale issue for panel icons by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2336
* Autoadvance wordlist in plan spool stage by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2339
* Rotary Corrections by @tatarize in https://github.com/meerk40t/meerk40t/pull/2340
* Improve Rotary, Finish Coordinate Systems by @tatarize in https://github.com/meerk40t/meerk40t/pull/2341
* Scene: Add in Ability to Scene Stack by @tatarize in https://github.com/meerk40t/meerk40t/pull/2342
* Lihuiyu driver move position for firing by @tatarize in https://github.com/meerk40t/meerk40t/pull/2344
* Italian translations by betaeta by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2345
* Execution Correction and Signal Crash Validation by @tatarize in https://github.com/meerk40t/meerk40t/pull/2347
* Implement Numba Fast Dithers by @tatarize in https://github.com/meerk40t/meerk40t/pull/2346
* Ruida Implementation Work by @tatarize in https://github.com/meerk40t/meerk40t/pull/2353
* Material Manager by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2337
* Matman: saving + ezcad3 support by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2360
* RuidaControl - Bridge Mode. by @tatarize in https://github.com/meerk40t/meerk40t/pull/2357
* Service Delegate Rotary by @tatarize in https://github.com/meerk40t/meerk40t/pull/2355
* Ruida:  Serial Connection by @tatarize in https://github.com/meerk40t/meerk40t/pull/2362
* Placement improvements by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2361
* Italian translations by betaeta by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2363
* Allow sizing of elements with one dimension set to zero by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2366
* Fix missing parent bound invalidation on element move/scale by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2365
* Balor: Display input pins in config by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2356
* Additional information in Material Manager by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2364
* Settings backup by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2359
* Allow import of 3D-polylines by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2368
* Device.safe_label + Bug Fixes by @tatarize in https://github.com/meerk40t/meerk40t/pull/2369
* Update Moshi Driver (Checks and Corrections) by @tatarize in https://github.com/meerk40t/meerk40t/pull/2370
* Proper placement grid by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2367
* Clearer visual indicator that rotary mode is active by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2372
* Placement - tiling improvements by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2371
* Extended snap logic by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2373
* Add service/kernel console command applied to lifecycle objects by @tatarize in https://github.com/meerk40t/meerk40t/pull/2375
* Speed up font rendering by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2377
* Use element dragging instead of selection rectangle after some time by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2378
* Format painter by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2376
* Vectorfont - fixes and poor man's kerning by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2379
* Effect Drag-and-Drop treatment correction. by @tatarize in https://github.com/meerk40t/meerk40t/pull/2381
* Matman fix by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2382
* Advanced Ribbon Tool, Tool Modes by @tatarize in https://github.com/meerk40t/meerk40t/pull/2384
* Add profiler option for meerk40t by @tatarize in https://github.com/meerk40t/meerk40t/pull/2380
* Merger fixes by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2386
* Create .po file for pt_BR by @tatarize in https://github.com/meerk40t/meerk40t/pull/2388
* GotoOperation Corrections by @tatarize in https://github.com/meerk40t/meerk40t/pull/2390
* lock/unlock of the helper pane updates  by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2389
* Geomstr simplify by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2392
* High dpi fixes by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2394
* BeamTable: Bentley Ottmann Intersections by @tatarize in https://github.com/meerk40t/meerk40t/pull/2387
* Fontwelding by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2395
* Inkscape Layer-Support / Accelerate loading by @jpirnay in https://github.com/meerk40t/meerk40t/pull/2397
* Update Simplify Code by @tatarize in https://github.com/meerk40t/meerk40t/pull/2396
