### PR TITLE
TTF Naming Table

### DIFF
--- a/meerk40t/tools/ttfparser.py
+++ b/meerk40t/tools/ttfparser.py
@@ -128,13 +128,9 @@ class TrueTypeFont:
                 if name_id == 1:
                     font_family = get_string(f, pos, length)
                 elif name_id == 2:
-                    font_family = get_string(
-                        f, pos, length
-                    )
+                    font_family = get_string(f, pos, length)
                 elif name_id == 4:
-                    font_name = get_string(
-                        f, pos, length
-                    )
+                    font_name = get_string(f, pos, length)
                 if font_family and font_subfamily and font_name:
                     break
             return font_family, font_subfamily, font_name

--- a/meerk40t/tools/ttfparser.py
+++ b/meerk40t/tools/ttfparser.py
@@ -1,5 +1,4 @@
 import struct
-import time
 from io import BytesIO
 
 ON_CURVE_POINT = 1
@@ -103,11 +102,11 @@ class TrueTypeFont:
             # We are now at the name table.
             table_start = f.tell()
             (
-                format,
+                fmt,
                 count,
                 strings_offset,
             ) = struct.unpack(">HHH", f.read(6))
-            if format == 1:
+            if fmt == 1:
                 (langtag_count,) = struct.unpack(">H", f.read(2))
                 for langtag_record in range(langtag_count):
                     (langtag_len, langtag_offset) = struct.unpack(">HH", f.read(4))


### PR DESCRIPTION
* Adds in `TrueTypeFont.query_name()` functionality which can do 126 fonts in about 4ms to get their names. We do this by parsing the file completely in place, without reading anymore data than we require.

* We also add in `parse_name` to the full true type font definition, giving the user of that routine access to the `font_family`, `font_subfamily`, and `font_name` through normal parsing.