### PR TITLE
Avoid drawing artifacts for effects

### DIFF
--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -1,7 +1,7 @@
 from copy import copy
 from math import sqrt
 
-from meerk40t.core.node.node import Node, Linecap, Linejoin
+from meerk40t.core.node.node import Node
 from meerk40t.core.units import Angle, Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -1,7 +1,7 @@
 from copy import copy
 from math import sqrt
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linecap, Linejoin
 from meerk40t.core.units import Angle, Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam
@@ -16,9 +16,13 @@ class HatchEffectNode(Node):
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
         self.fill = None
         self.stroke = Color("Blue")
-        self.stroke_width = 1000.0
+        self.stroke_width = 100.0
         self.stroke_scale = False
         self._stroke_zero = None
+
+        # Probably not as relevant as for wobble, but let's apply some sensible defaults anyway
+        self.linecap = Linecap.CAP_BUTT
+        self.linejoin = Linejoin.JOIN_BEVEL
         self.output = True
         self.hatch_distance = None
         self.hatch_angle = None

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -20,9 +20,6 @@ class HatchEffectNode(Node):
         self.stroke_scale = False
         self._stroke_zero = None
 
-        # Probably not as relevant as for wobble, but let's apply some sensible defaults anyway
-        self.linecap = Linecap.CAP_BUTT
-        self.linejoin = Linejoin.JOIN_BEVEL
         self.output = True
         self.hatch_distance = None
         self.hatch_angle = None

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -20,8 +20,6 @@ class WobbleEffectNode(Node):
         self.stroke_width = 100.0
         self.stroke_scale = False
         self._stroke_zero = None
-        self.linecap = Linecap.CAP_BUTT
-        self.linejoin = Linejoin.JOIN_BEVEL
         self.output = True
         self.wobble_radius = "1.5mm"
         self.wobble_interval = "0.1mm"

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -2,7 +2,7 @@ import math
 from copy import copy
 from math import sqrt
 
-from meerk40t.core.node.node import Node
+from meerk40t.core.node.node import Node, Linecap, Linejoin
 from meerk40t.core.units import Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam
@@ -17,9 +17,11 @@ class WobbleEffectNode(Node):
     def __init__(self, *args, id=None, label=None, lock=False, **kwargs):
         self.fill = None
         self.stroke = Color("Blue")
-        self.stroke_width = 1000.0
+        self.stroke_width = 100.0
         self.stroke_scale = False
         self._stroke_zero = None
+        self.linecap = Linecap.CAP_BUTT
+        self.linejoin = Linejoin.JOIN_BEVEL
         self.output = True
         self.wobble_radius = "1.5mm"
         self.wobble_interval = "0.1mm"
@@ -35,7 +37,6 @@ class WobbleEffectNode(Node):
             self.label = "Wobble"
         else:
             self.label = label
-
         self.recalculate()
 
         self._total_count = 0

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -2,7 +2,7 @@ import math
 from copy import copy
 from math import sqrt
 
-from meerk40t.core.node.node import Node, Linecap, Linejoin
+from meerk40t.core.node.node import Node
 from meerk40t.core.units import Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -425,7 +425,9 @@ class LaserRender:
                 self.pen.SetCap(wx.CAP_ROUND)
 
     def _set_linejoin_by_node(self, node):
-        if not hasattr(node, "linejoin") or node.linejoin is None:
+        if not hasattr(node, "linejoin"):
+            self.pen.SetJoin(wx.JOIN_BEVEL)
+        elif node.linejoin is None:
             self.pen.SetJoin(wx.JOIN_MITER)
         else:
             if node.linejoin == Linejoin.JOIN_ARCS:


### PR DESCRIPTION
Adding a couple of path default parameters to effects
<img width="495" alt="2024-02-05 14_17_20-MeerK40t v0 9 3030 git main - Galvo-Fiber - C__Users_Jens_Desktop_SVG_wobble tes" src="https://github.com/meerk40t/meerk40t/assets/2670784/e134f9d1-ddce-46df-85fb-2646019f606a">


<img width="276" alt="2024-02-05 14_18_00-MeerK40t v0 9 3030 git effect-display - Galvo-Fiber - C__Users_Jens_Desktop_SVG_" src="https://github.com/meerk40t/meerk40t/assets/2670784/358a3752-82fb-418e-ace2-a88575ebe53b">
