### PR TITLE
Add missing clearance status on load

### DIFF
--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -1520,6 +1520,7 @@ class SVGLoader:
             )
         except ParseError as e:
             raise BadFileError(str(e)) from e
+        elements_service._loading_cleared = True
         svg_processor = SVGProcessor(elements_service, True)
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()
@@ -1568,6 +1569,7 @@ class SVGLoaderPlain:
             )
         except ParseError as e:
             raise BadFileError(str(e)) from e
+        elements_service._loading_cleared = True
         svg_processor = SVGProcessor(elements_service, False)
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()

--- a/meerk40t/extra/ezd.py
+++ b/meerk40t/extra/ezd.py
@@ -889,6 +889,7 @@ class EZDLoader:
                 "File format was only partially unrecognized.\n"
                 "Please raise an github issue and submit this file for review.\n"
             )
+        elements_service._loading_cleared = True
 
         ez_processor = EZProcessor(elements_service)
         ez_processor.process(ezfile, pathname)

--- a/meerk40t/image/imagetools.py
+++ b/meerk40t/image/imagetools.py
@@ -2121,6 +2121,7 @@ class ImageLoader:
             raise BadFileError(
                 "Cannot load an .eps file without GhostScript installed"
             ) from e
+        elements_service._loading_cleared = True
         try:
             from PIL import ImageOps
 


### PR DESCRIPTION
...otherwise a valid svg file could throw an error (most noticeable, if the file only contained regmark nodes)