### PR TITLE
Fix to M7 M8 mismatch in callbacks

### DIFF
--- a/meerk40t/extra/coolant.py
+++ b/meerk40t/extra/coolant.py
@@ -203,13 +203,13 @@ def plugin(kernel, lifecycle):
 
         def base_coolant_grbl_m7(context, mode):
             if mode:
-                context("gcode M8\n")
+                context("gcode M7\n")
             else:
                 context("gcode M9\n")
 
         def base_coolant_grbl_m8(context, mode):
             if mode:
-                context("gcode M7\n")
+                context("gcode M8\n")
             else:
                 context("gcode M9\n")
 


### PR DESCRIPTION
There was a small mismatch in M7 M8 callbacks where M7 and M8 were inverted. 
Tested on arduino GRBL testbench