### PR TITLE
Fix rapid move issue for M3nano

### DIFF
--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -665,7 +665,10 @@ class LihuiyuController:
         # find pipe commands.
         if packet.endswith(b"\n"):
             packet = packet[:-1]
-            if packet.endswith(b"-"):  # wait finish
+            if packet.endswith(b"P"):
+                # This is a special case where the m3nano seems to fail. So we extend the buffer...
+                packet += b"F"
+            elif packet.endswith(b"-"):  # wait finish
                 packet = packet[:-1]
                 post_send_command = self.wait_finished
             elif packet.endswith(b"*"):  # abort

--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -665,6 +665,10 @@ class LihuiyuController:
         # find pipe commands.
         if packet.endswith(b"\n"):
             packet = packet[:-1]
+            # There's a special case where we have a trailing "\n" at an exactly 30 byte command,
+            # that requires another package of 30 x F to be sent, so we need to deal with an empty string...
+            if len(packet) == 0:
+                packet += b"F"
             if packet.endswith(b"P"):
                 # This is a special case where the m3nano seems to fail. So we extend the buffer...
                 packet += b"F"

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -407,7 +407,10 @@ class LihuiyuDriver(Parameters):
             else:
                 self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2P\n")
+                if self.service.board == "M3":
+                    self(b"IS2PF\n")
+                else:
+                    self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_OFF)
         elif self.state == DRIVER_STATE_FINISH:
@@ -435,7 +438,10 @@ class LihuiyuDriver(Parameters):
             else:
                 self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2P\n")
+                if self.service.board == "M3":
+                    self(b"IS2PF\n")
+                else:
+                    self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_ON)
         elif self.state == DRIVER_STATE_FINISH:
@@ -463,7 +469,10 @@ class LihuiyuDriver(Parameters):
             else:
                 self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2P\n")
+                if self.service.board == "M3":
+                    self(b"IS2PF\n")
+                else:
+                    self(b"IS2P\n")
         elif self.state in (
             DRIVER_STATE_PROGRAM,
             DRIVER_STATE_RASTER,
@@ -660,7 +669,10 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        self(b"IS1P\n")
+        if self.service.board == "M3":
+            self(b"IS1PF\n")
+        else:
+            self(b"IS1P\n")
 
     def unlock_rail(self, abort=False):
         """
@@ -669,7 +681,10 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        self(b"IS2P\n")
+        if self.service.board == "M3":
+            self(b"IS2PF\n")
+        else:
+            self(b"IS2P\n")
 
     def laser_disable(self, *values):
         self.laser_enabled = False
@@ -1204,9 +1219,15 @@ class LihuiyuDriver(Parameters):
             return
         self(b"I")
         self._goto_xy(dx, dy)
-        self(b"S1P\n")
+        if self.service.board == "M3":
+            self(b"S1PF\n")
+        else:
+            self(b"S1P\n")
         if not self.service.autolock:
-            self(b"IS2P\n")
+            if self.service.board == "M3":
+                self(b"IS2PF\n")
+            else:
+                self(b"IS2P\n")
 
     def _goto_relative(self, dx, dy, cut):
         """

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -399,7 +399,13 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_OFF)
-            self(b"S1P\n")
+            if self.service.board == "M3":
+                # The M3-Nano board requires a padding byte
+                # to make sure the command will be sent appropriately
+                # Covers Issue # 2490
+                self(b"S1PF\n")
+            else:
+                self(b"S1P\n")
             if not self.service.autolock:
                 self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
@@ -421,7 +427,13 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_ON)
-            self(b"S1P\n")
+            if self.service.board == "M3":
+                # The M3-Nano board requires a padding byte
+                # to make sure the command will be sent appropriately
+                # Covers Issue # 2490
+                self(b"S1PF\n")
+            else:
+                self(b"S1P\n")
             if not self.service.autolock:
                 self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
@@ -443,7 +455,13 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             return
         if self.state == DRIVER_STATE_FINISH:
-            self(b"S1P\n")
+            if self.service.board == "M3":
+                # The M3-Nano board requires a padding byte
+                # to make sure the command will be sent appropriately
+                # Covers Issue # 2490
+                self(b"S1PF\n")
+            else:
+                self(b"S1P\n")
             if not self.service.autolock:
                 self(b"IS2P\n")
         elif self.state in (

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -399,9 +399,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_OFF)
-            self(b"S1PF\n")
+            self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2PF\n")
+                self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_OFF)
         elif self.state == DRIVER_STATE_FINISH:
@@ -421,9 +421,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_ON)
-            self(b"S1PF\n")
+            self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2PF\n")
+                self(b"IS2P\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_ON)
         elif self.state == DRIVER_STATE_FINISH:
@@ -443,9 +443,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             return
         if self.state == DRIVER_STATE_FINISH:
-            self(b"S1PF\n")
+            self(b"S1P\n")
             if not self.service.autolock:
-                self(b"IS2PF\n")
+                self(b"IS2P\n")
         elif self.state in (
             DRIVER_STATE_PROGRAM,
             DRIVER_STATE_RASTER,
@@ -642,7 +642,7 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        self(b"IS1PF\n")
+        self(b"IS1P\n")
 
     def unlock_rail(self, abort=False):
         """
@@ -651,7 +651,7 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        self(b"IS2PF\n")
+        self(b"IS2P\n")
 
     def laser_disable(self, *values):
         self.laser_enabled = False
@@ -1186,9 +1186,9 @@ class LihuiyuDriver(Parameters):
             return
         self(b"I")
         self._goto_xy(dx, dy)
-        self(b"S1PF\n")
+        self(b"S1P\n")
         if not self.service.autolock:
-            self(b"IS2PF\n")
+            self(b"IS2P\n")
 
     def _goto_relative(self, dx, dy, cut):
         """

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -399,18 +399,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_OFF)
-            if self.service.board == "M3":
-                # The M3-Nano board requires a padding byte
-                # to make sure the command will be sent appropriately
-                # Covers Issue # 2490
-                self(b"S1PF\n")
-            else:
-                self(b"S1P\n")
+            self(b"S1PF\n")
             if not self.service.autolock:
-                if self.service.board == "M3":
-                    self(b"IS2PF\n")
-                else:
-                    self(b"IS2P\n")
+                self(b"IS2PF\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_OFF)
         elif self.state == DRIVER_STATE_FINISH:
@@ -430,18 +421,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")
             self(self.CODE_LASER_ON)
-            if self.service.board == "M3":
-                # The M3-Nano board requires a padding byte
-                # to make sure the command will be sent appropriately
-                # Covers Issue # 2490
-                self(b"S1PF\n")
-            else:
-                self(b"S1P\n")
+            self(b"S1PF\n")
             if not self.service.autolock:
-                if self.service.board == "M3":
-                    self(b"IS2PF\n")
-                else:
-                    self(b"IS2P\n")
+                self(b"IS2PF\n")
         elif self.state in (DRIVER_STATE_PROGRAM, DRIVER_STATE_RASTER):
             self(self.CODE_LASER_ON)
         elif self.state == DRIVER_STATE_FINISH:
@@ -461,18 +443,9 @@ class LihuiyuDriver(Parameters):
         if self.state == DRIVER_STATE_RAPID:
             return
         if self.state == DRIVER_STATE_FINISH:
-            if self.service.board == "M3":
-                # The M3-Nano board requires a padding byte
-                # to make sure the command will be sent appropriately
-                # Covers Issue # 2490
-                self(b"S1PF\n")
-            else:
-                self(b"S1P\n")
+            self(b"S1PF\n")
             if not self.service.autolock:
-                if self.service.board == "M3":
-                    self(b"IS2PF\n")
-                else:
-                    self(b"IS2P\n")
+                self(b"IS2PF\n")
         elif self.state in (
             DRIVER_STATE_PROGRAM,
             DRIVER_STATE_RASTER,
@@ -669,10 +642,7 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        if self.service.board == "M3":
-            self(b"IS1PF\n")
-        else:
-            self(b"IS1P\n")
+        self(b"IS1PF\n")
 
     def unlock_rail(self, abort=False):
         """
@@ -681,10 +651,7 @@ class LihuiyuDriver(Parameters):
         @return:
         """
         self.rapid_mode()
-        if self.service.board == "M3":
-            self(b"IS2PF\n")
-        else:
-            self(b"IS2P\n")
+        self(b"IS2PF\n")
 
     def laser_disable(self, *values):
         self.laser_enabled = False
@@ -1219,15 +1186,9 @@ class LihuiyuDriver(Parameters):
             return
         self(b"I")
         self._goto_xy(dx, dy)
-        if self.service.board == "M3":
-            self(b"S1PF\n")
-        else:
-            self(b"S1P\n")
+        self(b"S1PF\n")
         if not self.service.autolock:
-            if self.service.board == "M3":
-                self(b"IS2PF\n")
-            else:
-                self(b"IS2P\n")
+            self(b"IS2PF\n")
 
     def _goto_relative(self, dx, dy, cut):
         """


### PR DESCRIPTION
The M3-Nano board requires a padding byte to make sure the "S1P" command will be sent appropriately
Covers Issue # 2490
