### PR TITLE
Grbl z support

### DIFF
--- a/meerk40t/core/parameters.py
+++ b/meerk40t/core/parameters.py
@@ -443,6 +443,19 @@ class Parameters:
         self.__dict__["kerf"] = value
 
     #####################
+    # ZAXIS PROPERTIES
+    #####################
+
+    @property
+    def zaxis(self):
+        return self.settings.get("zaxis")
+
+    @zaxis.setter
+    def zaxis(self, value):
+        self.settings["zaxis"] = value
+        self.__dict__["zaxis"] = value
+
+    #####################
     # HATCH PROPERTIES
     #####################
 

--- a/meerk40t/grbl/gui/grbloperationconfig.py
+++ b/meerk40t/grbl/gui/grbloperationconfig.py
@@ -1,0 +1,88 @@
+import wx
+
+from meerk40t.core.units import Length
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, wxCheckBox
+
+_ = wx.GetTranslation
+
+
+class GRBLAdvancedPanel(wx.Panel):
+    name = "Advanced"
+
+    def __init__(self, *args, context=None, node=None, **kwds):
+        # begin wxGlade: LhyAdvancedPanel.__init__
+        kwds["style"] = kwds.get("style", 0)
+        wx.Panel.__init__(self, *args, **kwds)
+        self.context = context
+        self.SetHelpText("grbloperation")
+        self.operation = node
+
+        extras_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        advanced_sizer = StaticBoxSizer(
+            self, wx.ID_ANY, _("Advanced Features:"), wx.VERTICAL
+        )
+        extras_sizer.Add(advanced_sizer, 0, wx.EXPAND, 0)
+
+        sizer_11 = wx.BoxSizer(wx.HORIZONTAL)
+        advanced_sizer.Add(sizer_11, 0, wx.EXPAND, 0)
+
+        self.check_zaxis = wxCheckBox(self, wx.ID_ANY, _("Set Z-Axis value"))
+        self.check_zaxis.SetToolTip(
+            _("Enables the ability to set a specific z-Value.")
+        )
+        sizer_11.Add(self.check_zaxis, 1, 0, 0)
+
+        self.text_zaxis = TextCtrl(
+            self,
+            wx.ID_ANY,
+            "0",
+            limited=True,
+            check="length",
+            style=wx.TE_PROCESS_ENTER,
+        )
+        OPERATION_ZAXIS_TOOLTIP = _(
+            "If enabled this will allow to set a defined z-Axis value for all elements assigned to this operation"
+        )
+
+        self.text_zaxis.SetToolTip(OPERATION_ZAXIS_TOOLTIP)
+        sizer_11.Add(self.text_zaxis, 1, 0, 0)
+
+        self.SetSizer(extras_sizer)
+
+        self.Layout()
+
+        self.Bind(wx.EVT_CHECKBOX, self.on_check_zaxis, self.check_zaxis)
+        self.text_zaxis.SetActionRoutine(self.on_text_zaxis)
+
+    def pane_hide(self):
+        pass
+
+    def pane_show(self):
+        pass
+
+    def set_widgets(self, node):
+        self.operation = node
+        value = ""
+        flag = False
+        if self.operation.zaxis is not None:
+            try:
+                value = Length(self.operation.zaxis).preferred_length
+                flag = True
+            except ValueError:
+                pass
+
+        self.check_zaxis.SetValue(flag)
+        self.text_zaxis.SetValue(value)
+        self.text_zaxis.Enable(flag)
+
+    def on_check_zaxis(self, event=None):  # wxGlade: OperationProperty.<event_handler>
+        on = self.check_zaxis.GetValue()
+        self.text_zaxis.Enable(on)
+
+    def on_text_zaxis(self):
+        try:
+            self.operation.zaxis = Length(self.text_zaxis.GetValue())
+        except ValueError:
+            return
+        self.context.elements.signal("element_property_reload", self.operation)

--- a/meerk40t/grbl/gui/gui.py
+++ b/meerk40t/grbl/gui/gui.py
@@ -15,6 +15,7 @@ def plugin(service, lifecycle):
         from meerk40t.grbl.gui.grblconfiguration import GRBLConfiguration
         from meerk40t.grbl.gui.grblcontroller import GRBLController
         from meerk40t.grbl.gui.grblhardwareconfig import GRBLHardwareConfig
+        from meerk40t.grbl.gui.grbloperationconfig import GRBLAdvancedPanel
         from meerk40t.gui.icons import (
             icons8_computer_support,
             icons8_connected,
@@ -33,6 +34,11 @@ def plugin(service, lifecycle):
 
         service.register("window/GrblHardwareConfig", GRBLHardwareConfig)
 
+        service.register("property/RasterOpNode/GRBL", GRBLAdvancedPanel)
+        service.register("property/CutOpNode/GRBL", GRBLAdvancedPanel)
+        service.register("property/EngraveOpNode/GRBL", GRBLAdvancedPanel)
+        service.register("property/ImageOpNode/GRBL", GRBLAdvancedPanel)
+        service.register("property/DotsOpNode/GRBL", GRBLAdvancedPanel)
         _ = service._
 
         service.register(


### PR DESCRIPTION
Half hearted Z-Support for operations: you can now set a desired z-Value for an operation. Use-case for motorized z-Axis: have multiple cut operations where you lower the z-Axis every pass (ie for every cut operation)
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/9bf3d345-092a-4740-beb0-ed62264e5b0a)
Requires testing