### PR TITLE
Effects Toolbar Button and Default Effects Settings

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -10,7 +10,6 @@ from meerk40t.core.units import Angle, Length
 from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import Service, signal_listener
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class BalorDevice(Service, Status):
@@ -283,7 +282,54 @@ class BalorDevice(Service, Status):
         ]
         self.register_choices("balor", choices)
 
-        self.register_choices("balor-effects", get_effect_choices(self))
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("balor-effects", choices)
 
         choices = [
             {

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -10,6 +10,7 @@ from meerk40t.core.units import Angle, Length
 from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import Service, signal_listener
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class BalorDevice(Service, Status):
@@ -281,6 +282,8 @@ class BalorDevice(Service, Status):
             },
         ]
         self.register_choices("balor", choices)
+
+        self.register_choices("balor-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -10,6 +10,7 @@ from meerk40t.core.units import Angle, Length
 from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import Service, signal_listener
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class BalorDevice(Service, Status):
@@ -282,54 +283,7 @@ class BalorDevice(Service, Status):
         ]
         self.register_choices("balor", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("balor-effects", choices)
+        self.register_choices("balor-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -80,6 +81,11 @@ class BalorConfiguration(MWindow):
                 )
                 self.panels.append(newpanel)
                 self.notebook_main.AddPage(newpanel, pagetitle)
+
+        newpanel = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
+        self.panels.append(newpanel)
+        self.notebook_main.AddPage(newpanel, _("Effects"))
+
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
         self.notebook_main.AddPage(newpanel, _("Warning"))

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -386,7 +386,7 @@ def init_commands(kernel):
 
         if interval is None and hasattr(self.device, "effect_wobble_default_interval"):
             interval = getattr(self.device, "effect_wobble_default_interval")
-        elif distance is None:
+        elif interval is None:
             interval = "0.5mm"
 
         wtype = wtype.lower()

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -307,6 +307,22 @@ def init_commands(kernel):
         """
         Add an effect hatch object
         """
+
+        # I'd like to get these settings here
+        #   effect_hatch_default_distance
+        #   effect_hatch_default_angle
+
+        # hdistance = self.kernel.device.effect_hatch_default_distance
+        # AttributeError: 'BalorDevice' object has no attribute 'effect_hatch_default_distance'
+
+        # hdistance = kernel.device.effect_hatch_default_distance
+        # AttributeError: 'BalorDevice' object has no attribute 'effect_hatch_default_distance'
+
+        #print(hdistance)
+
+        #print(dir(kernel.device))
+        #['_', '__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_kernel', '_laser_status', '_module_delegate', '_path', '_registered', '_service_lifecycle', '_simulate', '_state', 'abs_path', 'add_service_delegate', 'alias', 'bind', 'calibration_file', 'camera', 'cf_1', 'cf_10', 'cf_11', 'cf_12', 'cf_2', 'cf_3', 'cf_4', 'cf_5', 'cf_6', 'cf_7', 'cf_8', 'cf_9', 'channel', 'clear_persistent', 'close', 'close_subpaths', 'colors', 'console', 'console_argument', 'console_command', 'console_command_remove', 'console_function', 'console_option', 'contexts', 'control_mode', 'cool_helper', 'corfile', 'corfile_enabled', 'current', 'cylinder', 'cylinder_active', 'cylinder_mirror_distance', 'cylinder_x_axis', 'cylinder_x_concave', 'cylinder_x_diameter', 'cylinder_y_axis', 'cylinder_y_concave', 'cylinder_y_diameter', 'dangerlevel_op_cut', 'dangerlevel_op_dots', 'dangerlevel_op_engrave', 'dangerlevel_op_hatch', 'dangerlevel_op_image', 'dangerlevel_op_raster', 'default_fpk', 'default_frequency', 'default_power', 'default_pulse_width', 'default_rapid_speed', 'default_speed', 'delay_distance_long', 'delay_end', 'delay_jump_long', 'delay_jump_short', 'delay_laser_off', 'delay_laser_on', 'delay_mode', 'delay_openmo', 'delay_polygon', 'derive', 'destroy', 'device', 'device_coolant', 'driver', 'elements', 'extension', 'find', 'first_pulse_killer', 'flip_x', 'flip_y', 'flush', 'fly_res_p1', 'fly_res_p2', 'fly_res_p3', 'fly_res_p4', 'footpedal_pin', 'formatter_branch_elems', 'formatter_branch_elems_active', 'formatter_branch_ops', 'formatter_branch_ops_active', 'formatter_branch_reg', 'formatter_branch_reg_active', 'formatter_elem_ellipse', 'formatter_elem_ellipse_active', 'formatter_op_engrave', 'formatter_op_engrave_active', 'fpk2_p1', 'fpk2_p2', 'fpk2_p3', 'fpk2_p4', 'get_context', 'get_open', 'has_feature', 'input_operation_hardware', 'input_passes_required', 'interp', 'job', 'kernel', 'label', 'laser_mode', 'laser_status', 'last_signal', 'lens_size', 'light_pin', 'listen', 'logging', 'lookup', 'lookup_all', 'machine_index', 'match', 'mock', 'name', 'native', 'open', 'open_as', 'opened', 'outline', 'path', 'penbox', 'planner', 'pulse_width_enabled', 'pwm_half_period', 'pwm_pulse_width', 'read_persistent', 'read_persistent_attributes', 'read_persistent_string_dict', 'realize', 'redlight_angle', 'redlight_offset_x', 'redlight_offset_y', 'redlight_preferred', 'redlight_speed', 'register', 'register_choices', 'registered_path', 'root', 'rotary', 'rotary_active', 'rotary_flip_x', 'rotary_flip_y', 'rotary_scale_x', 'rotary_scale_y', 'rotate', 'safe_label', 'schedule', 'service_attach', 'service_detach', 'setting', 'shutdown', 'signal', 'simulate_state', 'source', 'space', 'spooler', 'standby_param_1', 'standby_param_2', 'state', 'subpaths', 'suppress_home', 'swap_xy', 'themes', 'threaded', 'timing_mode', 'unlisten', 'unregister', 'unschedule', 'use_mm_min_for_speed_display', 'use_percent_for_power_display', 'user_margin_x', 'user_margin_y', 'view', 'viewbuffer', 'write_persistent', 'write_persistent_attributes']
+
         if data is None:
             data = list(self.elems(emphasized=True))
         if len(data) == 0:

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -284,9 +284,9 @@ def init_commands(kernel):
         self.signal("refresh_scene", "Scene")
 
     @self.console_option("etype", "e", type=str, default="scanline")
-    @self.console_option("distance", "d", type=Length, default="1mm")
-    @self.console_option("angle", "a", type=Angle, default="0deg")
-    @self.console_option("angle_delta", "b", type=Angle, default="0deg")
+    @self.console_option("distance", "d", type=Length, default=None)
+    @self.console_option("angle", "a", type=Angle, default=None)
+    @self.console_option("angle_delta", "b", type=Angle, default=None)
     @self.console_command(
         "effect-hatch",
         help=_("adds hatch-effect to scene"),
@@ -308,26 +308,27 @@ def init_commands(kernel):
         Add an effect hatch object
         """
 
-        # I'd like to get these settings here
-        #   effect_hatch_default_distance
-        #   effect_hatch_default_angle
-
-        # hdistance = self.kernel.device.effect_hatch_default_distance
-        # AttributeError: 'BalorDevice' object has no attribute 'effect_hatch_default_distance'
-
-        # hdistance = kernel.device.effect_hatch_default_distance
-        # AttributeError: 'BalorDevice' object has no attribute 'effect_hatch_default_distance'
-
-        #print(hdistance)
-
-        #print(dir(kernel.device))
-        #['_', '__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_kernel', '_laser_status', '_module_delegate', '_path', '_registered', '_service_lifecycle', '_simulate', '_state', 'abs_path', 'add_service_delegate', 'alias', 'bind', 'calibration_file', 'camera', 'cf_1', 'cf_10', 'cf_11', 'cf_12', 'cf_2', 'cf_3', 'cf_4', 'cf_5', 'cf_6', 'cf_7', 'cf_8', 'cf_9', 'channel', 'clear_persistent', 'close', 'close_subpaths', 'colors', 'console', 'console_argument', 'console_command', 'console_command_remove', 'console_function', 'console_option', 'contexts', 'control_mode', 'cool_helper', 'corfile', 'corfile_enabled', 'current', 'cylinder', 'cylinder_active', 'cylinder_mirror_distance', 'cylinder_x_axis', 'cylinder_x_concave', 'cylinder_x_diameter', 'cylinder_y_axis', 'cylinder_y_concave', 'cylinder_y_diameter', 'dangerlevel_op_cut', 'dangerlevel_op_dots', 'dangerlevel_op_engrave', 'dangerlevel_op_hatch', 'dangerlevel_op_image', 'dangerlevel_op_raster', 'default_fpk', 'default_frequency', 'default_power', 'default_pulse_width', 'default_rapid_speed', 'default_speed', 'delay_distance_long', 'delay_end', 'delay_jump_long', 'delay_jump_short', 'delay_laser_off', 'delay_laser_on', 'delay_mode', 'delay_openmo', 'delay_polygon', 'derive', 'destroy', 'device', 'device_coolant', 'driver', 'elements', 'extension', 'find', 'first_pulse_killer', 'flip_x', 'flip_y', 'flush', 'fly_res_p1', 'fly_res_p2', 'fly_res_p3', 'fly_res_p4', 'footpedal_pin', 'formatter_branch_elems', 'formatter_branch_elems_active', 'formatter_branch_ops', 'formatter_branch_ops_active', 'formatter_branch_reg', 'formatter_branch_reg_active', 'formatter_elem_ellipse', 'formatter_elem_ellipse_active', 'formatter_op_engrave', 'formatter_op_engrave_active', 'fpk2_p1', 'fpk2_p2', 'fpk2_p3', 'fpk2_p4', 'get_context', 'get_open', 'has_feature', 'input_operation_hardware', 'input_passes_required', 'interp', 'job', 'kernel', 'label', 'laser_mode', 'laser_status', 'last_signal', 'lens_size', 'light_pin', 'listen', 'logging', 'lookup', 'lookup_all', 'machine_index', 'match', 'mock', 'name', 'native', 'open', 'open_as', 'opened', 'outline', 'path', 'penbox', 'planner', 'pulse_width_enabled', 'pwm_half_period', 'pwm_pulse_width', 'read_persistent', 'read_persistent_attributes', 'read_persistent_string_dict', 'realize', 'redlight_angle', 'redlight_offset_x', 'redlight_offset_y', 'redlight_preferred', 'redlight_speed', 'register', 'register_choices', 'registered_path', 'root', 'rotary', 'rotary_active', 'rotary_flip_x', 'rotary_flip_y', 'rotary_scale_x', 'rotary_scale_y', 'rotate', 'safe_label', 'schedule', 'service_attach', 'service_detach', 'setting', 'shutdown', 'signal', 'simulate_state', 'source', 'space', 'spooler', 'standby_param_1', 'standby_param_2', 'state', 'subpaths', 'suppress_home', 'swap_xy', 'themes', 'threaded', 'timing_mode', 'unlisten', 'unregister', 'unschedule', 'use_mm_min_for_speed_display', 'use_percent_for_power_display', 'user_margin_x', 'user_margin_y', 'view', 'viewbuffer', 'write_persistent', 'write_persistent_attributes']
-
         if data is None:
             data = list(self.elems(emphasized=True))
         if len(data) == 0:
             channel(_("No selected elements."))
             return
+
+        if distance is None and hasattr(self.device, "effect_hatch_default_distance"):
+            distance = getattr(self.device, "effect_hatch_default_distance")
+        elif distance is None:
+            distance = "1mm"
+
+        if angle is None and hasattr(self.device, "effect_hatch_default_angle"):
+            angle = Angle(getattr(self.device, "effect_hatch_default_angle"))
+        elif angle is None:
+            angle = Angle("0deg")
+
+        if angle_delta is None and hasattr(self.device, "effect_hatch_default_angle_delta"):
+            angle_delta = Angle(getattr(self.device, "effect_hatch_default_angle_delta"))
+        elif angle_delta is None:
+            angle_delta = Angle("0deg")
+
         if etype is None:
             etype = "scanline"
         first_node = data[0]
@@ -350,8 +351,8 @@ def init_commands(kernel):
         node.focus()
 
     @self.console_option("wtype", "w", type=str, default="circle")
-    @self.console_option("radius", "r", type=Length, default="0.5mm")
-    @self.console_option("interval", "i", type=Length, default="0.05mm")
+    @self.console_option("radius", "r", type=Length, default=None)
+    @self.console_option("interval", "i", type=Length, default=None)
     @self.console_command(
         "effect-wobble",
         help=_("adds wobble-effect to selected elements"),
@@ -377,6 +378,17 @@ def init_commands(kernel):
             return
         if wtype is None:
             wtype = "circle"
+
+        if radius is None and hasattr(self.device, "effect_wobble_default_radius"):
+            radius = getattr(self.device, "effect_wobble_default_radius")
+        elif radius is None:
+            radius = "0.5mm"
+
+        if interval is None and hasattr(self.device, "effect_wobble_default_interval"):
+            interval = getattr(self.device, "effect_wobble_default_interval")
+        elif distance is None:
+            interval = "0.5mm"
+
         wtype = wtype.lower()
         allowed = (
             "circle",
@@ -391,10 +403,6 @@ def init_commands(kernel):
         if wtype not in allowed:
             channel(f"Invalid wobble type, allowed: {','.join(allowed)}")
             return
-        if radius is None:
-            radius = "0.5mm"
-        if interval is None:
-            interval = "0.05mm"
         try:
             rlen = Length(radius)
         except ValueError:

--- a/meerk40t/device/devicechoices.py
+++ b/meerk40t/device/devicechoices.py
@@ -1,0 +1,50 @@
+from meerk40t.kernel import _
+
+def get_effect_choices(context):
+    return [
+        {
+            "attr": "effect_hatch_default_distance",
+            "object": context,
+            "default": "1.0mm",
+            "type": str,
+            "label": _("Hatch Distance"),
+            "tip": _("Default Hatch Distance"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_hatch_default_angle",
+            "object": context,
+            "default": "0deg",
+            "type": str,
+            "label": _("Hatch Angle"),
+            "tip": _("Default Hatch Angle"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_hatch_default_angle_delta",
+            "object": context,
+            "default": "0deg",
+            "type": str,
+            "label": _("Hatch Angle Delta"),
+            "tip": _("Default Hatch Angle Delta"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_wobble_default_radius",
+            "object": context,
+            "default": "0.5mm",
+            "type": str,
+            "label": _("Wobble Radius"),
+            "tip": _("Default Wobble Radius"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_wobble_default_interval",
+            "object": context,
+            "default": "0.05mm",
+            "type": str,
+            "label": _("Wobble Interval"),
+            "tip": _("Default Wobble Interval"),
+            "section": "Effect Defaults",
+        },
+    ]

--- a/meerk40t/device/dummydevice.py
+++ b/meerk40t/device/dummydevice.py
@@ -1,7 +1,6 @@
 from meerk40t.core.spoolers import Spooler
 from meerk40t.core.view import View
 from meerk40t.kernel import Service, signal_listener
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 from .mixins import Status
 
@@ -93,7 +92,55 @@ class DummyDevice(Service, Status):
             },
         ]
         self.register_choices("bed_dim", choices)
-        self.register_choices("dummy-effects", get_effect_choices(self))
+
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("dummy-effects", choices)
 
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(

--- a/meerk40t/device/dummydevice.py
+++ b/meerk40t/device/dummydevice.py
@@ -1,6 +1,7 @@
 from meerk40t.core.spoolers import Spooler
 from meerk40t.core.view import View
 from meerk40t.kernel import Service, signal_listener
+from meerk40t.device.devicechoices import get_effect_choices
 
 from .mixins import Status
 
@@ -93,54 +94,7 @@ class DummyDevice(Service, Status):
         ]
         self.register_choices("bed_dim", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("dummy-effects", choices)
+        self.register_choices("dummy-effects", get_effect_choices(self))
 
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(

--- a/meerk40t/device/dummydevice.py
+++ b/meerk40t/device/dummydevice.py
@@ -1,6 +1,7 @@
 from meerk40t.core.spoolers import Spooler
 from meerk40t.core.view import View
 from meerk40t.kernel import Service, signal_listener
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 from .mixins import Status
 
@@ -92,6 +93,8 @@ class DummyDevice(Service, Status):
             },
         ]
         self.register_choices("bed_dim", choices)
+        self.register_choices("dummy-effects", get_effect_choices(self))
+
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(
             list, "dangerlevel_op_cut", (False, 0, False, 0, False, 0, False, 0)

--- a/meerk40t/device/gui/effectspanel.py
+++ b/meerk40t/device/gui/effectspanel.py
@@ -4,8 +4,58 @@ import wx
 #from meerk40t.core.node.image_raster import ImageRasterNode
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.wxutils import dip_size
+from meerk40t.core.units import Angle
 
 _ = wx.GetTranslation
+
+def get_effect_choices(context):
+    return [
+        {
+            "attr": "effect_hatch_default_distance",
+            "object": context,
+            "default": "1.0mm",
+            "type": str,
+            "label": _("Hatch Distance"),
+            "tip": _("Default Hatch Distance"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_hatch_default_angle",
+            "object": context,
+            "default": "0deg",
+            "type": str,
+            "label": _("Hatch Angle"),
+            "tip": _("Default Hatch Angle"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_hatch_default_angle_delta",
+            "object": context,
+            "default": "0deg",
+            "type": str,
+            "label": _("Hatch Angle Delta"),
+            "tip": _("Default Hatch Angle Delta"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_wobble_default_radius",
+            "object": context,
+            "default": "0.5mm",
+            "type": str,
+            "label": _("Wobble Radius"),
+            "tip": _("Default Wobble Radius"),
+            "section": "Effect Defaults",
+        },
+        {
+            "attr": "effect_wobble_default_interval",
+            "object": context,
+            "default": "0.05mm",
+            "type": str,
+            "label": _("Wobble Interval"),
+            "tip": _("Default Wobble Interval"),
+            "section": "Effect Defaults",
+        },
+    ]
 
 
 class EffectsPanel(wx.Panel):
@@ -24,56 +74,20 @@ class EffectsPanel(wx.Panel):
 
         self.data = {}
 
-        self.context.setting(str, "effect_hatch_default_distance", "1.0mm")
-        self.context.setting(str, "effect_hatch_default_angle", "0deg")
+        for choice in get_effect_choices(self.context):
+            self.context.setting(choice["type"], choice["attr"], choice["default"])
 
-        self.context.setting(str, "effect_wobble_default_radius", "0.5mm")
-        self.context.setting(str, "effect_wobble_default_interval", "0.05mm")
+        #self.context.setting(str, "effect_hatch_default_distance", "1.0mm")
+        #self.context.setting(str, "effect_hatch_default_angle", "0deg")
+
+        #self.context.setting(str, "effect_wobble_default_radius", "0.5mm")
+        #self.context.setting(str, "effect_wobble_default_interval", "0.05mm")
         #self.context.setting(str, "effect_wobble_default_speed", "50")
-
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self.context,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self.context,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self.context,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self.context,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
 
         testsize = dip_size(self, 20, 20)
         imgsize = testsize[1]
         epanel = ChoicePropertyPanel(
-            self, wx.ID_ANY, context=self.context, choices=choices
+            self, wx.ID_ANY, context=self.context, choices=get_effect_choices(self.context)
         )
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)

--- a/meerk40t/device/gui/effectspanel.py
+++ b/meerk40t/device/gui/effectspanel.py
@@ -1,0 +1,147 @@
+import wx
+
+#from meerk40t.core.elements.element_types import elem_group_nodes, op_nodes
+#from meerk40t.core.node.image_raster import ImageRasterNode
+from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
+from meerk40t.gui.wxutils import dip_size
+
+_ = wx.GetTranslation
+
+
+class EffectsPanel(wx.Panel):
+    """
+    EffectsPanel is a panel that should work for all devices (hence in its own directory)
+    It allows to define default settings for effects for a device
+    """
+
+    def __init__(self, *args, context=None, **kwds):
+        # begin wxGlade: PassesPanel.__init__
+        kwds["style"] = kwds.get("style", 0)
+        wx.Panel.__init__(self, *args, **kwds)
+        self.parent = args[0]
+        self.context = context
+        self.SetHelpText("effects")
+
+        self.data = {}
+
+        self.context.setting(str, "effect_hatch_default_distance", "1.0mm")
+        self.context.setting(str, "effect_hatch_default_angle", "0deg")
+
+        self.context.setting(str, "effect_wobble_default_radius", "0.5mm")
+        self.context.setting(str, "effect_wobble_default_interval", "0.05mm")
+        #self.context.setting(str, "effect_wobble_default_speed", "50")
+
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self.context,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self.context,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self.context,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self.context,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+
+        testsize = dip_size(self, 20, 20)
+        imgsize = testsize[1]
+        epanel = ChoicePropertyPanel(
+            self, wx.ID_ANY, context=self.context, choices=choices
+        )
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(epanel, 1, wx.EXPAND, 0)
+        self.SetSizer(main_sizer)
+        self.Layout()
+        self.parent.add_module_delegate(epanel)
+
+        self.update_widgets()
+
+    def get_node_patterns(self, nodetype):
+        from PIL import Image
+
+        # Get dictionary with all nodetypes
+        from meerk40t.core.node.bootstrap import bootstrap
+
+        node = None
+        available = ""
+        if nodetype in bootstrap:
+            # print (f"Try to get an instance of {nodetype}")
+            if nodetype.startswith("elem"):
+                if nodetype == "elem rect":
+                    node = bootstrap[nodetype](x=0, y=0, width=10, height=10)
+                elif nodetype == "elem ellipse":
+                    node = bootstrap[nodetype](cx=0, cy=0, rx=10, ry=10)
+                elif nodetype == "elem path":
+                    node = bootstrap[nodetype]()
+                elif nodetype in ("elem image", "image raster"):
+                    # Let's use an arbitrary image
+                    image = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+                    node = bootstrap[nodetype](image=image)
+                elif nodetype == "elem polyline":
+                    node = bootstrap[nodetype]()
+                else:
+                    node = bootstrap[nodetype]()
+            else:
+                node = bootstrap[nodetype]()
+
+        if node is not None:
+            mymap = node.default_map()
+            for entry in mymap:
+                if available != "":
+                    available += ", "
+                available += "{" + entry + "}"
+            available = "\n" + available
+
+        return available
+
+    def on_checkbox_check(self, entry, isMax):
+        def check(event=None):
+            event.Skip()
+
+        return check
+
+    def on_text_formatter(self, textctrl, entry, isMax):
+        def check(event=None):
+            return
+
+        return check
+
+    def update_settings(self, operation, attribute, minmax, active, value):
+        return
+
+    def update_widgets(self):
+        return
+
+    def pane_hide(self):
+        pass
+
+    def pane_show(self):
+        self.update_widgets()

--- a/meerk40t/device/gui/effectspanel.py
+++ b/meerk40t/device/gui/effectspanel.py
@@ -5,57 +5,9 @@ import wx
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.wxutils import dip_size
 from meerk40t.core.units import Angle
+from meerk40t.device.devicechoices import get_effect_choices
 
 _ = wx.GetTranslation
-
-def get_effect_choices(context):
-    return [
-        {
-            "attr": "effect_hatch_default_distance",
-            "object": context,
-            "default": "1.0mm",
-            "type": str,
-            "label": _("Hatch Distance"),
-            "tip": _("Default Hatch Distance"),
-            "section": "Effect Defaults",
-        },
-        {
-            "attr": "effect_hatch_default_angle",
-            "object": context,
-            "default": "0deg",
-            "type": str,
-            "label": _("Hatch Angle"),
-            "tip": _("Default Hatch Angle"),
-            "section": "Effect Defaults",
-        },
-        {
-            "attr": "effect_hatch_default_angle_delta",
-            "object": context,
-            "default": "0deg",
-            "type": str,
-            "label": _("Hatch Angle Delta"),
-            "tip": _("Default Hatch Angle Delta"),
-            "section": "Effect Defaults",
-        },
-        {
-            "attr": "effect_wobble_default_radius",
-            "object": context,
-            "default": "0.5mm",
-            "type": str,
-            "label": _("Wobble Radius"),
-            "tip": _("Default Wobble Radius"),
-            "section": "Effect Defaults",
-        },
-        {
-            "attr": "effect_wobble_default_interval",
-            "object": context,
-            "default": "0.05mm",
-            "type": str,
-            "label": _("Wobble Interval"),
-            "tip": _("Default Wobble Interval"),
-            "section": "Effect Defaults",
-        },
-    ]
 
 
 class EffectsPanel(wx.Panel):

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -16,6 +16,7 @@ from ..core.view import View
 from ..device.mixins import Status
 from .controller import GrblController
 from .driver import GRBLDriver
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class GRBLDevice(Service, Status):
@@ -173,54 +174,7 @@ class GRBLDevice(Service, Status):
         ]
         self.register_choices("bed_dim", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("grbl-effects", choices)
+        self.register_choices("grbl-effects", get_effect_choices(self))
 
         # This device prefers to display power level in percent
         self.setting(bool, "use_percent_for_power_display", True)

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -16,6 +16,7 @@ from ..core.view import View
 from ..device.mixins import Status
 from .controller import GrblController
 from .driver import GRBLDriver
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class GRBLDevice(Service, Status):
@@ -172,6 +173,8 @@ class GRBLDevice(Service, Status):
             },
         ]
         self.register_choices("bed_dim", choices)
+        self.register_choices("grbl-effects", get_effect_choices(self))
+
         # This device prefers to display power level in percent
         self.setting(bool, "use_percent_for_power_display", True)
         # This device prefers to display speed in mm/min

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -16,7 +16,6 @@ from ..core.view import View
 from ..device.mixins import Status
 from .controller import GrblController
 from .driver import GRBLDriver
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class GRBLDevice(Service, Status):
@@ -173,7 +172,55 @@ class GRBLDevice(Service, Status):
             },
         ]
         self.register_choices("bed_dim", choices)
-        self.register_choices("grbl-effects", get_effect_choices(self))
+
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("grbl-effects", choices)
 
         # This device prefers to display power level in percent
         self.setting(bool, "use_percent_for_power_display", True)

--- a/meerk40t/grbl/gui/grblconfiguration.py
+++ b/meerk40t/grbl/gui/grblconfiguration.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -219,6 +220,8 @@ class GRBLConfiguration(MWindow):
         panel_protocol = ChoicePropertyPanel(
             self, wx.ID_ANY, context=self.context, choices="protocol"
         )
+
+        panel_effects = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
         panel_warn = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         panel_actions = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         panel_formatter = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
@@ -227,6 +230,7 @@ class GRBLConfiguration(MWindow):
         self.panels.append(panel_interface)
         self.panels.append(panel_protocol)
         self.panels.append(panel_global)
+        self.panels.append(panel_effects)
         self.panels.append(panel_warn)
         self.panels.append(panel_actions)
         self.panels.append(panel_formatter)
@@ -235,6 +239,7 @@ class GRBLConfiguration(MWindow):
         self.notebook_main.AddPage(panel_interface, _("Interface"))
         self.notebook_main.AddPage(panel_protocol, _("Protocol"))
         self.notebook_main.AddPage(panel_global, _("Advanced"))
+        self.notebook_main.AddPage(panel_effects, _("Effects"))
         self.notebook_main.AddPage(panel_warn, _("Warning"))
         self.notebook_main.AddPage(panel_actions, _("Default Actions"))
         self.notebook_main.AddPage(panel_formatter, _("Display Options"))

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1291,6 +1291,24 @@ class MeerK40t(MWindow):
             # _("Apply a wobble movement along the path (circular, at the left side of the line)")
 
             eff = (
+                "effect-wobble",
+                "Apply a wobble movement along the path",
+                icon_hatch_diag_bidir,
+                "Wobble",
+                "Path",
+            )
+            kernel.register("registered_effects/SimpleWobble", eff)
+
+            eff = (
+                f"effect-hatch",  
+                "Wrap the current node in a hatch",
+                icon_hatch,
+                "Hatch",
+                "Fill (unidirectional)",
+            )
+            kernel.register("registered_effects/SimpleHatch", eff)
+
+            """             eff = (
                 "effect-hatch -e scanline",
                 "Wrap the current node in a hatch",
                 icon_hatch,
@@ -1325,6 +1343,7 @@ class MeerK40t(MWindow):
             kernel.register("registered_effects/DiagonalLineBD", eff)
 
             # Wobbles
+
             eff = (
                 "effect-wobble -w circle",
                 "Apply a wobble movement along the path (circular on top of the line)",
@@ -1351,6 +1370,7 @@ class MeerK40t(MWindow):
                 "Path",
             )
             kernel.register("registered_effects/WobbleCircleR", eff)
+        """
 
         def run_job(*args):
             busy = kernel.busyinfo
@@ -1623,12 +1643,15 @@ class MeerK40t(MWindow):
         for idx, hatch in enumerate(effects):
             if len(hatch) < 4:
                 continue
-            if not hatch[4].lower().startswith("fill"):
-                continue
+            # if not hatch[4].lower().startswith("fill"):
+            #    continue
 
             cmd = hatch[0]
             if first_hatch is None:
                 first_hatch = cmd
+            # cmd = "effect-remove\n" + cmd + "\nwindow open Properties"
+            cmd = f"element clipboard copy\nelement clipboard paste\n{cmd}\nwindow open Properties"
+
             tip = _(hatch[1]) + rightmsg
             icon = hatch[2]
             if icon is None:
@@ -3070,7 +3093,7 @@ class MeerK40t(MWindow):
             if result.startswith("_"):
                 idx = result.find("_", 1)
                 if idx >= 0:
-                    result = result[idx + 1 :]
+                    result = result[idx + 1:]
             elif result.startswith("~"):
                 result = result[1:]
             return result
@@ -3176,7 +3199,7 @@ class MeerK40t(MWindow):
             if result.startswith("_"):
                 idx = result.find("_", 1)
                 if idx >= 0:
-                    result = result[idx + 1 :]
+                    result = result[idx + 1:]
             return result
 
         label = _("Tools")
@@ -3688,7 +3711,7 @@ class MeerK40t(MWindow):
                 "segment": "Scene Appearance",
                 "subsegment": "Display Options",
             },
-            ## This will confuse the hell out of people, so omitted...
+            # This will confuse the hell out of people, so omitted...
             # {
             #     "label": _("Do Not Refresh"),
             #     "help": _("Don't refresh the scene when requested"),

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1300,7 +1300,7 @@ class MeerK40t(MWindow):
             kernel.register("registered_effects/SimpleWobble", eff)
 
             eff = (
-                f"effect-hatch",  
+                "effect-hatch",  
                 "Wrap the current node in a hatch",
                 icon_hatch,
                 "Hatch",
@@ -1650,7 +1650,7 @@ class MeerK40t(MWindow):
             if first_hatch is None:
                 first_hatch = cmd
             # cmd = "effect-remove\n" + cmd + "\nwindow open Properties"
-            cmd = f"element clipboard copy\nelement clipboard paste\n{cmd}\nwindow open Properties"
+            # cmd = f"element clipboard copy\nelement clipboard paste\n{cmd}\nwindow open Properties"
 
             tip = _(hatch[1]) + rightmsg
             icon = hatch[2]

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -17,7 +17,6 @@ from ..device.mixins import Status
 from .controller import LihuiyuController
 from .driver import LihuiyuDriver
 from .tcp_connection import TCPOutput
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class LihuiyuDevice(Service, Status):
@@ -345,7 +344,54 @@ class LihuiyuDevice(Service, Status):
         ]
         self.register_choices("lhy-general", choices)
 
-        self.register_choices("lhy-effects", get_effect_choices(self))
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("lhy-effects", choices)
 
         choices = [
             {

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -17,6 +17,7 @@ from ..device.mixins import Status
 from .controller import LihuiyuController
 from .driver import LihuiyuDriver
 from .tcp_connection import TCPOutput
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class LihuiyuDevice(Service, Status):
@@ -343,6 +344,8 @@ class LihuiyuDevice(Service, Status):
             },
         ]
         self.register_choices("lhy-general", choices)
+
+        self.register_choices("lhy-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -17,6 +17,7 @@ from ..device.mixins import Status
 from .controller import LihuiyuController
 from .driver import LihuiyuDriver
 from .tcp_connection import TCPOutput
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class LihuiyuDevice(Service, Status):
@@ -344,54 +345,7 @@ class LihuiyuDevice(Service, Status):
         ]
         self.register_choices("lhy-general", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("lhy-effects", choices)
+        self.register_choices("lhy-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -414,6 +415,8 @@ class LihuiyuDriverGui(MWindow):
             context=self.context,
             choices=("lhy-general", "lhy-jog", "lhy-rapid-override", "lhy-speed"),
         )
+
+        panel_effects = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
         panel_warn = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         panel_actions = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         panel_format = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
@@ -421,6 +424,7 @@ class LihuiyuDriverGui(MWindow):
         self.panels.append(panel_config)
         self.panels.append(panel_interface)
         self.panels.append(panel_setup)
+        self.panels.append(panel_effects)
         self.panels.append(panel_warn)
         self.panels.append(panel_actions)
         self.panels.append(panel_format)
@@ -428,6 +432,7 @@ class LihuiyuDriverGui(MWindow):
         self.notebook_main.AddPage(panel_config, _("Configuration"))
         self.notebook_main.AddPage(panel_interface, _("Interface"))
         self.notebook_main.AddPage(panel_setup, _("Setup"))
+        self.notebook_main.AddPage(panel_effects, _("Effects"))
         self.notebook_main.AddPage(panel_warn, _("Warning"))
         self.notebook_main.AddPage(panel_actions, _("Default Actions"))
         self.notebook_main.AddPage(panel_format, _("Display Options"))

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -14,6 +14,7 @@ from ..core.units import Length
 from ..device.mixins import Status
 from .controller import MoshiController
 from .driver import MoshiDriver
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class MoshiDevice(Service, Status):
@@ -221,6 +222,8 @@ class MoshiDevice(Service, Status):
             },
         ]
         self.register_choices("coolant", choices)
+
+        self.register_choices("moshi-effects", get_effect_choices(self))
 
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -14,6 +14,7 @@ from ..core.units import Length
 from ..device.mixins import Status
 from .controller import MoshiController
 from .driver import MoshiDriver
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class MoshiDevice(Service, Status):
@@ -222,54 +223,7 @@ class MoshiDevice(Service, Status):
         ]
         self.register_choices("coolant", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("moshi-effects", choices)
+        self.register_choices("moshi-effects", get_effect_choices(self))
 
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -14,7 +14,6 @@ from ..core.units import Length
 from ..device.mixins import Status
 from .controller import MoshiController
 from .driver import MoshiDriver
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class MoshiDevice(Service, Status):
@@ -223,7 +222,54 @@ class MoshiDevice(Service, Status):
         ]
         self.register_choices("coolant", choices)
 
-        self.register_choices("moshi-effects", get_effect_choices(self))
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("moshi-effects", choices)
 
         # Tuple contains 4 value pairs: Speed Low, Speed High, Power Low, Power High, each with enabled, value
         self.setting(

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -38,16 +39,19 @@ class MoshiDriverGui(MWindow):
             context=self.context,
             choices=("bed_dim", "coolant"),
         )
+        panel_effects = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
         panel_warn = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         panel_actions = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         newpanel = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
 
         self.panels.append(panel_config)
+        self.panels.append(panel_effects)
         self.panels.append(panel_warn)
         self.panels.append(panel_actions)
         self.panels.append(newpanel)
 
         self.notebook_main.AddPage(panel_config, _("Configuration"))
+        self.notebook_main.AddPage(panel_effects, _("Effects"))
         self.notebook_main.AddPage(panel_warn, _("Warning"))
         self.notebook_main.AddPage(panel_actions, _("Default Actions"))
         self.notebook_main.AddPage(newpanel, _("Display Options"))

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -8,6 +8,7 @@ from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import CommandSyntaxError, Service, signal_listener
 from meerk40t.newly.driver import NewlyDriver
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class NewlyDevice(Service, Status):
@@ -106,54 +107,7 @@ class NewlyDevice(Service, Status):
         ]
         self.register_choices("newly-speedchart", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("newly-effects", choices)
+        self.register_choices("newly-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -8,6 +8,7 @@ from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import CommandSyntaxError, Service, signal_listener
 from meerk40t.newly.driver import NewlyDriver
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class NewlyDevice(Service, Status):
@@ -105,6 +106,8 @@ class NewlyDevice(Service, Status):
             },
         ]
         self.register_choices("newly-speedchart", choices)
+
+        self.register_choices("newly-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -8,7 +8,6 @@ from meerk40t.core.view import View
 from meerk40t.device.mixins import Status
 from meerk40t.kernel import CommandSyntaxError, Service, signal_listener
 from meerk40t.newly.driver import NewlyDriver
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class NewlyDevice(Service, Status):
@@ -107,7 +106,54 @@ class NewlyDevice(Service, Status):
         ]
         self.register_choices("newly-speedchart", choices)
 
-        self.register_choices("newly-effects", get_effect_choices(self))
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("newly-effects", choices)
 
         choices = [
             {

--- a/meerk40t/newly/gui/newlyconfig.py
+++ b/meerk40t/newly/gui/newlyconfig.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -51,6 +52,10 @@ class NewlyConfiguration(MWindow):
         )
         self.panels.append(newpanel)
         self.notebook_main.AddPage(newpanel, _("Raster Chart"))
+
+        newpanel = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
+        self.panels.append(newpanel)
+        self.notebook_main.AddPage(newpanel, _("Effects"))
 
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -16,6 +16,7 @@ from .mock_connection import MockConnection
 from .serial_connection import SerialConnection
 from .tcp_connection import TCPConnection
 from .udp_connection import UDPConnection
+from meerk40t.device.devicechoices import get_effect_choices
 
 
 class RuidaDevice(Service):
@@ -196,54 +197,7 @@ class RuidaDevice(Service):
         ]
         self.register_choices("ruida-global", choices)
 
-        choices = [
-            {
-                "attr": "effect_hatch_default_distance",
-                "object": self,
-                "default": "1.0mm",
-                "type": str,
-                "label": _("Hatch Distance"),
-                "tip": _("Default Hatch Distance"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle"),
-                "tip": _("Default Hatch Angle"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_hatch_default_angle_delta",
-                "object": self,
-                "default": "0deg",
-                "type": str,
-                "label": _("Hatch Angle Delta"),
-                "tip": _("Default Hatch Angle Delta"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_radius",
-                "object": self,
-                "default": "0.5mm",
-                "type": str,
-                "label": _("Wobble Radius"),
-                "tip": _("Default Wobble Radius"),
-                "section": "Effect Defaults",
-            },
-            {
-                "attr": "effect_wobble_default_interval",
-                "object": self,
-                "default": "0.05mm",
-                "type": str,
-                "label": _("Wobble Interval"),
-                "tip": _("Default Wobble Interval"),
-                "section": "Effect Defaults",
-            },
-        ]
-        self.register_choices("ruida-effects", choices)
+        self.register_choices("ruida-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -16,7 +16,6 @@ from .mock_connection import MockConnection
 from .serial_connection import SerialConnection
 from .tcp_connection import TCPConnection
 from .udp_connection import UDPConnection
-from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class RuidaDevice(Service):
@@ -197,7 +196,54 @@ class RuidaDevice(Service):
         ]
         self.register_choices("ruida-global", choices)
 
-        self.register_choices("ruida-effects", get_effect_choices(self))
+        choices = [
+            {
+                "attr": "effect_hatch_default_distance",
+                "object": self,
+                "default": "1.0mm",
+                "type": str,
+                "label": _("Hatch Distance"),
+                "tip": _("Default Hatch Distance"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle"),
+                "tip": _("Default Hatch Angle"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_hatch_default_angle_delta",
+                "object": self,
+                "default": "0deg",
+                "type": str,
+                "label": _("Hatch Angle Delta"),
+                "tip": _("Default Hatch Angle Delta"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_radius",
+                "object": self,
+                "default": "0.5mm",
+                "type": str,
+                "label": _("Wobble Radius"),
+                "tip": _("Default Wobble Radius"),
+                "section": "Effect Defaults",
+            },
+            {
+                "attr": "effect_wobble_default_interval",
+                "object": self,
+                "default": "0.05mm",
+                "type": str,
+                "label": _("Wobble Interval"),
+                "tip": _("Default Wobble Interval"),
+                "section": "Effect Defaults",
+            },
+        ]
+        self.register_choices("ruida-effects", choices)
 
         choices = [
             {

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -16,6 +16,7 @@ from .mock_connection import MockConnection
 from .serial_connection import SerialConnection
 from .tcp_connection import TCPConnection
 from .udp_connection import UDPConnection
+from meerk40t.device.gui.effectspanel import get_effect_choices
 
 
 class RuidaDevice(Service):
@@ -195,6 +196,8 @@ class RuidaDevice(Service):
             },
         ]
         self.register_choices("ruida-global", choices)
+
+        self.register_choices("ruida-effects", get_effect_choices(self))
 
         choices = [
             {

--- a/meerk40t/ruida/gui/ruidaconfig.py
+++ b/meerk40t/ruida/gui/ruidaconfig.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.device.gui.defaultactions import DefaultActionPanel
 from meerk40t.device.gui.formatterpanel import FormatterPanel
 from meerk40t.device.gui.warningpanel import WarningPanel
+from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
@@ -189,6 +190,10 @@ class RuidaConfiguration(MWindow):
         )
         self.panels.append(panel_config)
         self.notebook_main.AddPage(panel_config, _("Configuration"))
+
+        newpanel = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
+        self.panels.append(newpanel)
+        self.notebook_main.AddPage(newpanel, _("Effects"))
 
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)


### PR DESCRIPTION
[Screencast from 2024-06-13 14-56-31.webm](https://github.com/meerk40t/meerk40t/assets/1604942/7824cd57-bc27-465f-ab07-e0e76492c6d3)

This PR makes two effective changes.

It changes the hatch button on the toolbar to an Effects Button that is populated by registered effects (currently wobble and hatch).

Additionally, it adds the ability to set default values for these effects that are device specific by adding a new Effects tab to each device config dialog.

One current weirdness that is perhaps added by this pr is that the preview in the hatch properties dialog is strange until you manually change it.  It might be an issue in conversion from str to Angle in that preview.  The hatch applies correctly to the object(s).