### PR TITLE
Allow suppression of config options for classroom sessions

### DIFF
--- a/meerk40t/balormk/gui/gui.py
+++ b/meerk40t/balormk/gui/gui.py
@@ -43,16 +43,18 @@ def plugin(service, lifecycle):
                 "action": lambda e: service("window toggle Controller\n"),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "help": "devicebalor",
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "help": "devicebalor",
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
 
         service.register("property/RasterOpNode/Balor", BalorOperationPanel)
         service.register("property/CutOpNode/Balor", BalorOperationPanel)

--- a/meerk40t/grbl/gui/gui.py
+++ b/meerk40t/grbl/gui/gui.py
@@ -51,16 +51,18 @@ def plugin(service, lifecycle):
                 "action": lambda v: service("window toggle GRBLController\n"),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "help": "devicegrbl",
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "help": "devicegrbl",
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
         service.register(
             "button/control/Pause",
             {

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -601,6 +601,9 @@ class DeviceManager(MWindow):
 
     @staticmethod
     def sub_register(kernel):
+        if hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config:
+            return
+
         kernel.register("wxpane/Devices", register_panel)
         kernel.register(
             "button/device/DeviceManager",

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -140,7 +140,9 @@ class LaserPanel(wx.Panel):
         self.btn_config_laser.SetToolTip(
             _("Opens device-specific configuration window")
         )
-
+        kernel = self.context.kernel
+        if hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config:
+            self.btn_config_laser.Enable(False)
         self.sizer_devices.Add(self.combo_devices, 1, wx.EXPAND, 0)
         self.btn_config_laser.SetMinSize(dip_size(self, 20, -1))
         self.sizer_devices.Add(self.btn_config_laser, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -875,7 +875,10 @@ class wxMeerK40t(wx.App, Module):
         )
 
         kernel.register("window/Console", Console)
-        kernel.register("window/Preferences", Preferences)
+        if hasattr(kernel.args, "lock_general_config") and kernel.args.lock_general_config:
+            pass
+        else:
+            kernel.register("window/Preferences", Preferences)
         kernel.register("window/About", About)
         kernel.register("window/Keymap", Keymap)
         kernel.register("window/Wordlist", WordlistEditor)
@@ -888,7 +891,10 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("window/ExecuteJob", ExecuteJob)
         kernel.register("window/BufferView", BufferView)
         kernel.register("window/Scene", SceneWindow)
-        kernel.register("window/DeviceManager", DeviceManager)
+        if hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config:
+            pass
+        else:
+            kernel.register("window/DeviceManager", DeviceManager)
         kernel.register("window/Alignment", Alignment)
         kernel.register("window/HersheyFontManager", HersheyFontManager)
         kernel.register("window/HersheyFontSelector", HersheyFontSelector)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -601,6 +601,7 @@ class MeerK40t(MWindow):
                 pass
             return res
 
+        kernel = self.context.kernel
         self.edit_menu_choice = [
             {
                 "label": _("&Undo\tCtrl-Z"),
@@ -722,25 +723,30 @@ class MeerK40t(MWindow):
                 "level": 1,
                 "segment": "",
             },
-            {
-                "label": "",
-                "level": 1,
-                "segment": "",
-            },
-            {
-                "label": _("Device-Manager"),
-                "help": _("Manage the Laser devices"),
-                "action": on_click_device_manager,
-                "level": 1,
-                "segment": "",
-            },
-            {
-                "label": _("Device-Configuration"),
-                "help": _("Manage the device settings"),
-                "action": on_click_device_settings,
-                "level": 1,
-                "segment": "",
-            },
+        ]
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            self.edit_menu_choice.extend([
+                {
+                    "label": "",
+                    "level": 1,
+                    "segment": "",
+                },
+                {
+                    "label": _("Device-Manager"),
+                    "help": _("Manage the Laser devices"),
+                    "action": on_click_device_manager,
+                    "level": 1,
+                    "segment": "",
+                },
+                {
+                    "label": _("Device-Configuration"),
+                    "help": _("Manage the device settings"),
+                    "action": on_click_device_settings,
+                    "level": 1,
+                    "segment": "",
+                },
+            ])
+        self.edit_menu_choice.extend([
             {
                 "label": "",
                 "level": 1,
@@ -767,20 +773,24 @@ class MeerK40t(MWindow):
                 "level": 2,
                 "segment": "Settings",
             },
-            {
-                "label": "",
-                "level": 2,
-                "segment": "Settings",
-            },
-            {
-                "label": _("Preferences\tCtrl-,"),
-                "help": _("Edit the general preferences"),
-                "action": on_click_preferences,
-                "level": 2,
-                "id": wx.ID_PREFERENCES,
-                "segment": "Settings",
-            },
-        ]
+        ])
+        if not (hasattr(kernel.args, "lock_general_config") and kernel.args.lock_general_config):
+            self.edit_menu_choice.extend((
+                {
+                    "label": "",
+                    "level": 2,
+                    "segment": "Settings",
+                },
+
+                {
+                    "label": _("Preferences\tCtrl-,"),
+                    "help": _("Edit the general preferences"),
+                    "action": on_click_preferences,
+                    "level": 2,
+                    "id": wx.ID_PREFERENCES,
+                    "segment": "Settings",
+                },
+            ))
 
     def destroy_statusbar_panels(self):
         self.main_statusbar.Clear()
@@ -3268,6 +3278,11 @@ class MeerK40t(MWindow):
                     caption = name[0].upper() + name[1:]
             if name in ("Scene", "About"):  # make no sense, so we omit these...
                 suppress = True
+            kernel = self.context.kernel
+            if hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config:
+                if submenu_name == "Device-Settings" and caption in ("Device Manager", "Configuration"):
+                    suppress = True
+
             if suppress:
                 continue
             menudata.append([submenu_name, caption, name, window, suffix_path])

--- a/meerk40t/lihuiyu/gui/gui.py
+++ b/meerk40t/lihuiyu/gui/gui.py
@@ -67,16 +67,18 @@ def plugin(service, lifecycle):
                 ),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "help": "devicek40",
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "help": "devicek40",
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
         service.register(
             "button/control/Pause",
             {

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -127,6 +127,8 @@ parser.add_argument(
     default=None,
     help="run meerk40t with profiler file specified",
 )
+parser.add_argument("-u", "--lock-device-config", action="store_true", help="lock device config from editing")
+parser.add_argument("-U", "--lock-general-config", action="store_true", help="lock general config from editing")
 
 
 def run():

--- a/meerk40t/moshi/gui/gui.py
+++ b/meerk40t/moshi/gui/gui.py
@@ -33,15 +33,17 @@ def plugin(service, lifecycle):
                 "action": lambda e: service("window toggle Controller\n"),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
         service.register(
             "button/control/Pause",
             {

--- a/meerk40t/newly/gui/gui.py
+++ b/meerk40t/newly/gui/gui.py
@@ -32,16 +32,18 @@ def plugin(service, lifecycle):
                 "action": lambda e: service("window toggle Controller\n"),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "help": "devicenewly",
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "help": "devicenewly",
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
 
     if lifecycle == "service_attach":
         from meerk40t.gui.icons import (

--- a/meerk40t/ruida/gui/gui.py
+++ b/meerk40t/ruida/gui/gui.py
@@ -23,15 +23,17 @@ def plugin(service, lifecycle):
                 "action": lambda e: service("window toggle Controller\n"),
             },
         )
-        service.register(
-            "button/device/Configuration",
-            {
-                "label": _("Config"),
-                "icon": icons8_computer_support,
-                "tip": _("Opens device-specific configuration window"),
-                "action": lambda v: service("window toggle Configuration\n"),
-            },
-        )
+        kernel = service.kernel
+        if not (hasattr(kernel.args, "lock_device_config") and kernel.args.lock_device_config):
+            service.register(
+                "button/device/Configuration",
+                {
+                    "label": _("Config"),
+                    "icon": icons8_computer_support,
+                    "tip": _("Opens device-specific configuration window"),
+                    "action": lambda v: service("window toggle Configuration\n"),
+                },
+            )
 
         service.register(
             "button/control/FocusZ",


### PR DESCRIPTION
Introduce two command line options:
```
-u, --lock-device-config
                        lock device config from editing
-U, --lock-general-config
                        lock general config from editing
```