### PR TITLE
User option for single node creation

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-2019, macos-latest]
         python-version: [3.8, 3.12]
 
     steps:

--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -31,6 +31,15 @@ class CircleTool(ToolWidget):
         self.old_mode = self.scene.context.setting(bool, "circle_from_corner", False)
         self.creation_mode = 0 if self.old_mode else 1
 
+    def end_tool(self, force=False):
+        self.p1 = None
+        self.p2 = None
+        self.scene.context.signal("statusmsg", "")
+        self.scene.request_refresh()
+        if force or self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context("tool none\n")
+
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
             matrix = gc.GetTransform().Get()
@@ -219,23 +228,16 @@ class CircleTool(ToolWidget):
                 if elements.classify_new:
                     elements.classify([node])
                 self.notify_created(node)
-                self.p1 = None
-                self.p2 = None
             except IndexError:
                 pass
-            self.scene.request_refresh()
-            self.scene.context.signal("statusmsg", "")
+            self.end_tool()
             response = RESPONSE_ABORT
-        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
-            self.p1 = None
-            self.p2 = None
-            self.scene.context.signal("statusmsg", "")
+        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape") or event_type == "rightdown":
             if self.scene.pane.tool_active:
-                self.scene.pane.tool_active = False
-                self.scene.request_refresh()
                 response = RESPONSE_CONSUME
             else:
                 response = RESPONSE_CHAIN
+            self.end_tool(force=True)
         elif update_required:
             self.scene.request_refresh()
             # Have we clicked already?

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -90,6 +90,15 @@ class EllipseTool(ToolWidget):
             s += _(" (Press Alt-Key to draw from center)")
             self.scene.context.signal("statusmsg", s)
 
+    def end_tool(self, force=False):
+        self.p1 = None
+        self.p2 = None
+        self.scene.context.signal("statusmsg", "")
+        self.scene.request_refresh()
+        if force or self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context("tool none\n")
+
     def event(
         self,
         window_pos=None,
@@ -189,23 +198,16 @@ class EllipseTool(ToolWidget):
                 if elements.classify_new:
                     elements.classify([node])
                 self.notify_created(node)
-                self.p1 = None
-                self.p2 = None
             except IndexError:
                 pass
-            self.scene.request_refresh()
-            self.scene.context.signal("statusmsg", "")
+            self.end_tool()
             response = RESPONSE_ABORT
-        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
+        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape") or (event_type=="rightdown"):
             if self.scene.pane.tool_active:
-                self.scene.pane.tool_active = False
-                self.scene.request_refresh()
                 response = RESPONSE_CONSUME
             else:
                 response = RESPONSE_CHAIN
-            self.p1 = None
-            self.p2 = None
-            self.scene.context.signal("statusmsg", "")
+            self.end_tool(force=True)
         elif update_required:
             self.scene.request_refresh()
             # Have we clicked already?

--- a/meerk40t/gui/toolwidgets/toolpoint.py
+++ b/meerk40t/gui/toolwidgets/toolpoint.py
@@ -18,6 +18,13 @@ class PointTool(ToolWidget):
     def process_draw(self, gc: wx.GraphicsContext):
         pass
 
+    def end_tool(self, force=False):
+        self.scene.context.signal("statusmsg", "")
+        self.scene.request_refresh()
+        if force or self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context("tool none\n")
+
     def event(
         self,
         window_pos=None,
@@ -48,12 +55,12 @@ class PointTool(ToolWidget):
             if elements.classify_new:
                 elements.classify([node])
             self.notify_created(node)
+            self.end_tool()
             response = RESPONSE_CONSUME
-        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
+        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape") or event_type == "rightdown":
             if self.scene.pane.tool_active:
-                self.scene.pane.tool_active = False
-                self.scene.request_refresh()
                 response = RESPONSE_CONSUME
             else:
                 response = RESPONSE_CHAIN
+            self.end_tool(force=True)
         return response

--- a/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
+++ b/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
@@ -195,6 +195,10 @@ class PointListTool(ToolWidget):
         self.scene.request_refresh()
         if followup:
             self.scene.context(f"{followup}\n")
+        elif self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context.signal("statusmsg", "")
+            self.scene.context("tool none\n")
 
     # Routines that can be overloaded -------------------
 

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -87,6 +87,15 @@ class RectTool(ToolWidget):
             s += _(" (Press Alt-Key to draw from center)")
             self.scene.context.signal("statusmsg", s)
 
+    def end_tool(self, force=False):
+        self.p1 = None
+        self.p2 = None
+        self.scene.context.signal("statusmsg", "")
+        self.scene.request_refresh()
+        if force or self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context("tool none\n")
+
     def event(
         self,
         window_pos=None,
@@ -150,10 +159,7 @@ class RectTool(ToolWidget):
                 dy = self.p1.imag - self.p2.imag
                 if abs(dx) < 1e-10 or abs(dy) < 1e-10:
                     # Degenerate? Ignore!
-                    self.p1 = None
-                    self.p2 = None
-                    self.scene.request_refresh()
-                    self.scene.context.signal("statusmsg", "")
+                    self.end_tool()
                     response = RESPONSE_ABORT
                     return response
                 if self.creation_mode == 1:
@@ -184,23 +190,16 @@ class RectTool(ToolWidget):
                 if elements.classify_new:
                     elements.classify([node])
                 self.notify_created(node)
-                self.p1 = None
-                self.p2 = None
             except IndexError:
                 pass
-            self.scene.request_refresh()
-            self.scene.context.signal("statusmsg", "")
+            self.end_tool()
             response = RESPONSE_ABORT
-        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
+        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape") or (event_type=="rightdown"):
             if self.scene.pane.tool_active:
-                self.scene.pane.tool_active = False
-                self.scene.request_refresh()
                 response = RESPONSE_CONSUME
             else:
                 response = RESPONSE_CHAIN
-            self.p1 = None
-            self.p2 = None
-            self.scene.context.signal("statusmsg", "")
+            self.end_tool(force=True)
         elif update_required:
             self.scene.request_refresh()
             # Have we clicked already?

--- a/meerk40t/gui/toolwidgets/tooltext.py
+++ b/meerk40t/gui/toolwidgets/tooltext.py
@@ -32,6 +32,13 @@ class TextTool(ToolWidget):
         self.scene.context.elements.set_emphasis([node])
         node.focus()
 
+    def end_tool(self, force=False):
+        self.scene.context.signal("statusmsg", "")
+        self.scene.request_refresh()
+        if force or self.scene.context.just_a_single_element:
+            self.scene.pane.tool_active = False
+            self.scene.context("tool none\n")
+
     def event(
         self,
         window_pos=None,
@@ -74,14 +81,14 @@ class TextTool(ToolWidget):
             # so we are trying to bring it back after all the ruckus happened...
             self.last_node_created = node
             wx.CallLater(750, self.refocus_text)
+            self.end_tool()
             response = RESPONSE_CONSUME
-        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape"):
+        elif event_type == "lost" or (event_type == "key_up" and modifiers == "escape") or (event_type=="rightdown"):
             if self.scene.pane.tool_active:
-                self.scene.pane.tool_active = False
-                self.scene.request_refresh()
                 response = RESPONSE_CONSUME
             else:
                 response = RESPONSE_CHAIN
+            self.end_tool(force=True)
         return response
 
     # @staticmethod

--- a/meerk40t/gui/toolwidgets/toolvector.py
+++ b/meerk40t/gui/toolwidgets/toolvector.py
@@ -207,3 +207,5 @@ class VectorTool(ToolWidget):
         self.scene.context.signal("statusmsg", "")
         self.mouse_position = None
         self.scene.request_refresh()
+        if self.scene.context.just_a_single_element:
+            self.scene.context("tool none\n")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1205,7 +1205,7 @@ class MeerK40t(MWindow):
             # },
             {
                 "attr": "button_repeat",
-                "object": self.context.root,
+                "object": context.root,
                 "default": 0.5,
                 "type": float,
                 "label": _("Button repeat-interval"),
@@ -1222,7 +1222,7 @@ class MeerK40t(MWindow):
             },
             {
                 "attr": "button_accelerate",
-                "object": self.context.root,
+                "object": context.root,
                 "default": True,
                 "type": bool,
                 "label": _("Accelerate repeats"),
@@ -1234,6 +1234,25 @@ class MeerK40t(MWindow):
                 "section": "Misc.",
                 "subsection": "Button-Behaviour",
                 "signals": "button-repeat",
+            },
+            {
+                "attr": "just_a_single_element",
+                "object": context.root,
+                "default": False,
+                "type": bool,
+                "label": _("Create a single element only"),
+                "tip": _(
+                    "When you design an element, e.g. a line, then MeerK40t will allow you to immediately create the next instance of this type."
+                )
+                + "\n"
+                + _(
+                    "If this option is active then it will create just a single element and return to selection mode."
+                )
+                + "\n"
+                + _("Hint: Escape or a right-click will leave creation mode as well."),
+                "page": "Gui",
+                # "hidden": True,
+                "section": "Misc.",
             },
             {
                 "attr": "process_while_typing",


### PR DESCRIPTION
When you design an element, e.g. a line, then MeerK40t will allow you to immediately create the next instance of this type.
If this new option is active then it will create just a single element and return to selection mode.
Hint: Escape or a right-click will leave creation mode as well.

![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/a51d044c-5e3d-4a4f-bf1c-cce8932e3ef3)
