### PR TITLE
Basic dash wobble pattern

### DIFF
--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -390,16 +390,7 @@ def init_commands(kernel):
             interval = "0.5mm"
 
         wtype = wtype.lower()
-        allowed = (
-            "circle",
-            "circle_right",
-            "circle_left",
-            "sinewave",
-            "sawtooth",
-            "jigsaw",
-            "gear",
-            "slowtooth",
-        )
+        allowed = list(self.kernel.root.match("wobble", suffix=True))
         if wtype not in allowed:
             channel(f"Invalid wobble type, allowed: {','.join(allowed)}")
             return

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -325,6 +325,15 @@ class WobbleEffectNode(Node):
                     speed=self.wobble_speed,
                 )
             )
+        elif self.wobble_type == "dash":
+            path.append(
+                Geomstr.wobble_dash(
+                    outlines,
+                    radius=self._radius,
+                    interval=self._interval,
+                    speed=self.wobble_speed,
+                )
+            )
         return path
 
     def modified(self):

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -485,64 +485,38 @@ def meander_2(wobble, x0, y0, x1, y1):
 
 def meander_3(wobble, x0, y0, x1, y1):
     pattern = (
-        (
-            "u",
-            4,
-        ),
-        (
-            "r",
-            3,
-        ),
-        (
-            "d",
-            3,
-        ),
-        (
-            "l",
-            2,
-        ),
-        (
-            "u",
-            2,
-        ),
-        (
-            "r",
-            1,
-        ),
-        (
-            "d",
-            1,
-        ),
+        ("u", 4),
+        ("r", 3),
+        ("d", 3),
+        ("l", 2),
+        ("u", 2),
+        ("r", 1),
+        ("d", 1),
         # and now backwards...
         # reverse of upper part
-        (
-            "u",
-            1,
-        ),
-        (
-            "l",
-            1,
-        ),
-        (
-            "d",
-            2,
-        ),
-        (
-            "r",
-            2,
-        ),
-        (
-            "u",
-            3,
-        ),
-        (
-            "l",
-            3,
-        ),
-        (
-            "d",
-            4,
-        ),
+        ("u", 1),
+        ("l", 1),
+        ("d", 2),
+        ("r", 2),
+        ("u", 3),
+        ("l", 3),
+        ("d", 4),
+        # other side
+        ("d", 4),
+        ("r", 3),
+        ("u", 3),
+        ("l", 2),
+        ("d", 2),
+        ("r", 1),
+        ("u", 1),
+        # and now backwards...
+        ("d", 1),
+        ("l", 1),
+        ("u", 2),
+        ("r", 2),
+        ("d", 3),
+        ("l", 3),
+        ("u", 4),
         # transition
         ("r", 4),
     )
@@ -553,6 +527,46 @@ def meander_3(wobble, x0, y0, x1, y1):
     max_x += 1
     yield from _meander(wobble, pattern, max_x, max_y, x0, y0, x1, y1)
 
+
+def _dashed(wobble, pattern, max_x, x0, y0, x1, y1):
+    if x1 is None or y1 is None:
+        yield x0, y0
+        return
+    # wobble has the following parameters:
+    # speed
+    # radius
+    # interval
+    distance_visible_2 = wobble.radius * wobble.speed * wobble.radius * wobble.speed
+    distance_invisible_2 = wobble.radius * wobble.radius
+    visible = True
+    distance_2 = distance_visible_2
+    total_distance_2 = 0
+    lx = x0
+    ly = y0
+    ct = 0
+    for tx, ty in wobble.wobble(x0, y0, x1, y1):
+        ct += 1
+        dist_2 = (tx - lx) * (tx - lx) + (ty - ly) * (ty - ly)
+        total_distance_2 += dist_2
+        print (f"[{ct}]: ({lx/1000:.2f}, {ly/1000:.2f})-({tx/1000:.2f}, {ty/1000:.2f})={dist_2/1000000:.2f}, total: {total_distance_2/1000000:.2f} from {distance_2/1000000:.2f}, mode={visible}")
+        if total_distance_2 >= distance_2:
+            visible = not visible
+            if visible:
+                distance_2 = distance_visible_2
+            else:
+                distance_2 = distance_invisible_2
+            total_distance_2 = 0
+        lx = tx
+        ly = ty
+        if visible:
+            yield tx, ty
+        else:
+            yield None, None
+
+def dashed_line(wobble, x0, y0, x1, y1):
+    max_x = 0
+    pattern = "- " # "- . " or "-- "
+    yield from _dashed(wobble, pattern, max_x, x0, y0, x1, y1)
 
 def plugin(kernel, lifecycle):
     if lifecycle == "register":
@@ -571,3 +585,4 @@ def plugin(kernel, lifecycle):
         context.register("wobble/meander_1", meander_1)
         context.register("wobble/meander_2", meander_2)
         context.register("wobble/meander_3", meander_3)
+        context.register("wobble/dash", dashed_line)

--- a/meerk40t/fill/fills.py
+++ b/meerk40t/fill/fills.py
@@ -17,6 +17,7 @@ class Wobble:
         self._last_x = None
         self._last_y = None
         self._algorithm = algorithm
+        self.flag = None
 
     def __call__(self, x0, y0, x1, y1):
         yield from self._algorithm(self, x0, y0, x1, y1)
@@ -36,6 +37,8 @@ class Wobble:
             self._total_distance += self.interval
             self._total_count += 1
             yield tx, ty
+            self._last_x = tx
+            self._last_y = ty
             positions += 1
         self._remainder += intervals
         self._remainder %= 1
@@ -528,7 +531,7 @@ def meander_3(wobble, x0, y0, x1, y1):
     yield from _meander(wobble, pattern, max_x, max_y, x0, y0, x1, y1)
 
 
-def _dashed(wobble, pattern, max_x, x0, y0, x1, y1):
+def _dashed(wobble, x0, y0, x1, y1):
     if x1 is None or y1 is None:
         yield x0, y0
         return
@@ -536,37 +539,24 @@ def _dashed(wobble, pattern, max_x, x0, y0, x1, y1):
     # speed
     # radius
     # interval
-    distance_visible_2 = wobble.radius * wobble.speed * wobble.radius * wobble.speed
-    distance_invisible_2 = wobble.radius * wobble.radius
-    visible = True
-    distance_2 = distance_visible_2
-    total_distance_2 = 0
-    lx = x0
-    ly = y0
-    ct = 0
+    if wobble.flag is None:
+        wobble.flag = True # Visible
+    last_ratio = int(wobble._total_distance / wobble.radius)
     for tx, ty in wobble.wobble(x0, y0, x1, y1):
-        ct += 1
-        dist_2 = (tx - lx) * (tx - lx) + (ty - ly) * (ty - ly)
-        total_distance_2 += dist_2
-        print (f"[{ct}]: ({lx/1000:.2f}, {ly/1000:.2f})-({tx/1000:.2f}, {ty/1000:.2f})={dist_2/1000000:.2f}, total: {total_distance_2/1000000:.2f} from {distance_2/1000000:.2f}, mode={visible}")
-        if total_distance_2 >= distance_2:
-            visible = not visible
-            if visible:
-                distance_2 = distance_visible_2
-            else:
-                distance_2 = distance_invisible_2
-            total_distance_2 = 0
-        lx = tx
-        ly = ty
-        if visible:
+
+        new_ratio = int(wobble._total_distance / wobble.radius)
+        if new_ratio != last_ratio:
+            wobble.flag = not wobble.flag
+            last_ratio = new_ratio
+        # if wobble.flag and wobble._last_x:
+        #     yield wobble._last_x, wobble._last_y
+        if wobble.flag:
             yield tx, ty
         else:
             yield None, None
 
 def dashed_line(wobble, x0, y0, x1, y1):
-    max_x = 0
-    pattern = "- " # "- . " or "-- "
-    yield from _dashed(wobble, pattern, max_x, x0, y0, x1, y1)
+    yield from _dashed(wobble, x0, y0, x1, y1)
 
 def plugin(kernel, lifecycle):
     if lifecycle == "register":

--- a/meerk40t/gui/propertypanels/wobbleproperty.py
+++ b/meerk40t/gui/propertypanels/wobbleproperty.py
@@ -133,6 +133,11 @@ class WobblePropertyPanel(ScrolledPanel):
 
         self.SetSizer(main_sizer)
 
+        self.text_interval.SetToolTip(_("Segmentation size, the wobble pattern will be applied at every segment"))
+        self.text_radius.SetToolTip(_("Wobble size, does influence the size of the wobble pattern"))
+        self.text_speed.SetToolTip(_("How quickly does the wobble pattern revolve around the path"))
+        self.combo_fill_style.SetToolTip(_("The wobble pattern to be applied"))
+
         self.text_radius.SetActionRoutine(self.on_text_radius)
         self.text_interval.SetActionRoutine(self.on_text_interval)
         self.text_speed.SetActionRoutine(self.on_text_speed)

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1725,6 +1725,12 @@ class Geomstr:
         return cls.wobble(algorithm, outer, radius, interval, speed)
 
     @classmethod
+    def wobble_dash(cls, outer, radius, interval, speed):
+        from meerk40t.fill.fills import dashed_line as algorithm
+
+        return cls.wobble(algorithm, outer, radius, interval, speed)
+
+    @classmethod
     def from_float_segments(cls, float_segments):
         sa = np.ndarray((len(float_segments), 5, 2))
         sa[:] = float_segments

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1645,15 +1645,17 @@ class Geomstr:
             last = None
             for pt in segments:
                 if last is not None:
-                    points.extend(
-                        [
-                            complex(wx, wy)
-                            for wx, wy in w(last.real, last.imag, pt.real, pt.imag)
-                        ]
-                    )
+                    for wx, wy in w(last.real, last.imag, pt.real, pt.imag):
+                        if wx is None:
+                            if len(points):
+                                geometry.append(Geomstr.lines(*points))
+                                geometry.end()
+                            points = []
+                        else:
+                            points.append(complex(wx, wy))
                 last = pt
-            if len(segments) > 1 and abs(segments[0] - segments[-1]) < 1e-5:
-                if abs(points[0] - points[1]) >= 1e-5:
+            if len(segments) > 1 and abs(segments[0] - segments[-1]) < 1e-5 and len(points) > 0:
+                if abs(points[0] - points[-1]) >= 1e-5:
                     points.append(points[0])
             geometry.append(Geomstr.lines(*points))
         return geometry

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -2193,6 +2193,9 @@ class Geomstr:
         @param settings: Unused settings value for break.
         @return:
         """
+        if self.index and self.segments[self.index][2].real == TYPE_END:
+            # No two consecutive ends
+            return
         self._ensure_capacity(self.index + 1)
         self.segments[self.index] = (
             np.nan,


### PR DESCRIPTION
Basic dash-pattern as outline for path like objects (lines, polylines, circle, ellipse, rect, path...)
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/51b932cf-9f42-439a-a2f9-a571e4b20328)

To have the dashed outline only, you should set the stroke color of the object to None
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/42e2c7af-8780-4d6c-9093-69f01e3e9bee)

As usual wobble interval defines the resolution of the shape trace and wobble radius will establish the length of the dash.
<img src="https://github.com/meerk40t/meerk40t/assets/2670784/644e2509-e1c2-4b46-912a-070515b4c607" width="300">
<img src="https://github.com/meerk40t/meerk40t/assets/2670784/c720c083-9f2f-40f0-bdd9-0f063032bc67" width="300">




For the time being we have equal spaced dashes only (blank space equals dash length)