### PR TITLE
Implement multiple camera timers for device specific background updates

### DIFF
--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -60,6 +60,7 @@ class CameraPanel(wx.Panel, Job):
         self.context = context
         self.SetHelpText("camera")
         self.index = index
+        self.cam_device_link = {}
         self.pane = pane
 
         if pane:
@@ -442,6 +443,17 @@ class CamInterfaceWidget(Widget):
 
                 return asp
 
+            def get_device_link():
+                if self.cam.index in self.cam.cam_device_link:
+                    return self.cam.cam_device_link[self.cam.index]
+                return ""
+
+            def set_device_link(devlabel):
+                if devlabel:
+                    self.cam.cam_device_link[self.cam.index] = devlabel
+                else: # Empty or None
+                    self.cam.cam_device_link.pop(self.cam.index, None)
+
             menu = wx.Menu()
 
             item = menu.Append(wx.ID_ANY, _("Update Background"), "")
@@ -454,8 +466,9 @@ class CamInterfaceWidget(Widget):
             def live_view(c_frames, c_sec):
                 def runcam(event=None):
                     ratio = c_sec / c_frames
+                    dev_label = get_device_link()
                     self.cam.context(
-                        f"timer.updatebg 0 {ratio} camera{self.cam.index} background\n"
+                        f"timer.updatebg 0 {ratio} camera{self.cam.index} background {dev_label}\n"
                     )
                     return
 
@@ -483,6 +496,34 @@ class CamInterfaceWidget(Widget):
                 lambda e: live_stop(),
                 id=item.GetId(),
             )
+            submenu.AppendSeparator()
+
+            def set_link(devlabel):
+                def handler(event):
+                    set_device_link(devlabel)
+                return handler
+
+            def unset_link(devlabel):
+                def handler(event):
+                    set_device_link("")
+                return handler
+
+            link = get_device_link()
+            item = submenu.Append(wx.ID_ANY, _("Device independent"), kind=wx.ITEM_RADIO)
+            if link == "":
+                item.Check(True)
+                self.cam.Bind(wx.EVT_MENU, unset_link(""), id=item.GetId())
+            else:
+                self.cam.Bind(wx.EVT_MENU, set_link(""), id=item.GetId())
+            available_devices = self.cam.context.kernel.services("device")
+            for i, spool in enumerate(available_devices):
+                item = submenu.Append(wx.ID_ANY, spool.label, kind=wx.ITEM_RADIO)
+                if link == spool.label:
+                    item.Check(True)
+                    self.cam.Bind(wx.EVT_MENU, unset_link(spool.label), id=item.GetId())
+                else:
+                    self.cam.Bind(wx.EVT_MENU, set_link(spool.label), id=item.GetId())
+
             menu.AppendSeparator()
             item = menu.Append(wx.ID_ANY, _("Export Snapshot"), "")
             self.cam.Bind(

--- a/meerk40t/camera/plugin.py
+++ b/meerk40t/camera/plugin.py
@@ -231,15 +231,23 @@ def plugin(kernel, lifecycle=None):
             else:
                 raise CommandSyntaxError
 
+        @kernel.console_argument("device", type=str)
         @kernel.console_command(
             "background",
             help="set background image",
             input_type="camera",
             output_type="image-array",
         )
-        def background_camera(data=None, **kwargs):
-            image_array = data.background()
-            return "image-array", image_array
+        def background_camera(data=None, device=None, **kwargs):
+            doit = True
+            if device:
+                if kernel.device.label != device:
+                    doit = False
+            if doit:
+                image_array = data.background()
+                return "image-array", image_array
+            else:
+                return
 
         @kernel.console_command(
             "export",

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -229,7 +229,7 @@ class Scene(Module, Job):
         self.clip = wx.Rect(0, 0, 0, 0)
 
         self.background_brush = wx.Brush(self.colors.color_background)
-        self.has_background = False
+        self._hasbackgrounds = {}
         # If set this color will be used for the scene background (used during burn)
         self.overrule_background = None
 
@@ -246,6 +246,18 @@ class Scene(Module, Job):
         # Snap information
         self.snap_display_points = None
         self.snap_attraction_points = None
+
+    @property
+    def has_background(self):
+        devlabel = self.context.device.label
+        if devlabel not in self._hasbackgrounds:
+            self._hasbackgrounds[devlabel] = False
+        return self._hasbackgrounds[devlabel]
+
+    @has_background.setter
+    def has_background(self, value):
+        devlabel = self.context.device.label
+        self._hasbackgrounds[devlabel] = value
 
     def module_open(self, *args, **kwargs):
         context = self.context

--- a/meerk40t/gui/scenewidgets/bedwidget.py
+++ b/meerk40t/gui/scenewidgets/bedwidget.py
@@ -27,7 +27,29 @@ class BedWidget(Widget):
             self.name = "Standard"
         else:
             self.name = name
-        self.background = None
+        self._background = {}
+
+    @property
+    def background(self):
+        try:
+            devlabel =  self.scene.context.device.label
+            if devlabel in self._background:
+                return self._background[devlabel]
+        except AttributeError:
+            pass
+        return None
+
+    @background.setter
+    def background(self, value):
+        try:
+            devlabel =  self.scene.context.device.label
+        except AttributeError:
+            return
+
+        if value is None:
+            self._background.pop(devlabel, None)
+        else:
+            self._background[devlabel] = value
 
     def hit(self):
         if self.background is None:

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -1142,7 +1142,15 @@ class MeerK40tScenePanel(wx.Panel):
             self.widget_scene.request_refresh()
 
         def stop_auto_update(event=None):
-            self.context("timer.updatebg --off\n")
+            devlabel = self.context.device.label
+            to_stop = []
+            for job, content in self.context.kernel.jobs.items():
+                if job.startswith("timer.updatebg"):
+                    cmd = str(content).strip()
+                    if cmd.endswith("background") or cmd.endswith(devlabel):
+                        to_stop.append(job)
+            for job in to_stop:
+                self.context(f"{job} --off\n")
 
         gui = self
         menu = wx.Menu()
@@ -1194,23 +1202,21 @@ class MeerK40tScenePanel(wx.Panel):
             )
             self.Bind(wx.EVT_MENU, toggle_grid_o, id=id4b.GetId())
             menu.Check(id4b.GetId(), self.grid.draw_offset_lines)
-        if self.widget_scene.has_background:
-            menu.AppendSeparator()
-            id5 = menu.Append(wx.ID_ANY, _("Remove Background"), "")
-            self.Bind(wx.EVT_MENU, self.remove_background, id=id5.GetId())
 
         if self.widget_scene.has_background:
             menu.AppendSeparator()
             id5 = menu.Append(wx.ID_ANY, _("Remove Background"), "")
             self.Bind(wx.EVT_MENU, remove_background, id=id5.GetId())
         # Do we have a timer called .updatebg?
+        devlabel = self.context.device.label
         we_have_a_job = False
-        try:
-            obj = self.context.kernel.jobs["timer.updatebg"]
-            if obj is not None:
-                we_have_a_job = True
-        except KeyError:
-            pass
+        for job, content in self.context.kernel.jobs.items():
+            if job.startswith("timer.updatebg"):
+                cmd = str(content).strip()
+                if cmd.endswith("background") or cmd.endswith(devlabel):
+                    we_have_a_job = True
+                    break
+
         if we_have_a_job:
             self.Bind(
                 wx.EVT_MENU,


### PR DESCRIPTION
Meerk4t supports multiple camera setups - every setup is attached to an USB port or an URI:
<img src="https://github.com/meerk40t/meerk40t/assets/2670784/fb72cecc-5dcd-4ce7-8f56-3c076159f9de" width="300">
<img src="https://github.com/meerk40t/meerk40t/assets/2670784/32bc89dd-661d-4604-beed-dc16d3994eb5" width="300">

Every camera can now be attached to a specific device and update the scene background of the specific device automatically.
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/204f486a-f089-4b65-b773-525cce0dd463)


