### PR TITLE
Add element hide status to suppress display & burning

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -277,6 +277,20 @@ def init_tree(kernel):
     def element_label(node, **kwargs):
         return
 
+    @tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 0)
+    @tree_operation(
+        _("Toggle visibility"), node_type=elem_nodes, help="",
+    )
+    def element_visibility_toggle(node, **kwargs):
+        data = list(self.elems(emphasized=True))
+        updated = []
+        for e in data:
+            if hasattr(e, "hidden"):
+                e.hidden = not e.hidden
+                updated.append(e)
+        self.signal("refresh_scene", "Scene")
+        self.signal("element_property_reload", updated)
+
     @tree_conditional(lambda node: not is_regmark(node))
     @tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 1)
     @tree_operation(_("Group elements"), node_type=elem_group_nodes, help="")

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -277,16 +277,32 @@ def init_tree(kernel):
     def element_label(node, **kwargs):
         return
 
-    @tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 0)
+    def add_node_and_children(node):
+        data = []
+        data.append(node)
+        for e in node.children:
+            if e.type in ("file", "group"):
+                data.extend(add_node_and_children(e))
+            else:
+                data.append(e)
+        return data
+
+    @tree_conditional(lambda node: len(list(self.elems(selected=True))) > 0)
     @tree_operation(
-        _("Toggle visibility"), node_type=elem_nodes, help="",
+        _("Toggle visibility"), node_type=elem_group_nodes, help="",
     )
     def element_visibility_toggle(node, **kwargs):
-        data = list(self.elems(emphasized=True))
+        raw_data = list(self.elems(selected=True))
+        data = self.condense_elements(raw_data, expand_at_end=False)
         updated = []
         for e in data:
             if hasattr(e, "hidden"):
                 e.hidden = not e.hidden
+                if e.hidden:
+                    e.emphasized = False
+            if e.type in ("file", "group"):
+                updated.extend(add_node_and_children(e))
+            else:
                 updated.append(e)
         self.signal("refresh_scene", "Scene")
         self.signal("element_property_reload", updated)

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1978,7 +1978,9 @@ class Elemental(Service):
         """
         Returns whether any element is emphasized
         """
-        for _ in self.elems_nodes(emphasized=True):
+        for e in self.elems_nodes(emphasized=True):
+            if hasattr(e, "hidden") and e.hidden:
+                continue
             return True
         return False
 
@@ -2220,6 +2222,8 @@ class Elemental(Service):
         ):
             if e.bounds is None:
                 continue
+            if hasattr(e, "hidden") and e.hidden:
+                continue
             box = e.bounds
             top_left = [box[0], box[1]]
             top_right = [box[2], box[1]]
@@ -2420,6 +2424,8 @@ class Elemental(Service):
                 bounds = node.bounds
             except AttributeError:
                 continue  # No bounds.
+            if hasattr(node, "hidden") and node.hidden:
+                continue
             # Empty group / files may cause problems
             if node.type in ("file", "group"):
                 if not node._children:

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -2,12 +2,13 @@ from copy import copy
 from math import sqrt
 
 from meerk40t.core.node.node import Node
+from meerk40t.core.node.mixins import Suppressable
 from meerk40t.core.units import Angle, Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam
 
 
-class HatchEffectNode(Node):
+class HatchEffectNode(Node, Suppressable):
     """
     Effect node performing a hatch. Effects are themselves a sort of geometry node that contains other geometry and
     the required data to produce additional geometry.
@@ -26,9 +27,12 @@ class HatchEffectNode(Node):
         self.hatch_angle_delta = None
         self.hatch_type = None
         self.loops = None
-        Node.__init__(
+        super().__init__(
             self, type="effect hatch", id=id, label=label, lock=lock, **kwargs
         )
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
+
         self._formatter = "{element_type} - {distance} {angle} ({children})"
 
         if label is None:

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -3,12 +3,13 @@ from copy import copy
 from math import sqrt
 
 from meerk40t.core.node.node import Node
+from meerk40t.core.node.mixins import Suppressable
 from meerk40t.core.units import Length
 from meerk40t.svgelements import Color
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam
 
 
-class WobbleEffectNode(Node):
+class WobbleEffectNode(Node, Suppressable):
     """
     Effect node performing a wobble. Effects are themselves a sort of geometry node that contains other geometry and
     the required data to produce additional geometry.
@@ -26,9 +27,11 @@ class WobbleEffectNode(Node):
         self.wobble_speed = 50
         self.wobble_type = "circle"
 
-        Node.__init__(
+        super().__init__(
             self, type="effect wobble", id=id, label=label, lock=lock, **kwargs
         )
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         self._formatter = "{element_type} - {type} {radius} ({children})"
 
         if label is None:

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -1,7 +1,7 @@
 from copy import copy
 from math import cos, sin, sqrt, tau
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Fillrule, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -13,7 +13,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     EllipseNode is the bootstrapped node type for the 'elem ellipse' type.
     """
@@ -55,6 +55,8 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         self.fillrule = Fillrule.FILLRULE_EVENODD
 
         super().__init__(type="elem ellipse", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         self.__formatter = "{element_type} {id} {stroke}"
         if self.cx is None:
             self.cx = 0

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -3,13 +3,13 @@ from copy import copy
 from math import ceil, floor
 
 from meerk40t.core.node.node import Node
-from meerk40t.core.node.mixins import LabelDisplay
+from meerk40t.core.node.mixins import LabelDisplay, Suppressable
 from meerk40t.core.units import UNITS_PER_INCH
 from meerk40t.image.imagetools import RasterScripts
 from meerk40t.svgelements import Matrix, Path, Polygon
 
 
-class ImageNode(Node, LabelDisplay):
+class ImageNode(Node, LabelDisplay, Suppressable):
     """
     ImageNode is the bootstrapped node type for the 'elem image' type.
 
@@ -36,6 +36,8 @@ class ImageNode(Node, LabelDisplay):
 
         self.passthrough = False
         super().__init__(type="elem image", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         # kwargs can actually reset quite a lot of the properties to none
         # so, we need to revert these changes...
         if self.red is None:

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -12,7 +12,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     LineNode is the bootstrapped node type for the 'elem line' type.
     """
@@ -55,6 +55,8 @@ class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
         super().__init__(type="elem line", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         if self.x1 is None:
             self.x1 = 0
         if self.y1 is None:

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -10,7 +10,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     PathNode is the bootstrapped node type for the 'elem path' type.
     """
@@ -50,6 +50,8 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
         super().__init__(type="elem path", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         if self.geometry is None:
             self.geometry = Geomstr()
         self._formatter = "{element_type} {id} {stroke}"

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -1,12 +1,12 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import FunctionalParameter, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Node
 from meerk40t.svgelements import Matrix, Point
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PointNode(Node, FunctionalParameter, LabelDisplay):
+class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
     """
     PointNode is the bootstrapped node type for the 'elem point' type.
     """
@@ -26,6 +26,8 @@ class PointNode(Node, FunctionalParameter, LabelDisplay):
         self.stroke = None
         self.stroke_width = 1000.0
         super().__init__(type="elem point", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         self._formatter = "{element_type} {id} {stroke}"
         if self.x is None:
             self.x = 0

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -13,7 +13,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PolylineNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class PolylineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     PolylineNode is the bootstrapped node type for the 'elem polyline' type.
     """
@@ -67,6 +67,8 @@ class PolylineNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         self.fillrule = Fillrule.FILLRULE_EVENODD
 
         super().__init__(type="elem polyline", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         if self.geometry is None:
             self.geometry = Geomstr()
         self._formatter = "{element_type} {id} {stroke}"

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -1,6 +1,6 @@
 from copy import copy
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Fillrule, Linejoin, Node
 from meerk40t.svgelements import (
     SVG_ATTR_VECTOR_EFFECT,
@@ -12,7 +12,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     RectNode is the bootstrapped node type for the 'elem rect' type.
     """
@@ -61,6 +61,8 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         self.linejoin = Linejoin.JOIN_MITER
         self.fillrule = Fillrule.FILLRULE_EVENODD
         super().__init__(type="elem rect", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         self._formatter = "{element_type} {id} {stroke}"
         if self.x is None:
             self.x = 0

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -2,7 +2,7 @@ import re
 from copy import copy
 from math import tau
 
-from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay
+from meerk40t.core.node.mixins import FunctionalParameter, Stroked, LabelDisplay, Suppressable
 from meerk40t.core.node.node import Node
 from meerk40t.core.units import UNITS_PER_POINT, Length
 from meerk40t.svgelements import (
@@ -40,7 +40,7 @@ REGEX_CSS_FONT_FAMILY = re.compile(
 )
 
 
-class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay):
+class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     TextNode is the bootstrapped node type for the 'elem text' type.
     """
@@ -82,6 +82,8 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay):
         else:
             font = None
         super().__init__(type="elem text", **kwargs)
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
 
         # We might have relevant forn-information hidden inside settings...
         rotangle = 0

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -10,11 +10,29 @@ class GroupNode(Node, LabelDisplay):
 
     def __init__(self, **kwargs):
         super().__init__(type="group", **kwargs)
+        self._hidden = False
+        if "hidden" in kwargs:
+            self._hidden = kwargs["hidden"]
         self._formatter = "{element_type} {id} ({children} elems)"
         self.set_dirty_bounds()
 
     def __repr__(self):
         return f"GroupNode('{self.type}', {str(self._parent)})"
+
+    @property
+    def hidden(self):
+        return self._hidden
+
+    @hidden.setter
+    def hidden(self, value):
+        self._hidden = value
+        for e in self.children:
+            if hasattr(e, "hidden"):
+                e.hidden = value
+                if not value:
+                    e.emphasized = False
+        if not value:
+            self.emphasized = False
 
     def bbox(self, transformed=True, with_stroke=False):
         """

--- a/meerk40t/core/node/mixins.py
+++ b/meerk40t/core/node/mixins.py
@@ -108,8 +108,18 @@ class FunctionalParameter(ABC):
 
 class LabelDisplay(ABC):
     """
-    Any node heriting this allow the display of the label on the scene
+    Any node inheriting this allow the display of the label on the scene
     """
     def __init__(self, *args, **kwargs):
         self.label_display = False
+        super().__init__()
+
+class Suppressable(ABC):
+    """
+    Any node inheriting this can be suppressed
+    """
+    def __init__(self, *args, **kwargs):
+        self.hidden = False
+        if "hidden" in kwargs:
+            self.hidden = kwargs["hidden"]
         super().__init__()

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -316,6 +316,8 @@ class CutOpNode(Node, Parameters):
         for node in self.children:
             if node.type == "reference":
                 node = node.node
+            if hasattr(node, "hidden") and node.hidden:
+                continue
             if node.type == "elem image":
                 box = node.bbox()
                 path = Path(

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -252,9 +252,13 @@ class DotsOpNode(Node, Parameters):
         """Generator of cutobjects for a particular operation."""
         settings = self.derive()
         for point_node in self.children:
+            if point_node.type == "reference":
+                point_node = point_node.node
             if point_node.type != "elem point":
                 continue
             if point_node.point is None:
+                continue
+            if getattr(point_node, "hidden", False):
                 continue
             yield DwellCut(
                 (point_node.point[0], point_node.point[1]),

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -290,6 +290,8 @@ class EngraveOpNode(Node, Parameters):
         for node in self.children:
             if node.type == "reference":
                 node = node.node
+            if getattr(node, "hidden", False):
+                continue
             if node.type == "elem image":
                 box = node.bbox()
                 path = Path(

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -265,8 +265,11 @@ class ImageOpNode(Node, Parameters):
         """
         for image_node in self.children:
             # Process each child. All settings are different for each child.
-
+            if image_node.type == "reference":
+                image_node = image_node.node
             if not hasattr(image_node, "as_image"):
+                continue
+            if getattr(image_node, "hidden", False):
                 continue
             settings = self.derive()
 

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -447,6 +447,10 @@ class RasterOpNode(Node, Parameters):
         for image_node in self.children:
             # Process each child. Some core settings are the same for each child.
 
+            if image_node.type == "reference":
+                image_node = image_node.node
+            if getattr(image_node, "hidden", False):
+                continue
             if image_node.type != "elem image":
                 continue
 

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -255,6 +255,9 @@ class LaserRender:
         @param alpha:
         @return: True if rendering was done, False if rendering could not be done.
         """
+        if hasattr(node, "hidden"):
+            if node.hidden:
+                return False
         if hasattr(node, "is_visible"):
             if not node.is_visible:
                 return False

--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -262,7 +262,12 @@ class IdPanel(wx.Panel):
         sizer_id_label.Add(self.sizer_label, 1, wx.EXPAND, 0)
         self.icon_display = wx.StaticBitmap(self, wx.ID_ANY)
         self.icon_display.SetSize(wx.Size(mkicons.STD_ICON_SIZE, mkicons.STD_ICON_SIZE))
+        self.icon_hidden = wx.StaticBitmap(self, wx.ID_ANY)
+        self.icon_hidden.SetSize(wx.Size(mkicons.STD_ICON_SIZE, mkicons.STD_ICON_SIZE))
+        self.icon_hidden.SetBitmap(mkicons.icons8_ghost.GetBitmap(resize=mkicons.STD_ICON_SIZE))
+        self.icon_hidden.SetToolTip(_("Element is hidden, so it will neither be displayed nor burnt"))
         sizer_id_label.Add(self.icon_display, 0, wx.EXPAND, 0)
+        sizer_id_label.Add(self.icon_hidden, 0, wx.EXPAND, 0)
 
         main_sizer.Add(sizer_id_label, 0, wx.EXPAND, 0)
 
@@ -275,6 +280,7 @@ class IdPanel(wx.Panel):
         self.check_label.SetToolTip(_("Display label on screen"))
         self.check_hidden.Bind(wx.EVT_CHECKBOX, self.on_check_hidden)
         self.check_hidden.SetToolTip(_("Suppress object for display and burning"))
+        self.icon_hidden.Bind(wx.EVT_LEFT_DOWN, self.on_hidden_click)
 
         self.set_widgets(self.node)
 
@@ -293,6 +299,16 @@ class IdPanel(wx.Panel):
         except AttributeError:
             pass
 
+    def add_node_and_children(self, node):
+        data = []
+        data.append(node)
+        for e in node.children:
+            if e.type in ("file", "group"):
+                data.extend(self.add_node_and_children(e))
+            else:
+                data.append(e)
+        return data
+
     def on_check_label(self, event):
         self.node.label_display = bool(self.check_label.GetValue())
         self.context.signal("element_property_update", self.node)
@@ -300,7 +316,21 @@ class IdPanel(wx.Panel):
 
     def on_check_hidden(self, event):
         self.node.hidden = bool(self.check_hidden.GetValue())
-        self.context.signal("element_property_update", self.node)
+        self.icon_hidden.Show(self.node.hidden)
+        self.Layout()
+        if self.node.type == "group":
+            self.context.signal("refresh_tree")
+        data = self.add_node_and_children(self.node)
+        self.context.signal("element_property_reload", data)
+        self.context.signal("refresh_scene", "Scene")
+
+    def on_hidden_click(self, event):
+        self.node.hidden = False
+        self.check_hidden.SetValue(False)
+        self.icon_hidden.Show(self.node.hidden)
+        self.Layout()
+        data = self.add_node_and_children(self.node)
+        self.context.signal("element_property_reload", data)
         self.context.signal("refresh_scene", "Scene")
 
     def pane_hide(self):
@@ -322,6 +352,7 @@ class IdPanel(wx.Panel):
         vis1 = False
         vis2 = False
         vis3 = False
+        vis_hidden = False
         try:
             if hasattr(self.node, "id") and self.showid:
                 vis1 = True
@@ -335,7 +366,9 @@ class IdPanel(wx.Panel):
             if hasattr(self.node, "hidden") and self.showid:
                 vis0 = True
                 self.check_hidden.SetValue(node.hidden)
+                vis_hidden = self.node.hidden
             self.check_hidden.Show(vis0)
+            self.icon_hidden.Show(vis_hidden)
         except RuntimeError:
             # Could happen if the propertypanel has been destroyed
             pass
@@ -399,6 +432,7 @@ class IdPanel(wx.Panel):
                 pass
 
         if vis1 or vis2:
+            self.Layout()
             self.Show()
         else:
             self.Hide()

--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -246,11 +246,13 @@ class IdPanel(wx.Panel):
         self.text_id = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_label = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.check_label = wxCheckBox(self, wx.ID_ANY)
+        self.check_hidden = wxCheckBox(self, wx.ID_ANY)
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         sizer_id_label = wx.BoxSizer(wx.HORIZONTAL)
-        self.sizer_id = StaticBoxSizer(self, wx.ID_ANY, _("Id"), wx.VERTICAL)
+        self.sizer_id = StaticBoxSizer(self, wx.ID_ANY, _("Id"), wx.HORIZONTAL)
         self.sizer_id.Add(self.text_id, 1, wx.EXPAND, 0)
+        self.sizer_id.Add(self.check_hidden, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.sizer_label = StaticBoxSizer(self, wx.ID_ANY, _("Label"), wx.VERTICAL)
         h_label_sizer = wx.BoxSizer(wx.HORIZONTAL)
         h_label_sizer.Add(self.text_label, 1, wx.EXPAND, 0)
@@ -271,6 +273,8 @@ class IdPanel(wx.Panel):
         self.text_label.SetActionRoutine(self.on_text_label_change)
         self.check_label.Bind(wx.EVT_CHECKBOX, self.on_check_label)
         self.check_label.SetToolTip(_("Display label on screen"))
+        self.check_hidden.Bind(wx.EVT_CHECKBOX, self.on_check_hidden)
+        self.check_hidden.SetToolTip(_("Suppress object for display and burning"))
 
         self.set_widgets(self.node)
 
@@ -294,6 +298,11 @@ class IdPanel(wx.Panel):
         self.context.signal("element_property_update", self.node)
         self.context.signal("refresh_scene", "Scene")
 
+    def on_check_hidden(self, event):
+        self.node.hidden = bool(self.check_hidden.GetValue())
+        self.context.signal("element_property_update", self.node)
+        self.context.signal("refresh_scene", "Scene")
+
     def pane_hide(self):
         pass
 
@@ -309,6 +318,7 @@ class IdPanel(wx.Panel):
 
         self.node = node
         # print(f"set_widget for {self.attribute} to {str(node)}")
+        vis0 = False
         vis1 = False
         vis2 = False
         vis3 = False
@@ -318,6 +328,14 @@ class IdPanel(wx.Panel):
                 self.text_id.SetValue(mklabel(node.id))
             self.text_id.Show(vis1)
             self.sizer_id.Show(vis1)
+        except RuntimeError:
+            # Could happen if the propertypanel has been destroyed
+            pass
+        try:
+            if hasattr(self.node, "hidden") and self.showid:
+                vis0 = True
+                self.check_hidden.SetValue(node.hidden)
+            self.check_hidden.Show(vis0)
         except RuntimeError:
             # Could happen if the propertypanel has been destroyed
             pass

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -113,6 +113,8 @@ class RectSelectWidget(Widget):
                 continue  # This element has no bounds.
             if q is None:
                 continue
+            if hasattr(node, "hidden") and node.hidden:
+                continue
             if hasattr(node, "can_emphasize") and not node.can_emphasize:
                 continue
             xmin = q[0]

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -1374,6 +1374,8 @@ class MoveWidget(Widget):
         to_be_copied = []
         emph_list = list(elements.elems(emphasized=True))
         for e in emph_list:
+            if hasattr(e, "hidden") and e.hidden:
+                continue
             if e.type in ("file", "group"):
                 for f in e.children:
                     if not f.emphasized:
@@ -1628,6 +1630,9 @@ class MoveWidget(Widget):
                 other_points = []
                 selected_points = []
                 for e in self.scene.context.elements.elems():
+                    if hasattr(e, "hidden") and e.hidden:
+                        continue
+
                     if e.emphasized:
                         target = selected_points
                     else:

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1,7 +1,7 @@
 import wx
 from wx import aui
 
-from meerk40t.core.elements.element_types import op_nodes
+from meerk40t.core.elements.element_types import op_nodes, elem_nodes
 
 from ..core.units import Length
 from ..kernel import signal_listener
@@ -1837,6 +1837,10 @@ class ShadowTree:
                 node.type in op_nodes
                 and hasattr(node, "is_visible")
                 and not node.is_visible
+            ) or (
+                node.type in elem_nodes
+                and hasattr(node, "hidden")
+                and node.hidden
             ):
                 state_num = self.iconstates["ghost"]
         self.wxtree.SetItemState(node._item, state_num)


### PR DESCRIPTION
You can now set for all basic elements a flag (which is *not* stored and loaded, so only during runtime) that will hide it on the scene and that will eliminate it from the set of the to be burnt elements. This flag can be set / unset either via the property panel:
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/8229ee8f-e7b2-4b05-acd9-74cbf52120c2)

or via the tree / element context menu:
![grafik](https://github.com/meerk40t/meerk40t/assets/2670784/9a595cbf-a264-41b6-97b1-431cf53e32b7)

![hide](https://github.com/meerk40t/meerk40t/assets/2670784/f2e9c307-1326-4edd-a3b6-1bb8a7067421)

