### PR TITLE
Console server fix

### DIFF
--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -896,6 +896,7 @@ def init_commands(kernel):
         node.stroke_width = self.default_strokewidth
         node.fill = self.default_fill
         node.altered()
+        self.set_emphasis([node])
         node.focus()
         post.append(classify_new(data))
         return "elements", data
@@ -2092,7 +2093,7 @@ def init_commands(kernel):
                 if hasattr(node, "update"):
                     if node not in images:
                         images.append(node)
-            
+
         # Calculate again
         area = Node.union_bounds(data)
         dx = x_pos - area[0]

--- a/meerk40t/extra/param_functions.py
+++ b/meerk40t/extra/param_functions.py
@@ -1107,11 +1107,10 @@ def plugin(kernel, lifecycle):
             node.stroke_width = self.default_strokewidth
             node.fill = self.default_fill
             node.altered()
-            node.emphasized = True
+            self.set_emphasis([node])
             node.focus()
 
             data = [node]
-            node.emphasized = True
             # Newly created! Classification needed?
             post.append(classify_new(data))
 

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -954,10 +954,8 @@ class ShadowTree:
         item = node._item
         self.check_validity(item)
         self.wxtree.EnsureVisible(item)
-        for s in self.wxtree.GetSelections():
-            self.wxtree.SelectItem(s, False)
-        self.wxtree.SelectItem(item)
         self.wxtree.ScrollTo(item)
+        # self.wxtree.SetFocusedItem(item)
 
     def on_force_element_update(self, *args):
         """

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2301,7 +2301,6 @@ class Kernel(Settings):
             text = text[1:]
         else:
             channel(f"[blue][bold][raw]{text}[/raw]", indent=False, ansi=True)
-        print ("Start analysis")
         data = None  # Initial command context data is null
         input_type = None  # Initial command context is None
         post = list()
@@ -2332,7 +2331,6 @@ class Kernel(Settings):
                     # Exact match only.
                     if regex != command:
                         continue
-                print (f"Found command: {funct} {name} {regex}")
                 try:
                     data, remainder, input_type = funct(
                         command=command,
@@ -2345,11 +2343,9 @@ class Kernel(Settings):
                         post_data=post_data,
                     )
                     command_executed = True
-                    print ("Command executed")
                     break  # command found and executed.
                 except CommandSyntaxError as e:
                     # If command function raises a syntax error, we abort the rest of the command.
-                    print (f"Error: {e}")
                     message = funct.help
                     if str(e):
                         message = str(e)
@@ -2375,7 +2371,6 @@ class Kernel(Settings):
                 )
                 return None
 
-            print (f"Remainder: {remainder}")
             # Process remainder as commands
             text = remainder.strip()
 
@@ -2389,7 +2384,6 @@ class Kernel(Settings):
                     ansi=True,
                 )
                 return None
-        print ("checking for post execution")
         # If post execution commands were added along the way, run them now.
         for post_execute_command in post:
             post_execute_command(

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2285,7 +2285,6 @@ class Kernel(Settings):
             pos = self._console_buffer.find("\n")
             command = self._console_buffer[0:pos].strip("\r")
             self._console_buffer = self._console_buffer[pos + 1 :]
-            print (f"Parsing line: {command}")
             data_out = self._console_parse(command, channel=self._console_channel)
         return data_out
 
@@ -2393,7 +2392,6 @@ class Kernel(Settings):
                 data_type=input_type,
                 **post_data,
             )
-        print ("done")
         return data
 
     # ==========

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2285,6 +2285,7 @@ class Kernel(Settings):
             pos = self._console_buffer.find("\n")
             command = self._console_buffer[0:pos].strip("\r")
             self._console_buffer = self._console_buffer[pos + 1 :]
+            print (f"Parsing line: {command}")
             data_out = self._console_parse(command, channel=self._console_channel)
         return data_out
 
@@ -2300,7 +2301,7 @@ class Kernel(Settings):
             text = text[1:]
         else:
             channel(f"[blue][bold][raw]{text}[/raw]", indent=False, ansi=True)
-
+        print ("Start analysis")
         data = None  # Initial command context data is null
         input_type = None  # Initial command context is None
         post = list()
@@ -2331,7 +2332,7 @@ class Kernel(Settings):
                     # Exact match only.
                     if regex != command:
                         continue
-
+                print (f"Found command: {funct} {name} {regex}")
                 try:
                     data, remainder, input_type = funct(
                         command=command,
@@ -2344,9 +2345,11 @@ class Kernel(Settings):
                         post_data=post_data,
                     )
                     command_executed = True
+                    print ("Command executed")
                     break  # command found and executed.
                 except CommandSyntaxError as e:
                     # If command function raises a syntax error, we abort the rest of the command.
+                    print (f"Error: {e}")
                     message = funct.help
                     if str(e):
                         message = str(e)
@@ -2372,6 +2375,7 @@ class Kernel(Settings):
                 )
                 return None
 
+            print (f"Remainder: {remainder}")
             # Process remainder as commands
             text = remainder.strip()
 
@@ -2385,7 +2389,7 @@ class Kernel(Settings):
                     ansi=True,
                 )
                 return None
-
+        print ("checking for post execution")
         # If post execution commands were added along the way, run them now.
         for post_execute_command in post:
             post_execute_command(
@@ -2395,6 +2399,7 @@ class Kernel(Settings):
                 data_type=input_type,
                 **post_data,
             )
+        print ("done")
         return data
 
     # ==========
@@ -3125,7 +3130,7 @@ class Kernel(Settings):
             if not os.path.exists(filename):
                 channel(_("The file does not exist"))
                 return
-            
+
             root = self.root
             try:
                 with open(filename, "r") as f:


### PR DESCRIPTION
If you issued commands via the telnet console that were using the node.focus() method, then these commands crashed, ie ended up in an endless loop within wxpython as the methods to clear the selection status of all / individual tree items failed.
