### PR TITLE
Ribbon tooltip fixes

### DIFF
--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -1162,12 +1162,16 @@ class ChoicePropertyPanel(ScrolledPanel):
                 current_sizer.Add(chart, expansion_flag * weight, wx.EXPAND, 0)
             elif data_type in (str, int, float):
                 # str, int, and float type objects get a TextCtrl setter.
-                if label != "":
+                if label != "" and data_style != "flat":
                     control_sizer = StaticBoxSizer(
                         self, wx.ID_ANY, label, wx.HORIZONTAL
                     )
                 else:
                     control_sizer = wx.BoxSizer(wx.HORIZONTAL)
+                    if label != "":
+                        label_text = wx.StaticText(self, id=wx.ID_ANY, label=label)
+                        control_sizer.Add(label_text, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+
                 if data_type == int:
                     check_flag = "int"
                     limit = True

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -180,7 +180,7 @@ and a wxpython version <= 4.1.1."""
                     )
                 ),
                 "page": "Gui",
-                "section": "General",
+                "section": "Tooltips",
                 "signals": "restart",
             },
             {
@@ -193,7 +193,33 @@ and a wxpython version <= 4.1.1."""
                     "You can suppress the tooltips over operations and elements in the tree"
                 ),
                 "page": "Gui",
-                "section": "General",
+                "section": "Tooltips",
+            },
+            {
+                "attr": "tooltip_delay",
+                "object": kernel.root,
+                "default": 100,
+                "type": int,
+                "style": "flat",
+                "label": _("ToolTip delay"),
+                "trailer": "ms",
+                "tip": _("How long do you need to hover over a control before the tooltip appears"),
+                "page": "Gui",
+                "section": "Tooltips",
+                "signals": "restart",
+            },
+            {
+                "attr": "tooltip_autopop",
+                "object": kernel.root,
+                "default": 10000,
+                "type": int,
+                "style": "flat",
+                "label": _("ToolTip duration"),
+                "trailer": "ms",
+                "tip": _("How long should the tooltip stay before it disappears"),
+                "page": "Gui",
+                "section": "Tooltips",
+                "signals": "restart",
             },
         ]
         kernel.register_choices("preferences", choices)

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -873,7 +873,11 @@ class RibbonBarPanel(wx.Control):
 
     def _exec_tooltip_job(self):
         # print (f"Executed with {self._tooltip}")
-        super().SetToolTip(self._tooltip)
+        try:
+            super().SetToolTip(self._tooltip)
+        except RuntimeError:
+            # Could happen on a shutdown...
+            return
 
     def SetToolTip(self, message):
         self._tooltip = message

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -799,6 +799,22 @@ class RibbonBarPanel(wx.Control):
         self.Bind(wx.EVT_LEFT_DOWN, self.on_click)
         self.Bind(wx.EVT_RIGHT_UP, self.on_click_right)
 
+        # Tooltip logic - as we do have a single control,
+        # this will prevent wxPython from resetting the timer
+        # when hovering to a different button
+        self._tooltip = ""
+        jobname = f"tooltip_ribbon_bar_{self.GetId()}"
+        #  print (f"Requesting job with name: '{jobname}'")
+        tooltip_delay = self.context.setting(int, "tooltip_delay", 100)
+        interval = tooltip_delay / 1000.0
+        self._tooltip_job = Job(
+            process=self._exec_tooltip_job,
+            job_name=jobname,
+            interval=interval,
+            times=1,
+            run_main=True,
+        )
+
     # Preparation for individual page visibility
     def visible_pages(self):
         count = 0
@@ -847,6 +863,27 @@ class RibbonBarPanel(wx.Control):
         self.art.hover_button = None
         self.art.hover_dropdown = None
         self.redrawn()
+
+    def stop_tooltip_job(self):
+        self._tooltip_job.cancel()
+
+    def start_tooltip_job(self):
+        # print (f"Schedule a job with {self._tooltip_job.interval:.2f}sec")
+        self.context.schedule(self._tooltip_job)
+
+    def _exec_tooltip_job(self):
+        # print (f"Executed with {self._tooltip}")
+        super().SetToolTip(self._tooltip)
+
+    def SetToolTip(self, message):
+        self._tooltip = message
+        if message == "":
+            self.stop_tooltip_job()
+            super().SetToolTip(message)
+        else:
+            # we restart the job and delete the tooltip in the meantime
+            super().SetToolTip("")
+            self.start_tooltip_job()
 
     def _check_hover_dropdown(self, drop, pos):
         if drop is not None and not drop.contains(pos):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1050,6 +1050,7 @@ class MeerK40t(MWindow):
                 "default": 0.1,
                 "trailer": "x",
                 "type": float,
+                "style": "flat",
                 "label": _("Default zoom factor:"),
                 "tip": _(
                     "Default zoom factor controls how quick or fast zooming happens."
@@ -1063,6 +1064,7 @@ class MeerK40t(MWindow):
                 "default": 25.0,
                 "trailer": "px",
                 "type": float,
+                "style": "flat",
                 "label": _("Default pan factor:"),
                 "tip": _("Default pan factor controls how quick panning happens."),
                 "page": "Gui",


### PR DESCRIPTION
- Honors the tooltip delay within a ribbon bar appear -  as we do have a single control, this had prevented wxPython from resetting the timer when hovering to a different button
- Adding the tooltip timer values to preferences