### PR TITLE
Add additional insights into internal device queue

### DIFF
--- a/meerk40t/balormk/controller.py
+++ b/meerk40t/balormk/controller.py
@@ -285,6 +285,7 @@ class GalvoController:
         self._list_executing = False
         self._number_of_list_packets = 0
         self.paused = False
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
 
     def define_pins(self):
         self._light_bit = self.service.setting(int, "light_pin", 8)
@@ -1047,6 +1048,15 @@ class GalvoController:
         x = int(x)
         y = int(y)
         self._list_write(listJumpTo, x, y, angle, distance)
+        if self._signal_updates:
+            view  = self.service.view
+            l_x, l_y = view.iposition(self._last_x, self._last_y)
+            n_x, n_y = view.iposition(x, y)
+            self.service.signal(
+                "driver;position",
+                (l_x, l_y, n_x, n_y),
+            )
+
         self._last_x = x
         self._last_y = y
 
@@ -1072,6 +1082,16 @@ class GalvoController:
         x = int(x)
         y = int(y)
         self._list_write(listMarkTo, x, y, angle, distance)
+
+        if self._signal_updates:
+            view  = self.service.view
+            l_x, l_y = view.iposition(self._last_x, self._last_y)
+            n_x, n_y = view.iposition(x, y)
+            self.service.signal(
+                "driver;position",
+                (l_x, l_y, n_x, n_y),
+            )
+
         self._last_x = x
         self._last_y = y
 

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -267,6 +267,18 @@ class BalorDevice(Service, Status):
                 "signals": "balorpin",
             },
             {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
+            },
+            {
                 "attr": "device_coolant",
                 "object": self,
                 "default": "",

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -171,6 +171,18 @@ class GRBLDevice(Service, Status):
                 "tip": _("Override native home location"),
                 "subsection": "_60_Home position",
             },
+            {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
+            },
         ]
         self.register_choices("bed_dim", choices)
 

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -81,6 +81,7 @@ class GRBLDriver(Parameters):
         self.elements = None
         self.power_scale = 1.0
         self.speed_scale = 1.0
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
 
     def __repr__(self):
         return f"GRBLDriver({self.name})"
@@ -176,10 +177,11 @@ class GRBLDriver(Parameters):
         x, y = self.service.view.position(x, y)
         self._move(x, y)
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def move_rel(self, dx, dy):
         """
@@ -206,10 +208,11 @@ class GRBLDriver(Parameters):
         self._move(unit_dx, unit_dy)
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def dwell(self, time_in_ms):
         """
@@ -562,10 +565,11 @@ class GRBLDriver(Parameters):
         else:
             self(f"G28{self.line_end}")
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def home(self):
         """
@@ -835,10 +839,11 @@ class GRBLDriver(Parameters):
             self.speed_dirty = False
         self(" ".join(line) + self.line_end)
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def _clean_motion(self):
         if self.absolute_dirty:

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -145,7 +145,7 @@ class SpoolerPanel(wx.Panel):
             wx.ID_ANY,
             style=wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES | wx.LC_SINGLE_SEL,
             context=self.context,
-            list_name="list_spoolerhistory", 
+            list_name="list_spoolerhistory",
         )
 
         self.__set_properties()
@@ -242,7 +242,7 @@ class SpoolerPanel(wx.Panel):
             _("Estimate"), format=wx.LIST_FORMAT_LEFT, width=73
         )
         self.list_job_spool.resize_columns()
-        
+
         self.list_job_history.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=48)
 
         self.list_job_history.AppendColumn(
@@ -755,13 +755,15 @@ class SpoolerPanel(wx.Panel):
                     try:
                         if spool_obj.steps_total == 0:
                             spool_obj.calc_steps()
-                        self.list_job_spool.SetItem(
-                            list_id,
-                            JC_STEPS,
-                            f"{spool_obj.steps_done}/{spool_obj.steps_total}",
-                        )
+                        info_s = f"{spool_obj.steps_done}/{spool_obj.steps_total}"
+                        if hasattr(spooler, "driver"):
+                            if hasattr(spooler.driver, "get_internal_queue_status"):
+                                internal_current, internal_total = spooler.driver.get_internal_queue_status()
+                                if internal_current != 0:
+                                    info_s += f" ({internal_current}/{internal_total})"
                     except AttributeError:
-                        self.list_job_spool.SetItem(list_id, JC_STEPS, "-")
+                        info_s = "-"
+                    self.list_job_spool.SetItem(list_id, JC_STEPS, info_s)
                     # PASSES
                     try:
                         loop = spool_obj.loops_executed
@@ -1101,13 +1103,20 @@ class SpoolerPanel(wx.Panel):
                     refresh_needed = True
 
             try:
-                pass_str = f"{spool_obj.steps_done}/{spool_obj.steps_total}"
-                self.list_job_spool.SetItem(list_id, JC_STEPS, pass_str)
+                if spool_obj.steps_total == 0:
+                    spool_obj.calc_steps()
+                info_s = f"{spool_obj.steps_done}/{spool_obj.steps_total}"
+                if hasattr(spooler, "driver"):
+                    if hasattr(spooler.driver, "get_internal_queue_status"):
+                        internal_current, internal_total = spooler.driver.get_internal_queue_status()
+                        if internal_current != 0:
+                            info_s += f" ({internal_current}/{internal_total})"
             except AttributeError:
-                if list_id < self.list_job_spool.GetItemCount():
-                    self.list_job_spool.SetItem(list_id, JC_STEPS, "-")
-                else:
+                info_s = "-"
+                if list_id >= self.list_job_spool.GetItemCount():
                     refresh_needed = True
+
+            self.list_job_spool.SetItem(list_id, JC_STEPS, info_s)
             try:
                 loop = spool_obj.loops_executed
                 total = spool_obj.loops

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -1101,6 +1101,9 @@ class SpoolerPanel(wx.Panel):
                     self.list_job_spool.SetItem(list_id, JC_RUNTIME, "-")
                 else:
                     refresh_needed = True
+            except RuntimeError:
+                # Form no longer valid
+                return
 
             try:
                 if spool_obj.steps_total == 0:

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -193,6 +193,18 @@ class LihuiyuDevice(Service, Status):
                 "section": "_10_" + _("Configuration"),
                 "subsection": "_50_" + _("Home position"),
             },
+            {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
+            },
         ]
         self.register_choices("bed_orientation", choices)
         choices = [

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -159,6 +159,8 @@ class LihuiyuDriver(Parameters):
         self.CODE_LASER_ON = b"D"
         self.CODE_LASER_OFF = b"U"
 
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
+
         self.paused = False
 
         def primary_hold():
@@ -633,10 +635,11 @@ class LihuiyuDriver(Parameters):
         self.state = DRIVER_STATE_RAPID
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def physical_home(self):
         """ "
@@ -1242,10 +1245,11 @@ class LihuiyuDriver(Parameters):
             self._mode_shift_on_the_fly(dx, dy)
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def _mode_shift_on_the_fly(self, dx=0, dy=0):
         """
@@ -1442,10 +1446,11 @@ class LihuiyuDriver(Parameters):
             self._goto_xy(dx, dy, on=on)
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def _code_declare_directions(self):
         x_dir = self.CODE_LEFT if self._leftward else self.CODE_RIGHT

--- a/meerk40t/moshi/device.py
+++ b/meerk40t/moshi/device.py
@@ -202,6 +202,18 @@ class MoshiDevice(Service, Status):
                 ),
                 "section": "_30_Interface",
             },
+            {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
+            },
         ]
         self.register_choices("bed_dim", choices)
 

--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -54,6 +54,8 @@ class MoshiDriver(Parameters):
 
         self.plot_planner = PlotPlanner(self.settings)
         self.queue = list()
+        self._queue_current = 0
+        self._queue_total = 0
 
         self.program = MoshiBuilder()
 
@@ -90,6 +92,13 @@ class MoshiDriver(Parameters):
             self.out_real(e)
         else:
             self.out_pipe(e)
+
+    def get_internal_queue_status(self):
+        return self._queue_current, self._queue_total
+
+    def _set_queue_status(self, current, total):
+        self._queue_current = current
+        self._queue_total = total
 
     def hold_work(self, priority):
         """
@@ -284,7 +293,12 @@ class MoshiDriver(Parameters):
 
         @return:
         """
+        total = len(self.queue)
+        current = 0
         for q in self.queue:
+            current += 1
+            self._set_queue_status(current, total)
+
             x = self.native_x
             y = self.native_y
             start_x, start_y = q.start
@@ -381,6 +395,7 @@ class MoshiDriver(Parameters):
                         continue
                     self._goto_absolute(x, y, on & 1)
         self.queue.clear()
+        self._set_queue_status(0, 0)
 
     def move_abs(self, x, y):
         """

--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -72,6 +72,8 @@ class MoshiDriver(Parameters):
         self.out_pipe = None
         self.out_real = None
 
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
+
         def primary_hold():
             if self.out_pipe is None:
                 return True
@@ -795,10 +797,11 @@ class MoshiDriver(Parameters):
         self.native_y = y
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def _move_absolute(self, x, y):
         """
@@ -811,10 +814,11 @@ class MoshiDriver(Parameters):
         self.native_y = y
 
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def laser_disable(self, *values):
         self.laser_enabled = False

--- a/meerk40t/newly/controller.py
+++ b/meerk40t/newly/controller.py
@@ -90,6 +90,7 @@ class NewlyController:
         self.mode = "init"
         self.paused = False
         self._command_buffer = []
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
 
     def __call__(self, cmd, *args, **kwargs):
         if isinstance(cmd, str):
@@ -190,7 +191,8 @@ class NewlyController:
         )
         x, y = self.service.view.iposition(self._last_x, self._last_y)
         self.sync()
-        self.service.signal("driver;position", (last_x, last_y, x, y))
+        if self._signal_updates:
+            self.service.signal("driver;position", (last_x, last_y, x, y))
 
     #######################
     # MODE SHIFTS

--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -271,6 +271,18 @@ class NewlyDevice(Service, Status):
                 ),
                 "section": "_30_Output",
             },
+            {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
+            },
         ]
         self.register_choices("newly", choices)
 

--- a/meerk40t/newly/driver.py
+++ b/meerk40t/newly/driver.py
@@ -35,6 +35,9 @@ class NewlyDriver:
         self._shutdown = False
 
         self.queue = list()
+        self._queue_current = 0
+        self._queue_total = 0
+
         self.plot_planner = PlotPlanner(
             dict(), single=True, ppi=False, shift=False, group=True
         )
@@ -72,6 +75,13 @@ class NewlyDriver:
 
     def abort_retry(self):
         self.connection.abort_connect()
+
+    def get_internal_queue_status(self):
+        return self._queue_current, self._queue_total
+
+    def _set_queue_status(self, current, total):
+        self._queue_current = current
+        self._queue_total = total
 
     #############
     # DRIVER COMMANDS
@@ -241,7 +251,12 @@ class NewlyDriver:
         con = self.connection
         queue = self.queue
         self.queue = list()
+        total = len(queue)
+        current = 0
         for q in queue:
+            current += 1
+            self._set_queue_status(current, total)
+
             con.program_mode()
             # LOOP CHECKS
             if self._aborting:
@@ -329,6 +344,7 @@ class NewlyDriver:
                 con.raster(q)
                 con.update()
         con.rapid_mode()
+        self._set_queue_status(0, 0)
 
     def move_abs(self, x, y):
         """

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -37,10 +37,20 @@ class RuidaDevice(Service):
                 if attr is not None and default is not None:
                     setattr(self, attr, default)
 
-        self.setting(str, "label", path)
+        # self.setting(str, "label", path)
 
         _ = self._
         choices = [
+            {
+                "attr": "label",
+                "object": self,
+                "default": path,
+                "type": str,
+                "label": _("Label"),
+                "tip": _("What is this device called."),
+                "section": "_00_General",
+                "priority": "10",
+            },
             {
                 "attr": "bedwidth",
                 "object": self,
@@ -172,6 +182,18 @@ class RuidaDevice(Service):
                 "label": _("Curve Interpolation"),
                 "section": "_10_Parameters",
                 "tip": _("Native units interpolation points."),
+            },
+            {
+                "attr": "signal_updates",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Device Position"),
+                "tip": _(
+                    "Do you want to see some indicator about the current device position?"
+                ),
+                "section": "_95_" + _("Screen updates"),
+                "signals": "restart",
             },
         ]
         self.register_choices("bed_dim", choices)

--- a/meerk40t/ruida/driver.py
+++ b/meerk40t/ruida/driver.py
@@ -50,6 +50,8 @@ class RuidaDriver(Parameters):
         self._shutdown = False
 
         self.queue = list()
+        self._queue_current = 0
+        self._queue_total = 0
         self.plot_planner = PlotPlanner(
             dict(), single=True, ppi=False, shift=False, group=True
         )
@@ -57,6 +59,13 @@ class RuidaDriver(Parameters):
 
     def __repr__(self):
         return f"RuidaDriver({self.name})"
+
+    def get_internal_queue_status(self):
+        return self._queue_current, self._queue_total
+
+    def _set_queue_status(self, current, total):
+        self._queue_current = current
+        self._queue_total = total
 
     #############
     # DRIVER COMMANDS
@@ -148,7 +157,11 @@ class RuidaDriver(Parameters):
         self.controller.job.write_header(self.queue)
         first = True
         last_settings = None
+        total = len(self.queue)
+        current = 0
         for q in self.queue:
+            current += 1
+            self._set_queue_status(current, total)
             if hasattr(q, "settings"):
                 current_settings = q.settings
                 if current_settings is not last_settings:
@@ -259,6 +272,7 @@ class RuidaDriver(Parameters):
                     self.on_value = on
                     self._move(x, y, cut=True)
         self.queue.clear()
+        self._set_queue_status(0, 0)
         # Ruida end data.
         self.controller.job.write_tail()
         self.controller.stop_record()

--- a/meerk40t/ruida/driver.py
+++ b/meerk40t/ruida/driver.py
@@ -56,6 +56,7 @@ class RuidaDriver(Parameters):
             dict(), single=True, ppi=False, shift=False, group=True
         )
         self._aborting = False
+        self._signal_updates = self.service.setting(bool, "signal_updates", True)
 
     def __repr__(self):
         return f"RuidaDriver({self.name})"
@@ -307,10 +308,11 @@ class RuidaDriver(Parameters):
         self.native_x = x
         self.native_y = y
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def move_rel(self, dx, dy):
         """
@@ -339,10 +341,11 @@ class RuidaDriver(Parameters):
         self.native_x += dx
         self.native_y += dy
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def focusz(self):
         """
@@ -524,7 +527,8 @@ class RuidaDriver(Parameters):
         self.native_x = x
         self.native_y = y
         new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self._signal_updates:
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )


### PR DESCRIPTION
## Spooler panel
Not extremely beautiful but somewhat useful to see progress. Looks at internal driver queue.
Most notable difference the K40 as it does have a different implementation compared to all other devices.
![grafik](https://github.com/user-attachments/assets/eaa80b2c-e68a-4ae4-b6b3-061dd112c65e)

## Screen laser reticles
* Make them appear for Balor
* Make them suppressable for each device