### PR TITLE
Add extended load

### DIFF
--- a/meerk40t/extra/outerworld.py
+++ b/meerk40t/extra/outerworld.py
@@ -50,10 +50,10 @@ def plugin(kernel, lifecycle):
 
 
     @kernel.console_argument("url", type=str, help=_("Image url to load"))
-    @kernel.console_argument("x", type=str, help="Sets the x-position of the image",)
-    @kernel.console_argument("y", type=str, help="Sets the y-position of the image",)
-    @kernel.console_argument("width", type=Length, help="Sets the width of the given image",)
-    @kernel.console_argument("height", type=Length, help="Sets the width of the given image",)
+    @kernel.console_argument("x", type=str, help="Sets the x-position of the data ('c' to center)",)
+    @kernel.console_argument("y", type=str, help="Sets the y-position of the data ('c' to center)",)
+    @kernel.console_argument("width", type=Length, help="Sets the width of the loaded data",)
+    @kernel.console_argument("height", type=Length, help="Sets the height of the loaded data",)
     @kernel.console_option("relative", "r", type=str, help="Establishes the id of an element that will act as the reference, if none given then reference is the scene")
     @kernel.console_command(
         "webload",
@@ -219,10 +219,10 @@ def plugin(kernel, lifecycle):
 
 
     @kernel.console_argument("filename", type=str, help=_("Filename to load"))
-    @kernel.console_argument("x", type=str, help="Sets the x-position of the image",)
-    @kernel.console_argument("y", type=str, help="Sets the y-position of the image",)
-    @kernel.console_argument("width", type=Length, help="Sets the width of the given image",)
-    @kernel.console_argument("height", type=Length, help="Sets the width of the given image",)
+    @kernel.console_argument("x", type=str, help="Sets the x-position of the data ('c' to center)",)
+    @kernel.console_argument("y", type=str, help="Sets the y-position of the data ('c' to center)",)
+    @kernel.console_argument("width", type=Length, help="Sets the width of the loaded data",)
+    @kernel.console_argument("height", type=Length, help="Sets the height of the loaded data",)
     @kernel.console_option("relative", "r", type=str, help="Establishes the id of an element that will act as the reference, if none given then reference is the scene")
     @kernel.console_command(
         "xload",

--- a/meerk40t/extra/outerworld.py
+++ b/meerk40t/extra/outerworld.py
@@ -168,49 +168,181 @@ def plugin(kernel, lifecycle):
             return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
 
         channel(f"Loaded {len(elements_service.added_elements)} elements")
-        if width is not None:
-            bb = union_box(elements_service.added_elements)
-            if bb is not None:
-                wd = float(width)
-                if height is None:
-                    # if we don't have a height then we use the ratio
-                    ratio = (bb[2] - bb[0]) / (bb[3] - bb[1])
-                    ht = wd / ratio
-                    channel(f"Setting height to {Length(ht, digits=2, preferred_units=units)}")
-                else:
-                    ht = float(height)
-            sx = wd / (bb[2] - bb[0])
-            sy = ht / (bb[3] - bb[1])
-            for n in elements_service.added_elements:
-                if hasattr(n, "matrix"):
-                    n.matrix.post_scale(sx, sy)
 
-        if x is not None and y is not None:
-            bb = union_box(elements_service.added_elements)
-            dx = 0
-            dy = 0
-            if bb is not None:
-                if x.lower() == "c":
-                    dx = (org_x + size_x / 2) - (bb[0] + bb[2]) / 2
-                else:
-                    try:
-                        px = float(Length(x))
-                        dx = (org_x + px) - bb[0]
-                    except ValueError:
-                        pass
-                if y.lower() == "c":
-                    dy = (org_y + size_y / 2) - (bb[1] + bb[3]) / 2
-                else:
-                    try:
-                        py = float(Length(y))
-                        dy = (org_y + py) - bb[1]
-                    except ValueError:
-                        pass
-
-            if dx != 0 or dy != 0:
+        with elements_service.undofree():
+            if width is not None:
+                bb = union_box(elements_service.added_elements)
+                if bb is not None:
+                    wd = float(width)
+                    if height is None:
+                        # if we don't have a height then we use the ratio
+                        ratio = (bb[2] - bb[0]) / (bb[3] - bb[1])
+                        ht = wd / ratio
+                        channel(f"Setting height to {Length(ht, digits=2, preferred_units=units)}")
+                    else:
+                        ht = float(height)
+                sx = wd / (bb[2] - bb[0])
+                sy = ht / (bb[3] - bb[1])
                 for n in elements_service.added_elements:
                     if hasattr(n, "matrix"):
-                        n.matrix.post_translate(dx, dy)
+                        n.matrix.post_scale(sx, sy)
+
+            if x is not None and y is not None:
+                bb = union_box(elements_service.added_elements)
+                dx = 0
+                dy = 0
+                if bb is not None:
+                    if x.lower() == "c":
+                        dx = (org_x + size_x / 2) - (bb[0] + bb[2]) / 2
+                    else:
+                        try:
+                            px = float(Length(x))
+                            dx = (org_x + px) - bb[0]
+                        except ValueError:
+                            pass
+                    if y.lower() == "c":
+                        dy = (org_y + size_y / 2) - (bb[1] + bb[3]) / 2
+                    else:
+                        try:
+                            py = float(Length(y))
+                            dy = (org_y + py) - bb[1]
+                        except ValueError:
+                            pass
+
+                if dx != 0 or dy != 0:
+                    for n in elements_service.added_elements:
+                        if hasattr(n, "matrix"):
+                            n.matrix.post_translate(dx, dy)
+        elements_service.clear_loaded_information()
+
+        context.signal("refresh_scene", "Scene")
+
+
+    @kernel.console_argument("filename", type=str, help=_("Filename to load"))
+    @kernel.console_argument("x", type=str, help="Sets the x-position of the image",)
+    @kernel.console_argument("y", type=str, help="Sets the y-position of the image",)
+    @kernel.console_argument("width", type=Length, help="Sets the width of the given image",)
+    @kernel.console_argument("height", type=Length, help="Sets the width of the given image",)
+    @kernel.console_option("relative", "r", type=str, help="Establishes the id of an element that will act as the reference, if none given then reference is the scene")
+    @kernel.console_command(
+        "xload",
+        help=_("xload <filename> <x> <y> <width> <height>")
+        + "\n"
+        + _("Gets a file and puts it on the screen"),
+        input_type=None,
+        output_type=None,
+    )
+    def get_xfile(
+        command,
+        channel,
+        _,
+        filename=None,
+        x=None,
+        y=None,
+        width=None,
+        height=None,
+        relative=None,
+        data=None,
+        post=None,
+        **kwargs,
+    ):
+        if filename is None:
+            channel(_("You need to provide a file to load"))
+            return
+        # Download the file data
+        elements_service = kernel.elements
+        units = kernel.root.units_name
+        org_x = 0
+        org_y = 0
+        size_x = kernel.device.view.width
+        size_y = kernel.device.view.height
+        if relative is not None:
+            relative = str(relative).lower()
+            # Let's try to find an element with that id
+            for e in elements_service.elems():
+                if e.id is None:
+                    continue
+                if str(e.id).lower() == relative:
+                    try:
+                        bb = e.bounds
+                    except AttributeError:
+                        continue
+                    if bb is None:
+                        continue
+                    org_x = bb[0]
+                    org_y = bb[1]
+                    size_x = bb[2] - bb[0]
+                    size_y = bb[3] - bb[1]
+                    channel (f"Reference element with id '{e.id}' found: '{e.display_label()}'")
+                    break
+        if org_x != 0 or org_y != 0:
+            channel(f"Upper left corner at: {Length(org_x, digits=2, preferred_units=units)}, {Length(org_y, digits=2, preferred_units=units)}")
+
+        res = elements_service.load(filename)
+        if not res:
+            channel("Could not load any data")
+            return
+
+        def union_box(elements):
+            boxes = []
+            for e in elements:
+                if not hasattr(e, "bbox"):
+                    continue
+                box = e.bbox()
+                if box is None:
+                    continue
+                boxes.append(box)
+            if len(boxes) == 0:
+                return None
+            (xmins, ymins, xmaxs, ymaxs) = zip(*boxes)
+            return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
+
+        channel(f"Loaded {len(elements_service.added_elements)} elements")
+
+        with elements_service.undofree():
+            if width is not None:
+                bb = union_box(elements_service.added_elements)
+                if bb is not None:
+                    wd = float(width)
+                    if height is None:
+                        # if we don't have a height then we use the ratio
+                        ratio = (bb[2] - bb[0]) / (bb[3] - bb[1])
+                        ht = wd / ratio
+                        channel(f"Setting height to {Length(ht, digits=2, preferred_units=units)}")
+                    else:
+                        ht = float(height)
+                sx = wd / (bb[2] - bb[0])
+                sy = ht / (bb[3] - bb[1])
+                for n in elements_service.added_elements:
+                    if hasattr(n, "matrix"):
+                        n.matrix.post_scale(sx, sy)
+
+            if x is not None and y is not None:
+                bb = union_box(elements_service.added_elements)
+                dx = 0
+                dy = 0
+                if bb is not None:
+                    if x.lower() == "c":
+                        dx = (org_x + size_x / 2) - (bb[0] + bb[2]) / 2
+                    else:
+                        try:
+                            px = float(Length(x))
+                            dx = (org_x + px) - bb[0]
+                        except ValueError:
+                            pass
+                    if y.lower() == "c":
+                        dy = (org_y + size_y / 2) - (bb[1] + bb[3]) / 2
+                    else:
+                        try:
+                            py = float(Length(y))
+                            dy = (org_y + py) - bb[1]
+                        except ValueError:
+                            pass
+
+                if dx != 0 or dy != 0:
+                    for n in elements_service.added_elements:
+                        if hasattr(n, "matrix"):
+                            n.matrix.post_translate(dx, dy)
         elements_service.clear_loaded_information()
 
         context.signal("refresh_scene", "Scene")

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -2879,6 +2879,17 @@ class MeerK40t(MWindow):
                     dlg.ShowModal()
                     dlg.Destroy()
 
+        @context.console_option("ops_too", "o", action="store_true", type=bool)
+        @context.console_command("clear_project")
+        def reset_workspace(command, channel, ops_too=False, **kwargs):
+            self.set_working_file_name(None)
+            self.context.elements.clear_all(ops_too=ops_too)
+            self.context(".planz clear\n")
+            self.context(".laserpath_clear\n")
+            self.validate_save()
+            self.context(".tool none\n")
+            self.context.elements.undo.mark("Clear Project")
+
     def __set_panes(self):
         self.context.setting(bool, "pane_lock", False)
 
@@ -4815,15 +4826,10 @@ class MeerK40t(MWindow):
         context = self.context
         kernel = context.kernel
         kernel.busyinfo.start(msg=_("Cleaning up..."))
-        self.set_working_file_name(None)
-        context.elements.clear_all(ops_too=ops_too)
-        context("planz clear\n")
-        self.context(".laserpath_clear\n")
-        self.validate_save()
+        options = " -o" if ops_too else ""
+        self.context(f".clear_project{options}\n")
         kernel.busyinfo.end()
-        self.context(".tool none\n")
         # Hint for translate check: _("Clear Project")
-        context.elements.undo.mark("Clear Project")
         self.context.signal("selected")
 
     def clear_and_open(self, pathname, preferred_loader=None):


### PR DESCRIPTION
``xload`` and ``webload`` do allow the (relative) positioning of a file to load:
```
[20:29:50]     	xload <filename> <x> <y> <width> <height> Gets a file and puts it on the screen
[20:29:50]     
[20:29:50]     
[20:29:50]     	xload <filename:str> <x:str> <y:str> <width:Length> <height:Length>
[20:29:50]     	(None) -> xload -> (None)
[20:29:50]     	Argument: str 'filename':
[20:29:50]     		Filename to load
[20:29:50]     	Argument: str 'x':
[20:29:50]     		Sets the x-position of the image
[20:29:50]     	Argument: str 'y':
[20:29:50]     		Sets the y-position of the image
[20:29:50]     	Argument: Length 'width':
[20:29:50]     		Sets the width of the given image
[20:29:50]     	Argument: Length 'height':
[20:29:50]     		Sets the width of the given image
[20:29:50]     	Option: str ('--relative', '-r'):
[20:29:50]     		Establishes the id of an element that will act as the reference, if none given then reference is the scene
```
and the same for webload - will just take an URL instead of a filename and will load the file from a webresource.
If you provide "c" for any of the X and Y parameters, then it will center the loaded content on that axis / inside the references object
![xload](https://github.com/user-attachments/assets/71fadda1-9ab7-43eb-8f7a-4c207859c6b2)

