### PR TITLE
Reuse operations on load

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -352,6 +352,11 @@ def plugin(kernel, lifecycle=None):
                 "page": "Scene",
                 "section": "General",
             },
+        ]
+        for c in choices:
+            c["help"] = "classification"
+        kernel.register_choices("preferences", choices)
+        choices = [
             {
                 "attr": "op_show_default",
                 "object": elements,
@@ -363,8 +368,8 @@ def plugin(kernel, lifecycle=None):
                 )
                 + "\n"
                 + _("Unticked: Show their current value."),
-                "page": "Scene",
-                "section": "Operation",
+                "page": "Operations",
+                "section": "Display",
             },
             {
                 "attr": "allow_reg_to_op_dragging",
@@ -379,12 +384,48 @@ def plugin(kernel, lifecycle=None):
                 + _(
                     "Unticked: A drag operation of regmark nodes to an operation will be ignored."
                 ),
-                "page": "Scene",
-                "section": "Operation",
+                "page": "Operations",
+                "section": "Behaviour",
+            },
+            {
+                "attr": "reuse_operations_on_load",
+                "object": elements,
+                "default": True,
+                "type": bool,
+                "label": _("Reuse existing"),
+                "tip": _(
+                    "Ticked: When loading a file we will reuse an existing operation with the same principal properties."
+                )
+                + "\n"
+                + _(
+                    "Unticked: We will add another operation aongside existing ones (always the case if properties differ)."
+                ),
+                "page": "Operations",
+                "section": "Loading",
+            },
+            {
+                "attr": "default_ops_display_mode",
+                "object": elements,
+                "default": 0,
+                "type": int,
+                "label": _("Statusbar display"),
+                "style": "option",
+                "display": (
+                    _("As in operations tree"),
+                    _("Group types together (CC EE RR II)"),
+                    _("Matching (CERI CERI)"),
+                ),
+                "choices": (0, 1, 2),
+                "tip": _(
+                    "Choose if and how you want to group together / display the default operations at the bottom of the screen"
+                ),
+                "page": "Operations",
+                "section": "_95_Default Operations",
+                "signals": "default_operations",
             },
         ]
         for c in choices:
-            c["help"] = "classification"
+            c["help"] = "operations"
         kernel.register_choices("preferences", choices)
         choices = [
             {
@@ -421,29 +462,7 @@ def plugin(kernel, lifecycle=None):
             },
         ]
         kernel.register_choices("preferences", choices)
-        choices = [
-            {
-                "attr": "default_ops_display_mode",
-                "object": elements,
-                "default": 0,
-                "type": int,
-                "label": _("Statusbar display"),
-                "style": "option",
-                "display": (
-                    _("As in operations tree"),
-                    _("Group types together (CC EE RR II)"),
-                    _("Matching (CERI CERI)"),
-                ),
-                "choices": (0, 1, 2),
-                "tip": _(
-                    "Choose if and how you want to group together / display the default operations at the bottom of the screen"
-                ),
-                "page": "Classification",
-                "section": "_95_Default Operations",
-                "signals": "default_operations",
-            },
-        ]
-        kernel.register_choices("preferences", choices)
+
         choices = [
             {
                 "attr": "auto_startup",
@@ -568,6 +587,7 @@ class Elemental(Service):
         # self.setting(bool, "classify_auto_inherit", False)
         self.setting(bool, "classify_default", True)
         self.setting(bool, "op_show_default", False)
+        self.setting(bool, "reuse_operations_on_load", True)
         self.setting(bool, "lock_allows_move", True)
         self.setting(bool, "auto_note", True)
         self.setting(int, "auto_startup", 1)

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -665,7 +665,7 @@ class SVGProcessor:
     Special care is taken to load MK specific objects like `note` and `operations`
     """
 
-    def __init__(self, elements, load_operations):
+    def __init__(self, elements, load_operations, reuse_operations=True):
         self.elements = elements
 
         self.operation_list = list()
@@ -674,9 +674,10 @@ class SVGProcessor:
 
         self.reverse = False
         self.requires_classification = True
-        self.operations_replaced = False
+        self.operations_generated = False
         self.pathname = None
         self.load_operations = load_operations
+        self.reuse_operations = reuse_operations
         self.mk_params = list(
             self.elements.kernel.lookup_all("registered_mk_svg_parameters")
         )
@@ -721,8 +722,9 @@ class SVGProcessor:
 
         self.parse(svg, file_node, self.element_list, branch="elements")
 
-        if self.load_operations and self.operations_replaced:
+        if self.load_operations and self.operations_generated:
             # print ("Will replace all operations...")
+            self.requires_classification = False
             for child in list(self.elements.op_branch.children):
                 if child in retain_op_list:
                     continue
@@ -739,8 +741,6 @@ class SVGProcessor:
                     continue
                 if refs is None:
                     continue
-
-                self.requires_classification = False
 
                 for ref in refs.split(" "):
                     for e in self.element_list:
@@ -1350,8 +1350,8 @@ class SVGProcessor:
             if not self.load_operations:
                 # We don't do that.
                 return
-            if not self.operations_replaced:
-                self.operations_replaced = True
+
+            self.operations_generated = True
 
             try:
                 if node_type == "op hatch":
@@ -1494,7 +1494,7 @@ class SVGProcessor:
                 if not self.load_operations:
                     # We don't do that.
                     return
-                self.operations_replaced = True
+                self.operations_generated = True
                 self.parse(
                     element,
                     self.elements.op_branch,
@@ -1509,10 +1509,61 @@ class SVGProcessor:
             for attr in ("type", "id", "label"):
                 if attr in e_dict:
                     del e_dict[attr]
-            context_node = context_node.add(
-                type=e_type, id=ident, label=_label, **e_dict
-            )
-            self.check_for_label_display(context_node, element)
+
+            #
+            already = False
+            if self.reuse_operations:
+                # No need to create another operation, if we do
+                # have an identical operation in place
+                if e_type.startswith("op "):
+                    # It needs to be non-empty to be used!
+                    for testop in self.elements.ops():
+                        if len(testop.children) == 0:
+                            continue
+                        if e_type != testop.type:
+                            continue
+                        differs = False
+                        for check_attr, check_default in (
+                            ("id", None),
+                            ("power", "1000"),
+                            ("speed", None),
+                            ("passes", "0"),
+                            ("color", None),
+                        ):
+                            if not hasattr(testop, check_attr):
+                                if check_attr in e_dict:
+                                    differs = True
+                                    break
+                                continue
+                            test_val = getattr(testop, check_attr, check_default)
+                            if test_val is None:
+                                test_val = ""
+                            else:
+                                test_val = str(test_val)
+                            if check_attr == "id":
+                                eop_val = ident
+                            else:
+                                if check_attr not in e_dict:
+                                    eop_val = check_default
+                                else:
+                                    eop_val = e_dict[check_attr]
+                            if eop_val is None:
+                                eop_val = ""
+                            if test_val != eop_val:
+                                differs = True
+                                # print (f"{testop.type}.{check_attr}: {eop_val} != {test_val}")
+                                break
+                        if differs:
+                            continue
+                        context_node = testop
+                        already = True
+                        break
+
+            if not already:
+                context_node = context_node.add(
+                    type=e_type, id=ident, label=_label, **e_dict
+                )
+                self.check_for_label_display(context_node, element)
             context_node._ref_load = element.values.get("references")
             e_list.append(context_node)
             if hasattr(context_node, "validate"):
@@ -1597,8 +1648,10 @@ class SVGLoader:
             )
         except ParseError as e:
             raise BadFileError(str(e)) from e
+        reuse = elements_service.reuse_operations_on_load
+        print (reuse)
         elements_service._loading_cleared = True
-        svg_processor = SVGProcessor(elements_service, True)
+        svg_processor = SVGProcessor(elements_service, load_operations=True, reuse_operations=reuse)
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()
         return True
@@ -1647,7 +1700,7 @@ class SVGLoaderPlain:
         except ParseError as e:
             raise BadFileError(str(e)) from e
         elements_service._loading_cleared = True
-        svg_processor = SVGProcessor(elements_service, False)
+        svg_processor = SVGProcessor(elements_service, load_operations=False)
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()
         return True

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -1649,7 +1649,6 @@ class SVGLoader:
         except ParseError as e:
             raise BadFileError(str(e)) from e
         reuse = elements_service.reuse_operations_on_load
-        print (reuse)
         elements_service._loading_cleared = True
         svg_processor = SVGProcessor(elements_service, load_operations=True, reuse_operations=reuse)
         svg_processor.process(svg, pathname)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -427,7 +427,6 @@ class PreferencesPixelsPerInchPanel(wx.Panel):
                 self.combo_svg_ppi.SetSelection(3)
         elements.svg_ppi = svg_ppi
 
-
 # end of class PreferencesPixelsPerInchPanel
 
 
@@ -436,7 +435,7 @@ class PreferencesMain(wx.Panel):
         # begin wxGlade: PreferencesMain.__init__
         kwds["style"] = kwds.get("style", 0)
         wx.Panel.__init__(self, *args, **kwds)
-        self.context = None
+        self.context = context
         self.SetHelpText("preferences")
         sizer_main = wx.BoxSizer(wx.VERTICAL)
 
@@ -446,15 +445,12 @@ class PreferencesMain(wx.Panel):
         self.panel_language = PreferencesLanguagePanel(self, wx.ID_ANY, context=context)
         sizer_main.Add(self.panel_language, 0, wx.EXPAND, 0)
 
-        self.panel_ppi = PreferencesPixelsPerInchPanel(self, wx.ID_ANY, context=context)
-        sizer_main.Add(self.panel_ppi, 0, wx.EXPAND, 0)
-
         self.panel_pref1 = ChoicePropertyPanel(
             self,
             id=wx.ID_ANY,
             context=context,
             choices="preferences",
-            constraint=("-Input/Output", "-Classification", "-Gui", "-Scene"),
+            constraint=("-Input/Output", "-Classification", "-Gui", "-Scene", "-Operations"),
         )
         sizer_main.Add(self.panel_pref1, 1, wx.EXPAND, 0)
 
@@ -467,12 +463,42 @@ class PreferencesMain(wx.Panel):
         # end wxGlade
 
     def delegates(self):
-        yield self.panel_ppi
         yield self.panel_language
         yield self.panel_units
         yield self.panel_pref1
         yield self.panel_management
 
+
+class PreferencesInputOutput(wx.Panel):
+    def __init__(self, *args, context=None, **kwds):
+        # begin wxGlade: PreferencesMain.__init__
+        kwds["style"] = kwds.get("style", 0)
+        wx.Panel.__init__(self, *args, **kwds)
+        self.context = context
+        self.SetHelpText("preferences")
+        sizer_main = wx.BoxSizer(wx.VERTICAL)
+
+        self.panel_ppi = PreferencesPixelsPerInchPanel(self, wx.ID_ANY, context=context)
+        sizer_main.Add(self.panel_ppi, 0, wx.EXPAND, 0)
+
+        self.panel_input_output = ChoicePropertyPanel(
+            self,
+            id=wx.ID_ANY,
+            context=self.context,
+            choices="preferences",
+            constraint="Input/Output",
+        )
+        self.panel_input_output.SetupScrolling()
+        sizer_main.Add(self.panel_input_output, 1, wx.EXPAND, 0)
+
+        self.SetSizer(sizer_main)
+
+        self.Layout()
+        # end wxGlade
+
+    def delegates(self):
+        yield self.panel_ppi
+        yield self.panel_input_output
 
 # end of class PreferencesMain
 
@@ -524,14 +550,8 @@ class Preferences(MWindow):
         # self.panel_main = PreferencesPanel(self, wx.ID_ANY, context=self.context)
         self.panel_main = PreferencesMain(self, wx.ID_ANY, context=self.context)
 
-        self.panel_input_output = ChoicePropertyPanel(
-            self,
-            id=wx.ID_ANY,
-            context=self.context,
-            choices="preferences",
-            constraint="Input/Output",
-        )
-        self.panel_input_output.SetupScrolling()
+        self.panel_input_output = PreferencesInputOutput(self, wx.ID_ANY, context=self.context)
+
         inject_choices = [
             {
                 "attr": "preset_classify_automatic",
@@ -598,6 +618,15 @@ class Preferences(MWindow):
             injector=inject_choices,
         )
         self.panel_classification.SetupScrolling()
+
+        self.panel_ops = ChoicePropertyPanel(
+            self,
+            id=wx.ID_ANY,
+            context=self.context,
+            choices="preferences",
+            constraint="Operations",
+        )
+        self.panel_ops.SetupScrolling()
 
         self.panel_gui = ChoicePropertyPanel(
             self,
@@ -688,6 +717,7 @@ class Preferences(MWindow):
         self.notebook_main.AddPage(self.panel_main, _("General"))
         self.notebook_main.AddPage(self.panel_input_output, _("Input/Output"))
         self.notebook_main.AddPage(self.panel_classification, _("Classification"))
+        self.notebook_main.AddPage(self.panel_ops, _("Operations"))
         self.notebook_main.AddPage(self.panel_gui, _("GUI"))
         self.notebook_main.AddPage(self.panel_scene, _("Scene"))
         self.notebook_main.AddPage(self.panel_color, _("Colors"))
@@ -697,12 +727,13 @@ class Preferences(MWindow):
             self.panel_main,
             self.panel_input_output,
             self.panel_classification,
+            self.panel_ops,
             self.panel_gui,
             self.panel_scene,
             self.panel_color,
             self.panel_ribbon,
         ]
-        self.panel_ids = ["main", "classification", "gui", "scene", "color", "ribbon"]
+        self.panel_ids = ["main", "classification", "ops", "gui", "scene", "color", "ribbon"]
         self.context.setting(bool, "developer_mode", False)
         if self.context.developer_mode:
             panel_space = ChoicePropertyPanel(


### PR DESCRIPTION
When loading a file alongside existing operations that are in use, we create every single operation that is defined in that file, regardless whether an "identical" operation exists. Try to load the same file several times along each other (Recent or Import).
![reuse1](https://github.com/user-attachments/assets/1df714aa-4c04-4630-8875-7cd773beb321)

This has been amended that we will look for identical operations and use these instead of creating new ones. 
The criteria list for being identical is intentionally rather strict, the following attributes need to be the same:
- Optype 
- ID
- Speed
- Power
- Passes
- Color
![reuse2](https://github.com/user-attachments/assets/bca464f5-050a-498a-a817-8cd67b03cf68)

If you want to have the old behaviour back then disable the flag in the settings (which have been slightly rearranged).
![grafik](https://github.com/user-attachments/assets/9767e5dc-316d-4781-8bd6-a49ea46d2cfd)
