### PR TITLE
Change driver.py and geomstr.py to do interpolation for a line.

### DIFF
--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -235,13 +235,7 @@ class MoshiDriver(Parameters):
             self.settings.update(sets)
 
             if segment_type == "line":
-                interp = self.service.interp
-                g.clear()
-                g.line(start, end)
-                for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.hold_work(0):
-                        time.sleep(0.05)
-                    self._goto_absolute(p.real, p.imag, 1)
+                self._goto_absolute(end.real, end.imag, 1)
             elif segment_type == "end":
                 pass
             elif segment_type == "quad":
@@ -314,13 +308,36 @@ class MoshiDriver(Parameters):
                 self._goto_absolute(start_x, start_y, 0)
             self.settings.update(q.settings)
             if isinstance(q, LineCut):
-                interp = self.service.interp
-                g = Geomstr()
-                g.line(complex(*q.start), complex(*q.end))
-                for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.hold_work(0):
-                        time.sleep(0.05)
-                    self._goto_absolute(p.real, p.imag, 1)
+                x0, y0, x1, y1 = int(q.start[0]), int(q.start[1]), int(q.end[0]), int(q.end[1])
+                dx, dy = abs(x1 - x0), abs(y1 - y0)
+                # horizontal, vertical or 45 deg angled line
+                if dx == 0 or dy == 0 or dx == dy:
+                    self._goto_absolute(*q.end, 1)
+                else:
+                    # other oblique line
+                    if dx > dy:
+                        d = dy
+                        sx = float((x1 - x0) / dy)
+                        if y1 - y0 > 0:
+                            sy = 1
+                        else:
+                            sy = -1
+                    else:
+                        d = dx
+                        if x1 - x0 > 0:
+                            sx = 1
+                        else:
+                            sx = -1
+                        sy = float((y1 - y0) / dx)
+                    x = x0
+                    y = y0
+                    self._goto_absolute(*q.start, 0)
+                    for i in range(d):
+                        while self.hold_work(0):
+                            time.sleep(0.05)
+                        x += sx
+                        y += sy
+                        self._goto_absolute(int(x), int(y), 1)
             elif isinstance(q, QuadCut):
                 interp = self.service.interp
                 g = Geomstr()

--- a/meerk40t/moshi/driver.py
+++ b/meerk40t/moshi/driver.py
@@ -235,7 +235,13 @@ class MoshiDriver(Parameters):
             self.settings.update(sets)
 
             if segment_type == "line":
-                self._goto_absolute(end.real, end.imag, 1)
+                interp = self.service.interp
+                g.clear()
+                g.line(start, end)
+                for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
+                    while self.hold_work(0):
+                        time.sleep(0.05)
+                    self._goto_absolute(p.real, p.imag, 1)
             elif segment_type == "end":
                 pass
             elif segment_type == "quad":
@@ -308,7 +314,13 @@ class MoshiDriver(Parameters):
                 self._goto_absolute(start_x, start_y, 0)
             self.settings.update(q.settings)
             if isinstance(q, LineCut):
-                self._goto_absolute(*q.end, 1)
+                interp = self.service.interp
+                g = Geomstr()
+                g.line(complex(*q.start), complex(*q.end))
+                for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
+                    while self.hold_work(0):
+                        time.sleep(0.05)
+                    self._goto_absolute(p.real, p.imag, 1)
             elif isinstance(q, QuadCut):
                 interp = self.service.interp
                 g = Geomstr()

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1949,20 +1949,7 @@ class Geomstr:
                 at_start = True
                 continue
             elif seg_type == TYPE_LINE:
-                ts = np.linspace(0, 1, 1000)
-                pts = self._line_position(e, ts)
-                distances = np.abs(pts[:-1] - pts[1:])
-                distances = np.cumsum(distances)
-                max_distance = distances[-1]
-                dist_values = np.linspace(
-                    0,
-                    max_distance,
-                    int(np.ceil(max_distance / distance)),
-                    endpoint=False,
-                )[1:]
-                near_t = np.searchsorted(distances, dist_values, side="right")
-                pts = pts[near_t]
-                yield from pts
+                pass
             elif seg_type == TYPE_QUAD:
                 ts = np.linspace(0, 1, 1000)
                 pts = self._quad_position(e, ts)

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -1949,7 +1949,20 @@ class Geomstr:
                 at_start = True
                 continue
             elif seg_type == TYPE_LINE:
-                pass
+                ts = np.linspace(0, 1, 1000)
+                pts = self._line_position(e, ts)
+                distances = np.abs(pts[:-1] - pts[1:])
+                distances = np.cumsum(distances)
+                max_distance = distances[-1]
+                dist_values = np.linspace(
+                    0,
+                    max_distance,
+                    int(np.ceil(max_distance / distance)),
+                    endpoint=False,
+                )[1:]
+                near_t = np.searchsorted(distances, dist_values, side="right")
+                pts = pts[near_t]
+                yield from pts
             elif seg_type == TYPE_QUAD:
                 ts = np.linspace(0, 1, 1000)
                 pts = self._quad_position(e, ts)


### PR DESCRIPTION
This request is needed for Moshiboard based laser cutter since Moshiboard do not interpolate as expected as in the Meerk40t codes.

Moshiboard does not correctly cut an oblique line like in following image. 
![Screenshot from 2024-10-02 13-40-22](https://github.com/user-attachments/assets/631eeb00-7d59-452f-a2e0-a22c1eeb504e)

When Moshiboard is requested to cut a oblique line, it cuts with two lines. One is 45 degrees angled line and the other is horizontal or vertical line. The following image shows this.
![IMG_0577](https://github.com/user-attachments/assets/5468b714-2b82-43a4-913c-af1760462b16)
Above shows the issue and below shows the result with the changes included in this pull request.