### PR TITLE
Change dpi meaning in op image

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -671,7 +671,7 @@ def init_tree(kernel):
     @tree_values("dpi", (100, 200, 250, 300, 333.3, 500, 666.6, 750, 1000))
     @tree_operation(
         _("DPI {dpi}"),
-        node_type=("op raster", "elem image"),
+        node_type=("op raster", "op image", "elem image"),
         help=_("Change dpi values"),
     )
     def set_step_n(node, dpi=1, **kwargs):
@@ -680,6 +680,8 @@ def init_tree(kernel):
             if not hasattr(n, "dpi"):
                 continue
             n.dpi = dpi
+            if hasattr(n, "override_dpi"):
+                n.override_dpi = True
             data.append(n)
         for n in list(self.elems(emphasized=True)):
             if n.type == "elem image":

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -25,6 +25,7 @@ class ImageOpNode(Node, Parameters):
         self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
         self.stopop = True
         self.label = "Image"
+        self.overrule_dpi = False
 
         self.allowed_attributes = []
         super().__init__(type="op image", **kwargs)
@@ -36,7 +37,7 @@ class ImageOpNode(Node, Parameters):
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Image"
-        default_map["dpi"] = str(int(self.dpi))
+        default_map["dpi"] = str(int(self.dpi)) if self.overrule_dpi else ""
         default_map["danger"] = "❌" if self.dangerous else ""
         default_map["defop"] = "✓" if self.default else ""
         default_map["enabled"] = "(Disabled) " if not self.output else ""
@@ -232,8 +233,9 @@ class ImageOpNode(Node, Parameters):
         self.settings["native_mm"] = native_mm
         self.settings["native_speed"] = self.speed * native_mm
         self.settings["native_rapid_speed"] = self.rapid_speed * native_mm
-
         for node in self.children:
+            if self.overrule_dpi and self.dpi:
+                node.dpi = self.dpi 
 
             def actual(image_node):
                 def process_images():

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -179,7 +179,10 @@ class ImageOpNode(Node, Parameters):
                 node = node.node
             try:
                 e = node.image
-                dpi = node.dpi
+                if self.overrule_dpi and self.dpi:
+                    dpi = self.dpi
+                else:
+                    dpi = node.dpi
             except AttributeError:
                 continue
             min_x, min_y, max_x, max_y = node.bounds

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -1177,6 +1177,7 @@ class ImagePropertyPanel(ScrolledPanel):
         self.check_enable_dither = wxCheckBox(self, wx.ID_ANY, _("Dither"))
         self.choices = [
             "Floyd-Steinberg",
+            "Legacy-Floyd-Steinberg",
             "Atkinson",
             "Jarvis-Judice-Ninke",
             "Stucki",
@@ -1189,7 +1190,7 @@ class ImagePropertyPanel(ScrolledPanel):
             self,
             wx.ID_ANY,
             choices=self.choices,
-            style=wx.CB_DROPDOWN,
+            style=wx.CB_READONLY | wx.CB_DROPDOWN,
         )
         self.check_enable_depthmap = wxCheckBox(self, wx.ID_ANY, _("Depthmap"))
         resolutions = list((f"{2**p} - {p}bit" for p in range(8, 1, -1)))

--- a/meerk40t/image/dither.py
+++ b/meerk40t/image/dither.py
@@ -23,7 +23,7 @@ except Exception as e:
 
 
 _DIFFUSION_MAPS = {
-    "floyd-steinberg": (
+    "legacy-floyd-steinberg": (
         (1, 0, 7 / 16),
         (-1, 1, 3 / 16),
         (0, 1, 5 / 16),
@@ -317,7 +317,7 @@ def fast_dither(image, diff_map):
 
 function_map = {
     "atkinson": atkinson,
-    "floyd-steinberg": floyd_steinberg,
+    "legacy-floyd-steinberg": floyd_steinberg,
     "jarvis-judice-ninke": jarvis_judice_ninke,
     "stucki": stucki,
     "burkes": burkes,
@@ -327,7 +327,7 @@ function_map = {
 }
 
 
-def dither(image, method="Floyd-Steinberg"):
+def dither(image, method="Legacy-Floyd-Steinberg"):
     method = method.lower()
     dither_function = function_map.get(method)
     if not dither_function:


### PR DESCRIPTION
The dpi setting in an image op did not have any relevance so far. The image node dpi was the relevant value. 
(Reason: historical copy + paste issue from raster operation where the dpi setting is very relevant).

You can now use this value to override any defined dpi value in the image node. For compatibility reasons this will only become active if the corresponding override_dpi has been set, too:
![grafik](https://github.com/user-attachments/assets/4b0ee99d-046e-40ef-8ad4-98e42945bd40)

The material test has been updated to take this into account
![grafik](https://github.com/user-attachments/assets/7a0b15d5-8d77-4e81-87bb-4c398c355b0b)
