### PR TITLE
Image convex hull

### DIFF
--- a/meerk40t/balormk/livelightjob.py
+++ b/meerk40t/balormk/livelightjob.py
@@ -395,11 +395,18 @@ class LiveLightJob:
         """
         geometry = Geomstr()
         for n in elements:
-            if hasattr(n, "as_geometry"):
-                geometry.append(n.as_geometry())
-            if hasattr(n, "as_image"):
-                nx, ny, mx, my = n.bounds
-                geometry.append(Geomstr.rect(nx, ny, mx - nx, my - ny))
+            e = None
+            if hasattr(n, "convex_hull"):
+                e = n.convex_hull()
+            if e is None and hasattr(n, "as_geometry"):
+                e = n.as_geometry()
+
+            if e is not None:
+                geometry.append(e)
+            else:
+                if hasattr(n, "as_image"):
+                    nx, ny, mx, my = n.bounds
+                    geometry.append(Geomstr.rect(nx, ny, mx - nx, my - ny))
         if not geometry:
             # There are no elements, return a default crosshair.
             return self._crosshairs(con)
@@ -439,7 +446,11 @@ class LiveLightJob:
             geometry = Geomstr()
             for node in elements:
                 try:
-                    e = node.as_geometry()
+                    e = None
+                    if hasattr(node, "convex_hull"):
+                        e = node.convex_hull()
+                    if e is None:
+                        e = node.as_geometry()
                 except AttributeError:
                     continue
                 geometry.append(e)

--- a/meerk40t/core/elements/trace.py
+++ b/meerk40t/core/elements/trace.py
@@ -247,6 +247,12 @@ def generate_hull_shape_quick(data):
 def generate_hull_shape_hull(data):
     pts = []
     for node in data:
+        if hasattr(node, "convex_hull"):
+            ghull = node.convex_hull()
+            if ghull is not None:
+                for pt in ghull.as_points():
+                    pts.append((pt.real, pt.imag))
+                continue
         try:
             path = node.as_path()
             p = path.first_point

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -187,7 +187,8 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         # print (image_np)
         # Find non-white pixels
         # Iterate over each row in the image
-        non_white_pixels = []
+        left_side = []
+        right_side = []
         for y in range(image_np.shape[0]):
             row = image_np[y]
             non_white_indices = np.where(row < 255)[0]
@@ -195,20 +196,37 @@ class ImageNode(Node, LabelDisplay, Suppressable):
             if non_white_indices.size > 0:
                 leftmost = non_white_indices[0]
                 rightmost = non_white_indices[-1]
-                non_white_pixels.append((y, leftmost))
-                non_white_pixels.append((y, rightmost))
+                left_side.append((leftmost, y))
+                right_side.insert(0, (rightmost, y))
+        left_side.extend(right_side)
+        non_white_pixels = left_side
+        t1 = time.perf_counter()
         # Compute the convex hull
-        c_points = list(complex(p[0], p[1]) for p in non_white_pixels)
-        # t1 = time.perf_counter()
-        # print("Pixel gathering done")
-        pts = list(Geomstr.convex_hull(None, c_points))
+        pts = None
+        try:
+            # The ConvexHull routine from scipy provides less points
+            # and is faster (plus it has fewer non-understood artifacts)
+            from scipy.spatial import ConvexHull
+            c_points = np.array(non_white_pixels)
+            hull = ConvexHull(c_points)
+            hpts = c_points[hull.vertices]
+            pts = list( ( p[0], p[1] ) for p in hpts)
+            # print (f"scipy Hull has {len(pts)} pts")
+        except ImportError:
+            pass
+        if pts is None:
+            c_points = list(complex(p[0], p[1]) for p in non_white_pixels)
+            pts = list(Geomstr.convex_hull(None, c_points))
+            if pts:
+                pts.append(pts[0])
         # print("convex hull done")
-        # t2 = time.perf_counter()
-        if pts:
-            pts.append(pts[0])
+        t2 = time.perf_counter()
+        # print (f"Hull has {len(pts)} pts")
         self._convex_hull = Geomstr.lines(*pts)
+        # print (f"Hull dimension: {self._convex_hull.bbox()} (for reference: image is {self.active_image.width}x{self.active_image.height} pixels)")
         self._convex_hull.transform(self.active_matrix)
-        # t3 = time.perf_counter()
+        # print (f"Final dimension: {self._convex_hull.bbox()}")
+        t3 = time.perf_counter()
         # print (f"Time to get pixels: {t1-t0:.3f}s, convex_hull: {t2-t1:.3f}s, total: {t3-t0:.3f}s")
         return self._convex_hull
 


### PR DESCRIPTION
Added a convex_hull routine to an image operation, so instead of the image bbox it will create a real hull shape.
Being used in balor livelightjobs and for regular trace commands.