### PR TITLE
No recalculation on image copy

### DIFF
--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -1,3 +1,32 @@
+"""
+ImageNode is the bootstrapped node type for handling image elements within the application.
+
+This class manages the properties and behaviors associated with image nodes, including
+image processing, transformations, and keyhole functionalities. It supports various
+operations such as cropping, dither effects, and applying raster scripts, while also
+maintaining the necessary metadata for rendering and manipulation.
+
+Args:
+    **kwargs: Additional keyword arguments for node initialization.
+
+Attributes:
+    image: The original image loaded into the node.
+    matrix: The transformation matrix applied to the image.
+    dpi: The resolution of the image in dots per inch.
+    operations: A list of operations to be applied to the image.
+    keyhole_reference: Reference for keyhole operations.
+    active_image: The processed image ready for rendering.
+    active_matrix: The matrix that combines the main matrix with the processed matrix.
+    convex_hull: The convex hull of the non-white pixels in the image.
+
+Methods:
+    set_keyhole(keyhole_ref, geom=None): Sets the keyhole reference and geometry.
+    process_image(step_x=None, step_y=None, crop=True): Processes the image based on the specified steps and cropping options.
+    update(context): Initiates the image processing thread and updates the image.
+    as_image(): Returns the active image and its bounding box.
+    bbox(transformed=True, with_stroke=False): Returns the bounding box of the image.
+"""
+
 import numpy as np
 import threading
 import time

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -168,10 +168,7 @@ class ImageNode(Node, LabelDisplay, Suppressable):
             newnode._processed_image = copy(self._processed_image)
             newnode._processed_matrix = copy(self._processed_matrix)
             newnode._actualized_matrix = copy(self._actualized_matrix)
-        if self._keyhole_geometry is not None:
-            g = copy(self._keyhole_geometry)
-        else:
-            g = None
+        g = None if self._keyhole_geometry is None else copy(self._keyhole_geometry)
         newnode.set_keyhole(self.keyhole_reference, g)
         return newnode
 
@@ -481,12 +478,11 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         from PIL import Image
 
         img = self.image
-        if img is not None:
-            if img.mode == "RGBA":
-                r, g, b, a = img.split()
-                background = Image.new("RGB", img.size, "white")
-                background.paste(img, mask=a)
-                img = background
+        if img is not None and img.mode == "RGBA":
+            r, g, b, a = img.split()
+            background = Image.new("RGB", img.size, "white")
+            background.paste(img, mask=a)
+            img = background
         return img
 
     def _convert_image_to_grayscale(self, image):
@@ -956,9 +952,9 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         except ZeroDivisionError:
             m = [1] * N
         # b = y - mx
-        b = [p[i][1] - (m[i] * p[i][0]) for i in range(0, N)]
+        b = [p[i][1] - (m[i] * p[i][0]) for i in range(N)]
         r = list()
-        for i in range(0, p[0][0]):
+        for i in range(p[0][0]):
             r.append(0)
         for i in range(len(p) - 1):
             x0 = p[i][0]
@@ -981,21 +977,21 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         """
         try:
             N = len(p) - 1
-            w = [(p[i + 1][0] - p[i][0]) for i in range(0, N)]
-            h = [(p[i + 1][1] - p[i][1]) / w[i] for i in range(0, N)]
+            w = [(p[i + 1][0] - p[i][0]) for i in range(N)]
+            h = [(p[i + 1][1] - p[i][1]) / w[i] for i in range(N)]
             ftt = (
                 [0]
-                + [3 * (h[i + 1] - h[i]) / (w[i + 1] + w[i]) for i in range(0, N - 1)]
+                + [3 * (h[i + 1] - h[i]) / (w[i + 1] + w[i]) for i in range(N - 1)]
                 + [0]
             )
-            A = [(ftt[i + 1] - ftt[i]) / (6 * w[i]) for i in range(0, N)]
-            B = [ftt[i] / 2 for i in range(0, N)]
-            C = [h[i] - w[i] * (ftt[i + 1] + 2 * ftt[i]) / 6 for i in range(0, N)]
-            D = [p[i][1] for i in range(0, N)]
+            A = [(ftt[i + 1] - ftt[i]) / (6 * w[i]) for i in range(N)]
+            B = [ftt[i] / 2 for i in range(N)]
+            C = [h[i] - w[i] * (ftt[i + 1] + 2 * ftt[i]) / 6 for i in range(N)]
+            D = [p[i][1] for i in range(N)]
         except ZeroDivisionError:
             return list(range(256))
         r = list()
-        for i in range(0, p[0][0]):
+        for i in range(p[0][0]):
             r.append(0)
         for i in range(len(p) - 1):
             a = p[i][0]

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -1,3 +1,25 @@
+"""
+ImageOpNode defines an operation for processing images in the laser cutting application.
+
+This class represents a node of type "op image" and manages the settings and behaviors
+associated with image operations, including image processing, classification, and
+time estimation for operations. It allows for the manipulation of image attributes,
+the application of raster cuts, and the handling of drag-and-drop functionality for
+image nodes.
+
+Args:
+    settings (dict, optional): Initial settings for the operation.
+    **kwargs: Additional keyword arguments for node initialization.
+
+Methods:
+    classify(node, fuzzy=False, fuzzydistance=100, usedefault=False): Classifies the given node based on its attributes.
+    load(settings, section): Loads settings from a specified section.
+    save(settings, section): Saves the current settings to a specified section.
+    time_estimate(): Estimates the time required for the operation based on its parameters.
+    preprocess(context, matrix, plan): Preprocesses the operation for execution based on the provided context and matrix.
+    as_cutobjects(closed_distance=15, passes=1): Generates cut objects for the image operation.
+"""
+
 from math import isnan
 
 from meerk40t.core.cutcode.rastercut import RasterCut
@@ -238,7 +260,7 @@ class ImageOpNode(Node, Parameters):
         self.settings["native_rapid_speed"] = self.rapid_speed * native_mm
         for node in self.children:
             if self.overrule_dpi and self.dpi:
-                node.dpi = self.dpi 
+                node.dpi = self.dpi
 
             def actual(image_node):
                 def process_images():
@@ -296,7 +318,7 @@ class ImageOpNode(Node, Parameters):
             horizontal = False
             start_on_left = False
             start_on_top = False
-            if direction == 0 or direction == 4:
+            if direction in [0, 4]:
                 horizontal = True
                 start_on_top = True
             elif direction == 1:


### PR DESCRIPTION
- ``e = copy(n)`` with n being an instance of an ImageNode would lead to a recalculation of the processed image although it could just be copied over: changed
- n.active_image would immediately start a recaclulation of the image even if the processing action was still running. (Taking up to 2 times as long as ideally needed). Will wait now for a second before it calls it a day and asks for a recalculation. Probably not ideal but I was heistant to have an eternal wait loop.