### PR TITLE
Foolproof column width

### DIFF
--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -1098,9 +1098,11 @@ class CameraURIPanel(wx.Panel):
 
     def pane_show(self):
         self.on_list_refresh()
+        self.list_uri.load_column_widths()
 
     def pane_hide(self):
         self.commit()
+        self.list_uri.save_column_widths()
 
     def commit(self):
         if not self.changed:

--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -1943,6 +1943,11 @@ class ComponentPanel(ScrolledPanel):
             # print ("couldn't access clipboard")
             wx.Bell()
 
+    def pane_show(self):
+        self.list_preview.load_column_widths()
+    
+    def pane_hide(self):
+        self.list_preview.save_column_widths()
 
 class About(MWindow):
     def __init__(self, *args, **kwds):

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -86,7 +86,7 @@ class FontGlyphPicker(wx.Dialog):
 
         self.list_glyphs.Bind(wx.EVT_LEFT_DCLICK, self.on_dbl_click)
         self.SetSizer(mainsizer)
-
+        self.list_glyphs.load_column_widths()
         self.Layout()
         # end wxGlade
         self.load_font()

--- a/meerk40t/gui/keymap.py
+++ b/meerk40t/gui/keymap.py
@@ -48,9 +48,10 @@ class KeymapPanel(wx.Panel):
     def pane_show(self):
         self.reload_keymap()
         self.Children[0].SetFocus()
+        self.list_keymap.load_column_widths()
 
     def pane_hide(self):
-        pass
+        self.list_keymap.save_column_widths()
 
     def __set_properties(self):
         self.list_keymap.SetToolTip(_("What keys are bound to which actions?"))

--- a/meerk40t/gui/operation_info.py
+++ b/meerk40t/gui/operation_info.py
@@ -175,10 +175,10 @@ class OpInfoPanel(ScrolledPanel):
         self.refresh_data()
 
     def pane_show(self):
-        pass
+        self.list_operations.load_column_widths()
 
     def pane_hide(self):
-        pass
+        self.list_operations.save_column_widths()
 
     def on_tree_popup_mark_elem(self, elemtype=""):
         def emphas(event=None):

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -654,10 +654,14 @@ class ImageModificationPanel(ScrolledPanel):
             menu.Destroy()
 
     def pane_show(self):
+        self.list_operations.load_column_widths()
         self.fill_operations()
 
     def pane_active(self):
         self.fill_operations()
+
+    def pane_hide(self):
+        self.list_operations.save_column_widths()
 
     def signal(self, signalstr, myargs):
         return

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -1158,6 +1158,14 @@ class SpoolerPanel(wx.Panel):
     def update_queue(self):
         if self.shown:
             self.on_device_update(None)
+    
+    def pane_show(self):
+        self.list_job_history.load_column_widths()
+        self.list_job_spool.load_column_widths()
+
+    def pane_hide(self):
+        self.list_job_history.save_column_widths()
+        self.list_job_spool.save_column_widths()
 
 
 class JobSpooler(MWindow):

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -388,11 +388,14 @@ class WordlistPanel(wx.Panel):
         self.parent_panel = par_panel
 
     def pane_show(self):
+        self.grid_wordlist.load_column_widths()
+        self.grid_content.load_column_widths()
         self.populate_gui()
         self.grid_wordlist.SetFocus()
 
     def pane_hide(self):
-        pass
+        self.grid_wordlist.save_column_widths()
+        self.grid_content.save_column_widths()
 
     def autosave(self):
         if self.check_autosave.GetValue():

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -1098,7 +1098,7 @@ class wxListCtrl(wx.ListCtrl):
         if self.context is None or self.list_name is None:
             return
         sizes = list()
-        for col in range(self.ColumnCount):
+        for col in range(self.GetColumnCount()):
             sizes.append(self.GetColumnWidth(col)) 
         self.context.setting(tuple, self.list_name, None)
         setattr(self.context, self.list_name, sizes)
@@ -1110,7 +1110,7 @@ class wxListCtrl(wx.ListCtrl):
         if sizes is None:
             return
         # print(f"Found for {self.list_name}: {sizes}")
-        available = self.ColumnCount
+        available = self.GetColumnCount()
         for idx, width in enumerate(sizes):
             if idx >= available:
                 break
@@ -1137,14 +1137,20 @@ class wxListCtrl(wx.ListCtrl):
         list_width = size[0]
         total = gap
         last = 0
-        for col in range(self.ColumnCount):
+        for col in range(self.GetColumnCount()):
             last = self.GetColumnWidth(col)
             total += last 
-        # print(f"{self.list_name}, cols={self.ColumnCount}, available={list_width}, used={total}")
+        # print(f"{self.list_name}, cols={self.GetColumnCount()}, available={list_width}, used={total}")
         if total < list_width:
-            col = self.ColumnCount - 1 
+            col = self.GetColumnCount() - 1 
+            if col < 0 :
+                return False
             # print(f"Will adjust last column from {last} to {last + (list_width - total)}")
-            self.SetColumnWidth(col, last + (list_width - total))
+            try:
+                self.SetColumnWidth(col, last + (list_width - total))
+            except Exception as e:
+                print(f"Something strange happened while resizing the last columns for {self.list_name}: {e}")
+                return False
             return True
         return False
 
@@ -1152,7 +1158,7 @@ class wxListCtrl(wx.ListCtrl):
         # We are not touching the event object to allow other routines to tap into it
         event.Skip()
         # print (f"Resize called from {self.GetId()} - {self.list_name}: {event.Size}")
-        if self.adjust_last_column(event.Size):    
+        if self.adjust_last_column(event.Size): 
             self.save_column_widths()
 
 


### PR DESCRIPTION
## Summary by Sourcery

Improve column width management by using GetColumnCount() instead of ColumnCount and add load/save functionality for column widths in various GUI components.

Enhancements:
- Replace direct access to ColumnCount with GetColumnCount() for improved robustness in column width handling.
- Add exception handling in adjust_last_column to prevent errors during column resizing.