### PR TITLE
Add info tooltips

### DIFF
--- a/meerk40t/gui/gui_mixins.py
+++ b/meerk40t/gui/gui_mixins.py
@@ -318,6 +318,9 @@ class Warnings:
         )
         info_low.SetValue(txt_low)
         sizer.Add(info_low, 1, wx.EXPAND, 0)
+        info_hi.SetToolTip(_("Critical: might damage your laser (e.g. laserhead bumping into rail)"))
+        info_mid.SetToolTip(_("Normal: might ruin your burn (e.g. unassigned=unburnt elements)"))
+        info_low.SetToolTip(_("Low: I hope you know what your doing (e.g. disabled operations)"))
 
         choices = []
         prechoices = self.context.lookup("choices/preferences")

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -235,7 +235,12 @@ and a wxpython version <= 4.1.1."""
                 ),
                 "choices": (1, 2, 3, 4),
                 "label": _("Level"),
-                "tip": _("Which warning severity level do you want to recognize"),
+                "tip": (
+                    _("Which warning severity level do you want to recognize") + "\n" +
+                    _("Critical: might damage your laser (e.g. laserhead bumping into rail)") + "\n" +
+                    _("Normal: might ruin your burn (e.g. unassigned=unburnt elements)") + "\n" +
+                    _("Low: I hope you know what your doing (e.g. disabled operations)") 
+                ),
                 "page": "Gui",
                 "section": "Warning-Indicator",
                 "signals": ("icons", "warn_state_update"),

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1076,16 +1076,19 @@ class ShadowTree:
 
         self.wxtree.Expand(op_item)
         unassigned, unburnt = self.elements.have_unburnable_elements()
-        if unassigned or unburnt:
+        needs_showing = False
+        warn_level = self.context.setting(int, "concern_level", 1)
+        messages = []
+        if unassigned and warn_level <= 2:
+            needs_showing = True
+            messages.append( _("You have unassigned elements, that won't be burned") )
+        if unburnt and warn_level <= 1:
+            needs_showing = True
+            messages.append( _("You have elements in disabled operations, that won't be burned") )
+
+        if needs_showing:
             self.wxtree.SetItemState(op_item, self.iconstates["warning"])
-            s1 = _("You have elements in disabled operations, that won't be burned")
-            s2 = _("You have unassigned elements, that won't be burned")
-            if unassigned and unburnt:
-                status = s1 + "\n" + s2
-            elif unburnt:
-                status = s1
-            elif unassigned:
-                status = s2
+            status = "\n".join(messages)
         else:
             self.wxtree.SetItemState(op_item, wx.TREE_ITEMSTATE_NONE)
             status = ""


### PR DESCRIPTION
- Recognize setting for tree warnsymbol
- Add explanations to preference option

![grafik](https://github.com/user-attachments/assets/b84a4031-1ceb-46e7-8535-8adc43d8f777)
Resolves #2581

## Summary by Sourcery

Introduce tooltips to explain warning severity levels in the GUI and enhance the logic for displaying warning messages based on these levels.

New Features:
- Add tooltips to provide explanations for different warning severity levels in the GUI.

Enhancements:
- Improve the logic for displaying warning messages based on user-defined severity levels.