### PR TITLE
Improved / more logical drag handling

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -378,7 +378,7 @@ def init_tree(kernel):
 
             for gnode in to_treat:
                 for n in list(gnode.children):
-                    gnode.insert_sibling(n)
+                    gnode.insert_sibling(n, below=False)
                 gnode.remove_node()  # Removing group/file node.
 
     @tree_conditional(lambda node: not is_regmark(node))

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -2214,7 +2214,7 @@ class Elemental(Service):
         self.last_file_autoexec_active = False
         self.signal("autoexec")
 
-    def drag_and_drop(self, dragging_nodes, drop_node):
+    def drag_and_drop(self, dragging_nodes, drop_node, flag=False):
         data = dragging_nodes
         success = False
         to_classify = []
@@ -2284,8 +2284,8 @@ class Elemental(Service):
             if op_treatment and drag_node.has_ancestor("branch reg"):
                 # We need to first relocate the drag_node to the elem branch
                 # print(f"Relocate {drag_node.type} to elem branch")
-                self.elem_branch.drop(drag_node)
-            if drop_node.drop(drag_node, modify=False):
+                self.elem_branch.drop(drag_node, flag=flag)
+            if drop_node.drop(drag_node, modify=False, flag=flag):
                 # Is the drag node coming from the regmarks branch?
                 # If yes then we might need to classify.
                 if drag_node.has_ancestor("branch reg"):
@@ -2294,7 +2294,7 @@ class Elemental(Service):
                             to_classify.append(e)
                     else:
                         to_classify.append(drag_node)
-                drop_node.drop(drag_node, modify=True)
+                drop_node.drop(drag_node, modify=True, flag=flag)
                 success = True
             else:
                 # print(f"Drag {drag_node.type} to {drop_node.type} - Drop node vetoed")

--- a/meerk40t/core/node/blobnode.py
+++ b/meerk40t/core/node/blobnode.py
@@ -33,7 +33,7 @@ class BlobNode(Node):
         default_map["length"] = d
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         return False
 
     def allow_save(self):

--- a/meerk40t/core/node/branch_elems.py
+++ b/meerk40t/core/node/branch_elems.py
@@ -16,7 +16,7 @@ class BranchElementsNode(Node):
         default_map["element_type"] = "Elements"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.append_child(drag_node)
@@ -25,6 +25,17 @@ class BranchElementsNode(Node):
             if modify:
                 self.append_child(drag_node)
             return True
+        return False
+    
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type == "group":
+                return True
         return False
 
     def is_draggable(self):

--- a/meerk40t/core/node/branch_ops.py
+++ b/meerk40t/core/node/branch_ops.py
@@ -26,12 +26,23 @@ class BranchOperationsNode(Node):
                 default_map["loops"] = ""
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         if drag_node.type.startswith("op"):
             # Dragging operation to op branch to effectively move to bottom.
             if modify:
                 self.append_child(drag_node)
             return True
+        return False
+        
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.type.startswith("op"):
+                return True
         return False
 
     def is_draggable(self):

--- a/meerk40t/core/node/branch_regmark.py
+++ b/meerk40t/core/node/branch_regmark.py
@@ -24,7 +24,7 @@ class BranchRegmarkNode(Node):
         for ref in list(node.children):
             self.remove_references(ref)
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
                 self.remove_references(drag_node)
@@ -35,6 +35,17 @@ class BranchRegmarkNode(Node):
                 self.remove_references(drag_node)
                 self.append_child(drag_node)
             return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type == "group":
+                return True
         return False
 
     def is_draggable(self):

--- a/meerk40t/core/node/cutnode.py
+++ b/meerk40t/core/node/cutnode.py
@@ -25,7 +25,7 @@ class CutNode(Node):
         default_map["element_type"] = "Cutcode"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         return False
 
     def as_cutobjects(self, closed_distance=15):

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -278,7 +278,7 @@ class HatchEffectNode(Node, Suppressable):
     def modified(self):
         self.altered()
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("effect"):
             if modify:
@@ -308,7 +308,7 @@ class HatchEffectNode(Node, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect
@@ -319,4 +319,15 @@ class HatchEffectNode(Node, Suppressable):
                     self.append_child(drag_node)
                 self.altered()
             return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+                return True
         return False

--- a/meerk40t/core/node/effect_warp.py
+++ b/meerk40t/core/node/effect_warp.py
@@ -205,7 +205,7 @@ class WarpEffectNode(Node, FunctionalParameter):
     def modified(self):
         self.altered()
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("effect"):
             if modify:
@@ -235,7 +235,7 @@ class WarpEffectNode(Node, FunctionalParameter):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect
@@ -246,6 +246,17 @@ class WarpEffectNode(Node, FunctionalParameter):
                     self.append_child(drag_node)
                 self.altered()
             return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+                return True
         return False
 
     @property

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -373,7 +373,7 @@ class WobbleEffectNode(Node, Suppressable):
     def modified(self):
         self.altered()
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.type.startswith("effect"):
             if modify:
@@ -403,7 +403,7 @@ class WobbleEffectNode(Node, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect
@@ -414,4 +414,15 @@ class WobbleEffectNode(Node, Suppressable):
                     self.append_child(drag_node)
                 self.altered()
             return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+                return True
         return False

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -260,7 +260,7 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -271,7 +271,23 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -314,7 +314,7 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         default_map["element_type"] = "Image"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -323,7 +323,23 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -234,7 +234,7 @@ class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -245,7 +245,23 @@ class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -200,7 +200,7 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -211,7 +211,23 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -84,7 +84,7 @@ class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -95,7 +95,23 @@ class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -231,7 +231,7 @@ class PolylineNode(
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -242,7 +242,23 @@ class PolylineNode(
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -239,7 +239,7 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -250,7 +250,23 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
             # then we will reverse the game, but we will take the operations color
             if hasattr(drag_node, "color") and drag_node.color is not None:
                 self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -195,7 +195,7 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -204,7 +204,23 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                # drag_node.type in ("file", "group") or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/filenode.py
+++ b/meerk40t/core/node/filenode.py
@@ -33,13 +33,28 @@ class FileNode(Node):
             candidate = candidate.parent
         return False
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Do not allow dragging onto children
         if self.is_a_child_of(drag_node):
             return False
         if drag_node.type == "group":
             if modify:
                 self.append_child(drag_node)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if self.is_a_child_of(drag_node):
+                continue
+            if (
+                drag_node.type == "group"
+            ):
+                return True
         return False
 
     @property

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -102,7 +102,7 @@ class GroupNode(Node, LabelDisplay):
             candidate = candidate.parent
         return False
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Do not allow dragging onto children
         if self.is_a_child_of(drag_node):
             return False
@@ -120,7 +120,25 @@ class GroupNode(Node, LabelDisplay):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if self.is_a_child_of(drag_node):
+                continue
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                drag_node.type == "group" or
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     @property

--- a/meerk40t/core/node/image_processed.py
+++ b/meerk40t/core/node/image_processed.py
@@ -162,7 +162,7 @@ class ImageProcessedNode(Node):
         default_map["element_type"] = "Image"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -171,7 +171,22 @@ class ImageProcessedNode(Node):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/image_raster.py
+++ b/meerk40t/core/node/image_raster.py
@@ -91,7 +91,7 @@ class ImageRasterNode(Node):
         default_map["element_type"] = "Image"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             if modify:
@@ -100,7 +100,22 @@ class ImageRasterNode(Node):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify)
+            return drag_node.drop(self, modify=modify, flag=flag)
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                hasattr(drag_node, "as_geometry") or 
+                hasattr(drag_node, "as_image") or 
+                drag_node.type.startswith("op")
+            ):
+                return True
         return False
 
     def notify_scaled(self, *args, **kwargs):

--- a/meerk40t/core/node/layernode.py
+++ b/meerk40t/core/node/layernode.py
@@ -23,7 +23,7 @@ class LayerNode(Node):
             if hasattr(self.parent, "activate"):
                 self.parent.activate(self.layer_name)
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         return False
 
     @property

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1134,16 +1134,25 @@ class Node:
         if new_child is None:
             return
         new_parent = self
+        belonged_to_me = bool(new_child.parent is self)
         if new_child.parent is not None:
             source_siblings = new_child.parent.children
+            if belonged_to_me and source_siblings.index(new_child) == 0:
+                # The very first will be moved to the end
+                belonged_to_me = False
             source_siblings.remove(new_child)  # Remove child
         destination_siblings = new_parent.children
 
         new_child.notify_detached(new_child)
 
-        destination_siblings.append(new_child)  # Add child.
-        new_child._parent = new_parent
-        new_child.notify_attached(new_child)
+        if belonged_to_me:
+            destination_siblings.insert(0, new_child)
+            new_child._parent = new_parent
+            new_child.notify_attached(new_child, pos=0)
+        else:
+            destination_siblings.append(new_child)  # Add child.
+            new_child._parent = new_parent
+            new_child.notify_attached(new_child)
 
     def insert_sibling(self, new_sibling, below=True):
         """

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1141,7 +1141,7 @@ class Node:
         new_child._parent = new_parent
         new_child.notify_attached(new_child)
 
-    def insert_sibling(self, new_sibling):
+    def insert_sibling(self, new_sibling, below=True):
         """
         Add the new_sibling node next to the current node.
         If the node exists elsewhere in the tree it will be removed from that location.
@@ -1150,9 +1150,10 @@ class Node:
         source_siblings = new_sibling.parent.children
         destination_siblings = reference_sibling.parent.children
 
-        reference_position = destination_siblings.index(reference_sibling)
-
         source_siblings.remove(new_sibling)
+        reference_position = destination_siblings.index(reference_sibling)
+        if below:
+            reference_position += 1
 
         new_sibling.notify_detached(new_sibling)
         destination_siblings.insert(reference_position, new_sibling)

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -581,8 +581,12 @@ class Node:
 
     def is_draggable(self):
         return True
+    
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        return False
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         """
         Process drag and drop node values for tree reordering.
 

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -114,7 +114,7 @@ class CutOpNode(Node, Parameters):
 
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if hasattr(drag_node, "as_geometry"):
             if (
@@ -128,7 +128,7 @@ class CutOpNode(Node, Parameters):
             return True
         elif drag_node.type == "reference":
             # Disallow drop of image refelems onto a Dot op.
-            if not drag_node.node.type in self._allowed_elements_dnd:
+            if drag_node.node.type not in self._allowed_elements_dnd:
                 return False
             # Move a refelem to end of op.
             if modify:
@@ -150,6 +150,28 @@ class CutOpNode(Node, Parameters):
                         self.add_reference(e)
                     some_nodes = True
             return some_nodes
+        return False    
+    
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                (
+                    hasattr(drag_node, "as_geometry") and
+                    drag_node.type in self._allowed_elements_dnd
+ 
+                ) or 
+                drag_node.type in ("file", "group") or 
+                drag_node.type in op_nodes or
+                drag_node.type == "reference"
+            ):
+                return True
         return False
 
     def has_color_attribute(self, attribute):

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -70,7 +70,7 @@ class DotsOpNode(Node, Parameters):
             default_map["ppi"] = f"{self.power:.0f}"
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if hasattr(drag_node, "as_geometry"):
             if (
@@ -105,6 +105,30 @@ class DotsOpNode(Node, Parameters):
                     self.add_reference(e)
                 some_nodes = True
             return some_nodes
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                (
+                    hasattr(drag_node, "as_geometry") and
+                    drag_node.type in self._allowed_elements_dnd
+                ) or 
+                (   
+                    drag_node.type in ("file", "group") and not 
+                    drag_node.has_ancestor("branch reg")
+                ) or
+                drag_node.type in op_nodes or
+                drag_node.type == "reference"
+            ):
+                return True
         return False
 
     def has_color_attribute(self, attribute):

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -100,7 +100,7 @@ class EngraveOpNode(Node, Parameters):
         )
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if hasattr(drag_node, "as_geometry"):
             if (
@@ -136,6 +136,27 @@ class EngraveOpNode(Node, Parameters):
                         self.add_reference(e)
                     some_nodes = True
             return some_nodes
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                (
+                    hasattr(drag_node, "as_geometry") and
+                    drag_node.type in self._allowed_elements_dnd
+                ) or 
+                drag_node.type in ("file", "group") or 
+                drag_node.type in op_nodes or
+                drag_node.type == "reference"
+            ):
+                return True
         return False
 
     def has_color_attribute(self, attribute):

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -106,7 +106,7 @@ class ImageOpNode(Node, Parameters):
         )
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if hasattr(drag_node, "as_image"):
             if drag_node.has_ancestor("branch reg"):
@@ -140,6 +140,27 @@ class ImageOpNode(Node, Parameters):
                         self.add_reference(e)
                     some_nodes = True
             return some_nodes
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                (
+                    hasattr(drag_node, "as_image") and
+                    drag_node.type in self._allowed_elements_dnd 
+                ) or 
+                drag_node.type in ("file", "group") or 
+                drag_node.type in op_nodes or
+                drag_node.type == "reference"
+            ):
+                return True
         return False
 
     def is_referenced(self, node):

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -119,7 +119,7 @@ class RasterOpNode(Node, Parameters):
         )
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         count = 0
         existing = 0
         result = False
@@ -165,6 +165,24 @@ class RasterOpNode(Node, Parameters):
                 some_nodes = True
             result = some_nodes
         return result
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                drag_node.type in self._allowed_elements_dnd or
+                drag_node.type in ("file", "group") or 
+                drag_node.type in op_nodes or
+                drag_node.type == "reference"
+            ):
+                return True
+        return False
 
     def has_color_attribute(self, attribute):
         return attribute in self.allowed_attributes

--- a/meerk40t/core/node/place_current.py
+++ b/meerk40t/core/node/place_current.py
@@ -36,5 +36,5 @@ class PlaceCurrentNode(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         return False

--- a/meerk40t/core/node/place_point.py
+++ b/meerk40t/core/node/place_point.py
@@ -327,5 +327,5 @@ class PlacePointNode(Node):
 
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         return False

--- a/meerk40t/core/node/refnode.py
+++ b/meerk40t/core/node/refnode.py
@@ -29,7 +29,7 @@ class ReferenceNode(Node):
         default_map["ref_id"] = str(self.id)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image"):
             op = self.parent
             drop_index = op.children.index(self)
@@ -40,6 +40,23 @@ class ReferenceNode(Node):
             if modify:
                 self.insert_sibling(drag_node)
             return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if drag_node.has_ancestor("branch reg"):
+                continue
+            if (
+                hasattr(drag_node, "as_geometry") or
+                hasattr(drag_node, "as_image") or 
+                drag_node.type == "reference"
+            ):
+                return True
         return False
 
     def notify_destroyed(self, node=None, **kwargs):

--- a/meerk40t/core/node/util_console.py
+++ b/meerk40t/core/node/util_console.py
@@ -28,17 +28,25 @@ class ConsoleOperation(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False    
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def generate(self):

--- a/meerk40t/core/node/util_goto.py
+++ b/meerk40t/core/node/util_goto.py
@@ -38,17 +38,25 @@ class GotoOperation(Node):
         default_map["absolute"] = "=" if self.absolute else ""
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def preprocess(self, context, matrix, plan):

--- a/meerk40t/core/node/util_home.py
+++ b/meerk40t/core/node/util_home.py
@@ -32,17 +32,25 @@ class HomeOperation(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def as_cutobjects(self, closed_distance=15, passes=1):

--- a/meerk40t/core/node/util_input.py
+++ b/meerk40t/core/node/util_input.py
@@ -76,17 +76,25 @@ class InputOperation(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def as_cutobjects(self, closed_distance=15, passes=1):

--- a/meerk40t/core/node/util_output.py
+++ b/meerk40t/core/node/util_output.py
@@ -76,17 +76,25 @@ class OutputOperation(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def as_cutobjects(self, closed_distance=15, passes=1):

--- a/meerk40t/core/node/util_wait.py
+++ b/meerk40t/core/node/util_wait.py
@@ -36,17 +36,25 @@ class WaitOperation(Node):
         default_map.update(self.__dict__)
         return default_map
 
-    def drop(self, drag_node, modify=True):
+    def drop(self, drag_node, modify=True, flag=False):
         drop_node = self
         if drag_node.type in op_nodes:
             if modify:
                 drop_node.insert_sibling(drag_node)
             return True
-        elif drop_node.type == "branch ops":
-            # Dragging operation to op branch to effectively move to bottom.
-            if modify:
-                drop_node.append_child(drag_node)
-            return True
+        return False
+
+    def would_accept_drop(self, drag_nodes):
+        # drag_nodes can be a single node or a list of nodes
+        if isinstance(drag_nodes, (list, tuple)):
+            data = drag_nodes
+        else:
+            data = list(drag_nodes)
+        for drag_node in data:
+            if (
+                drag_node.type in op_nodes
+            ):
+                return True
         return False
 
     def as_cutobjects(self, closed_distance=15, passes=1):

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1941,7 +1941,7 @@ class ShadowTree:
         if self.dragging_nodes is None:
             event.Skip()
             return
-
+        self.wxtree.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
         drop_item = event.GetItem()
         if drop_item is None or drop_item.ID is None:
             event.Skip()
@@ -1988,6 +1988,17 @@ class ShadowTree:
             state = self.wxtree.GetItemState(item)
             node = self.wxtree.GetItemData(item)
             if node is not None:
+                # Lets check the dragging status
+                if self.dragging_nodes is not None:
+                    if hasattr(node, "would_accept_drop"):
+                        would_drop = node.would_accept_drop(self.dragging_nodes)
+                    else:
+                        would_drop = False
+                    if would_drop:
+                        self.wxtree.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+                    else:
+                        self.wxtree.SetCursor(wx.Cursor(wx.CURSOR_NO_ENTRY))
+
                 if hasattr(node, "_tooltip"):
                     # That has precedence and will be displayed in all cases
                     ttip = node._tooltip


### PR DESCRIPTION
Addresses the concerns raised in Discord about the visual (non-)representation of the drag and drop operation:
- By default drag and drop within the same hierarchy will insert the dragged node *below* the drop node
- A drag to the root branches will insert the dragged node on top of the list, if it's a a top-level node (before it was added to the end)
- Visual indicator if you can drop the dragged nodes on the target node