### PR TITLE
Windows restore

### DIFF
--- a/meerk40t/gui/mwindow.py
+++ b/meerk40t/gui/mwindow.py
@@ -122,6 +122,10 @@ class MWindow(wx.Frame, Module):
     def window_open(self):
         pass
 
+    def restore(self, *args, **kwargs):
+        if self.IsIconized():
+            self.Iconize(False)
+
     def window_close(self):
         pass
 

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -713,7 +713,14 @@ class wxMeerK40t(wx.App, Module):
                     raise CommandSyntaxError
             else:  # Toggle.
                 if window_class is not None:
-                    if window_name in path.opened:
+                    to_be_closed = bool(window_name in path.opened)
+                    if to_be_closed:
+                        win = path.opened[window_name]
+                        if hasattr(win, "IsIconized") and win.IsIconized():
+                            # Minimized windows will reappear first
+                            to_be_closed = False
+
+                    if to_be_closed:
                         if wx.IsMainThread():
                             window_close(None)
                         else:


### PR DESCRIPTION
Addresses issue #2644

## Summary by Sourcery

Bug Fixes:
- Fix an issue where minimized windows would not restore properly when toggled.