### PR TITLE
Effect recombination for faster optimization

### DIFF
--- a/meerk40t/core/cutcode/cutgroup.py
+++ b/meerk40t/core/cutcode/cutgroup.py
@@ -19,6 +19,7 @@ class CutGroup(list, CutObject, ABC):
         constrained=False,
         closed=False,
         color=None,
+        origin=None,
     ):
         list.__init__(self, children)
         CutObject.__init__(
@@ -27,6 +28,7 @@ class CutGroup(list, CutObject, ABC):
         self.closed = closed
         self.constrained = constrained
         self.burn_started = False
+        self.origin = origin
 
     def __copy__(self):
         return CutGroup(self.parent, self)
@@ -109,7 +111,7 @@ class CutGroup(list, CutObject, ABC):
                             break
                     else:
                         candidates.remove(grp)
-            if len(candidates) == 0:
+            if not candidates:
                 candidates = list(self)
 
         for grp in candidates:

--- a/meerk40t/core/cutcode/cutgroup.py
+++ b/meerk40t/core/cutcode/cutgroup.py
@@ -20,6 +20,7 @@ class CutGroup(list, CutObject, ABC):
         closed=False,
         color=None,
         origin=None,
+        skip=False
     ):
         list.__init__(self, children)
         CutObject.__init__(
@@ -29,6 +30,7 @@ class CutGroup(list, CutObject, ABC):
         self.constrained = constrained
         self.burn_started = False
         self.origin = origin
+        self.skip = skip 
 
     def __copy__(self):
         return CutGroup(self.parent, self)

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 import numpy as np
 
-from ..svgelements import Group, Polygon, Matrix, Path
+from ..svgelements import Group, Matrix, Path, Polygon
 from ..tools.geomstr import Geomstr
 from ..tools.pathtools import VectorMontonizer
 from .cutcode.cutcode import CutCode
@@ -94,7 +94,7 @@ class CutPlan:
             # Executing command can add a command, complete them all.
             commands = self.commands[:]
             self.commands.clear()
-            for command in commands:                
+            for command in commands:
                 command()
                 self._debug_me(f"At end of {command.__name__}")
 
@@ -475,7 +475,9 @@ class CutPlan:
                         self.channel(f"  {type(cut).__name__}: --childless--")
 
             elif hasattr(pitem, "children"):
-                self.channel(f"  {type(pitem).__name__}: {len(pitem.children)} children")
+                self.channel(
+                    f"  {type(pitem).__name__}: {len(pitem.children)} children"
+                )
             else:
                 self.channel(f"  {type(pitem).__name__}: --childless--")
 
@@ -601,9 +603,10 @@ class CutPlan:
 
     def combine_effects(self):
         """
-        Will browse through the cutcode entries grouping everything together 
+        Will browse through the cutcode entries grouping everything together
         that as a common 'source' attribute
         """
+
         def update_group_sequence(group):
             if len(group) == 0:
                 return
@@ -630,19 +633,23 @@ class CutPlan:
             grouping = {}
             l_pitem = len(pitem)
             for idx, cut in enumerate(pitem):
-                total += 1 
+                total += 1
                 if busy.shown and total % 50 == 0:
                     busy.change(
-                        msg=_("Combine effect primitives") + f" {idx + 1}/{l_pitem} ({plan_idx + 1}/{l_plan})", keep=1
+                        msg=_("Combine effect primitives")
+                        + f" {idx + 1}/{l_pitem} ({plan_idx + 1}/{l_plan})",
+                        keep=1,
                     )
-                    busy.show()            
+                    busy.show()
                 if not isinstance(cut, CutGroup) or cut.origin is None:
                     continue
                 if cut.origin not in grouping:
                     # First instance
                     grouping[cut.origin] = idx
                     if self.channel:
-                        self.channel (f"New group: {cut.origin} - items at start: {len(cut)}")
+                        self.channel(
+                            f"New group: {cut.origin} - items at start: {len(cut)}"
+                        )
                     group_count += 1
                 else:
                     mastercut = grouping[cut.origin]
@@ -655,14 +662,14 @@ class CutPlan:
                     to_be_deleted.append(idx)
                     combined += 1
             for key, item in grouping.items():
-                # Reestablish 
+                # Reestablish
                 update_group_sequence(pitem[item])
                 if self.channel:
                     self.channel(f"Group: {key} - items at end: {len(pitem[item])}")
             for p in reversed(to_be_deleted):
                 pitem.pop(p)
         if self.channel:
-            self.channel (f"Combined: {combined}, groups: {group_count}")
+            self.channel(f"Combined: {combined}, groups: {group_count}")
 
     def optimize_travel_2opt(self):
         """
@@ -781,7 +788,7 @@ class CutPlan:
                     )
                     c = self.plan[i]
                 if last is not None:
-                    c._start_x, c._start_y = last                    
+                    c._start_x, c._start_y = last
                 self.plan[i] = short_travel_cutcode(
                     c,
                     kernel=self.context.kernel,
@@ -938,6 +945,7 @@ def is_inside(inner, outer, tolerance=0):
     @param tolerance: 0
     @return: whether path1 is wholly inside path2.
     """
+
     def convex_geometry(raster) -> Geomstr:
         dx = raster.bounding_box[0]
         dy = raster.bounding_box[1]
@@ -1199,7 +1207,9 @@ def inner_first_ident(context: CutGroup, kernel=None, channel=None, tolerance=0)
             f"using {end_times[0] - start_times[0]:.3f} seconds CPU"
         )
         for outer in closed_groups:
-            channel(f"Outer {type(outer).__name__} contains: {len(outer.contains)} cutcode elements")
+            channel(
+                f"Outer {type(outer).__name__} contains: {len(outer.contains)} cutcode elements"
+            )
 
     return context
 

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -473,9 +473,13 @@ class CutPlan:
                 if debug_level > 0:
                     for cut in pitem:
                         if isinstance(cut, (tuple, list)):
-                            self.channel(f"--{type(pitem).__name__}: {type(cut).__name__}: {len(cut)} items")
+                            self.channel(
+                                f"--{type(pitem).__name__}: {type(cut).__name__}: {len(cut)} items"
+                            )
                         else:
-                            self.channel(f"--{type(pitem).__name__}: {type(cut).__name__}: --childless--")
+                            self.channel(
+                                f"--{type(pitem).__name__}: {type(cut).__name__}: --childless--"
+                            )
 
             elif hasattr(pitem, "children"):
                 self.channel(
@@ -609,7 +613,6 @@ class CutPlan:
         Will browse through the cutcode entries grouping everything together
         that as a common 'source' attribute
         """
-        from time import perf_counter
 
         def update_group_sequence(group):
             if len(group) == 0:
@@ -623,10 +626,6 @@ class CutPlan:
                 cut_obj.previous = group[i - 1]
             group.path = group._geometry.as_path()
 
-        tseq = 0
-        tdel = 0
-        tpath = 0
-        t_start = perf_counter()
         busy = self.context.kernel.busyinfo
         _ = self.context.kernel.translation
         if busy.shown:
@@ -662,33 +661,23 @@ class CutPlan:
                     group_count += 1
                 else:
                     mastercut = grouping[cut.origin]
-                    ta = perf_counter()
                     # We just extend the geometry and do the path conversion at the end
                     geom = cut._geometry
-                    tb = perf_counter()
-                    tpath += tb - ta
                     pitem[mastercut].skip = True
                     pitem[mastercut].extend(cut)
                     pitem[mastercut]._geometry.append(geom)
                     cut.clear()
                     to_be_deleted.append(idx)
                     combined += 1
-            t1 = perf_counter()
             for key, item in grouping.items():
                 # Reestablish
                 update_group_sequence(pitem[item])
                 if self.channel:
                     self.channel(f"Group: {key} - items at end: {len(pitem[item])}")
-            t2 = perf_counter()
             for p in reversed(to_be_deleted):
                 pitem.pop(p)
-            t3 = perf_counter()
-            tseq += t2 - t1
-            tdel += t3 - t2
-        t_end = perf_counter()
         if self.channel:
             self.channel(f"Combined: {combined}, groups: {group_count}")
-            self.channel(f"Overall time: {t_end-t_start:.2f}s, sequence:{tseq:.2f}s, deletion: {tdel:.2f}s, path: {tpath:.2f}s")
 
     def optimize_travel_2opt(self):
         """
@@ -1259,12 +1248,12 @@ def short_travel_cutcode(
         channel(f"Length at start: {start_length:.0f} steps")
     unordered = []
     context = copy(cutcontext)
-    for idx in range(len(context) -1, -1, -1):
+    for idx in range(len(context) - 1, -1, -1):
         c = context[idx]
         if isinstance(c, CutGroup) and c.skip:
             unordered.append(c)
             context.pop(idx)
-    
+
     curr = context.start
     curr = 0 if curr is None else complex(curr[0], curr[1])
 

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -470,9 +470,9 @@ class CutPlan:
             if isinstance(pitem, (tuple, list)):
                 for cut in pitem:
                     if isinstance(cut, (tuple, list)):
-                        self.channel(f"  {type(cut).__name__}: {len(cut)} items")
+                        self.channel(f"  {type(pitem).__name__}: {type(cut).__name__}: {len(cut)} items")
                     else:
-                        self.channel(f"  {type(cut).__name__}: --childless--")
+                        self.channel(f"  {type(pitem).__name__}: {type(cut).__name__}: --childless--")
 
             elif hasattr(pitem, "children"):
                 self.channel(

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -638,6 +638,8 @@ class CutPlan:
         group_count = 0
         for plan_idx, pitem in enumerate(self.plan):
             # We don't combine across plan boundaries
+            if not isinstance(pitem, CutGroup):
+                continue
             grouping = {}
             l_pitem = len(pitem)
             for idx, cut in enumerate(pitem):
@@ -1223,7 +1225,7 @@ def inner_first_ident(context: CutGroup, kernel=None, channel=None, tolerance=0)
 
 
 def short_travel_cutcode(
-    cutcontext: CutCode,
+    context: CutCode,
     kernel=None,
     channel=None,
     complete_path: Optional[bool] = False,
@@ -1241,13 +1243,12 @@ def short_travel_cutcode(
     checks.
     """
     if channel:
-        start_length = cutcontext.length_travel(True)
+        start_length = context.length_travel(True)
         start_time = time()
         start_times = times()
         channel("Executing Greedy Short-Travel optimization")
         channel(f"Length at start: {start_length:.0f} steps")
     unordered = []
-    context = copy(cutcontext)
     for idx in range(len(context) - 1, -1, -1):
         c = context[idx]
         if isinstance(c, CutGroup) and c.skip:
@@ -1389,8 +1390,8 @@ def short_travel_cutcode(
     # print (f"And after extension {len(ordered)} items in list")
     # for c in ordered:
     #     print (f"{type(c).__name__} - {len(c) if isinstance(c, (list, tuple)) else '-childless-'}")
-    if cutcontext.start is not None:
-        ordered._start_x, ordered._start_y = cutcontext.start
+    if context.start is not None:
+        ordered._start_x, ordered._start_y = context.start
     else:
         ordered._start_x = 0
         ordered._start_y = 0

--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -805,6 +805,7 @@ class CutPlan:
                     channel=channel,
                     complete_path=self.context.opt_complete_subpaths,
                     grouped_inner=grouped_inner,
+                    hatch_optimize=self.context.opt_effect_optimize,
                 )
                 last = self.plan[i].end
 
@@ -1230,6 +1231,7 @@ def short_travel_cutcode(
     channel=None,
     complete_path: Optional[bool] = False,
     grouped_inner: Optional[bool] = False,
+    hatch_optimize: Optional[bool] = False,
 ):
     """
     Selects cutcode from candidate cutcode (burns_done < passes in this CutCode),
@@ -1385,6 +1387,11 @@ def short_travel_cutcode(
         curr = complex(end[0], end[1])
         ordered.append(c)
     # print (f"Now we have {len(ordered)} items in list")
+    if hatch_optimize:
+        for idx, c in enumerate(unordered):
+            if isinstance(c, CutGroup):
+                c.skip = False
+                unordered[idx] = short_travel_cutcode(context=c, kernel=kernel, complete_path=False, grouped_inner=False, channel=channel)
     # As these are reversed, we reverse again...
     ordered.extend(reversed(unordered))
     # print (f"And after extension {len(ordered)} items in list")

--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -1,3 +1,4 @@
+import itertools
 from copy import copy
 from math import sqrt
 
@@ -266,6 +267,32 @@ class HatchEffectNode(Node, Suppressable):
                 )
             )
         return path
+
+    def as_geometries(self, **kws):
+        """
+        Calculates the hatch effect geometries and returns the geometries 
+        for each pass and child object individually. 
+        The pass index is the number of copies of this geometry whereas the
+        internal loops value is rotated each pass by the angle-delta.
+
+        @param kws:
+        @return:
+        """
+        outlines = [
+            node.as_geometry(**kws)
+            for node in self.affected_children()
+            if hasattr(node, "as_geometry")
+        ]
+        if self._distance is None:
+            self.recalculate()
+        for p in range(self.loops):
+            for o in outlines:
+                yield Geomstr.hatch(
+                    o,
+                    distance=self._distance,
+                    angle=self._angle + p * self._angle_delta,
+                )
+
 
     def set_interim(self):
         self.empty_cache()

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -139,7 +139,7 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
 
     def final_geometry(self, **kws) -> Geomstr:
         """
-        This will resolve and apply all effektcs like tabs and dashes/dots
+        This will resolve and apply all effects like tabs and dashes/dots
         """
         unit_factor = kws.get("unitfactor", 1)
         x = self.x

--- a/meerk40t/core/node/nutils.py
+++ b/meerk40t/core/node/nutils.py
@@ -7,7 +7,7 @@ from meerk40t.core.cutcode.cutgroup import CutGroup
 from meerk40t.core.cutcode.linecut import LineCut
 from meerk40t.core.cutcode.quadcut import QuadCut
 from meerk40t.svgelements import Close, CubicBezier, Line, Move, Path, QuadraticBezier
-
+from meerk40t.tools.geomstr import Geomstr
 
 def path_to_cutobjects(
     path,
@@ -48,6 +48,7 @@ def path_to_cutobjects(
             origin=origin,
         )
         group.path = sp
+        group._geometry = Geomstr.svg(sp.d())
         group.original_op = original_op
         for seg in sp:
             if isinstance(seg, Move):

--- a/meerk40t/core/node/nutils.py
+++ b/meerk40t/core/node/nutils.py
@@ -18,6 +18,7 @@ def path_to_cutobjects(
     color=None,
     kerf=0,
     offset_routine=None,
+    origin=None,
 ):
     source = path
     if kerf != 0 and offset_routine is not None:
@@ -44,6 +45,7 @@ def path_to_cutobjects(
             settings=settings,
             passes=passes,
             color=color,
+            origin=origin,
         )
         group.path = sp
         group.original_op = original_op

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -376,7 +376,8 @@ class CutOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
+                # pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
+                pathlist.append( (None, path) )
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -376,7 +376,7 @@ class CutOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (f"{node.display_label()}_{perf_counter_ns}", path) )
+                pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -117,20 +117,28 @@ class CutOpNode(Node, Parameters):
     def can_drop(self, drag_node):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.has_ancestor("branch reg"):
-            # Will be dealt with in elements - 
+            # Will be dealt with in elements -
             # we don't implement a more sophisticated routine here
             return False
-        if hasattr(drag_node, "as_geometry") and drag_node.type in self._allowed_elements_dnd:
+        if (
+            hasattr(drag_node, "as_geometry")
+            and drag_node.type in self._allowed_elements_dnd
+        ):
             return True
-        elif drag_node.type == "reference" and drag_node.node.type in self._allowed_elements_dnd:
+        elif (
+            drag_node.type == "reference"
+            and drag_node.node.type in self._allowed_elements_dnd
+        ):
             return True
         elif drag_node.type in op_nodes:
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
-        return False    
-    
+            return any(
+                drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes)
+            )
+        return False
+
     def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if hasattr(drag_node, "as_geometry"):
@@ -167,8 +175,8 @@ class CutOpNode(Node, Parameters):
                         self.add_reference(e)
                     some_nodes = True
             return some_nodes
-        return False    
-    
+        return False
+
     def would_accept_drop(self, drag_nodes):
         # drag_nodes can be a single node or a list of nodes
         if isinstance(drag_nodes, (list, tuple)):
@@ -180,13 +188,12 @@ class CutOpNode(Node, Parameters):
                 continue
             if (
                 (
-                    hasattr(drag_node, "as_geometry") and
-                    drag_node.type in self._allowed_elements_dnd
- 
-                ) or 
-                drag_node.type in ("file", "group") or 
-                drag_node.type in op_nodes or
-                drag_node.type == "reference"
+                    hasattr(drag_node, "as_geometry")
+                    and drag_node.type in self._allowed_elements_dnd
+                )
+                or drag_node.type in ("file", "group")
+                or drag_node.type in op_nodes
+                or drag_node.type == "reference"
             ):
                 return True
         return False
@@ -351,8 +358,10 @@ class CutOpNode(Node, Parameters):
 
     def as_cutobjects(self, closed_distance=15, passes=1):
         """Generator of cutobjects for a particular operation."""
+
         def get_pathlist(node, factor):
             from time import perf_counter_ns
+
             pathlist = []
             if node.type == "reference":
                 node = node.node
@@ -366,40 +375,44 @@ class CutOpNode(Node, Parameters):
                                 (box[0], box[1]),
                                 (box[0], box[3]),
                                 (box[2], box[3]),
-                                (box[2], box[1]),                            
+                                (box[2], box[1]),
                             )
-                        )
+                        ),
                     )
                 )
             elif hasattr(node, "final_geometry"):
                 # This will deliver all relevant effects
                 # like tabs, dots/dashes applied to the element
-                path = node.final_geometry(unitfactor = factor).as_path()
+                path = node.final_geometry(unitfactor=factor).as_path()
                 path.approximate_arcs_with_cubics()
                 # pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
-                pathlist.append( (None, path) )
+                pathlist.append((None, path))
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (None, path) )
+                pathlist.append((None, path))
             elif node.type.startswith("effect"):
                 if hasattr(node, "as_geometries"):
                     pathlist.extend(
-                        (f"hatch_{idx}_{perf_counter_ns()}", effect_geom.as_path()) 
+                        (f"hatch_{idx}_{perf_counter_ns()}", effect_geom.as_path())
                         for idx, effect_geom in enumerate(list(node.as_geometries()))
                     )
                 else:
-                    pathlist.append( (None, node.as_geometry().as_path()) )
+                    pathlist.append((None, node.as_geometry().as_path()))
             else:
                 path = abs(Path(node.shape))
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (None, path) )
+                pathlist.append((None, path))
             return pathlist
-        
+
         settings = self.derive()
         factor = settings["native_mm"] / UNITS_PER_MM if "native_mm" in settings else 1
         for node in self.children:
-            if hasattr(node, "hidden") and node.hidden or node.type not in self._allowed_elements_dnd:
+            if (
+                hasattr(node, "hidden")
+                and node.hidden
+                or node.type not in self._allowed_elements_dnd
+            ):
                 continue
 
             pathlist = get_pathlist(node, factor)

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -328,7 +328,7 @@ class EngraveOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (f"{node.display_label()}_{perf_counter_ns}", path) )
+                pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -303,16 +303,11 @@ class EngraveOpNode(Node, Parameters):
 
     def as_cutobjects(self, closed_distance=15, passes=1):
         """Generator of cutobjects for a particular operation."""
-        from time import perf_counter_ns
-
-        settings = self.derive()
-        factor = settings["native_mm"] / UNITS_PER_MM if "native_mm" in settings else 1
-        for node in self.children:
+        def get_pathlist(node, factor):
+            from time import perf_counter_ns
             pathlist = []
             if node.type == "reference":
                 node = node.node
-            if getattr(node, "hidden", False):
-                continue
             if node.type == "elem image":
                 box = node.bbox()
                 pathlist.append(
@@ -323,7 +318,7 @@ class EngraveOpNode(Node, Parameters):
                                 (box[0], box[1]),
                                 (box[0], box[3]),
                                 (box[2], box[3]),
-                                (box[2], box[1]),
+                                (box[2], box[1]),                            
                             )
                         )
                     )
@@ -331,7 +326,6 @@ class EngraveOpNode(Node, Parameters):
             elif hasattr(node, "final_geometry"):
                 # This will deliver all relevant effects
                 # like tabs, dots/dashes applied to the element
-
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
                 pathlist.append( (f"{node.display_label()}_{perf_counter_ns}", path) )
@@ -347,13 +341,20 @@ class EngraveOpNode(Node, Parameters):
                     )
                 else:
                     pathlist.append( (None, node.as_geometry().as_path()) )
-            elif node.type not in self._allowed_elements_dnd:
-                # These aren't valid.
-                continue
             else:
                 path = abs(Path(node.shape))
                 path.approximate_arcs_with_cubics()
                 pathlist.append( (None, path) )
+            return pathlist
+
+        settings = self.derive()
+        factor = settings["native_mm"] / UNITS_PER_MM if "native_mm" in settings else 1
+        for node in self.children:
+            if hasattr(node, "hidden") and node.hidden or node.type not in self._allowed_elements_dnd:
+                continue
+
+            pathlist = get_pathlist(node, factor)
+
             try:
                 stroke = node.stroke
             except AttributeError:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -303,24 +303,29 @@ class EngraveOpNode(Node, Parameters):
 
     def as_cutobjects(self, closed_distance=15, passes=1):
         """Generator of cutobjects for a particular operation."""
+        from time import perf_counter_ns
+
         settings = self.derive()
-        if "native_mm" in settings:
-            factor = settings["native_mm"] / UNITS_PER_MM
-        else:
-            factor = 1
+        factor = settings["native_mm"] / UNITS_PER_MM if "native_mm" in settings else 1
         for node in self.children:
+            pathlist = []
             if node.type == "reference":
                 node = node.node
             if getattr(node, "hidden", False):
                 continue
             if node.type == "elem image":
                 box = node.bbox()
-                path = Path(
-                    Polygon(
-                        (box[0], box[1]),
-                        (box[0], box[3]),
-                        (box[2], box[3]),
-                        (box[2], box[1]),
+                pathlist.append(
+                    (
+                        None,
+                        Path(
+                            Polygon(
+                                (box[0], box[1]),
+                                (box[0], box[3]),
+                                (box[2], box[3]),
+                                (box[2], box[1]),
+                            )
+                        )
                     )
                 )
             elif hasattr(node, "final_geometry"):
@@ -329,27 +334,38 @@ class EngraveOpNode(Node, Parameters):
 
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
+                pathlist.append( (f"{node.display_label()}_{perf_counter_ns}", path) )
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()
+                pathlist.append( (None, path) )
             elif node.type.startswith("effect"):
-                path = node.as_geometry().as_path()
+                if hasattr(node, "as_geometries"):
+                    pathlist.extend(
+                        (f"hatch_{idx}_{perf_counter_ns()}", effect_geom.as_path()) 
+                        for idx, effect_geom in enumerate(list(node.as_geometries()))
+                    )
+                else:
+                    pathlist.append( (None, node.as_geometry().as_path()) )
             elif node.type not in self._allowed_elements_dnd:
                 # These aren't valid.
                 continue
             else:
                 path = abs(Path(node.shape))
                 path.approximate_arcs_with_cubics()
+                pathlist.append( (None, path) )
             try:
                 stroke = node.stroke
             except AttributeError:
                 # ImageNode does not have a stroke.
                 stroke = None
-            yield from path_to_cutobjects(
-                path,
-                settings=settings,
-                closed_distance=closed_distance,
-                passes=passes,
-                original_op=self.type,
-                color=stroke,
-            )
+            for origin, path in pathlist:
+                yield from path_to_cutobjects(
+                    path,
+                    settings=settings,
+                    closed_distance=closed_distance,
+                    passes=passes,
+                    original_op=self.type,
+                    color=stroke,
+                    origin=origin,
+                )

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -328,7 +328,8 @@ class EngraveOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor = factor).as_path()
                 path.approximate_arcs_with_cubics()
-                pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
+                # pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
+                pathlist.append( (None, path) )
             elif node.type == "elem path":
                 path = abs(node.path)
                 path.approximate_arcs_with_cubics()

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -271,7 +271,7 @@ def plugin(kernel, lifecycle=None):
             {
                 "attr": "opt_effect_optimize",
                 "object": context,
-                "default": True,
+                "default": False,
                 "type": bool,
                 "label": _("Optimize internally"),
                 "tip": (

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -256,6 +256,19 @@ def plugin(kernel, lifecycle=None):
                 "hidden": True,
             },
             {
+                "attr": "opt_effect_combine",
+                "object": context,
+                "default": True,
+                "type": bool,
+                "label": _("Don't break down effects"),
+                "tip": (
+                    _("Active: effects like hatches are dealt with as a bigger shape") + "\n" + 
+                    _("Inactive: every single line segment will be dealt with individually.")
+                ),
+                "page": "Optimisations",
+                "section": "_20_Reducing Movements",
+            },
+            {
                 "attr": "opt_reduce_details",
                 "object": context,
                 "default": False,

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -260,7 +260,7 @@ def plugin(kernel, lifecycle=None):
                 "object": context,
                 "default": True,
                 "type": bool,
-                "label": _("Don't break down effects"),
+                "label": _("Keep effect lines together"),
                 "tip": (
                     _("Active: effects like hatches are dealt with as a bigger shape") + "\n" + 
                     _("Inactive: every single line segment will be dealt with individually.")

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -262,11 +262,25 @@ def plugin(kernel, lifecycle=None):
                 "type": bool,
                 "label": _("Keep effect lines together"),
                 "tip": (
-                    _("Active: effects like hatches are dealt with as a bigger shape") + "\n" + 
+                    _("Active: effects like hatches are dealt with as a bigger shape") + "\n" +
                     _("Inactive: every single line segment will be dealt with individually.")
                 ),
                 "page": "Optimisations",
-                "section": "_20_Reducing Movements",
+                "section": "_25_Effects",
+            },
+            {
+                "attr": "opt_effect_optimize",
+                "object": context,
+                "default": True,
+                "type": bool,
+                "label": _("Optimize internally"),
+                "tip": (
+                    _("Active: hatch lines will be optimized internally") + "\n" +
+                    _("Inactive: hatch lines will be burnt sequentially.")
+                ),
+                "page": "Optimisations",
+                "section": "_25_Effects",
+                "conditional": (context, "opt_effect_combine"),
             },
             {
                 "attr": "opt_reduce_details",


### PR DESCRIPTION
Offers the opportunity to recombine hatches and wobbles to treat them as a single cut group, greatly reducing optimization time.

Needs thorough testing for all different kinds of optimization combinations.

Addresses issue #2638

From a functional perspective the reassembled effects will now be added to the end of the ordered list within  the optimize travel routine. They will not be reordered accordingly to minimize their travel (unless explicitly required)

So this will provide the intended use as a kind of post activity, eg to clean the surface on the object on a fibre laser, but will cause more laser head movements.
![Bildschirmfoto 2024-10-19 um 20 56 22](https://github.com/user-attachments/assets/09e2c6f6-0282-4ef5-bf0d-728b0042e7fb)

If you don't care for the sequence but more for minimizing the overall travel then you should disable the option:
![Bildschirmfoto 2024-10-19 um 20 58 29](https://github.com/user-attachments/assets/f682ba3c-cada-446e-b156-d4efc0b3a0da)


## Summary by Sourcery

Implement effect recombination to treat hatches and path-splitted effects as a single cut group, significantly reducing optimization time. Add debugging capabilities to monitor the optimization process.

New Features:
- Introduce a feature to recombine hatches and other path-splitted effects into a single cut group for optimization.

Enhancements:
- Add debugging functionality to track the execution and state of plans during optimization.

## Summary by Sourcery

Implement effect recombination to treat hatches and path-splitted effects as a single cut group, significantly reducing optimization time. Add debugging capabilities to monitor the optimization process.

New Features:
- Introduce a feature to recombine hatches and other path-splitted effects into a single cut group for optimization.

Enhancements:
- Add debugging functionality to track the execution and state of plans during optimization.