### PR TITLE
Fix warp effect

### DIFF
--- a/meerk40t/core/node/effect_warp.py
+++ b/meerk40t/core/node/effect_warp.py
@@ -145,12 +145,66 @@ class WarpEffectNode(Node, FunctionalParameter):
         pass
 
     def preprocess(self, context, matrix, plan):
-        pass
+        """
+        We need to adjust the internal warp parameters according to the matrix
+
+        p1 to p4 define the original rectangle - they will be recalculated in as_geometry, so no need to do it here
+        n1 to n4 define the skewed rectangle - again recalculated by applying d1 to d4 to p1 to p4
+        The problem is that the attribution of d1 to p1 and d2 to p2 etc. could be swapped
+        as the bbox might turn the sequence of points around
+
+        So lets have a look at where the old points would fall now
+        nx, ny, mx, my = b
+        self.p1 = complex(nx, ny)
+        self.p2 = complex(mx, ny)
+        self.p3 = complex(mx, my)
+        self.p4 = complex(nx, my)
+        """
+        n1 = self.p1 + self.d1
+        n2 = self.p2 + self.d2
+        n3 = self.p3 + self.d3
+        n4 = self.p4 + self.d4
+        p1 = matrix.point_in_matrix_space((self.p1.real, self.p1.imag))
+        p2 = matrix.point_in_matrix_space((self.p2.real, self.p2.imag))
+        p3 = matrix.point_in_matrix_space((self.p3.real, self.p3.imag))
+        p4 = matrix.point_in_matrix_space((self.p4.real, self.p4.imag))
+        n1 = matrix.point_in_matrix_space((n1.real, n1.imag))
+        n2 = matrix.point_in_matrix_space((n2.real, n2.imag))
+        n3 = matrix.point_in_matrix_space((n3.real, n3.imag))
+        n4 = matrix.point_in_matrix_space((n4.real, n4.imag))
+        # We need to establish the top left point of p1 to p4 and swap n1 to n4 accordingly
+        nx = min(p1.x, p2.x, p3.x, p4.x)
+        mx = max(p1.x, p2.x, p3.x, p4.x)
+        ny = min(p1.y, p2.y, p3.y, p4.y)
+        my = max(p1.y, p2.y, p3.y, p4.y)
+        candidates = [(p1, n1), (p2, n2), (p3, n3), (p4, n4)]
+
+        def find_values(x, y):
+            for idx in range(len(candidates)):
+                content = candidates[idx]
+                if content is None:
+                    continue
+                p, n = content
+                if p.x == x and p.y == y:
+                    candidates[idx] = None
+                    return p, n
+            # This will never happen!
+            return None, None
+
+        pp1, nn1 = find_values(nx, ny)
+        pp2, nn2 = find_values(mx, ny)
+        pp3, nn3 = find_values(mx, my)
+        pp4, nn4 = find_values(nx, my)
+        self.d1 = complex(nn1.x - pp1.x, nn1.y - pp1.y)
+        self.d2 = complex(nn2.x - pp2.x, nn2.y - pp2.y)
+        self.d3 = complex(nn3.x - pp3.x, nn3.y - pp3.y)
+        self.d4 = complex(nn4.x - pp4.x, nn4.y - pp4.y)
+
 
     def default_map(self, default_map=None):
         default_map = super().default_map(default_map=default_map)
         default_map["element_type"] = "Warp"
-        default_map["enabled"] = "(Disabled) " if not self.output else ""
+        default_map["enabled"] = "" if self.output else "(Disabled) "
 
         default_map["children"] = str(len(self.children))
         return default_map


### PR DESCRIPTION
The warp effect did not work at all - now after some struggles it will work on all devices.
![grafik](https://github.com/user-attachments/assets/47016544-ad58-480f-bc38-e019d5602a21)

## Summary by Sourcery

Bug Fixes:
- Fix the warp effect to function correctly on all devices by adjusting internal warp parameters and recalculating point positions.