### PR TITLE
Some minor Linux tweaks

### DIFF
--- a/meerk40t/gui/guicolors.py
+++ b/meerk40t/gui/guicolors.py
@@ -198,6 +198,6 @@ class GuiColors(Service):
         """
         for key, value in default_color.items():
             setattr(self, key, value)
-        if self._kernel.root.themes.dark and brighter:
+        if self._kernel.root.themes.dark and not brighter:
             for key, value in default_colors_dark.items():
                 setattr(self, key, value)

--- a/meerk40t/gui/guicolors.py
+++ b/meerk40t/gui/guicolors.py
@@ -192,12 +192,12 @@ class GuiColors(Service):
         for key in default_color:
             setattr(self, key, random_color())
 
-    def set_default_colors(self):
+    def set_default_colors(self, brighter=False):
         """
         Reset all colors to default values...
         """
         for key, value in default_color.items():
             setattr(self, key, value)
-        if self._kernel.root.themes.dark:
+        if self._kernel.root.themes.dark and brighter:
             for key, value in default_colors_dark.items():
                 setattr(self, key, value)

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -9,6 +9,7 @@ from meerk40t.gui.icons import (
     icon_closed_door,
     icon_open_door,
     icon_update_plan,
+    icons8_computer_support,
     icons8_delete,
     icons8_emergency_stop_button,
     icons8_gas_industry,
@@ -26,6 +27,7 @@ from meerk40t.gui.wxutils import (
     disable_window,
     wxButton,
     wxCheckBox,
+    wxStaticBitmap,
     wxStaticText,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
@@ -146,7 +148,9 @@ class LaserPanel(wx.Panel):
         self.combo_devices.SetToolTip(
             _("Select device from list of configured devices")
         )
-        self.btn_config_laser = wxButton(self, wx.ID_ANY, "*")
+        ss = dip_size(self, 23, 23)
+        self.btn_config_laser = wxButton(self, wx.ID_ANY, size=ss)
+        self.btn_config_laser.SetBitmap(icons8_computer_support.GetBitmap(resize=ss[0]))
         self.btn_config_laser.SetToolTip(
             _("Opens device-specific configuration window")
         )
@@ -157,10 +161,7 @@ class LaserPanel(wx.Panel):
         ):
             self.btn_config_laser.Enable(False)
         self.sizer_devices.Add(self.combo_devices, 1, wx.EXPAND, 0)
-        if platform.system() == "Windows":
-            minsize = 20
-        else:
-            minsize = 30
+        minsize = 32
         self.btn_config_laser.SetMinSize(dip_size(self, minsize, -1))
         self.sizer_devices.Add(self.btn_config_laser, 0, wx.EXPAND, 0)
 
@@ -343,7 +344,8 @@ class LaserPanel(wx.Panel):
         self.Bind(wx.EVT_SLIDER, self.on_slider_speed, self.slider_speed)
         self.Bind(wx.EVT_SLIDER, self.on_slider_power, self.slider_power)
         self.Bind(wx.EVT_CHECKBOX, self.on_optimize, self.checkbox_optimize)
-        self.Bind(wx.EVT_BUTTON, self.on_config_button, self.btn_config_laser)
+        # self.btn_config_laser.Bind(wx.EVT_LEFT_DOWN, self.on_config_button)
+        self.btn_config_laser.Bind(wx.EVT_BUTTON, self.on_config_button)
         # end wxGlade
         self.checkbox_adjust.SetValue(False)
         self.on_check_adjust(None)

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -388,12 +388,13 @@ and a wxpython version <= 4.1.1."""
                 image = None
             from ..main import APPLICATION_VERSION
             from platform import system
-            kernel.busyinfo.start(msg=_("Start MeerK40t|V. {version}".format(version=APPLICATION_VERSION)), image=image)
-            kernel.busyinfo.change(msg=_("Load main module"), keep=1)
+            if system() != "Linux":
+                kernel.busyinfo.start(msg=_("Start MeerK40t|V. {version}".format(version=APPLICATION_VERSION)), image=image)
+                kernel.busyinfo.change(msg=_("Load main module"), keep=1)
             meerk40tgui = kernel_root.open("module/wxMeerK40t")
 
             @kernel.console_command(
-                ("quit", "shutdown"), help=_("shuts down the gui and exits")
+                ("quit", "shutdown", "exit"), help=_("shuts down the gui and exits")
             )
             def shutdown(**kwargs):
                 try:

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -716,6 +716,17 @@ class Preferences(MWindow):
                 "section": "_ZZ_",
             }
         )
+        if self.window_context.themes.dark:
+            color_choices.append(
+                {
+                    "attr": "color_reset_brighter",
+                    "object": self,
+                    "type": bool,
+                    "style": "button",
+                    "label": _("Reset Colors to brighter defaults"),
+                    "section": "_ZZ_",
+                }
+            )
 
         self.panel_color = ChoicePropertyPanel(
             self,
@@ -793,6 +804,21 @@ class Preferences(MWindow):
         if value:
             # We are resetting all GUI.colors
             self.context("scene color unset\n")
+            self.context.root.label_display_color = "#ff0000ff"
+            self.context.signal("theme", True)
+            self.panel_color.reload()
+            self.context.signal("restart")
+
+    @property
+    def color_reset_brighter(self):
+        # Not relevant
+        return False
+
+    @color_reset.setter
+    def color_reset_brighter(self, value):
+        if value:
+            # We are resetting all GUI.colors
+            self.context("scene color unsetbright\n")
             self.context.root.label_display_color = "#ff0000ff"
             self.context.signal("theme", True)
             self.panel_color.reload()

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -497,6 +497,10 @@ class MeerK40tScenePanel(wx.Panel):
             else:
                 color_key = f"color_{aspect}"
                 if aspect == "unset":  # reset all
+                    self.widget_scene.colors.set_default_colors(brighter=True)
+                    self.context.signal("theme", True)
+                    return "scene", data
+                if aspect == "unsetbright":  # reset all
                     self.widget_scene.colors.set_default_colors()
                     self.context.signal("theme", True)
                     return "scene", data

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -497,11 +497,11 @@ class MeerK40tScenePanel(wx.Panel):
             else:
                 color_key = f"color_{aspect}"
                 if aspect == "unset":  # reset all
-                    self.widget_scene.colors.set_default_colors(brighter=True)
+                    self.widget_scene.colors.set_default_colors()
                     self.context.signal("theme", True)
                     return "scene", data
                 if aspect == "unsetbright":  # reset all
-                    self.widget_scene.colors.set_default_colors()
+                    self.widget_scene.colors.set_default_colors(brighter=True)
                     self.context.signal("theme", True)
                     return "scene", data
                 if aspect == "random":  # reset all


### PR DESCRIPTION
- Use icon instead of "*" for property button behind device selector in laserpanel
- Allow brighter color defaults for dark systems
- And add "exit" aside "quit" and "shutdown" as program termination command