### PR TITLE
Minor fix: Color mismatch

### DIFF
--- a/meerk40t/gui/guicolors.py
+++ b/meerk40t/gui/guicolors.py
@@ -62,7 +62,7 @@ default_colors_dark= {
     "grid": "#6B6B6B",
     "guide": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
     "background": "#282C57",
-    "bed": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENU)),
+    "bed": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)),
     "grid2": "#6B6B6B",
     "guide2": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
     "grid3": "#6B6B6B",

--- a/meerk40t/gui/guicolors.py
+++ b/meerk40t/gui/guicolors.py
@@ -59,13 +59,13 @@ def to_hex(col:wx.Colour):
     return s
 
 default_colors_dark= {
-    "grid": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVEBORDER)),
+    "grid": "#6B6B6B",
     "guide": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
-    "background": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
-    "bed": "#282C57",
-    "grid2": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVEBORDER)),
+    "background": "#282C57",
+    "bed": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENU)),
+    "grid2": "#6B6B6B",
     "guide2": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
-    "grid3": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVEBORDER)),
+    "grid3": "#6B6B6B",
     "guide3": to_hex(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)),
 }
 


### PR DESCRIPTION
Two colors were accidentally swapped at some point in commit history, this fixes that. Also changes the grid color in dark mode to be less sharp of a contrast, making it easier on the eyes.

## Summary by Sourcery

Fix color mismatches in the dark mode color scheme by correcting swapped colors and adjusting the grid color for better visual comfort.

Bug Fixes:
- Correct the swapped colors for 'background' and 'bed' in the dark mode color scheme.

Enhancements:
- Adjust the grid color in dark mode to a less contrasting shade for improved visual comfort.