### PR TITLE
Fix incorrect hatch orientation on special devices

### DIFF
--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -5,7 +5,7 @@ from math import sqrt
 from meerk40t.core.node.node import Node
 from meerk40t.core.node.mixins import Suppressable
 from meerk40t.core.units import Angle, Length
-from meerk40t.svgelements import Color
+from meerk40t.svgelements import Color, Point
 from meerk40t.tools.geomstr import Geomstr  # ,  Scanbeam
 
 
@@ -61,9 +61,7 @@ class HatchEffectNode(Node, Suppressable):
         self._angle = None
         self._angle_delta = 0
         self._effect = True
-        self._child_geometries = []
-        self._geometries = []
-        self.recalculate("init")
+        self.recalculate()
 
     @property
     def implied_stroke_width(self):
@@ -76,51 +74,37 @@ class HatchEffectNode(Node, Suppressable):
         nd = self.node_dict
         nd["stroke"] = copy(self.stroke)
         nd["fill"] = copy(self.fill)
-        node = HatchEffectNode(**nd)
-        node._distance = self._distance
-        node._angle = self._angle
-        node._angle_delta= self._angle_delta
-        node.recalculate("copy")
-        node._child_geometries = list(self._child_geometries)
-        node._geometries = list(self._geometries)
-        return node
-
-    # def copy_children_as_real(self, copy_node):
-    #     print ("Copy children started")
-    #     super().copy_children_as_real(copy_node)
-    #     self._child_geometries = list(copy_node._child_geometries)
-    #     self._geometries = list(copy_node._geometries)
-    #     print ("Copy children ended")
+        return HatchEffectNode(**nd)
 
     def scaled(self, sx, sy, ox, oy, interim=False):
         if interim:
             self.set_interim()
         else:
-            self.altered(source="scaled")
+            self.altered()
 
     def notify_attached(self, node=None, **kwargs):
         Node.notify_attached(self, node=node, **kwargs)
         if node is self:
             return
-        self.altered(source="attached")
+        self.altered()
 
     def notify_detached(self, node=None, **kwargs):
         Node.notify_detached(self, node=node, **kwargs)
         if node is self:
             return
-        self.altered(source="detached")
+        self.altered()
 
     def notify_modified(self, node=None, **kwargs):
         Node.notify_modified(self, node=node, **kwargs)
         if node is self:
             return
-        self.altered(source="notify_modify")
+        self.altered()
 
     def notify_altered(self, node=None, **kwargs):
         Node.notify_altered(self, node=node, **kwargs)
         if node is self:
             return
-        self.altered("notify_altered")
+        self.altered()
 
     def notify_scaled(self, node=None, sx=1, sy=1, ox=0, oy=0, interim=False, **kwargs):
         Node.notify_scaled(self, node, sx, sy, ox, oy, interim=interim, **kwargs)
@@ -129,7 +113,7 @@ class HatchEffectNode(Node, Suppressable):
         if interim:
             self.set_interim()
         else:
-            self.altered("notify_scaled")
+            self.altered()
 
     def notify_translated(self, node=None, dx=0, dy=0, interim=False, **kwargs):
         Node.notify_translated(self, node, dx, dy, interim=interim, **kwargs)
@@ -138,7 +122,7 @@ class HatchEffectNode(Node, Suppressable):
         if interim:
             self.set_interim()
         else:
-            self.altered("notify_translated")
+            self.altered()
 
     @property
     def angle(self):
@@ -147,7 +131,7 @@ class HatchEffectNode(Node, Suppressable):
     @angle.setter
     def angle(self, value):
         self.hatch_angle = value
-        self.recalculate("angle")
+        self.recalculate()
 
     @property
     def delta(self):
@@ -156,7 +140,7 @@ class HatchEffectNode(Node, Suppressable):
     @delta.setter
     def delta(self, value):
         self.hatch_angle_delta = value
-        self.recalculate("delta")
+        self.recalculate()
 
     @property
     def distance(self):
@@ -165,14 +149,13 @@ class HatchEffectNode(Node, Suppressable):
     @distance.setter
     def distance(self, value):
         self.hatch_distance = value
-        self.recalculate("distance")
+        self.recalculate()
 
-    def recalculate(self, source):
+    def recalculate(self):
         """
         Ensure that the properties for distance, angle and angle_delta are in usable units.
         @return:
         """
-        print (f"Recalculate was called from {source}")
         h_dist = self.hatch_distance
         h_angle = self.hatch_angle
         h_angle_delta = self.hatch_angle_delta
@@ -191,16 +174,20 @@ class HatchEffectNode(Node, Suppressable):
         # transformed_vector = self.matrix.transform_vector([0, distance_y])
         transformed_vector = [0, distance_y]
         self._distance = abs(complex(transformed_vector[0], transformed_vector[1]))
-        self._geometries.clear()
 
     def preprocess(self, context, matrix, plan):
-        print (f"Preprocess called with {matrix}")
         factor = sqrt(abs(matrix.determinant))
         self._distance *= factor
-        for geom in self._child_geometries:
-            geom.transform(matrix)
-        for geom in self._geometries:
-            geom.transform(matrix)
+        # Let's establish the angle
+        p1:Point = matrix.point_in_matrix_space((0, 0))
+        p2:Point = matrix.point_in_matrix_space((1, 0))
+        angle = p1.angle_to(p2)
+        self._angle -= angle
+        # from math import tau
+        # print(f"Angle: {angle} - {angle/tau * 360:.1f}°")
+
+        # for c in self._children:
+        #     c.matrix *= matrix
 
         self.set_dirty_bounds()
 
@@ -267,19 +254,26 @@ class HatchEffectNode(Node, Suppressable):
         @param kws:
         @return:
         """
-        if self._distance is None:
-            self.recalculate("as_geometry-distance")
-        self.get_outlines()
-        self.get_hatch()
+        outlines = Geomstr()
+        for node in self.affected_children():
+            try:
+                outlines.append(node.as_geometry(**kws))
+            except AttributeError:
+                # If direct children lack as_geometry(), do nothing.
+                pass
         if self._interim:
-            outlines = Geomstr()
-            for geom in self._child_geometries:
-                outlines.append(geom)
             return outlines
-
         path = Geomstr()
-        for geom in self._geometries:
-            path.append(geom)
+        if self._distance is None:
+            self.recalculate()
+        for p in range(self.loops):
+            path.append(
+                Geomstr.hatch(
+                    outlines,
+                    distance=self._distance,
+                    angle=self._angle + p * self._angle_delta,
+                )
+            )
         return path
 
     def as_geometries(self, **kws):
@@ -292,12 +286,20 @@ class HatchEffectNode(Node, Suppressable):
         @param kws:
         @return:
         """
-        print ("as geometries was called")
+        outlines = [
+            node.as_geometry(**kws)
+            for node in self.affected_children()
+            if hasattr(node, "as_geometry")
+        ]
         if self._distance is None:
-            self.recalculate(("as_geometries - distance"))
-        self.get_outlines()
-        self.get_hatch()
-        yield from self._geometries
+            self.recalculate()
+        for p in range(self.loops):
+            for o in outlines:
+                yield Geomstr.hatch(
+                    o,
+                    distance=self._distance,
+                    angle=self._angle + p * self._angle_delta,
+                )
 
 
     def set_interim(self):
@@ -306,40 +308,10 @@ class HatchEffectNode(Node, Suppressable):
 
     def altered(self, *args, **kwargs):
         self._interim = False
-        print(f"altered: {kwargs.get('source', '')}")
-        self._child_geometries.clear()
-        self._geometries.clear()
         super().altered()
 
-    def get_outlines(self):
-        if len(self._child_geometries):
-            return
-        print ("Need to recalculate outlines")
-        # Invalidate hatch too
-        self._geometries.clear()
-        self._child_geometries = [
-            node.as_geometry()
-            for node in self.affected_children()
-            if hasattr(node, "as_geometry")
-        ]
-
-    def get_hatch(self):
-        if len(self._geometries):
-            return
-        print ("Need to recalculate hatch")
-        self._geometries.clear()
-        for p in range(self.loops):
-            for o in self._child_geometries:
-                self._geometries.append(
-                    Geomstr.hatch(
-                        o,
-                        distance=self._distance,
-                        angle=self._angle + p * self._angle_delta,
-                    )
-                )
-
     def modified(self):
-        self.altered(source="modified")
+        self.altered()
 
     def can_drop(self, drag_node):
         if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
@@ -357,7 +329,7 @@ class HatchEffectNode(Node, Suppressable):
                 else:
                     self.swap_node(drag_node)
                 drag_node.altered()
-                self.altered(source="drag1")
+                self.altered()
             return True
         if hasattr(drag_node, "as_geometry"):
             # Dragging element onto operation adds that element to the op.
@@ -366,7 +338,7 @@ class HatchEffectNode(Node, Suppressable):
                     self.add_reference(drag_node)
                 else:
                     self.append_child(drag_node)
-                self.altered(source="drag2")
+                self.altered()
             return True
         elif drag_node.type == "reference":
             if modify:
@@ -387,6 +359,6 @@ class HatchEffectNode(Node, Suppressable):
                     return False
                 else:
                     self.append_child(drag_node)
-                self.altered(source="dragfile")
+                self.altered()
             return True
         return False


### PR DESCRIPTION

Before the fix:
<table>
<tr>
<td>balor</td><td><img src="https://github.com/user-attachments/assets/cd72f5ed-87d6-4289-91ba-ecd9157e57c8" width="400"></td>
</tr>
<tr>
<td>m2nano</td><td>
<img src="https://github.com/user-attachments/assets/3a4cd55b-964e-4502-baa2-9f581bddf11d" width="400"></td>
</tr>
</table>

So in a nutshell:
m2nano before the fix: correct hatch orientation for the non-orientated placements, an incorrect one (everything needs to be rotated) for the rotated one
balor before the fix: all hatches are  rotated by 90 deg compared to m2nano

After the fix:
<table>
<tr>
<td>balor</td><td><img src="https://github.com/user-attachments/assets/43279234-a7c6-4a34-bfb3-f380f315e279" width="400"></td>
</tr>
<tr>
<td>m2nano</td><td>
<img src="https://github.com/user-attachments/assets/69672f8c-60ab-4ca4-a762-a617d831d47b" width="400"></td>
</tr>
</table>