### PR TITLE
Make Beep sound user-configurable

### DIFF
--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1009,12 +1009,16 @@ class wxMeerK40t(wx.App, Module):
 
         wildcard = "Sound-Files|*.wav;*.mp3;*.ogg|All files|*.*"
         OS_NAME = platform.system()
+        addon = ""
         if OS_NAME == "Darwin":   
             wildcard = f"System-Sounds|*.aiff|{wildcard}"
+        elif OS_NAME == "Linux":   
+            wildcard = f"System-Sounds|*.oga;*.wav;*.mp3|{wildcard}"
+            addon = "\n" + _("This uses the 'play' command that comes with the sox package,\nso you might need to install it with 'sudo apt install sox' first.")
         system_sound = {
             "Windows": r"c:\Windows\Media\Alarm01.wav",
             "Darwin": "/System/Library/Sounds/Ping.aiff",
-            "Linux": "",
+            "Linux": "/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga",
         }
         default_snd = system_sound.get(OS_NAME, "")
 
@@ -1046,7 +1050,7 @@ class wxMeerK40t(wx.App, Module):
                 "style": "file",
                 "wildcard": wildcard,
                 "label": _("Soundfile"),
-                "tip": _("Define the soundfile MeerK40t will play when the 'beep' command is issued"),
+                "tip": _("Define the soundfile MeerK40t will play when the 'beep' command is issued") + addon,
                 "page": "Start",
             }
         ]

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1008,8 +1008,15 @@ class wxMeerK40t(wx.App, Module):
             register_widget_icon(kernel.root)
 
         wildcard = "Sound-Files|*.wav;*.mp3;*.ogg|All files|*.*"
-        if platform.system() == "Darwin":
+        OS_NAME = platform.system()
+        if OS_NAME == "Darwin":   
             wildcard = f"System-Sounds|*.aiff|{wildcard}"
+        system_sound = {
+            "Windows": r"c:\Windows\Media\Alarm01.wav",
+            "Darwin": "/System/Library/Sounds/Ping.aiff",
+            "Linux": "",
+        }
+        default_snd = system_sound.get(OS_NAME, "")
 
         choices = [
             {
@@ -1035,7 +1042,7 @@ class wxMeerK40t(wx.App, Module):
                 "attr": "beep_soundfile",
                 "object": context.root,
                 "type": str,
-                "default": "",
+                "default": default_snd,
                 "style": "file",
                 "wildcard": wildcard,
                 "label": _("Soundfile"),

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1007,6 +1007,10 @@ class wxMeerK40t(wx.App, Module):
 
             register_widget_icon(kernel.root)
 
+        wildcard = "Sound-Files|*.wav;*.mp3;*.ogg|All files|*.*"
+        if platform.system() == "Darwin":
+            wildcard = f"System-Sounds|*.aiff|{wildcard}"
+
         choices = [
             {
                 "attr": "single_instance_only",
@@ -1027,6 +1031,17 @@ class wxMeerK40t(wx.App, Module):
                 "page": "Start",
                 "signals": "restart",
             },
+            {
+                "attr": "beep_soundfile",
+                "object": context.root,
+                "type": str,
+                "default": "",
+                "style": "file",
+                "wildcard": wildcard,
+                "label": _("Soundfile"),
+                "tip": _("Define the soundfile MeerK40t will play when the 'beep' command is issued"),
+                "page": "Start",
+            }
         ]
         kernel.register_choices("preferences", choices)
 

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2819,19 +2819,36 @@ class Kernel(Settings):
         @self.console_command("beep", _("Perform beep"))
         def beep(channel, _, **kwargs):
             OS_NAME = platform.system()
+            system_sound = {
+                "Windows": r"c:\Windows\Media\Alarm01.wav",
+                "Darwin": "/System/Library/Sounds/Ping.aiff",
+                "Linux": "",
+            }
+            default_snd = system_sound.get(OS_NAME, "")
+            sys_snd = self.root.setting(str, "beep_soundfile", default_snd)
+            if sys_snd and not os.path.exists(sys_snd):
+                sys_snd = ""
             if OS_NAME == "Windows":
                 try:
                     import winsound
-
-                    for x in range(5):
-                        winsound.Beep(2000, 100)
-                except Exception:
+                    if sys_snd:
+                        winsound.PlaySound(sys_snd, winsound.SND_FILENAME)
+                    else:
+                        for x in range(5):
+                            winsound.Beep(2000, 100)
+                except Exception as e:
+                    print (e)
                     pass
             elif OS_NAME == "Darwin":  # Mac
-                os.system("afplay /System/Library/Sounds/Ping.aiff")
+                if sys_snd:
+                    os.system(f"afplay {sys_snd}")
+
             elif OS_NAME == "Linux":
-                print("\a")  # Beep.
-                os.system('say "Ding"')
+                if sys_snd:
+                    os.system(f"play {sys_snd}")
+                else:
+                    print("\a")  # Beep.
+                    os.system('say "Ding"')
 
             else:  # Assuming other linux like system
                 print("\a")  # Beep.

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -2822,7 +2822,7 @@ class Kernel(Settings):
             system_sound = {
                 "Windows": r"c:\Windows\Media\Alarm01.wav",
                 "Darwin": "/System/Library/Sounds/Ping.aiff",
-                "Linux": "",
+                "Linux": "/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga",
             }
             default_snd = system_sound.get(OS_NAME, "")
             sys_snd = self.root.setting(str, "beep_soundfile", default_snd)
@@ -2837,7 +2837,6 @@ class Kernel(Settings):
                         for x in range(5):
                             winsound.Beep(2000, 100)
                 except Exception as e:
-                    print (e)
                     pass
             elif OS_NAME == "Darwin":  # Mac
                 if sys_snd:
@@ -2845,7 +2844,9 @@ class Kernel(Settings):
 
             elif OS_NAME == "Linux":
                 if sys_snd:
-                    os.system(f"play {sys_snd}")
+                    player = "play"
+                    # player =" gst-play-1.0"
+                    rc = os.system(f"{player} {sys_snd}")
                 else:
                     print("\a")  # Beep.
                     os.system('say "Ding"')


### PR DESCRIPTION
## Summary by Sourcery

Add user-configurable beep sound feature, enabling users to select custom sound files for the beep command across different operating systems.

New Features:
- Introduce user-configurable beep sound functionality, allowing users to specify a custom sound file for the beep command.

Enhancements:
- Refactor beep command to support different sound file formats across Windows, macOS, and Linux platforms.