### PR TITLE
Avoid linetext crash under Linux

### DIFF
--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -1,5 +1,5 @@
 import os
-
+from time import sleep
 import wx
 
 from meerk40t.core.units import Length
@@ -715,17 +715,20 @@ class LineTextPropertyPanel(wx.Panel):
         self.PopupMenu(menu)
         menu.Destroy()
 
-    def select_text(self):
-        self.text_text.SetFocus()
-        self.text_text.SelectAll()
 
     def signal(self, signalstr, myargs):
         if signalstr == "textselect" and self.IsShown():
             # This can crash for completely unknown reasons under Linux!
-            if self._islinux:
-                wx.CallLater(500, self.select_text)
-            else:
-                self.select_text()
+            # Hypothesis: you can't focus / SelectStuff if the control is not yet shown.
+            attempts = 0
+            while attempts < 5 and not self.text_text.IsFocusable():
+                print (f"Attempt #{attempts} - still waiting")
+                attempts += 1
+                sleep(0.5)
+
+            if self.text_text.IsFocusable():
+                self.text_text.SelectAll()
+                self.text_text.SetFocus()
 
 
 class PanelFontSelect(wx.Panel):

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -1,5 +1,5 @@
 import os
-from time import sleep
+import platform
 import wx
 
 from meerk40t.core.units import Length
@@ -360,7 +360,6 @@ class LineTextPropertyPanel(wx.Panel):
         self.node = node
         self.fonts = []
 
-        import platform
         # We neeed this to avoid a crash under Linux when textselection is called too quickly
         self._islinux = platform.system() == "Linux"
 
@@ -720,15 +719,10 @@ class LineTextPropertyPanel(wx.Panel):
         if signalstr == "textselect" and self.IsShown():
             # This can crash for completely unknown reasons under Linux!
             # Hypothesis: you can't focus / SelectStuff if the control is not yet shown.
-            attempts = 0
-            while attempts < 5 and not self.text_text.IsFocusable():
-                print (f"Attempt #{attempts} - still waiting")
-                attempts += 1
-                sleep(0.5)
-
-            if self.text_text.IsFocusable():
-                self.text_text.SelectAll()
-                self.text_text.SetFocus()
+            if self._islinux:
+                return
+            self.text_text.SelectAll()
+            self.text_text.SetFocus()
 
 
 class PanelFontSelect(wx.Panel):

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -1,4 +1,5 @@
 import platform
+from time import sleep
 
 import wx
 
@@ -726,8 +727,15 @@ class TextPropertyPanel(ScrolledPanel):
 
     def signal(self, signal, *args):
         if signal == "textselect" and self.IsShown():
-            self.text_text.SelectAll()
-            self.text_text.SetFocus()
+            # This can crash for completely unknown reasons under Linux!
+            # Hypothesis: you can't focus / SelectStuff if the control is not yet shown.
+            attempts = 0
+            while attempts < 5 and not self.text_text.IsFocusable():
+                attempts += 1
+                sleep(0.5)
+            if self.text_text.IsFocusable():
+                self.text_text.SelectAll()
+                self.text_text.SetFocus()
 
 
 class TextProperty(MWindow):


### PR DESCRIPTION
Both the linetext and the regular text tool open the associated property panel after creation. They the try to focus the text entry box and select all text to simplify the text editing process.
While this works flawlessly uder Windows and Darwin, this method crashes under Linux. The hypothesis is that wxPython is flawed in this aspect that it will crash if the window / control are not fully established yet. Unfortunately no indicator does expose that unready state.
As we can't contain it, we will skip the textselection under Linux. Sorry.

## Summary by Sourcery

Bug Fixes:
- Prevent crash on Linux by skipping text selection when the control is not fully established.