### PR TITLE
Deal with 32bit grayscale images

### DIFF
--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -317,12 +317,12 @@ class ImageNode(Node, LabelDisplay, Suppressable):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
             drag_node.type.startswith("op") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -469,12 +469,7 @@ class ImageNode(Node, LabelDisplay, Suppressable):
             bb = self.bbox()
             self._bounds = bb
             self._paint_bounds = bb
-        except (
-            MemoryError,
-            Image.DecompressionBombError,
-            ValueError,
-            ZeroDivisionError,
-        ) as e:
+        except Exception as e:
             # Memory error if creating requires too much memory.
             # DecompressionBomb if over 272 megapixels.
             # ValueError if bounds are NaN.


### PR DESCRIPTION
32 bit grayscale images like this one:
<img src="https://github.com/user-attachments/assets/d068fb3f-34ce-423b-aa21-98427571c766" width="300">

were not recognized properly:
<img src="https://github.com/user-attachments/assets/9bc5aef6-3792-4f99-90cb-d66a0215e67e" width="600">


That's fixed now:
<img src= "https://github.com/user-attachments/assets/da111054-c168-4807-bcdd-81fb0857a168" width="600">

## Summary by Sourcery

Improve handling of 32-bit grayscale images by converting them to 8-bit grayscale, ensuring proper recognition and processing. Simplify exception handling in image processing functions.

Bug Fixes:
- Fix recognition of 32-bit grayscale images by converting them to 8-bit grayscale format.

Enhancements:
- Simplify exception handling in image processing by catching a general Exception instead of specific ones.