### PR TITLE
Sync and remember lock status

### DIFF
--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -940,14 +940,18 @@ class PositionSizePanel(wx.Panel):
             check="length",
             nonzero=True,
         )
+        self.context.setting(bool, "lock_active", True)
         self.btn_lock_ratio = wxToggleButton(self, wx.ID_ANY, "")
-        self.btn_lock_ratio.SetValue(True)
         self.bitmap_locked = mkicons.icons8_lock.GetBitmap(
             resize=mkicons.STD_ICON_SIZE / 2, use_theme=False
         )
         self.bitmap_unlocked = mkicons.icons8_unlock.GetBitmap(
             resize=mkicons.STD_ICON_SIZE / 2, use_theme=False
         )
+        self.btn_lock_ratio.bitmap_toggled = self.bitmap_locked
+        self.btn_lock_ratio.bitmap_untoggled = self.bitmap_unlocked
+        self.btn_lock_ratio.SetValue(self.context.lock_active)
+
         self.__set_properties()
         self.__do_layout()
 
@@ -977,8 +981,6 @@ class PositionSizePanel(wx.Panel):
         self.btn_lock_ratio.SetToolTip(
             _("Lock the ratio of width / height to the original values")
         )
-        # Set Bitmap
-        self.on_toggle_ratio(None)
 
         sizer_opt.Add(self.btn_lock_ratio, 0, wx.ALIGN_CENTER_HORIZONTAL, 0)
 
@@ -1028,6 +1030,9 @@ class PositionSizePanel(wx.Panel):
                 self.set_widgets(self.node)
         elif signalstr == "modified_by_tool":
             self.set_widgets(self.node)
+        elif signalstr == "lock_active":
+            if self.btn_lock_ratio.GetValue() != self.context.lock_active:
+                self.btn_lock_ratio.SetValue(self.context.lock_active)
 
     def _set_widgets_hidden(self):
         self.text_x.SetValue("")
@@ -1148,10 +1153,10 @@ class PositionSizePanel(wx.Panel):
             self.context.elements.signal("refresh_scene", "Scene")
 
     def on_toggle_ratio(self, event):
-        if self.btn_lock_ratio.GetValue():
-            self.btn_lock_ratio.SetBitmap(self.bitmap_locked)
-        else:
-            self.btn_lock_ratio.SetBitmap(self.bitmap_unlocked)
+        self.btn_lock_ratio.update_button(None)
+        if self.context.lock_active != self.btn_lock_ratio.GetValue():
+            self.context.lock_active = self.btn_lock_ratio.GetValue()
+            self.context.signal("lock_active")
 
     def on_text_x_enter(self):
         self.translate_it()

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -204,34 +204,32 @@ class PropertyWindow(MWindow):
             if self.channel:
                 self.channel(f"Took {t2-t1:.2f} seconds to load")
 
+    def propagate_signal(self, signal, *args):
+        myargs = list(args)
+        for p in self.panel_instances:
+            if hasattr(p, "signal"):
+                p.signal(signal, myargs)
+
+    @signal_listener("lock_active")
+    def on_tool_locksignal(self, origin, *args):
+        self.propagate_signal("lock_active", args)
+
     @signal_listener("refresh_scene")
     def on_refresh_scene(self, origin, *args):
-        myargs = [i for i in args]
-        if len(args) > 0 and args[0] == "Scene":
-            for p in self.panel_instances:
-                if hasattr(p, "signal"):
-                    p.signal("refresh_scene", myargs)
+        if args and args[0] == "Scene":
+            self.propagate_signal("refresh_scene", args)
 
     @signal_listener("modified_by_tool")
     def on_tool_modified(self, origin, *args):
-        myargs = [i for i in args]
-        for p in self.panel_instances:
-            if hasattr(p, "signal"):
-                p.signal("modified_by_tool", myargs)
+        self.propagate_signal("modified_by_tool", args)
 
     @signal_listener("nodetype")
     def on_nodetype(self, origin, *args):
-        myargs = [i for i in args]
-        for p in self.panel_instances:
-            if hasattr(p, "signal"):
-                p.signal("nodetype", myargs)
+        self.propagate_signal("nodetype", args)
 
     @signal_listener("textselect")
     def on_textselect(self, origin, *args):
-        myargs = [i for i in args]
-        for p in self.panel_instances:
-            if hasattr(p, "signal"):
-                p.signal("textselect", myargs)
+        self.propagate_signal("textselect", args)
 
     @signal_listener("selected")
     def on_selected(self, origin, *args):

--- a/meerk40t/gui/statusbarwidgets/shapepropwidget.py
+++ b/meerk40t/gui/statusbarwidgets/shapepropwidget.py
@@ -259,6 +259,7 @@ class PositionWidget(StatusBarWidget):
 
     def GenerateControls(self, parent, panelidx, identifier, context):
         super().GenerateControls(parent, panelidx, identifier, context)
+        self.context.setting(bool, "lock_active", True)
         self._needs_generation = False
         self.xy_lbl = wxStaticText(self.parent, wx.ID_ANY, label=_("X, Y"))
         self.node = None
@@ -367,7 +368,8 @@ class PositionWidget(StatusBarWidget):
         )
 
         self._lock_ratio = True
-        self.lock_ratio = True
+        self.lock_ratio =  self.context.lock_active
+
 
     @property
     def units_name(self):
@@ -384,6 +386,9 @@ class PositionWidget(StatusBarWidget):
             self.button_lock_ratio.SetBitmap(self.bitmap_locked)
         else:
             self.button_lock_ratio.SetBitmap(self.bitmap_unlocked)
+        if self.context.lock_active != value:
+            self.context.lock_active = value
+            self.context.signal("lock_active")
 
     # Position icon routines
     def calculate_icons(self, bmap_size):
@@ -744,3 +749,5 @@ class PositionWidget(StatusBarWidget):
     def Signal(self, signal, *args):
         if signal in ("emphasized", "modified", "modified", "element_property_update"):
             self.GenerateInfos()
+        if signal == "lock_active":
+            self.lock_ratio = self.context.lock_active

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -4602,6 +4602,10 @@ class MeerK40t(MWindow):
     def on_def_ops(self, origin, *args):
         self.main_statusbar.Signal("default_operations")
 
+    @signal_listener("lock_active")
+    def on_def_ops(self, origin, *args):
+        self.main_statusbar.Signal("lock_active")
+
     @signal_listener("snap_grid")
     @signal_listener("snap_points")
     def on_sig_snap(self, origin, *args):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -4603,7 +4603,7 @@ class MeerK40t(MWindow):
         self.main_statusbar.Signal("default_operations")
 
     @signal_listener("lock_active")
-    def on_def_ops(self, origin, *args):
+    def on_lock_active(self, origin, *args):
         self.main_statusbar.Signal("lock_active")
 
     @signal_listener("snap_grid")

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -1040,6 +1040,23 @@ class wxToggleButton(wx.ToggleButton):
 
             self.Bind(wx.EVT_MOTION, on_mouse_over_check(super()))
         set_color_according_to_theme(self, "button_bg", "button_fg")
+        self.bitmap_toggled = None
+        self.bitmap_untoggled = None
+
+    def update_button(self, value):
+        # We just act as a man in the middle
+        if value is None:
+            value = self.GetValue()
+        if value:
+            if self.bitmap_toggled is not None:
+                self.SetBitmap(self.bitmap_toggled)
+        else:
+            if self.bitmap_untoggled is not None:
+                self.SetBitmap(self.bitmap_untoggled)
+
+    def SetValue(self, value):
+        super().SetValue(value)
+        self.update_button(value)
 
     def SetToolTip(self, tooltip):
         self._tool_tip = tooltip


### PR DESCRIPTION
Addresses comment in MeerK40t facebook group asking for a default dimension unlock feature (https://www.facebook.com/share/v/JvE3kYg7BvUJcvNA/)
MeerK40t will sync and remember the status over the different places where you can modify object dimensions.

## Summary by Sourcery

Implement a feature to sync and remember the lock status of object dimensions across different panels, enhancing user experience by maintaining consistent settings. Refactor signal propagation to streamline the handling of various signals.

New Features:
- Add functionality to sync and remember the lock status of object dimensions across different panels.

Enhancements:
- Refactor signal propagation to use a common method for various signals.