### PR TITLE
Push svgelements to 1.9.6

### DIFF
--- a/meerk40t/svgelements.py
+++ b/meerk40t/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.9.5"
+SVGELEMENTS_VERSION = "1.9.6"
 
 MIN_DEPTH = 5
 ERROR = 1e-12
@@ -340,8 +340,6 @@ class SVGLexicalParser:
         return position[0] + current_pos.x, position[1] + current_pos.y
 
     def parse(self, parser, pathd):
-        if pathd is None:
-            return
         self.parser = parser
         self.parser.start()
         self.pathd = pathd
@@ -3085,10 +3083,6 @@ class Matrix:
         @param p2:
         @param p3:
         @param p4:
-        @param p5:
-        @param p6:
-        @param p7:
-        @param p8:
         @return:
         """
         m1 = Matrix.perspective(p1, p2, p3, p4)
@@ -4001,7 +3995,7 @@ class PathSegment:
 
     These segments define a 1:1 relationship with the path_d or path data attribute, denoted in
     SVG by the 'd' attribute. These are moveto, closepath, lineto, and the curves which are cubic
-    B?zier curves, quadratic B?zier curves, and elliptical arc. These are classed as Move, Close,
+    Bézier curves, quadratic Bézier curves, and elliptical arc. These are classed as Move, Close,
     Line, CubicBezier, QuadraticBezier, and Arc. And in path_d are denoted as M, Z, L, C, Q, A.
 
     There are lowercase versions of these commands. And for C, and Q there are S and T which are
@@ -4260,6 +4254,7 @@ class PathSegment:
         tb_hit = qb[hits] / denom[hits]
 
         for i, hit in enumerate(where_hit):
+
             at = ta[0] + float(hit[1]) * step_a  # Zoomed min+segment intersected.
             bt = tb[0] + float(hit[0]) * step_b
             a_fractional = (
@@ -4520,7 +4515,7 @@ class Line(Linear):
 
 
 class QuadraticBezier(Curve):
-    """Represents Quadratic B?zier commands."""
+    """Represents Quadratic Bézier commands."""
 
     def __init__(self, start, control, end, **kwargs):
         Curve.__init__(self, start, end, **kwargs)
@@ -4610,7 +4605,7 @@ class QuadraticBezier(Curve):
 
     def bbox(self):
         """
-        Returns the bounding box for the quadratic B?zier curve.
+        Returns the bounding box for the quadratic Bézier curve.
         """
         n = self.start.x - self.control.x
         d = self.start.x - 2 * self.control.x + self.end.x
@@ -4702,7 +4697,7 @@ class QuadraticBezier(Curve):
 
 
 class CubicBezier(Curve):
-    """Represents Cubic B?zier commands."""
+    """Represents Cubic Bézier commands."""
 
     def __init__(self, start, control1, control2, end, **kwargs):
         Curve.__init__(self, start, end, **kwargs)
@@ -4807,7 +4802,7 @@ class CubicBezier(Curve):
             return [Point(*_compute_point(position)) for position in positions]
 
     def bbox(self):
-        """returns the tight-fitting bounding box of the B?zier curve.
+        """returns the tight-fitting bounding box of the Bézier curve.
         Code by:
         https://github.com/mathandy/svgpathtools
         """
@@ -5337,7 +5332,7 @@ class Arc(Curve):
     def length(self, error=ERROR, min_depth=MIN_DEPTH):
         """The length of an elliptical arc segment requires numerical
         integration, and in that case it's simpler to just do a geometric
-        approximation, as for cubic B?zier curves.
+        approximation, as for cubic Bézier curves.
         """
         if self.sweep == 0:
             return 0
@@ -6037,8 +6032,7 @@ class Path(Shape, MutableSequence):
     @property
     def first_point(self):
         """First point along the Path. This is the start point of the first segment unless it starts
-        with a Move command with a None start in which case first point is that Move's destination.
-        """
+        with a Move command with a None start in which case first point is that Move's destination."""
         if len(self._segments) == 0:
             return None
         if self._segments[0].start is not None:
@@ -6504,7 +6498,7 @@ class Path(Shape, MutableSequence):
 
     def approximate_arcs_with_cubics(self, error=0.1):
         """
-        Iterates through this path and replaces any Arcs with cubic B?zier curves.
+        Iterates through this path and replaces any Arcs with cubic Bézier curves.
         """
         sweep_limit = tau * error
         for s in range(len(self) - 1, -1, -1):
@@ -6515,7 +6509,7 @@ class Path(Shape, MutableSequence):
 
     def approximate_arcs_with_quads(self, error=0.1):
         """
-        Iterates through this path and replaces any Arcs with quadratic B?zier curves.
+        Iterates through this path and replaces any Arcs with quadratic Bézier curves.
         """
         sweep_limit = tau * error
         for s in range(len(self) - 1, -1, -1):
@@ -6526,7 +6520,7 @@ class Path(Shape, MutableSequence):
 
     def approximate_bezier_with_circular_arcs(self, error=0.01):
         """
-        Iterates through this path and replaces any B?zier curves with circular arcs.
+        Iterates through this path and replaces any Bézier curves with circular arcs.
         """
         for s in range(len(self) - 1, -1, -1):
             segment = self[s]
@@ -7864,7 +7858,6 @@ class Group(SVGElement, Transformable, list):
         """
         Returns the union of the bounding boxes for the elements within the iterator.
 
-        :param elements: different path nodes
         :param transformed: Should the children of this object be properly transformed.
         :param with_stroke: should the stroke-width be included in the bounds of the elements
         :return: union of all bounding boxes of elements within the iterable.
@@ -7980,7 +7973,6 @@ class Use(SVGElement, Transformable, list):
         """
         Returns the union of the bounding boxes for the elements within the iterator.
 
-        :param elements: different path nodes
         :param transformed: Should the children of this object be properly transformed.
         :param with_stroke: should the stroke-width be included in the bounds of the elements
         :return: union of all bounding boxes of elements within the iterable.
@@ -9163,7 +9155,7 @@ class SVG(Group):
                         height = s.viewbox.height if s.viewbox is not None else 1000
 
                     s.render(ppi=ppi, width=width, height=height, viewbox=s.viewbox)
-                    height, width = s.width, s.height
+                    width, height = s.width, s.height
                     if s.viewbox is not None:
                         try:
                             if s.height == 0 or s.width == 0:
@@ -9241,7 +9233,7 @@ class SVG(Group):
                         if SVG_TAG_PATH == tag:
                             # Delayed path parsing, for partial paths.
                             s = Path(values, pathd_loaded=True)
-                            s.parse(values.get(SVG_ATTR_DATA))
+                            s.parse(values.get(SVG_ATTR_DATA, ""))
                         elif SVG_TAG_CIRCLE == tag:
                             s = Circle(values)
                         elif SVG_TAG_ELLIPSE == tag:
@@ -9568,6 +9560,8 @@ def _write_node(node, xml_tree=None, viewport_transform=None):
             xml_tree.set(SVG_ATTR_FONT_STYLE, str(node.font_style))
         if node.font_variant:
             xml_tree.set(SVG_ATTR_FONT_VARIANT, str(node.font_variant))
+        if node.font_weight:
+            xml_tree.set(SVG_ATTR_FONT_WEIGHT, str(node.font_weight))
         if node.font_stretch:
             xml_tree.set(SVG_ATTR_FONT_STRETCH, node.font_stretch)
         if node.font_size:


### PR DESCRIPTION
Sync with latest patches from svgelements

## Summary by Sourcery

Update svgelements to version 1.9.6 and fix several parsing issues including width-height assignment, path data defaults, and font weight handling.

Bug Fixes:
- Fix the order of width and height assignment in the parse function.
- Ensure path data is parsed with a default empty string if not provided.
- Add handling for font weight attribute in SVG parsing.

Enhancements:
- Update svgelements version to 1.9.6.