### PR TITLE
Fix placement bounds calculation

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -2735,7 +2735,7 @@ def init_tree(kernel):
         if not data:
             return
         try:
-            bounds = Node.union_bounds(data, attr="paint_bounds")
+            bounds = Node.union_bounds(data, attr="paint_bounds", ignore_hidden=True)
             width = bounds[2] - bounds[0]
             height = bounds[3] - bounds[1]
         except TypeError:

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -581,10 +581,10 @@ class Node:
 
     def is_draggable(self):
         return True
-    
+
     def can_drop(self, drag_node):
         return False
-    
+
     def would_accept_drop(self, drag_nodes):
         # drag_nodes can be a single node or a list of nodes
         # drag_nodes can be a single node or a list of nodes
@@ -1337,7 +1337,7 @@ class Node:
         dest.insert_node(self, pos=pos)
 
     @staticmethod
-    def union_bounds(nodes, bounds=None, attr="bounds"):
+    def union_bounds(nodes, bounds=None, attr="bounds", ignore_locked=True, ignore_hidden=False):
         """
         Returns the union of the node list given, optionally unioned the given bounds value
 
@@ -1351,7 +1351,9 @@ class Node:
         else:
             xmin, ymin, xmax, ymax = bounds
         for e in nodes:
-            if e.lock:
+            if ignore_locked and e.lock:
+                continue
+            if ignore_hidden and getattr(e, "hidden", False):
                 continue
             box = getattr(e, attr, None)
             if box is None:

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -453,3 +453,15 @@ class CutOpNode(Node, Parameters):
                     offset_routine=self.offset_routine,
                     origin=origin,
                 )
+
+    @property
+    def bounds(self):
+        if not self._bounds_dirty:
+            return self._bounds
+
+        self._bounds = None
+        if self.output:
+            if self._children:
+                self._bounds = Node.union_bounds(self._children, bounds=self._bounds, ignore_locked=False, ignore_hidden=True)
+            self._bounds_dirty = False
+        return self._bounds

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -73,7 +73,7 @@ class DotsOpNode(Node, Parameters):
     def can_drop(self, drag_node):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.has_ancestor("branch reg"):
-            # Will be dealt with in elements - 
+            # Will be dealt with in elements -
             # we don't implement a more sophisticated routine here
             return False
         if hasattr(drag_node, "as_geometry") and drag_node.type in self._allowed_elements_dnd:
@@ -85,7 +85,7 @@ class DotsOpNode(Node, Parameters):
             return True
         elif drag_node.type in ("file", "group"):
             return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
-        return False    
+        return False
 
     def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
@@ -283,3 +283,15 @@ class DotsOpNode(Node, Parameters):
                 settings=settings,
                 passes=passes,
             )
+
+    @property
+    def bounds(self):
+        if not self._bounds_dirty:
+            return self._bounds
+
+        self._bounds = None
+        if self.output:
+            if self._children:
+                self._bounds = Node.union_bounds(self._children, bounds=self._bounds, ignore_locked=False, ignore_hidden=True)
+            self._bounds_dirty = False
+        return self._bounds

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -405,3 +405,15 @@ class EngraveOpNode(Node, Parameters):
                     color=stroke,
                     origin=origin,
                 )
+
+    @property
+    def bounds(self):
+        if not self._bounds_dirty:
+            return self._bounds
+
+        self._bounds = None
+        if self.output:
+            if self._children:
+                self._bounds = Node.union_bounds(self._children, bounds=self._bounds, ignore_locked=False, ignore_hidden=True)
+            self._bounds_dirty = False
+        return self._bounds

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -109,7 +109,7 @@ class ImageOpNode(Node, Parameters):
     def can_drop(self, drag_node):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.has_ancestor("branch reg"):
-            # Will be dealt with in elements - 
+            # Will be dealt with in elements -
             # we don't implement a more sophisticated routine here
             return False
         if hasattr(drag_node, "as_image") and drag_node.type in self._allowed_elements_dnd:
@@ -121,7 +121,7 @@ class ImageOpNode(Node, Parameters):
             return True
         elif drag_node.type in ("file", "group"):
             return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
-        return False    
+        return False
 
     def drop(self, drag_node, modify=True, flag=False):
         # Default routine for drag + drop for an op node - irrelevant for others...
@@ -548,3 +548,15 @@ class ImageOpNode(Node, Parameters):
             # Yield all generated cutcodes of this image
             for cut in cutcodes:
                 yield cut
+
+    @property
+    def bounds(self):
+        if not self._bounds_dirty:
+            return self._bounds
+
+        self._bounds = None
+        if self.output:
+            if self._children:
+                self._bounds = Node.union_bounds(self._children, bounds=self._bounds, ignore_locked=False, ignore_hidden=True)
+            self._bounds_dirty = False
+        return self._bounds

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -122,7 +122,7 @@ class RasterOpNode(Node, Parameters):
     def can_drop(self, drag_node):
         # Default routine for drag + drop for an op node - irrelevant for others...
         if drag_node.has_ancestor("branch reg"):
-            # Will be dealt with in elements - 
+            # Will be dealt with in elements -
             # we don't implement a more sophisticated routine here
             return False
         if drag_node.type.startswith("elem ") and drag_node.type in self._allowed_elements_dnd:
@@ -134,7 +134,7 @@ class RasterOpNode(Node, Parameters):
             return True
         elif drag_node.type in ("file", "group"):
             return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
-        return False    
+        return False
 
     def drop(self, drag_node, modify=True, flag=False):
         count = 0
@@ -555,3 +555,15 @@ class RasterOpNode(Node, Parameters):
                 cut.path = path
                 cut.original_op = self.type
                 yield cut
+
+    @property
+    def bounds(self):
+        if not self._bounds_dirty:
+            return self._bounds
+
+        self._bounds = None
+        if self.output:
+            if self._children:
+                self._bounds = Node.union_bounds(self._children, bounds=self._bounds, ignore_locked=False, ignore_hidden=True)
+            self._bounds_dirty = False
+        return self._bounds


### PR DESCRIPTION
Placements were off, if the plan contained disabled operations and/or hidden elements

## Summary by Sourcery

Bug Fixes:
- Fix placement bounds calculation to correctly account for disabled operations and hidden elements.