### PR TITLE
Revert python statements that are incompatible with Python 3.6

### DIFF
--- a/.github/workflows/unittest-py36.yml
+++ b/.github/workflows/unittest-py36.yml
@@ -1,0 +1,80 @@
+name: Unittest
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [main, legacy6, legacy7, legacy8]
+    paths:
+      - '**.py'
+      - '.github/workflows/unittests.yml'
+  pull_request:
+    branches: [main, legacy6, legacy7, legacy8]
+    paths:
+      - '**.py'
+      - '.github/workflows/unittests.yml'
+
+concurrency:
+  group: unittests-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  unittests:
+
+    name: ${{ matrix.os }}+py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019]
+        python-version: [3.6]
+
+    steps:
+
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Identify precise Python version
+      id: full-python-version
+      shell: bash
+      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+    - name: Cache Python env for ${{ matrix.os }}-py${{ steps.full-python-version.outputs.version }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pythonLocation }}
+        key: new-${{ matrix.os }}-py${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements-nogui.txt') }}
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade --upgrade-strategy eager pip setuptools wheel babel
+        if [ -f requirements-nogui.txt ]; then pip install --upgrade --upgrade-strategy eager -r requirements-nogui.txt; fi
+
+    - name: List environment
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+        JOB_CONTEXT: ${{ toJSON(job) }}
+        STEPS_CONTEXT: ${{ toJSON(steps) }}
+        RUNNER_CONTEXT: ${{ toJSON(runner) }}
+        STRATEGY_CONTEXT: ${{ toJSON(strategy) }}
+        MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+      run: |
+        pip list
+        env
+
+    - name: Run Unittests
+      run: |
+        python -m unittest discover test -v
+        if ${{ matrix.experimental }} == true; then
+            exit 0
+        fi

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -291,13 +291,11 @@ class CutOpNode(Node, Parameters):
         if not self.valid_node_for_reference(node):
             # We could raise a ValueError but that will break things...
             return
-        if first_is_effect :=  (
+        first_is_effect =  (
             len(self._children) > 0 and
             self._children[0].type.startswith("effect ")
-        ):
-            effect = self._children[0]
-        else:
-            effect = None
+        )
+        effect = self._children[0] if first_is_effect else None
         ref = self.add(node=node, type="reference", pos=pos, **kwargs)
         node._references.append(ref)
         if first_is_effect:

--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -378,7 +378,7 @@ class CutOpNode(Node, Parameters):
         """Generator of cutobjects for a particular operation."""
 
         def get_pathlist(node, factor):
-            from time import perf_counter_ns
+            from time import perf_counter
 
             pathlist = []
             if node.type == "reference":
@@ -403,7 +403,6 @@ class CutOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor=factor).as_path()
                 path.approximate_arcs_with_cubics()
-                # pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
                 pathlist.append((None, path))
             elif node.type == "elem path":
                 path = abs(node.path)
@@ -411,8 +410,9 @@ class CutOpNode(Node, Parameters):
                 pathlist.append((None, path))
             elif node.type.startswith("effect"):
                 if hasattr(node, "as_geometries"):
+                    time_indicator = f"{perf_counter():.5f}".replace(".", "")
                     pathlist.extend(
-                        (f"hatch_{idx}_{perf_counter_ns()}", effect_geom.as_path())
+                        (f"hatch_{idx}_{time_indicator}", effect_geom.as_path())
                         for idx, effect_geom in enumerate(list(node.as_geometries()))
                     )
                 else:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -255,13 +255,11 @@ class EngraveOpNode(Node, Parameters):
         if not self.valid_node_for_reference(node):
             # We could raise a ValueError but that will break things...
             return
-        if first_is_effect :=  (
+        first_is_effect =  (
             len(self._children) > 0 and
             self._children[0].type.startswith("effect ")
-        ):
-            effect = self._children[0]
-        else:
-            effect = None
+        )
+        effect = self._children[0] if first_is_effect else None
         ref = self.add(node=node, type="reference", pos=pos, **kwargs)
         node._references.append(ref)
         if first_is_effect:

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -331,7 +331,7 @@ class EngraveOpNode(Node, Parameters):
         """Generator of cutobjects for a particular operation."""
 
         def get_pathlist(node, factor):
-            from time import perf_counter_ns
+            from time import perf_counter
 
             pathlist = []
             if node.type == "reference":
@@ -356,7 +356,6 @@ class EngraveOpNode(Node, Parameters):
                 # like tabs, dots/dashes applied to the element
                 path = node.final_geometry(unitfactor=factor).as_path()
                 path.approximate_arcs_with_cubics()
-                # pathlist.append( (f"{node.display_label()}_{perf_counter_ns()}", path) )
                 pathlist.append((None, path))
             elif node.type == "elem path":
                 path = abs(node.path)
@@ -364,8 +363,9 @@ class EngraveOpNode(Node, Parameters):
                 pathlist.append((None, path))
             elif node.type.startswith("effect"):
                 if hasattr(node, "as_geometries"):
+                    time_indicator = f"{perf_counter():.5f}".replace(".", "")
                     pathlist.extend(
-                        (f"hatch_{idx}_{perf_counter_ns()}", effect_geom.as_path())
+                        (f"hatch_{idx}_{time_indicator}", effect_geom.as_path())
                         for idx, effect_geom in enumerate(list(node.as_geometries()))
                     )
                 else:

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -483,7 +483,8 @@ class ContourPanel(wx.Panel):
             self.matrix = self.node.matrix
         else:
             reapply = False
-            if remembered_dither := self.node.dither:
+            remembered_dither = self.node.dither
+            if remembered_dither:
                 reapply = True
                 self.node.dither = False
                 self.node.update(None)
@@ -518,7 +519,8 @@ class ContourPanel(wx.Panel):
             return
         t_a = time.perf_counter()
 
-        if (method:=self.parameters["cnt_method"]) == 0:
+        method = self.parameters["cnt_method"]
+        if method == 0:
             self.contours = img_to_polygons(
                 self.image,
                 minimal=self.parameters["cnt_minimum"],

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -1053,9 +1053,11 @@ class ShadowTree:
                     # A timer can update after the tree closes.
                     return
 
-        if branch_elems_item := self.elements.get(type="branch elems")._item:
+        branch_elems_item = self.elements.get(type="branch elems")._item
+        if branch_elems_item:
             self.wxtree.Expand(branch_elems_item)
-        if branch_reg_item := self.elements.get(type="branch reg")._item:
+        branch_reg_item = self.elements.get(type="branch reg")._item
+        if branch_reg_item:
             self.wxtree.Expand(branch_reg_item)
         self.context.elements.signal("warn_state_update")
         self.freeze_tree(False)

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -466,10 +466,12 @@ def set_color_according_to_theme(control, background, foreground):
     while win is not None:
         if hasattr(win, "context") and hasattr(win.context, "themes"):
             if background:
-                if col := win.context.themes.get(background):
+                col = win.context.themes.get(background)
+                if col:
                     control.SetBackgroundColour(col)
             if foreground:
-                if col := win.context.themes.get(foreground):
+                col = win.context.themes.get(foreground)
+                if col:
                     control.SetForegroundColour(col)
             break
         win = win.GetParent()


### PR DESCRIPTION
We still need Python 3.6 for Raspberry Pi 32 bit compiles - the walrus operator (if-assignment ``if flag:=condition:``) has been introduced with python 3.8 and is hence unsupported.

## Summary by Sourcery

Revert Python code to remove the walrus operator for compatibility with Python 3.6 and add a CI workflow to run unittests on Python 3.6.

Bug Fixes:
- Revert usage of the walrus operator to ensure compatibility with Python 3.6.

CI:
- Add a new GitHub Actions workflow to run unittests on Python 3.6 for branches main, legacy6, legacy7, and legacy8.