### PR TITLE
Node Drag+Drop - Fix crash / invalid any statement

### DIFF
--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -134,9 +134,7 @@ class CutOpNode(Node, Parameters):
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(
-                drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes)
-            )
+            return any(e.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
         return False
 
     def drop(self, drag_node, modify=True, flag=False):

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -84,7 +84,7 @@ class DotsOpNode(Node, Parameters):
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
+            return any(e.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
         return False
 
     def drop(self, drag_node, modify=True, flag=False):

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -120,9 +120,7 @@ class EngraveOpNode(Node, Parameters):
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(
-                drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes)
-            )
+            return any(e.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
         return False
 
     def drop(self, drag_node, modify=True, flag=False):

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -48,6 +48,8 @@ class ImageOpNode(Node, Parameters):
         self.stopop = True
         self.label = "Image"
         self.overrule_dpi = False
+        self._allowed_elements_dnd = ("elem image",)
+        self._allowed_elements = ("elem image",)
 
         self.allowed_attributes = []
         super().__init__(type="op image", **kwargs)
@@ -112,15 +114,15 @@ class ImageOpNode(Node, Parameters):
             # Will be dealt with in elements -
             # we don't implement a more sophisticated routine here
             return False
-        if hasattr(drag_node, "as_image") and drag_node.type in self._allowed_elements_dnd:
+        if hasattr(drag_node, "as_image"):
             return True
-        elif drag_node.type == "reference" and drag_node.node.type in self._allowed_elements_dnd:
+        elif drag_node.type == "reference" and hasattr(drag_node.node, "as_image"):
             return True
         elif drag_node.type in op_nodes:
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
+            return any(e.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
         return False
 
     def drop(self, drag_node, modify=True, flag=False):

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -133,7 +133,7 @@ class RasterOpNode(Node, Parameters):
             # Move operation to a different position.
             return True
         elif drag_node.type in ("file", "group"):
-            return any(drag_node.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
+            return any(e.has_ancestor("branch reg") for e in drag_node.flat(elem_nodes))
         return False
 
     def drop(self, drag_node, modify=True, flag=False):


### PR DESCRIPTION
- Fixes a couple of logic issues for drag and drop 
- Resolve crash for image op can_drop

## Summary by Sourcery

Fix crash in the drag and drop functionality for image operations by correcting logic issues in the 'can_drop' method and refactor similar logic across multiple operation nodes for consistency.

Bug Fixes:
- Fix crash in the 'can_drop' method for image operations by correcting logic checks.

Enhancements:
- Refactor 'can_drop' method across multiple operation nodes to improve logic consistency and readability.