### PR TITLE
Introduction of GUI light mode / some fixes for dark mode

### DIFF
--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -32,7 +32,7 @@ class BalorControllerPanel(wx.ScrolledWindow):
         self.service = self.context.device
         self._buffer = ""
         self._buffer_lock = threading.Lock()
-        self.text_usb_log = wx.TextCtrl(
+        self.text_usb_log = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.text_usb_log.SetFont(font)

--- a/meerk40t/balormk/gui/balorcontroller.py
+++ b/meerk40t/balormk/gui/balorcontroller.py
@@ -8,7 +8,7 @@ from meerk40t.gui.icons import (
     icons8_disconnected,
 )
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import dip_size, wxButton
+from meerk40t.gui.wxutils import TextCtrl, dip_size, wxButton
 from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -1064,7 +1064,7 @@ class CameraURIPanel(wx.Panel):
             context=self.context, list_name="list_camerauri",
         )
         self.button_add = wxButton(self, wx.ID_ANY, _("Add URI"))
-        self.text_uri = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_uri = TextCtrl(self, wx.ID_ANY, "")
 
         self.__set_properties()
         self.__do_layout()

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -19,7 +19,7 @@ from meerk40t.gui.scene.sceneconst import (
 )
 from meerk40t.gui.scene.scenepanel import ScenePanel
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.gui.wxutils import wxButton, wxBitmapButton, wxCheckBox, wxListCtrl
+from meerk40t.gui.wxutils import TextCtrl, wxButton, wxBitmapButton, wxCheckBox, wxListCtrl
 from meerk40t.kernel import Job, signal_listener
 from meerk40t.svgelements import Color
 

--- a/meerk40t/device/gui/defaultactions.py
+++ b/meerk40t/device/gui/defaultactions.py
@@ -86,12 +86,12 @@ class DefaultActionPanel(wx.Panel):
         self.prepend_list = wxListCtrl(
             self, wx.ID_ANY, style=wx.LC_LIST | wx.LC_SINGLE_SEL, context=self.context,
         )
-        self.text_param_prepend = wx.TextCtrl(self, wx.ID_ANY)
+        self.text_param_prepend = TextCtrl(self, wx.ID_ANY)
 
         self.append_list = wxListCtrl(
             self, wx.ID_ANY, style=wx.LC_LIST | wx.LC_SINGLE_SEL, context=self.context,
         )
-        self.text_param_append = wx.TextCtrl(self, wx.ID_ANY)
+        self.text_param_append = TextCtrl(self, wx.ID_ANY)
         self.button_del_prepend = wxStaticBitmap(self, wx.ID_ANY, size=iconsize)
         self.button_up_prepend = wxStaticBitmap(self, wx.ID_ANY, size=iconsize)
         self.button_down_prepend = wxStaticBitmap(self, wx.ID_ANY, size=iconsize)

--- a/meerk40t/extra/updater.py
+++ b/meerk40t/extra/updater.py
@@ -490,7 +490,7 @@ def plugin(kernel, lifecycle):
                         import wx
 
                         from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
-                        from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticTexts
+                        from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticText, TextCtrl
 
                         has_wx = True
                     except ImportError:
@@ -515,7 +515,7 @@ def plugin(kernel, lifecycle):
 
                             label = wxStaticText(dlg, wx.ID_ANY, header)
                             sizer.Add(label, 0, wx.EXPAND, 0)
-                            info = wx.TextCtrl(
+                            info = TextCtrl(
                                 dlg, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
                             )
                             info.SetValue(content)

--- a/meerk40t/grbl/gui/grblcontroller.py
+++ b/meerk40t/grbl/gui/grblcontroller.py
@@ -13,7 +13,7 @@ from meerk40t.gui.icons import (
     icons8_disconnected,
 )
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticText
+from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticText, TextCtrl
 from meerk40t.kernel import get_safe_path, signal_listener
 
 _ = wx.GetTranslation
@@ -63,7 +63,7 @@ class GRBLControllerPanel(wx.Panel):
         static_line_2.SetMinSize(dip_size(self, 483, 5))
         sizer_1.Add(static_line_2, 0, wx.EXPAND, 0)
 
-        self.data_exchange = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_MULTILINE)
+        self.data_exchange = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_MULTILINE)
         self.data_exchange.SetMinSize(dip_size(self, -1, 100))
         sizer_1.Add(self.data_exchange, 1, wx.EXPAND, 0)
 
@@ -109,7 +109,7 @@ class GRBLControllerPanel(wx.Panel):
         sizer_2.Add(self.btn_clear, 0, wx.EXPAND), 0
         sizer_1.Add(sizer_2, 0, wx.EXPAND, 0)
 
-        self.gcode_text = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.gcode_text = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.gcode_text.SetToolTip(_("Enter a Gcode-Command and send it to the laser"))
         self.gcode_text.SetFocus()
         sizer_1.Add(self.gcode_text, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -13,6 +13,7 @@ from .wxutils import (
     wxButton,
     wxListCtrl,
     wxStaticText,
+    TextCtrl,
 )
 
 _ = wx.GetTranslation
@@ -1548,9 +1549,9 @@ class InformationPanel(ScrolledPanel):
         ScrolledPanel.__init__(self, *args, **kwds)
         self.context = context
         self.context.themes.set_window_colors(self)
-        self.mk_version = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.config_path = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.os_version = wx.TextCtrl(
+        self.mk_version = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.config_path = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.os_version = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         self.os_version.SetMinSize(wx.Size(-1, 5 * 25))

--- a/meerk40t/gui/autoexec.py
+++ b/meerk40t/gui/autoexec.py
@@ -7,7 +7,7 @@ from wx import aui
 
 from .icons import STD_ICON_SIZE, icons8_circled_play
 from .mwindow import MWindow
-from .wxutils import wxCheckBox, wxButton, dip_size
+from .wxutils import wxCheckBox, wxButton, dip_size, TextCtrl
 
 _ = wx.GetTranslation
 
@@ -20,7 +20,7 @@ class AutoExecPanel(wx.Panel):
         self.context.themes.set_window_colors(self)
         self.SetHelpText("autoexec")
         self.pane = pane
-        self.text_autoexec = wx.TextCtrl(
+        self.text_autoexec = TextCtrl(
             self,
             wx.ID_ANY,
             "",

--- a/meerk40t/gui/basicops.py
+++ b/meerk40t/gui/basicops.py
@@ -29,6 +29,7 @@ from .wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxStaticBitmap,
     wxStaticText,
 )
@@ -74,7 +75,7 @@ class BasicOpPanel(wx.Panel):
             _("Op inherits color"),
             _("Elem inherits color"),
         ]
-        self.combo_apply_color = wx.ComboBox(
+        self.combo_apply_color = wxComboBox(
             self,
             wx.ID_ANY,
             choices=choices,

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -12,6 +12,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxRadioBox,
     wxStaticBitmap,
     wxStaticText,
@@ -595,7 +596,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                 else:
                     control_sizer = wx.BoxSizer(wx.HORIZONTAL)
                 choice_list = list(map(str, c.get("choices", [c.get("default")])))
-                control = wx.ComboBox(
+                control = wxComboBox(
                     self,
                     wx.ID_ANY,
                     choices=choice_list,
@@ -693,7 +694,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                         data = c.get("default")
                     display_list.insert(0, str(data))
                     choice_list.insert(0, str(data))
-                control = wx.ComboBox(
+                control = wxComboBox(
                     self,
                     wx.ID_ANY,
                     choices=display_list,
@@ -739,7 +740,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                 control_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
                 choice_list = list(map(str, c.get("choices", [c.get("default")])))
-                control = wx.ComboBox(
+                control = wxComboBox(
                     self,
                     wx.ID_ANY,
                     choices=choice_list,

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -7,6 +7,7 @@ from wx import aui
 from meerk40t.gui.icons import STD_ICON_SIZE, icons8_console
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.kernel import get_safe_path, signal_listener
+from meerk40t.gui.wxutils import TextCtrl
 
 try:
     from wx import richtext
@@ -167,7 +168,7 @@ class ConsolePanel(wx.ScrolledWindow):
         self.context.themes.set_window_colors(self)
         self.SetHelpText("notes")
         font = self.get_font()
-        self.text_entry = wx.TextCtrl(
+        self.text_entry = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER | wx.TE_PROCESS_TAB
         )
         self.richtext = False
@@ -215,7 +216,7 @@ class ConsolePanel(wx.ScrolledWindow):
             self.richtext = True
 
         except NameError:
-            self.text_main = wx.TextCtrl(
+            self.text_main = TextCtrl(
                 self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
             )
             self.text_main.SetFont(font)

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -10,6 +10,7 @@ from meerk40t.gui.wxutils import (
     wxListCtrl,
     wxStaticText,
     wxTreeCtrl,
+    TextCtrl,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
 
@@ -55,7 +56,7 @@ class SelectDevice(wx.Dialog):
         label_filter = wxStaticText(self, wx.ID_ANY, _("Device:"))
         sizer_3.Add(label_filter, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.text_filter = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_filter = TextCtrl(self, wx.ID_ANY, "")
         sizer_3.Add(self.text_filter, 0, wx.EXPAND, 0)
 
         self.tree_devices = wxTreeCtrl(

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -5,7 +5,12 @@ from meerk40t.kernel import signal_listener
 from .choicepropertypanel import ChoicePropertyPanel
 from .icons import get_default_icon_size, icons8_laser_beam
 from .mwindow import MWindow
-from .wxutils import disable_window, wxButton, wxListBox
+from .wxutils import (
+    disable_window, 
+    wxButton, 
+    wxComboBox,
+    wxListBox,
+)
 
 _ = wx.GetTranslation
 
@@ -29,7 +34,7 @@ class PlannerPanel(wx.Panel):
                 break
         spools = [s.label for s in self.available_devices]
 
-        self.combo_device = wx.ComboBox(
+        self.combo_device = wxComboBox(
             self, wx.ID_ANY, choices=spools, style=wx.CB_DROPDOWN
         )
         self.combo_device.SetSelection(index)

--- a/meerk40t/gui/gui_mixins.py
+++ b/meerk40t/gui/gui_mixins.py
@@ -14,7 +14,7 @@ from meerk40t.gui.icons import (
     icon_paint_brush_green,
     icon_warning,
 )
-from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticText
+from meerk40t.gui.wxutils import dip_size, wxButton, wxStaticText, TextCtrl
 
 _ = wx.GetTranslation
 
@@ -299,7 +299,7 @@ class Warnings:
 
         label1 = wxStaticText(dlg, wx.ID_ANY, l_hi)
         sizer.Add(label1, 0, wx.EXPAND, 0)
-        info_hi = wx.TextCtrl(
+        info_hi = TextCtrl(
             dlg, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         info_hi.SetValue(txt_critical)
@@ -307,7 +307,7 @@ class Warnings:
 
         label2 = wxStaticText(dlg, wx.ID_ANY, l_mid)
         sizer.Add(label2, 0, wx.EXPAND, 0)
-        info_mid = wx.TextCtrl(
+        info_mid = TextCtrl(
             dlg, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         info_mid.SetValue(txt_mid)
@@ -315,7 +315,7 @@ class Warnings:
 
         label3 = wxStaticText(dlg, wx.ID_ANY, l_low)
         sizer.Add(label3, 0, wx.EXPAND, 0)
-        info_low = wx.TextCtrl(
+        info_low = TextCtrl(
             dlg, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         info_low.SetValue(txt_low)

--- a/meerk40t/gui/helper.py
+++ b/meerk40t/gui/helper.py
@@ -11,7 +11,7 @@
 import wx
 from wx import aui
 
-from meerk40t.gui.wxutils import wxCheckBox  # , wxButton
+from meerk40t.gui.wxutils import wxCheckBox, TextCtrl  # , wxButton
 from meerk40t.kernel import Job, signal_listener
 
 _ = wx.GetTranslation
@@ -49,7 +49,7 @@ class HelperPanel(wx.Panel):
         self.context = context
         self.context.themes.set_window_colors(self)
         self._lock_updates = None
-        self.text_info = wx.TextCtrl(
+        self.text_info = TextCtrl(
             self, wx.ID_ANY, style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.check_allow = wxCheckBox(self, wx.ID_ANY, _("Display control-information"))

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -29,6 +29,7 @@ from meerk40t.gui.wxutils import (
     wxStaticBitmap,
     wxStaticText,
     wxToggleButton,
+    TextCtrl,
 )
 from meerk40t.kernel.kernel import signal_listener
 from meerk40t.tools.geomstr import TYPE_ARC, TYPE_CUBIC, TYPE_LINE, TYPE_QUAD, Geomstr
@@ -77,7 +78,7 @@ class FontGlyphPicker(wx.Dialog):
         self.images = wx.ImageList()
         self.images.Create(width=self.icon_size, height=self.icon_size)
         self.list_glyphs.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
-        self.txt_result = wx.TextCtrl(self, wx.ID_ANY)
+        self.txt_result = TextCtrl(self, wx.ID_ANY)
         mainsizer.Add(self.list_glyphs, 1, wx.EXPAND, 0)
         mainsizer.Add(self.txt_result, 0, wx.EXPAND, 0)
 
@@ -366,7 +367,7 @@ class LineTextPropertyPanel(wx.Panel):
         main_sizer = StaticBoxSizer(self, wx.ID_ANY, _("Vector-Text"), wx.VERTICAL)
 
         sizer_text = StaticBoxSizer(self, wx.ID_ANY, _("Content"), wx.HORIZONTAL)
-        self.text_text = wx.TextCtrl(
+        self.text_text = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE
         )
         sizer_text.Add(self.text_text, 1, wx.EXPAND, 0)
@@ -964,7 +965,7 @@ class PanelFontManager(wx.Panel):
 
         self.font_infos = []
 
-        self.text_info = wx.TextCtrl(
+        self.text_info = TextCtrl(
             self,
             wx.ID_ANY,
             _(
@@ -986,7 +987,7 @@ class PanelFontManager(wx.Panel):
         )
         mainsizer.Add(sizer_directory, 0, wx.EXPAND, 0)
 
-        self.text_fontdir = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_fontdir = TextCtrl(self, wx.ID_ANY, "")
         sizer_directory.Add(self.text_fontdir, 1, wx.EXPAND, 0)
         self.text_fontdir.SetToolTip(
             _(

--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -24,6 +24,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxListBox,
     wxListCtrl,
     wxStaticBitmap,
@@ -1047,7 +1048,7 @@ class PanelFontManager(wx.Panel):
             _("Hershey Fonts - #2"),
             _("Autocad-SHX-Fonts"),
         ]
-        self.combo_webget = wx.ComboBox(
+        self.combo_webget = wxComboBox(
             self,
             wx.ID_ANY,
             choices=choices,

--- a/meerk40t/gui/keymap.py
+++ b/meerk40t/gui/keymap.py
@@ -4,7 +4,7 @@ import wx
 
 from .icons import icons8_keyboard
 from .mwindow import MWindow
-from .wxutils import get_key_name, wxButton, wxListCtrl
+from .wxutils import get_key_name, wxButton, wxListCtrl, TextCtrl
 
 _ = wx.GetTranslation
 
@@ -25,8 +25,8 @@ class KeymapPanel(wx.Panel):
             context=self.context, list_name="list_keymap",
         )
         self.button_add = wxButton(self, wx.ID_ANY, _("Add Hotkey"))
-        self.text_key_name = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_command_name = wx.TextCtrl(
+        self.text_key_name = TextCtrl(self, wx.ID_ANY, "")
+        self.text_command_name = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
 

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -28,6 +28,7 @@ from meerk40t.gui.wxutils import (
     disable_window,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxStaticBitmap,
     wxStaticText,
 )
@@ -143,7 +144,7 @@ class LaserPanel(wx.Panel):
         # Devices Initialize.
         self.available_devices = self.context.kernel.services("device")
 
-        self.combo_devices = wx.ComboBox(
+        self.combo_devices = wxComboBox(
             self, wx.ID_ANY, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.combo_devices.SetToolTip(

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -23,6 +23,7 @@ from meerk40t.gui.wxutils import (
     HoverButton,
     ScrolledPanel,
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     disable_window,
     wxButton,
@@ -732,7 +733,7 @@ class JobPanel(wx.Panel):
         sizer_source = wx.BoxSizer(wx.HORIZONTAL)
         sizer_main.Add(sizer_source, 0, wx.EXPAND, 0)
 
-        self.text_plan = wx.TextCtrl(
+        self.text_plan = TextCtrl(
             self, wx.ID_ANY, _("--- Empty ---"), style=wx.TE_READONLY
         )
         sizer_source.Add(self.text_plan, 2, 0, 0)

--- a/meerk40t/gui/lasertoolpanel.py
+++ b/meerk40t/gui/lasertoolpanel.py
@@ -10,6 +10,7 @@ from meerk40t.gui.icons import (
 )
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
+    TextCtrl,
     dip_size,
     wxButton,
     wxCheckBox,
@@ -272,7 +273,7 @@ class LaserToolPanel(wx.Panel):
         label_wd = wxStaticText(self.nb_square, wx.ID_ANY, _("Dimension"))
         size_width.Add(label_wd, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.txt_width = wx.TextCtrl(self.nb_square, wx.ID_ANY, DEFAULT_LEN)
+        self.txt_width = TextCtrl(self.nb_square, wx.ID_ANY, DEFAULT_LEN)
         self.txt_width.SetToolTip(_("Extension of the square to create"))
         self.txt_width.SetMinSize(dip_size(self.nb_square, 60, -1))
         size_width.Add(self.txt_width, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -34,6 +34,7 @@ from meerk40t.gui.wxutils import (
     wxCheckBox,
     wxComboBox,
     wxStaticText,
+    wxTreeCtrl,
 )
 from meerk40t.kernel.kernel import get_safe_path
 from meerk40t.kernel.settings import Settings
@@ -353,7 +354,7 @@ class MaterialPanel(ScrolledPanel):
         result_box = StaticBoxSizer(
             self, wx.ID_ANY, _("Matching library entries"), wx.VERTICAL
         )
-        self.tree_library = wx.TreeCtrl(
+        self.tree_library = wxTreeCtrl(
             self,
             wx.ID_ANY,
             style=wx.BORDER_SUNKEN | wx.TR_HAS_BUTTONS
@@ -368,6 +369,7 @@ class MaterialPanel(ScrolledPanel):
             style=wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES | wx.LC_SINGLE_SEL,
             context=self.context, list_name="list_materialmanager"
         )
+        
         self.list_preview.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=55)
         self.list_preview.AppendColumn(
             _("Operation"),

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -32,6 +32,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxStaticText,
 )
 from meerk40t.kernel.kernel import get_safe_path
@@ -311,7 +312,7 @@ class MaterialPanel(ScrolledPanel):
         label_1 = wxStaticText(self, wx.ID_ANY, _("Material"))
         filter_box.Add(label_1, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.txt_material = wx.ComboBox(
+        self.txt_material = wxComboBox(
             self, wx.ID_ANY, choices=materials, style=wx.CB_SORT
         )
         # self.txt_material = TextCtrl(self, wx.ID_ANY, "", limited=True)
@@ -336,7 +337,7 @@ class MaterialPanel(ScrolledPanel):
         for e in dev_infos:
             self.laser_choices.append(e[0][0])
 
-        self.combo_lasertype = wx.ComboBox(
+        self.combo_lasertype = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.laser_choices,
@@ -446,7 +447,7 @@ class MaterialPanel(ScrolledPanel):
         size_it(label, 60, 100)
         box2.Add(label, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         # self.txt_entry_material = TextCtrl(self, wx.ID_ANY, "")
-        self.txt_entry_material = wx.ComboBox(
+        self.txt_entry_material = wxComboBox(
             self, wx.ID_ANY, choices=materials, style=wx.CB_SORT
         )
 
@@ -463,7 +464,7 @@ class MaterialPanel(ScrolledPanel):
         box3.Add(label, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         choices = self.laser_choices  # [1:]
-        self.combo_entry_type = wx.ComboBox(
+        self.combo_entry_type = wxComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.combo_entry_type.SetMaxSize(dip_size(self, 110, -1))

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -49,17 +49,17 @@ class ImportDialog(wx.Dialog):
         wx.Dialog.__init__(self, *args, **kwds)
         self.context = context
         self.context.themes.set_window_colors(self)
-        self.txt_filename = wx.TextCtrl(self, wx.ID_ANY)
+        self.txt_filename = TextCtrl(self, wx.ID_ANY)
         self.btn_file = wxButton(self, wx.ID_ANY, "...")
         self.check_consolidate = wxCheckBox(
             self, wx.ID_ANY, _("Consolidate same thickness for material")
         )
         self.check_lens = wxCheckBox(self, wx.ID_ANY, _("Compensate Lens-Sizes"))
-        self.txt_lens_old = wx.TextCtrl(self, wx.ID_ANY)
-        self.txt_lens_new = wx.TextCtrl(self, wx.ID_ANY)
+        self.txt_lens_old = TextCtrl(self, wx.ID_ANY)
+        self.txt_lens_new = TextCtrl(self, wx.ID_ANY)
         self.check_wattage = wxCheckBox(self, wx.ID_ANY, _("Compensate Power-Levels"))
-        self.txt_wattage_old = wx.TextCtrl(self, wx.ID_ANY)
-        self.txt_wattage_new = wx.TextCtrl(self, wx.ID_ANY)
+        self.txt_wattage_old = TextCtrl(self, wx.ID_ANY)
+        self.txt_wattage_new = TextCtrl(self, wx.ID_ANY)
         self.btn_ok = wxButton(self, wx.ID_OK, _("OK"))
         self.btn_cancel = wxButton(self, wx.ID_CANCEL, _("Cancel"))
 
@@ -422,7 +422,7 @@ class MaterialPanel(ScrolledPanel):
         label = wxStaticText(self, wx.ID_ANY, _("Title"))
         # size_it(label, 60, 100)
         box1.Add(label, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        self.txt_entry_title = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.txt_entry_title = TextCtrl(self, wx.ID_ANY, "")
         box1.Add(self.txt_entry_title, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
         self.btn_set = wxButton(self, wx.ID_ANY, _("Set"))
@@ -445,7 +445,7 @@ class MaterialPanel(ScrolledPanel):
         label = wxStaticText(self, wx.ID_ANY, _("Material"))
         size_it(label, 60, 100)
         box2.Add(label, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        # self.txt_entry_material = wx.TextCtrl(self, wx.ID_ANY, "")
+        # self.txt_entry_material = TextCtrl(self, wx.ID_ANY, "")
         self.txt_entry_material = wx.ComboBox(
             self, wx.ID_ANY, choices=materials, style=wx.CB_SORT
         )
@@ -510,7 +510,7 @@ class MaterialPanel(ScrolledPanel):
         box4.Add(self.txt_entry_lens, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         box4.Add(unit, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.txt_entry_note = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_MULTILINE)
+        self.txt_entry_note = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_MULTILINE)
         self.txt_entry_note.SetMinSize(dip_size(self, -1, 2 * 23))
         self.box_extended.Add(self.txt_entry_note, 0, wx.EXPAND, 0)
 
@@ -2802,7 +2802,7 @@ class AboutPanel(wx.Panel):
         info_box = StaticBoxSizer(self, wx.ID_ANY, _("How to use..."), wx.VERTICAL)
         self.parent_panel = None
         s = self.context.asset("material_howto")
-        info_label = wx.TextCtrl(
+        info_label = TextCtrl(
             self, wx.ID_ANY, value=s, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         fsize = 16 if system() == "Darwin" else 10

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -45,7 +45,7 @@ class SaveLoadPanel(wx.Panel):
         self.SetSizer(sizer_main)
         sizer_name = wx.BoxSizer(wx.HORIZONTAL)
         lbl_info = wxStaticText(self, wx.ID_ANY, _("Template-Name"))
-        self.txt_name = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.txt_name = TextCtrl(self, wx.ID_ANY, "")
         self.btn_save = wxButton(self, wx.ID_ANY, _("Save"))
         self.btn_load = wxButton(self, wx.ID_ANY, _("Load"))
         self.btn_delete = wxButton(self, wx.ID_ANY, _("Delete"))
@@ -476,7 +476,7 @@ class TemplatePanel(wx.Panel):
             "by creating a testpattern that varies two different parameters."
         )
 
-        info_label = wx.TextCtrl(
+        info_label = TextCtrl(
             self, wx.ID_ANY, value=infomsg, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         info_label.SetBackgroundColour(self.GetBackgroundColour())

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -18,6 +18,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxListBox,
     wxStaticText,
 )
@@ -210,7 +211,7 @@ class TemplatePanel(wx.Panel):
 
         LABEL_WIDTH = 115
 
-        self.combo_ops = wx.ComboBox(
+        self.combo_ops = wxComboBox(
             self, id=wx.ID_ANY, choices=opchoices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.images = []
@@ -231,7 +232,7 @@ class TemplatePanel(wx.Panel):
                     label += "(" + node.display_label() + ")"
                 self.image_labels.append(label)
 
-        self.combo_images = wx.ComboBox(
+        self.combo_images = wxComboBox(
             self,
             id=wx.ID_ANY,
             choices=self.image_labels,
@@ -246,7 +247,7 @@ class TemplatePanel(wx.Panel):
         self.check_labels = wxCheckBox(self, wx.ID_ANY, _("Labels"))
         self.check_values = wxCheckBox(self, wx.ID_ANY, _("Values"))
 
-        self.combo_param_1 = wx.ComboBox(
+        self.combo_param_1 = wxComboBox(
             self, id=wx.ID_ANY, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.spin_count_1 = wx.SpinCtrl(self, wx.ID_ANY, initial=5, min=1, max=100)
@@ -259,7 +260,7 @@ class TemplatePanel(wx.Panel):
         self.unit_param_1a = wxStaticText(self, wx.ID_ANY, "")
         self.unit_param_1b = wxStaticText(self, wx.ID_ANY, "")
 
-        self.combo_color_1 = wx.ComboBox(
+        self.combo_color_1 = wxComboBox(
             self,
             wx.ID_ANY,
             choices=color_choices,
@@ -267,7 +268,7 @@ class TemplatePanel(wx.Panel):
         )
         self.check_color_direction_1 = wxCheckBox(self, wx.ID_ANY, _("Growing"))
 
-        self.combo_param_2 = wx.ComboBox(
+        self.combo_param_2 = wxComboBox(
             self, id=wx.ID_ANY, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.spin_count_2 = wx.SpinCtrl(self, wx.ID_ANY, initial=5, min=1, max=100)
@@ -280,7 +281,7 @@ class TemplatePanel(wx.Panel):
         self.unit_param_2a = wxStaticText(self, wx.ID_ANY, "")
         self.unit_param_2b = wxStaticText(self, wx.ID_ANY, "")
 
-        self.combo_color_2 = wx.ComboBox(
+        self.combo_color_2 = wxComboBox(
             self,
             wx.ID_ANY,
             choices=color_choices,

--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -17,6 +17,7 @@ from meerk40t.gui.wxutils import (
     TextCtrl,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxRadioBox,
     wxStaticBitmap,
     wxStaticText,
@@ -479,7 +480,7 @@ class DebugIconPanel(wx.Panel):
                 s = getattr(mkicons, entry)
                 if isinstance(s, (mkicons.VectorIcon, mkicons.PyEmbeddedImage)):
                     self.icon_list.append(entry)
-        self.combo_icons = wx.ComboBox(
+        self.combo_icons = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.icon_list,
@@ -547,7 +548,7 @@ class DebugWindowPanel(wx.Panel):
             value, name, suffix = find
             self.window_list.append(suffix)
 
-        self.combo_windows = wx.ComboBox(
+        self.combo_windows = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.window_list,
@@ -566,8 +567,8 @@ class DebugWindowPanel(wx.Panel):
             choices=("Option 1", "Option 2", "Option 3"),
             style=wx.CB_READONLY | wx.CB_DROPDOWN,
         )
-        text_left = TextCtrl(self, wx.ID_ANY, "")
-        check_left = wxCheckBox(self, wx.ID_ANY, label="Checkbox")
+        text_left = wx.TextCtrl(self, wx.ID_ANY, "")
+        check_left = wx.CheckBox(self, wx.ID_ANY, label="Checkbox")
         btn_left = wx.Button(self, wx.ID_ANY, "A button")
         toggle_left = wx.ToggleButton(self, wx.ID_ANY, "Toggle")
         radio_left = wx.RadioBox(self, wx.ID_ANY, choices=("Yes", "No", "Maybe"))
@@ -575,7 +576,7 @@ class DebugWindowPanel(wx.Panel):
             self, wx.ID_ANY, mkicons.icon_bell.GetBitmap(resize=25)
         )
         slider_left = wx.Slider(self, wx.ID_ANY, value=0, minValue=0, maxValue=100)
-        static_left = wxStaticBitmap(
+        static_left = wx.StaticBitmap(
             self, wx.ID_ANY, mkicons.icon_closed_door.GetBitmap(resize=50)
         )
         left_side.Add(cb_left, 0, 0, 0)

--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -229,9 +229,9 @@ class DebugTreePanel(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
         self.context = context
         self.context.themes.set_window_colors(self)
-        self.lb_selected = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_MULTILINE)
-        self.lb_emphasized = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_MULTILINE)
-        self.txt_first = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.lb_selected = TextCtrl(self, wx.ID_ANY, style=wx.TE_MULTILINE)
+        self.lb_emphasized = TextCtrl(self, wx.ID_ANY, style=wx.TE_MULTILINE)
+        self.txt_first = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
 
         self.__set_properties()
         self.__do_layout()
@@ -566,7 +566,7 @@ class DebugWindowPanel(wx.Panel):
             choices=("Option 1", "Option 2", "Option 3"),
             style=wx.CB_READONLY | wx.CB_DROPDOWN,
         )
-        text_left = wx.TextCtrl(self, wx.ID_ANY, "")
+        text_left = TextCtrl(self, wx.ID_ANY, "")
         check_left = wxCheckBox(self, wx.ID_ANY, label="Checkbox")
         btn_left = wx.Button(self, wx.ID_ANY, "A button")
         toggle_left = wx.ToggleButton(self, wx.ID_ANY, "Toggle")

--- a/meerk40t/gui/notes.py
+++ b/meerk40t/gui/notes.py
@@ -3,7 +3,7 @@ from wx import aui
 
 from .icons import STD_ICON_SIZE, icons8_comments
 from .mwindow import MWindow
-from .wxutils import wxCheckBox
+from .wxutils import wxCheckBox, TextCtrl
 
 _ = wx.GetTranslation
 
@@ -41,7 +41,7 @@ class NotePanel(wx.Panel):
             self.check_auto_open_notes = wxCheckBox(
                 self, wx.ID_ANY, _("Automatically Open Notes")
             )
-        self.text_notes = wx.TextCtrl(
+        self.text_notes = TextCtrl(
             self,
             wx.ID_ANY,
             "",

--- a/meerk40t/gui/opassignment.py
+++ b/meerk40t/gui/opassignment.py
@@ -10,7 +10,7 @@ from meerk40t.gui.icons import (
     icons8_laserbeam_weak,
 )
 from meerk40t.gui.laserrender import swizzlecolor
-from meerk40t.gui.wxutils import dip_size, wxButton, wxCheckBox
+from meerk40t.gui.wxutils import dip_size, wxButton, wxCheckBox, wxComboBox
 from meerk40t.svgelements import Color
 
 from ..kernel import signal_listener
@@ -63,7 +63,7 @@ class OperationAssignPanel(wx.Panel):
             _("-> OP"),
             _("-> Elem"),
         ]
-        self.cbo_apply_color = wx.ComboBox(
+        self.cbo_apply_color = wxComboBox(
             self,
             wx.ID_ANY,
             choices=choices,

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -77,8 +77,7 @@ and a wxpython version <= 4.1.1."""
         kernel_root.register("font/wx_to_svg", wxfont_to_svg)
     if lifecycle == "register":
         from meerk40t.gui.themes import Themes
-        force_dark = kernel_root.setting(bool, "force_dark", False)
-        kernel.add_service("themes", Themes(kernel, force_dark=force_dark))
+        kernel.add_service("themes", Themes(kernel))
 
         from meerk40t.gui.guicolors import GuiColors
         kernel.add_service("colors", GuiColors(kernel))

--- a/meerk40t/gui/position.py
+++ b/meerk40t/gui/position.py
@@ -4,7 +4,14 @@ from wx import aui
 from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.units import UNITS_PER_PIXEL, Length
 from meerk40t.gui.icons import get_default_icon_size, icons8_compress
-from meerk40t.gui.wxutils import wxBitmapButton, StaticBoxSizer, TextCtrl, dip_size, wxCheckBox
+from meerk40t.gui.wxutils import (
+    StaticBoxSizer,
+    TextCtrl,
+    dip_size,
+    wxBitmapButton,
+    wxCheckBox,
+    wxComboBox,
+)
 from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
@@ -80,7 +87,7 @@ class PositionPanel(wx.Panel):
         self.button_execute = wxBitmapButton(self, wx.ID_ANY)
         self.button_param = wxBitmapButton(self, wx.ID_ANY)
         self.choices = ["mm", "cm", "inch", "mil", "%"]
-        self.combo_box_units = wx.ComboBox(
+        self.combo_box_units = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.choices,

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -11,7 +11,14 @@ from .choicepropertypanel import ChoicePropertyPanel
 from .icons import icons8_administrative_tools
 from .mwindow import MWindow
 from .wxmribbon import RibbonEditor
-from .wxutils import StaticBoxSizer, TextCtrl, dip_size, wxButton, wxRadioBox
+from .wxutils import (
+    StaticBoxSizer,
+    TextCtrl,
+    dip_size,
+    wxButton,
+    wxComboBox,
+    wxRadioBox,
+)
 
 _ = wx.GetTranslation
 
@@ -107,7 +114,7 @@ class PreferencesLanguagePanel(wx.Panel):
             language_name
             for language_code, language_name, language_index in supported_languages
         ]
-        self.combo_language = wx.ComboBox(
+        self.combo_language = wxComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_READONLY
         )
         self.combo_language.SetToolTip(
@@ -360,7 +367,7 @@ class PreferencesPixelsPerInchPanel(wx.Panel):
             self, wx.ID_ANY, _("SVG Pixel Per Inch"), wx.HORIZONTAL
         )
 
-        self.combo_svg_ppi = wx.ComboBox(
+        self.combo_svg_ppi = wxComboBox(
             self,
             wx.ID_ANY,
             choices=[

--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -475,16 +475,16 @@ class LinePropPanel(wx.Panel):
         }
         linestylechoices = [_(e) for e in self.dash_patterns]
         linestylechoices.append(_("User defined"))
-        self.combo_cap = wx.ComboBox(
+        self.combo_cap = wxComboBox(
             self, wx.ID_ANY, choices=capchoices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
-        self.combo_join = wx.ComboBox(
+        self.combo_join = wxComboBox(
             self, wx.ID_ANY, choices=joinchoices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
-        self.combo_fill = wx.ComboBox(
+        self.combo_fill = wxComboBox(
             self, wx.ID_ANY, choices=fillchoices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
-        self.combo_linestyle = wx.ComboBox(
+        self.combo_linestyle = wxComboBox(
             self,
             wx.ID_ANY,
             choices=linestylechoices,
@@ -759,7 +759,7 @@ class StrokeWidthPanel(wx.Panel):
         self.text_width.SetMaxSize(dip_size(self, 100, -1))
 
         self.unit_choices = ["px", "pt", "mm", "cm", "inch", "mil"]
-        self.combo_units = wx.ComboBox(
+        self.combo_units = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.unit_choices,

--- a/meerk40t/gui/propertypanels/blobproperty.py
+++ b/meerk40t/gui/propertypanels/blobproperty.py
@@ -3,7 +3,7 @@ import wx
 from meerk40t.core.node.blobnode import BlobNode
 from meerk40t.gui.icons import icons8_vector
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import ScrolledPanel, wxRadioBox
+from meerk40t.gui.wxutils import ScrolledPanel, wxRadioBox, TextCtrl
 
 from .attributes import IdPanel
 
@@ -33,7 +33,7 @@ class BlobPropertyPanel(ScrolledPanel):
             style=wx.RA_SPECIFY_COLS,
         )
         self.option_view.SetSelection(0)
-        self.text_blob = wx.TextCtrl(
+        self.text_blob = TextCtrl(
             self, id=wx.ID_ANY, value="", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.Bind(wx.EVT_RADIOBOX, self.on_option_view, self.option_view)

--- a/meerk40t/gui/propertypanels/consoleproperty.py
+++ b/meerk40t/gui/propertypanels/consoleproperty.py
@@ -1,8 +1,8 @@
 import wx
 
-from ..icons import icons8_comments
-from ..mwindow import MWindow
-
+from meerk40t.gui.icons import icons8_comments
+from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import TextCtrl
 _ = wx.GetTranslation
 
 
@@ -36,8 +36,8 @@ class ConsolePropertiesPanel(wx.Panel):
         self.context.themes.set_window_colors(self)
 
         self.console_operation = node
-        # self.command_name = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.command_text = wx.TextCtrl(
+        # self.command_name = TextCtrl(self, wx.ID_ANY, "")
+        self.command_text = TextCtrl(
             self,
             wx.ID_ANY,
             "Command text",

--- a/meerk40t/gui/propertypanels/groupproperties.py
+++ b/meerk40t/gui/propertypanels/groupproperties.py
@@ -3,7 +3,7 @@ import time
 
 import wx
 
-from meerk40t.gui.wxutils import ScrolledPanel
+from meerk40t.gui.wxutils import ScrolledPanel, TextCtrl
 
 # from ...svgelements import SVG_ATTR_ID
 from ..icons import icons8_group_objects
@@ -25,7 +25,7 @@ class ElemcountPanel(wx.Panel):
         self.context.themes.set_window_colors(self)
         self.node = node
         # Shall we display id / label?
-        self.text_elements = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_elements = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         self.sizer_id = StaticBoxSizer(self, wx.ID_ANY, _("Elements:"), wx.VERTICAL)
@@ -126,10 +126,10 @@ class FilePropertiesPanel(ScrolledPanel):
         self.context.themes.set_window_colors(self)
 
         self.node = node
-        self.text_filename = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_path = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_datetime = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_size = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_filename = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_path = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_datetime = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_size = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
         self.panel_ct = ElemcountPanel(
             self, id=wx.ID_ANY, context=self.context, node=node
         )

--- a/meerk40t/gui/propertypanels/hatchproperty.py
+++ b/meerk40t/gui/propertypanels/hatchproperty.py
@@ -117,7 +117,7 @@ class HatchPropertyPanel(ScrolledPanel):
         main_sizer.Add(sizer_fill, 6, wx.EXPAND, 0)
 
         self.fills = list(self.context.match("hatch", suffix=True))
-        self.combo_fill_style = wx.ComboBox(
+        self.combo_fill_style = wxComboBox(
             self, wx.ID_ANY, choices=self.fills, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         sizer_fill.Add(self.combo_fill_style, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -101,7 +101,7 @@ class ContourPanel(wx.Panel):
             _("Center (unrotated)"),
             _("Center (rotated)"),
         )
-        self.combo_placement = wx.ComboBox(self, wx.ID_ANY, choices=placement_choices, style=wx.CB_DROPDOWN | wx.CB_READONLY)
+        self.combo_placement = wxComboBox(self, wx.ID_ANY, choices=placement_choices, style=wx.CB_DROPDOWN | wx.CB_READONLY)
 
         self.bitmap_preview = wxStaticBitmap(self, wx.ID_ANY)
         self.label_info = wxStaticText(self, wx.ID_ANY)
@@ -1088,7 +1088,7 @@ class ImageModificationPanel(ScrolledPanel):
         for entry in list(self.context.match("raster_script/.*", suffix=True)):
             self.scripts.append(entry)
             choices.append(_("Apply {entry}").format(entry=entry))
-        self.combo_scripts = wx.ComboBox(
+        self.combo_scripts = wxComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_READONLY | wx.CB_DROPDOWN
         )
         self.combo_scripts.SetSelection(0)
@@ -1373,7 +1373,7 @@ class ImageVectorisationPanel(ScrolledPanel):
             "Majority",
             "Random",
         ]
-        self.combo_turnpolicy = wx.ComboBox(
+        self.combo_turnpolicy = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.turn_choices,
@@ -1780,7 +1780,7 @@ class ImagePropertyPanel(ScrolledPanel):
             "Sierra2",
             "Sierra-2-4a",
         ]
-        self.combo_dither = wx.ComboBox(
+        self.combo_dither = wxComboBox(
             self,
             wx.ID_ANY,
             choices=self.choices,
@@ -1788,7 +1788,7 @@ class ImagePropertyPanel(ScrolledPanel):
         )
         self.check_enable_depthmap = wxCheckBox(self, wx.ID_ANY, _("Depthmap"))
         resolutions = list((f"{2**p} - {p}bit" for p in range(8, 1, -1)))
-        self.combo_depthmap = wx.ComboBox(
+        self.combo_depthmap = wxComboBox(
             self,
             wx.ID_ANY,
             choices=resolutions,
@@ -1803,7 +1803,7 @@ class ImagePropertyPanel(ScrolledPanel):
         #     self.op_choices.append(_("Apply: {script}").format(script=op))
         #     self.image_ops.append(op)
 
-        # self.combo_operations = wx.ComboBox(
+        # self.combo_operations = wxComboBox(
         #     self,
         #     wx.ID_ANY,
         #     choices=self.op_choices,

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -716,10 +716,10 @@ class CropPanel(wx.Panel):
         self.slider_bottom = wx.Slider(
             self, wx.ID_ANY, 0, -127, 127, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_left = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_right = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_top = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
-        self.text_bottom = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_left = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_right = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_top = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_bottom = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
 
         self.__set_properties()
         self.__do_layout()
@@ -1816,23 +1816,23 @@ class ImagePropertyPanel(ScrolledPanel):
         self.slider_grayscale_red = wx.Slider(
             self, wx.ID_ANY, 0, -1000, 1000, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_grayscale_red = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_grayscale_red = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.slider_grayscale_green = wx.Slider(
             self, wx.ID_ANY, 0, -1000, 1000, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_grayscale_green = wx.TextCtrl(
+        self.text_grayscale_green = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_grayscale_blue = wx.Slider(
             self, wx.ID_ANY, 0, -1000, 1000, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_grayscale_blue = wx.TextCtrl(
+        self.text_grayscale_blue = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_grayscale_lightness = wx.Slider(
             self, wx.ID_ANY, 500, 0, 1000, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_grayscale_lightness = wx.TextCtrl(
+        self.text_grayscale_lightness = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
 

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -855,10 +855,10 @@ class InfoPanel(wx.Panel):
             self, wx.ID_ANY, _("Est. burn-time:"), wx.HORIZONTAL
         )
 
-        self.text_children = wx.TextCtrl(self, wx.ID_ANY, "0", style=wx.TE_READONLY)
+        self.text_children = TextCtrl(self, wx.ID_ANY, "0", style=wx.TE_READONLY)
         self.text_children.SetMinSize(dip_size(self, 25, -1))
         self.text_children.SetMaxSize(dip_size(self, 55, -1))
-        self.text_time = wx.TextCtrl(self, wx.ID_ANY, "---", style=wx.TE_READONLY)
+        self.text_time = TextCtrl(self, wx.ID_ANY, "---", style=wx.TE_READONLY)
         self.text_time.SetMinSize(dip_size(self, 55, -1))
         self.text_time.SetMaxSize(dip_size(self, 100, -1))
         self.text_children.SetToolTip(

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -8,6 +8,7 @@ from meerk40t.gui.wxutils import (
     set_ctrl_value,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxRadioBox,
     wxStaticText,
 )
@@ -112,7 +113,7 @@ class LayerSettingPanel(wx.Panel):
         ):
             layer_sizer.Add(h_classify_sizer, 1, wx.EXPAND, 0)
 
-        # self.combo_type = wx.ComboBox(
+        # self.combo_type = wxComboBox(
         #     self,
         #     wx.ID_ANY,
         #     choices=["Engrave", "Cut", "Raster", "Image", "Hatch", "Dots"],
@@ -668,7 +669,7 @@ class PassesPanel(wx.Panel):
             self, wx.ID_ANY, _("Coolant:"), wx.HORIZONTAL
         )
         cool_choices = [_("No changes"), _("Turn on"), _("Turn off")]
-        self.combo_coolant = wx.ComboBox(
+        self.combo_coolant = wxComboBox(
             self,
             wx.ID_ANY,
             choices=cool_choices,
@@ -1372,7 +1373,7 @@ class RasterSettingsPanel(wx.Panel):
         sizer_4 = StaticBoxSizer(self, wx.ID_ANY, _("Direction:"), wx.HORIZONTAL)
         raster_sizer.Add(sizer_4, 0, wx.EXPAND, 0)
 
-        self.combo_raster_direction = wx.ComboBox(
+        self.combo_raster_direction = wxComboBox(
             self,
             wx.ID_ANY,
             choices=[

--- a/meerk40t/gui/propertypanels/pathproperty.py
+++ b/meerk40t/gui/propertypanels/pathproperty.py
@@ -15,7 +15,7 @@ from meerk40t.gui.propertypanels.attributes import (
     RoundedRectPanel,
     StrokeWidthPanel,
 )
-from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, wxButton, wxCheckBox
+from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, wxButton, wxCheckBox
 from meerk40t.svgelements import Color
 
 _ = wx.GetTranslation
@@ -90,10 +90,10 @@ class PathPropertyPanel(ScrolledPanel):
         self.panels.append(panel_xy)
 
         # Property display
-        self.lbl_info_segments = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.lbl_info_points = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.lbl_info_length = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.lbl_info_area = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.lbl_info_segments = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.lbl_info_points = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.lbl_info_length = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.lbl_info_area = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.btn_info_get = wxButton(self, wx.ID_ANY, _("Retrieve"))
         self.check_classify = wxCheckBox(
             self, wx.ID_ANY, _("Immediately classify after colour change")

--- a/meerk40t/gui/propertypanels/placementproperty.py
+++ b/meerk40t/gui/propertypanels/placementproperty.py
@@ -15,6 +15,7 @@ from meerk40t.gui.wxutils import (
     set_ctrl_value,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxStaticText,
 )
 from meerk40t.kernel import signal_listener
@@ -281,7 +282,7 @@ class PlacementPanel(wx.Panel):
             self, wx.ID_ANY, _("Orientation:"), wx.HORIZONTAL
         )
         info_corner = wxStaticText(self, wx.ID_ANY, _("Corner:"))
-        self.combo_corner = wx.ComboBox(
+        self.combo_corner = wxComboBox(
             self,
             wx.ID_ANY,
             choices=[
@@ -302,7 +303,7 @@ class PlacementPanel(wx.Panel):
         self.corner_sizer.Add(info_corner, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.corner_sizer.Add(self.combo_corner, 1, wx.EXPAND, 0)
         info_orientation = wxStaticText(self, wx.ID_ANY, _("Orientation:"))
-        self.combo_orientation = wx.ComboBox(
+        self.combo_orientation = wxComboBox(
             self,
             wx.ID_ANY,
             choices=[
@@ -340,7 +341,7 @@ class PlacementPanel(wx.Panel):
         )
         choices = [e[0] for e in self.shape_information]
 
-        self.combo_shape = wx.ComboBox(
+        self.combo_shape = wxComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         ttip = _("Please provide some data about the intended tiling")

--- a/meerk40t/gui/propertypanels/rasterwizardpanels.py
+++ b/meerk40t/gui/propertypanels/rasterwizardpanels.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import wx
 
 from meerk40t.core.node.elem_image import ImageNode
-from meerk40t.gui.wxutils import StaticBoxSizer, dip_size, wxButton, wxCheckBox
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size, wxButton, wxCheckBox
 
 _ = wx.GetTranslation
 
@@ -47,13 +47,13 @@ class ContrastPanel(wx.Panel):
         self.slider_contrast_contrast = wx.Slider(
             self, wx.ID_ANY, 0, -127, 127, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_contrast_contrast = wx.TextCtrl(
+        self.text_contrast_contrast = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_contrast_brightness = wx.Slider(
             self, wx.ID_ANY, 0, -127, 127, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_contrast_brightness = wx.TextCtrl(
+        self.text_contrast_brightness = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
 
@@ -198,19 +198,19 @@ class HalftonePanel(wx.Panel):
         self.slider_halftone_sample = wx.Slider(
             self, wx.ID_ANY, 10, 0, 50, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_halftone_sample = wx.TextCtrl(
+        self.text_halftone_sample = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_halftone_angle = wx.Slider(
             self, wx.ID_ANY, 22, 0, 90, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_halftone_angle = wx.TextCtrl(
+        self.text_halftone_angle = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_halftone_oversample = wx.Slider(
             self, wx.ID_ANY, 2, 0, 50, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_halftone_oversample = wx.TextCtrl(
+        self.text_halftone_oversample = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
 
@@ -582,19 +582,19 @@ class SharpenPanel(wx.Panel):
         self.slider_sharpen_percent = wx.Slider(
             self, wx.ID_ANY, 500, 0, 1000, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_sharpen_percent = wx.TextCtrl(
+        self.text_sharpen_percent = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_sharpen_radius = wx.Slider(
             self, wx.ID_ANY, 20, 0, 50, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_sharpen_radius = wx.TextCtrl(
+        self.text_sharpen_radius = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.slider_sharpen_threshold = wx.Slider(
             self, wx.ID_ANY, 6, 0, 50, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_sharpen_threshold = wx.TextCtrl(
+        self.text_sharpen_threshold = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
 
@@ -775,7 +775,7 @@ class GammaPanel(wx.Panel):
         self.slider_gamma_factor = wx.Slider(
             self, wx.ID_ANY, 100, 0, 500, style=wx.SL_AUTOTICKS | wx.SL_HORIZONTAL
         )
-        self.text_gamma_factor = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_gamma_factor = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
 
         self.__set_properties()
         self.__do_layout()

--- a/meerk40t/gui/propertypanels/regbranchproperties.py
+++ b/meerk40t/gui/propertypanels/regbranchproperties.py
@@ -1,6 +1,6 @@
 import wx
 
-from meerk40t.gui.wxutils import StaticBoxSizer, wxButton
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, wxButton
 from meerk40t.gui.laserrender import DRAW_MODE_REGMARKS
 
 _ = wx.GetTranslation
@@ -17,7 +17,7 @@ class RegBranchPanel(wx.Panel):
         self.context = context
         self.context.themes.set_window_colors(self)
         self.node = node
-        self.text_elements = wx.TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
+        self.text_elements = TextCtrl(self, id=wx.ID_ANY, style=wx.TE_READONLY)
         self.button_visible = wxButton(self, wx.ID_ANY, _("Toggle"))
         self.button_visible.SetToolTip(_("Toggle visibility of regmarks"))
         self.button_move_back = wxButton(self, wx.ID_ANY, _("Move all back"))

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -8,6 +8,7 @@ from meerk40t.gui.laserrender import LaserRender, swizzlecolor
 from meerk40t.gui.wxutils import (
     ScrolledPanel,
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxBitmapButton,
     wxButton,
@@ -190,7 +191,7 @@ class TextPropertyPanel(ScrolledPanel):
         # We neeed this to avoid a crash under Linux when textselection is called too quickly
         self._islinux = platform.system() == "Linux"
 
-        self.text_text = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_text = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.node = node
         self.label_fonttest = wxStaticText(
             self, wx.ID_ANY, "", style=wx.ST_ELLIPSIZE_END | wx.ST_NO_AUTORESIZE

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -13,6 +13,7 @@ from meerk40t.gui.wxutils import (
     wxBitmapButton,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxListBox,
     wxRadioBox,
     wxStaticText,
@@ -26,11 +27,11 @@ from .attributes import ColorPanel, IdPanel, PositionSizePanel, PreventChangePan
 _ = wx.GetTranslation
 
 
-class PromptingComboBox(wx.ComboBox):
+class PromptingComboBox(wxComboBox):
     def __init__(self, parent, choices=None, style=0, **kwargs):
         if choices is None:
             choices = []
-        wx.ComboBox.__init__(
+        wxComboBox.__init__(
             self,
             parent,
             wx.ID_ANY,

--- a/meerk40t/gui/propertypanels/wobbleproperty.py
+++ b/meerk40t/gui/propertypanels/wobbleproperty.py
@@ -3,7 +3,7 @@ import wx
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
 
 from ...core.units import Length
-from ..wxutils import TextCtrl, set_ctrl_value, wxCheckBox
+from ..wxutils import TextCtrl, set_ctrl_value, wxCheckBox, wxComboBox
 from .attributes import ColorPanel, IdPanel, AutoHidePanel
 
 _ = wx.GetTranslation
@@ -127,7 +127,7 @@ class WobblePropertyPanel(ScrolledPanel):
         main_sizer.Add(sizer_fill, 6, wx.EXPAND, 0)
 
         self.fills = list(self.context.match("wobble", suffix=True))
-        self.combo_fill_style = wx.ComboBox(
+        self.combo_fill_style = wxComboBox(
             self, wx.ID_ANY, choices=self.fills, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         sizer_fill.Add(self.combo_fill_style, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/simpleui.py
+++ b/meerk40t/gui/simpleui.py
@@ -14,7 +14,7 @@ from ..core.exceptions import BadFileError
 from .icons import get_default_icon_size, icons8_computer_support, icons8_opened_folder
 from .mwindow import MWindow
 from .navigationpanels import Drag, Jog
-from .wxutils import StaticBoxSizer, wxButton, wxStaticText
+from .wxutils import StaticBoxSizer, TextCtrl, wxButton, wxStaticText
 
 _ = wx.GetTranslation
 
@@ -72,15 +72,15 @@ class ProjectPanel(wx.Panel):
         line1 = wx.BoxSizer(wx.HORIZONTAL)
         lbl = wxStaticText(self, wx.ID_ANY, "File:")
         lbl.SetMinSize(wx.Size(70, -1))
-        self.info_file = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.info_file = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
         line1.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         line1.Add(self.info_file, 1, wx.EXPAND, 0)
 
         line2 = wx.BoxSizer(wx.HORIZONTAL)
         lbl = wxStaticText(self, wx.ID_ANY, "Content:")
         lbl.SetMinSize(wx.Size(70, -1))
-        self.info_elements = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
-        self.info_operations = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.info_elements = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.info_operations = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
         line2.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         line2.Add(self.info_elements, 1, wx.EXPAND, 0)
         line2.Add(self.info_operations, 1, wx.EXPAND, 0)
@@ -88,7 +88,7 @@ class ProjectPanel(wx.Panel):
         line3 = wx.BoxSizer(wx.HORIZONTAL)
         lbl = wxStaticText(self, wx.ID_ANY, "Status:")
         lbl.SetMinSize(wx.Size(70, -1))
-        self.info_status = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
+        self.info_status = TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY)
         line3.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         line3.Add(self.info_status, 1, wx.EXPAND, 0)
 

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -489,7 +489,7 @@ class CutcodePanel(wx.Panel):
         )
         self.last_selected = []
         self.display_highlighted_only = False
-        # self.text_operation_param = wx.TextCtrl(
+        # self.text_operation_param = TextCtrl(
         #     self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         # )
         # self.text_operation_param.SetToolTip(
@@ -887,45 +887,45 @@ class SimulationPanel(wx.Panel, Job):
 
         self.slider_progress = wx.Slider(self, wx.ID_ANY, self.max, 0, self.max)
         self.slider_progress.SetFocus()
-        self.text_distance_laser = wx.TextCtrl(
+        self.text_distance_laser = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_distance_travel = wx.TextCtrl(
+        self.text_distance_travel = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_distance_total = wx.TextCtrl(
+        self.text_distance_total = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_time_laser = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_time_travel = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_time_extra = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_time_total = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_distance_laser_step = wx.TextCtrl(
+        self.text_time_laser = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_time_travel = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_time_extra = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_time_total = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_distance_laser_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_distance_travel_step = wx.TextCtrl(
+        self.text_distance_travel_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_distance_total_step = wx.TextCtrl(
+        self.text_distance_total_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_time_laser_step = wx.TextCtrl(
+        self.text_time_laser_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_time_travel_step = wx.TextCtrl(
+        self.text_time_travel_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_time_extra_step = wx.TextCtrl(
+        self.text_time_extra_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_time_total_step = wx.TextCtrl(
+        self.text_time_total_step = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.button_play = wxButton(self, wx.ID_ANY, "")
         self.button_play.SetToolTip(_("Start the simulation replay"))
         self.slider_playbackspeed = wx.Slider(self, wx.ID_ANY, 180, 0, 310)
         self.slider_playbackspeed.SetToolTip(_("Set the speed for the simulation"))
-        self.text_playback_speed = wx.TextCtrl(
+        self.text_playback_speed = TextCtrl(
             self, wx.ID_ANY, "100%", style=wx.TE_READONLY
         )
         self.radio_cut = wx.RadioButton(self, wx.ID_ANY, _("Steps"))

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -19,6 +19,7 @@ from meerk40t.gui.wxutils import (
     EditableListCtrl,
     HoverButton,
     wxButton,
+    wxComboBox,
     wxListCtrl,
     wxStaticText,
 )
@@ -110,7 +111,7 @@ class SpoolerPanel(wx.Panel):
         self.splitter.SetMinimumPaneSize(50)
         self.splitter.SplitHorizontally(self.win_top, self.win_bottom, -100)
         self.splitter.SetSashPosition(self.context.spooler_sash_position)
-        self.combo_device = wx.ComboBox(
+        self.combo_device = wxComboBox(
             self.win_top, wx.ID_ANY, choices=spools, style=wx.CB_DROPDOWN
         )
         self.combo_device.SetSelection(0)  # All by default...

--- a/meerk40t/gui/statusbarwidgets/opassignwidget.py
+++ b/meerk40t/gui/statusbarwidgets/opassignwidget.py
@@ -9,7 +9,7 @@ from meerk40t.gui.icons import (
     icons8_laserbeam_weak,
 )
 from meerk40t.gui.laserrender import swizzlecolor
-from meerk40t.gui.wxutils import wxCheckBox, wxStaticBitmap
+from meerk40t.gui.wxutils import wxCheckBox, wxComboBox, wxStaticBitmap
 from meerk40t.svgelements import Color
 
 from .statusbarwidget import StatusBarWidget
@@ -32,7 +32,7 @@ class OperationAssignOptionWidget(StatusBarWidget):
             _("-> OP"),
             _("-> Elem"),
         ]
-        self.combo_apply_color = wx.ComboBox(
+        self.combo_apply_color = wxComboBox(
             self.parent,
             wx.ID_ANY,
             choices=choices,

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -2,7 +2,7 @@ import wx
 
 from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.units import Length
-from meerk40t.gui.wxutils import wxCheckBox, wxStaticBitmap, wxStaticText
+from meerk40t.gui.wxutils import TextCtrl, wxCheckBox, wxStaticBitmap, wxStaticText
 
 from .statusbarwidget import StatusBarWidget
 
@@ -127,7 +127,7 @@ class StrokeWidget(StatusBarWidget):
                 wx.FONTWEIGHT_NORMAL,
             )
         )
-        self.spin_width = wx.TextCtrl(
+        self.spin_width = TextCtrl(
             self.parent, id=wx.ID_ANY, value="0.10", style=wx.TE_PROCESS_ENTER
         )
         self.spin_width.SetFont(

--- a/meerk40t/gui/statusbarwidgets/strokewidget.py
+++ b/meerk40t/gui/statusbarwidgets/strokewidget.py
@@ -2,7 +2,7 @@ import wx
 
 from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.units import Length
-from meerk40t.gui.wxutils import TextCtrl, wxCheckBox, wxStaticBitmap, wxStaticText
+from meerk40t.gui.wxutils import TextCtrl, wxCheckBox, wxComboBox, wxStaticBitmap, wxStaticText
 
 from .statusbarwidget import StatusBarWidget
 
@@ -142,7 +142,7 @@ class StrokeWidget(StatusBarWidget):
         self.spin_width.SetMaxSize(wx.Size(80, -1))
 
         self.unit_choices = ["px", "pt", "mm", "cm", "inch", "mil"]
-        self.combo_units = wx.ComboBox(
+        self.combo_units = wxComboBox(
             self.parent,
             wx.ID_ANY,
             choices=self.unit_choices,

--- a/meerk40t/gui/themes.py
+++ b/meerk40t/gui/themes.py
@@ -89,14 +89,14 @@ class Themes(Service):
 
     def load_system_default(self):
         self._theme = "system"
-        res1 = wx.SystemSettings().GetAppearance().IsDark()
-        res2 = wx.SystemSettings().GetColour(wx.SYS_COLOUR_WINDOW)[0] < 127
         # print (f"wx claims: {res1}, we think: {res2}, overload: {self.force_dark}")
         if self.forced_theme == "dark":
             self._dark = True
-        elif self.forced_theme == "dark":
+        elif self.forced_theme == "light":
             self._dark = False
         else:
+            res1 = wx.SystemSettings().GetAppearance().IsDark()
+            res2 = wx.SystemSettings().GetColour(wx.SYS_COLOUR_WINDOW)[0] < 127
             self._dark = res1 or res2
         from platform import system
 
@@ -118,11 +118,25 @@ class Themes(Service):
         tp["highlight"] = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
         tp["inactive_bg"] = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVECAPTION)
         tp["inactive_fg"] = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVECAPTIONTEXT)
-        for key, col in tp.items():
-            print (f'tp["{key}"] = wx.Colour({col.red}, {col.green}, {col.blue}, {col.alpha})')
+        # for key, col in tp.items():
+        #     print (f'tp["{key}"] = wx.Colour({col.red}, {col.green}, {col.blue}, {col.alpha})')
 
         if not self.dark and is_a_dark_color(tp["win_bg"]):
-            base_bg = wx.Colour()
+            base_bg = wx.Colour(255, 255, 255)
+            base_fg = wx.Colour(0, 0, 0)
+            tp["win_bg"] = base_bg
+            tp["win_fg"] = base_fg
+            tp["button_bg"] = wx.Colour(240, 240, 240, 255)
+            tp["button_fg"] = base_fg
+            tp["text_bg"] = base_bg
+            tp["text_fg"] = base_fg
+            tp["list_bg"] = base_bg
+            tp["list_fg"] = base_fg
+            tp["label_bg"] = base_bg
+            tp["label_fg"] = base_fg
+            tp["highlight"] = wx.Colour(0, 120, 215, 255)
+            tp["inactive_bg"] = wx.Colour(191, 205, 219, 255)
+            tp["inactive_fg"] = base_fg        
         if self.dark and is_a_bright_color(tp["win_bg"]):
             base_bg = wx.Colour(23, 23, 23)
             base_fg = wx.Colour(255, 255, 255, 216)

--- a/meerk40t/gui/tips.py
+++ b/meerk40t/gui/tips.py
@@ -23,7 +23,7 @@ from .icons import (
     icons8_manager,
 )
 from .mwindow import MWindow
-from .wxutils import dip_size, wxButton, wxCheckBox, wxStaticBitmap, wxStaticText
+from .wxutils import TextCtrl, dip_size, wxButton, wxCheckBox, wxStaticBitmap, wxStaticText
 
 _ = wx.GetTranslation
 
@@ -61,7 +61,7 @@ class TipPanel(wx.Panel):
         sizer_main = wx.BoxSizer(wx.VERTICAL)
         self.image_tip = wxStaticBitmap(self, wx.ID_ANY, style=wx.SB_FLAT)
         self.image_tip.SetMinSize(dip_size(self, 250, -1))
-        self.no_image_message = wx.TextCtrl(self, wx.ID_ANY, _("Image missing!"))
+        self.no_image_message = TextCtrl(self, wx.ID_ANY, _("Image missing!"))
         self.no_image_message.SetToolTip(
             _(
                 "Couldn't find the cached image for this tip!\nNo permissions to download from the internet."
@@ -70,7 +70,7 @@ class TipPanel(wx.Panel):
         self.no_image_message.Show(False)
         # self.image_tip.SetMaxSize(wx.Size(250, -1))
         # self.image_tip.SetSize(wx.Size(250, -1))
-        self.text_tip = wx.TextCtrl(
+        self.text_tip = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         tip_area = wx.BoxSizer(wx.HORIZONTAL)

--- a/meerk40t/gui/usbconnect.py
+++ b/meerk40t/gui/usbconnect.py
@@ -2,7 +2,7 @@ import wx
 
 from meerk40t.gui.icons import icons8_usb_connector
 from meerk40t.gui.mwindow import MWindow
-
+from meerk40t.gui.wxutils import TextCtrl
 _ = wx.GetTranslation
 
 
@@ -13,10 +13,10 @@ class UsbConnectPanel(wx.Panel):
         self.context = context
         self.context.themes.set_window_colors(self)
 
-        self.text_main = wx.TextCtrl(
+        self.text_main = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_READONLY
         )
-        self.text_entry = wx.TextCtrl(
+        self.text_entry = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER | wx.TE_PROCESS_TAB
         )
 

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -19,6 +19,7 @@ from .icons import (
 from .mwindow import MWindow
 from .wxutils import (
     StaticBoxSizer,
+    TextCtrl, 
     dip_size,
     wxButton,
     wxCheckBox,
@@ -314,7 +315,7 @@ class WordlistPanel(wx.Panel):
         sizer_grid_right.Add(sizer_index_right, 0, wx.EXPAND, 0)
         sizer_grid_right.Add(self.grid_content, 1, wx.EXPAND, 0)
 
-        self.txt_pattern = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.txt_pattern = TextCtrl(self, wx.ID_ANY, "")
 
         sizer_buttons = wx.BoxSizer(wx.HORIZONTAL)
         sizer_buttons.Add(self.txt_pattern, 1, wx.ALIGN_CENTER_VERTICAL, 0)
@@ -745,7 +746,7 @@ class ImportPanel(wx.Panel):
         label_1 = wxStaticText(self, wx.ID_ANY, _("Import CSV-File"))
         sizer_csv.Add(label_1, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.txt_filename = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.txt_filename = TextCtrl(self, wx.ID_ANY, "")
         sizer_csv.Add(self.txt_filename, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
         self.btn_fileDialog = wxButton(self, wx.ID_ANY, "...")
@@ -772,7 +773,7 @@ class ImportPanel(wx.Panel):
         sizer_header.Add(self.rbox_header, 1, wx.EXPAND, 0)
         info_box.Add(sizer_header, 0, wx.EXPAND)
 
-        self.text_preview = wx.TextCtrl(
+        self.text_preview = TextCtrl(
             self, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
 
@@ -874,7 +875,7 @@ class AboutPanel(wx.Panel):
         info_box = StaticBoxSizer(self, wx.ID_ANY, _("How to use..."), wx.VERTICAL)
         self.parent_panel = None
         s = self.context.asset("wordlist_howto")
-        info_label = wx.TextCtrl(
+        info_label = TextCtrl(
             self, wx.ID_ANY, value=s, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         font = wx.Font(

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -23,6 +23,7 @@ from .wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxListCtrl,
     wxRadioBox,
     wxStaticBitmap,
@@ -179,7 +180,7 @@ class WordlistPanel(wx.Panel):
 
         label_2 = wxStaticText(self, wx.ID_ANY, _("Start Index for CSV-based data:"))
         sizer_index_left.Add(label_2, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        self.cbo_Index = wx.ComboBox(
+        self.cbo_Index = wxComboBox(
             self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         sizer_index_left.Add(self.cbo_Index, 0, wx.ALIGN_CENTER_VERTICAL, 0)
@@ -301,7 +302,7 @@ class WordlistPanel(wx.Panel):
         sizer_index_right = wx.BoxSizer(wx.HORIZONTAL)
         label_2 = wxStaticText(self, wx.ID_ANY, _("Start Index for field:"))
         sizer_index_right.Add(label_2, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        self.cbo_index_single = wx.ComboBox(
+        self.cbo_index_single = wxComboBox(
             self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         sizer_index_right.Add(self.cbo_index_single, 1, wx.ALIGN_CENTER_VERTICAL, 0)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -21,7 +21,7 @@ from meerk40t.gui.spoolerpanel import JobSpooler
 #     pass
 from meerk40t.gui.themes import Themes
 from meerk40t.gui.wxmscene import SceneWindow
-from meerk40t.gui.wxutils import wxButton, wxStaticText
+from meerk40t.gui.wxutils import TextCtrl, wxButton, wxStaticText
 from meerk40t.kernel import CommandSyntaxError, Module, get_safe_path
 from meerk40t.kernel.kernel import Job
 
@@ -1288,7 +1288,7 @@ def handleGUIException(exc_type, exc_value, exc_traceback):
 
         label = wxStaticText(dlg, wx.ID_ANY, header)
         sizer.Add(label, 1, wx.EXPAND, 0)
-        info = wx.TextCtrl(dlg, wx.ID_ANY, style=wx.TE_MULTILINE | wx.TE_READONLY)
+        info = TextCtrl(dlg, wx.ID_ANY, style=wx.TE_MULTILINE | wx.TE_READONLY)
         info.SetValue(body)
         sizer.Add(info, 5, wx.EXPAND, 0)
         btnsizer = wx.StdDialogButtonSizer()

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1038,16 +1038,6 @@ class wxMeerK40t(wx.App, Module):
                 "page": "Start",
             },
             {
-                "attr": "force_dark",
-                "object": context.root,
-                "default": False,
-                "type": bool,
-                "label": _("Force Darkmode"),
-                "tip": _("Will force MeerK40t to start in darkmode despite the system settings"),
-                "page": "Start",
-                "signals": "restart",
-            },
-            {
                 "attr": "beep_soundfile",
                 "object": context.root,
                 "type": str,

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -9,7 +9,6 @@ import wx
 from PIL import Image
 from wx import aui
 
-from meerk40t.main import APPLICATION_NAME
 from meerk40t.core.exceptions import BadFileError
 from meerk40t.gui.gui_mixins import FormatPainter, Warnings
 from meerk40t.gui.statusbarwidgets.defaultoperations import DefaultOperationWidget
@@ -30,26 +29,24 @@ from meerk40t.gui.statusbarwidgets.shapepropwidget import (
 )
 from meerk40t.gui.statusbarwidgets.statusbar import CustomStatusBar
 from meerk40t.gui.statusbarwidgets.strokewidget import ColorWidget, StrokeWidget
-from meerk40t.gui.wxutils import wxButton, wxStaticText, TextCtrl
+from meerk40t.gui.wxutils import TextCtrl, wxButton, wxComboBox, wxStaticText
 from meerk40t.kernel import Job, get_safe_path, lookup_listener, signal_listener
+from meerk40t.main import APPLICATION_NAME
 
 from ..core.units import DEFAULT_PPI, UNITS_PER_INCH, UNITS_PER_PIXEL, Length
 from ..svgelements import Color, Matrix, Path
 from .icons import (  # icon_duplicate,; icon_nohatch,
     STD_ICON_SIZE,
+    icon_air_off,
+    icon_air_on,
     icon_bmap_text,
     icon_cag_common,
     icon_cag_subtract,
     icon_cag_union,
     icon_cag_xor,
     icon_closed_door,
-    icon_air_on,
-    icon_air_off,
-    icon_open_door,
     icon_effect_wobble,
     icon_hatch,
-    icons8_comments,
-    icons8_circled_play,
     icon_line,
     icon_meerk40t,
     icon_mk_align_bottom,
@@ -64,12 +61,15 @@ from .icons import (  # icon_duplicate,; icon_nohatch,
     icon_mk_rectangular,
     icon_mk_redo,
     icon_mk_undo,
+    icon_open_door,
     icon_power_button,
     icon_tabs,
     icons8_centerh,
     icons8_centerv,
     icons8_circled_left,
+    icons8_circled_play,
     icons8_circled_right,
+    icons8_comments,
     icons8_copy,
     icons8_curly_brackets,
     icons8_cursor,
@@ -4942,7 +4942,7 @@ class MeerK40t(MWindow):
             sizer.Add(label, 0, wx.EXPAND, 0)
             s1 = wx.BoxSizer(wx.HORIZONTAL)
             lbl1 = wxStaticText(dlg, wx.ID_ANY, _("Horizontal:"))
-            combo1 = wx.ComboBox(
+            combo1 = wxComboBox(
                 dlg, wx.ID_ANY, choices=options_1, style=wx.CB_DROPDOWN | wx.CB_READONLY
             )
             combo1.SetSelection(0)
@@ -4950,7 +4950,7 @@ class MeerK40t(MWindow):
             s1.Add(combo1, 1, wx.ALIGN_CENTER_VERTICAL, 0)
             s2 = wx.BoxSizer(wx.HORIZONTAL)
             lbl2 = wxStaticText(dlg, wx.ID_ANY, _("Vertical:"))
-            combo2 = wx.ComboBox(
+            combo2 = wxComboBox(
                 dlg, wx.ID_ANY, choices=options_2, style=wx.CB_DROPDOWN | wx.CB_READONLY
             )
             combo2.SetSelection(0)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -30,7 +30,7 @@ from meerk40t.gui.statusbarwidgets.shapepropwidget import (
 )
 from meerk40t.gui.statusbarwidgets.statusbar import CustomStatusBar
 from meerk40t.gui.statusbarwidgets.strokewidget import ColorWidget, StrokeWidget
-from meerk40t.gui.wxutils import wxButton, wxStaticText
+from meerk40t.gui.wxutils import wxButton, wxStaticText, TextCtrl
 from meerk40t.kernel import Job, get_safe_path, lookup_listener, signal_listener
 
 from ..core.units import DEFAULT_PPI, UNITS_PER_INCH, UNITS_PER_PIXEL, Length
@@ -251,7 +251,7 @@ class MeerK40t(MWindow):
             pass
         # print(self.GetDPIScaleFactor())
         # What is the standardsize of a textbox?
-        testbox = wx.TextCtrl(self, wx.ID_ANY)
+        testbox = TextCtrl(self, wx.ID_ANY)
         tb_size = testbox.Size
         testbox.Destroy()
         factor = 4 * tb_size[1] / 100.0

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -37,6 +37,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxListBox,
     wxStaticBitmap,
     wxStaticText,
@@ -730,7 +731,7 @@ class RibbonEditor(wx.Panel):
         )
 
         choices = [v for v in self.context._ribbons]
-        self.combo_ribbons = wx.ComboBox(
+        self.combo_ribbons = wxComboBox(
             self, wx.ID_ANY, choices=choices, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         self.check_labels = wxCheckBox(self, wx.ID_ANY, _("Show the Ribbon Labels"))
@@ -1401,7 +1402,7 @@ class RibbonEditor(wx.Panel):
         )
         line5 = wx.BoxSizer(wx.HORIZONTAL)
         label5 = wxStaticText(dlg, wx.ID_ANY, _("Rule to enable"))
-        combo_enable = wx.ComboBox(
+        combo_enable = wxComboBox(
             dlg, wx.ID_ANY, choices=rule_options, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         if entry["enable"] == "selected2":
@@ -1416,7 +1417,7 @@ class RibbonEditor(wx.Panel):
 
         line6 = wx.BoxSizer(wx.HORIZONTAL)
         label6 = wxStaticText(dlg, wx.ID_ANY, _("Rule to display"))
-        combo_visible = wx.ComboBox(
+        combo_visible = wxComboBox(
             dlg, wx.ID_ANY, choices=rule_options, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         if entry["visible"] == "selected2":
@@ -1441,7 +1442,7 @@ class RibbonEditor(wx.Panel):
 
         line7 = wx.BoxSizer(wx.HORIZONTAL)
         label7 = wxStaticText(dlg, wx.ID_ANY, _("Icon"))
-        combo_icon = wx.ComboBox(
+        combo_icon = wxComboBox(
             dlg, wx.ID_ANY, choices=icon_list, style=wx.CB_DROPDOWN | wx.CB_READONLY
         )
         preview = wxStaticBitmap(dlg, wx.ID_ANY, size=dip_size(self, 30, 30))

--- a/meerk40t/gui/wxmribbon.py
+++ b/meerk40t/gui/wxmribbon.py
@@ -33,6 +33,7 @@ from meerk40t.gui.icons import (
 from meerk40t.gui.ribbon import RibbonBarPanel
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxButton,
     wxCheckBox,
@@ -738,7 +739,7 @@ class RibbonEditor(wx.Panel):
         sizer_ribbons.Add(self.check_labels, 0, wx.EXPAND, 0)
         self.list_pages = wxListBox(self, wx.ID_ANY, style=wx.LB_SINGLE)
 
-        self.text_param_page = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
+        self.text_param_page = TextCtrl(self, wx.ID_ANY, style=wx.TE_PROCESS_ENTER)
 
         self.list_panels = wxListBox(self, wx.ID_ANY, style=wx.LB_SINGLE)
         bsize = dip_size(self, 30, 30)
@@ -1371,25 +1372,25 @@ class RibbonEditor(wx.Panel):
 
         line1 = wx.BoxSizer(wx.HORIZONTAL)
         label1 = wxStaticText(dlg, wx.ID_ANY, _("Label"))
-        txt_label = wx.TextCtrl(dlg, wx.ID_ANY, value=entry["label"])
+        txt_label = TextCtrl(dlg, wx.ID_ANY, value=entry["label"])
         line1.Add(label1, 0, wx.EXPAND, 0)
         line1.Add(txt_label, 1, wx.EXPAND, 0)
 
         line2 = wx.BoxSizer(wx.HORIZONTAL)
         label2 = wxStaticText(dlg, wx.ID_ANY, _("Tooltip"))
-        txt_tip = wx.TextCtrl(dlg, wx.ID_ANY, value=entry["tip"])
+        txt_tip = TextCtrl(dlg, wx.ID_ANY, value=entry["tip"])
         line2.Add(label2, 0, wx.EXPAND, 0)
         line2.Add(txt_tip, 1, wx.EXPAND, 0)
 
         line3 = wx.BoxSizer(wx.HORIZONTAL)
         label3 = wxStaticText(dlg, wx.ID_ANY, _("Action left click"))
-        txt_action_left = wx.TextCtrl(dlg, wx.ID_ANY, value=entry["action_left"])
+        txt_action_left = TextCtrl(dlg, wx.ID_ANY, value=entry["action_left"])
         line3.Add(label3, 0, wx.EXPAND, 0)
         line3.Add(txt_action_left, 1, wx.EXPAND, 0)
 
         line4 = wx.BoxSizer(wx.HORIZONTAL)
         label4 = wxStaticText(dlg, wx.ID_ANY, _("Action right click"))
-        txt_action_right = wx.TextCtrl(dlg, wx.ID_ANY, value=entry["action_right"])
+        txt_action_right = TextCtrl(dlg, wx.ID_ANY, value=entry["action_right"])
         line4.Add(label4, 0, wx.EXPAND, 0)
         line4.Add(txt_action_right, 1, wx.EXPAND, 0)
 

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -927,6 +927,35 @@ class wxCheckBox(wx.CheckBox):
         self._tool_tip = tooltip
         super().SetToolTip(self._tool_tip)
 
+class wxComboBox(wx.ComboBox):
+    """
+    This class wraps around wx.ComboBox and creates a series of mouse over tool tips to permit Linux tooltips that
+    otherwise do not show.
+    """
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        self._tool_tip = None
+        super().__init__(*args, **kwargs)
+        if platform.system() == "Linux":
+
+            def on_mouse_over_check(ctrl):
+                def mouse(event=None):
+                    ctrl.SetToolTip(self._tool_tip)
+                    event.Skip()
+
+                return mouse
+
+            self.Bind(wx.EVT_MOTION, on_mouse_over_check(super()))
+        set_color_according_to_theme(self, "text_bg", "text_fg")
+
+    def SetToolTip(self, tooltip):
+        self._tool_tip = tooltip
+        super().SetToolTip(self._tool_tip)
+
 
 class wxTreeCtrl(wx.TreeCtrl):
     """

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -207,7 +207,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
                         if dtype == bool:
                             control = wxCheckBox(dlg, wx.ID_ANY)
                         else:
-                            control = wx.TextCtrl(dlg, wx.ID_ANY)
+                            control = TextCtrl(dlg, wx.ID_ANY)
                             control.SetMaxSize(dip_size(dlg, 75, -1))
                         fields.append(control)
                         sizer.Add(control, 0, wx.EXPAND, 0)

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -1272,6 +1272,7 @@ class EditableListCtrl(wxListCtrl, listmix.TextEditMixin):
         """Constructor"""
         wxListCtrl.__init__(self, parent=parent, ID=ID, pos=pos, size=size, style=style, context=context, list_name=list_name)
         listmix.TextEditMixin.__init__(self)
+        set_color_according_to_theme(self, "list_bg", "list_fg")
 
 
 class HoverButton(wxButton):

--- a/meerk40t/lihuiyu/gui/lhyaccelgui.py
+++ b/meerk40t/lihuiyu/gui/lhyaccelgui.py
@@ -5,6 +5,7 @@ from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     ScrolledPanel,
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxCheckBox,
     wxStaticText,
@@ -20,20 +21,20 @@ class LihuiyuAccelerationChartPanel(ScrolledPanel):
         context.themes.set_window_colors(self)
         self.context = context.device
         self.checkbox_vector_accel_enable = wxCheckBox(self, wx.ID_ANY, _("Enable"))
-        self.text_vector_accel_1 = wx.TextCtrl(self, wx.ID_ANY, "25.4")
-        self.text_vector_accel_2 = wx.TextCtrl(self, wx.ID_ANY, "60")
-        self.text_vector_accel_3 = wx.TextCtrl(self, wx.ID_ANY, "127")
-        self.text_vector_accel_4 = wx.TextCtrl(self, wx.ID_ANY, _("infinity"))
+        self.text_vector_accel_1 = TextCtrl(self, wx.ID_ANY, "25.4")
+        self.text_vector_accel_2 = TextCtrl(self, wx.ID_ANY, "60")
+        self.text_vector_accel_3 = TextCtrl(self, wx.ID_ANY, "127")
+        self.text_vector_accel_4 = TextCtrl(self, wx.ID_ANY, _("infinity"))
         self.checkbox_vraster_accel_enable = wxCheckBox(self, wx.ID_ANY, _("Enable"))
-        self.text_vraster_accel_1 = wx.TextCtrl(self, wx.ID_ANY, "25.4")
-        self.text_vraster_accel_2 = wx.TextCtrl(self, wx.ID_ANY, "60")
-        self.text_vraster_accel_3 = wx.TextCtrl(self, wx.ID_ANY, "127")
-        self.text_vraster_accel_4 = wx.TextCtrl(self, wx.ID_ANY, _("infinity"))
+        self.text_vraster_accel_1 = TextCtrl(self, wx.ID_ANY, "25.4")
+        self.text_vraster_accel_2 = TextCtrl(self, wx.ID_ANY, "60")
+        self.text_vraster_accel_3 = TextCtrl(self, wx.ID_ANY, "127")
+        self.text_vraster_accel_4 = TextCtrl(self, wx.ID_ANY, _("infinity"))
         self.checkbox_raster_accel_enable = wxCheckBox(self, wx.ID_ANY, _("Enable"))
-        self.text_raster_accel_1 = wx.TextCtrl(self, wx.ID_ANY, "25.4")
-        self.text_raster_accel_2 = wx.TextCtrl(self, wx.ID_ANY, "127")
-        self.text_raster_accel_3 = wx.TextCtrl(self, wx.ID_ANY, "320")
-        self.text_raster_accel_4 = wx.TextCtrl(self, wx.ID_ANY, _("infinity"))
+        self.text_raster_accel_1 = TextCtrl(self, wx.ID_ANY, "25.4")
+        self.text_raster_accel_2 = TextCtrl(self, wx.ID_ANY, "127")
+        self.text_raster_accel_3 = TextCtrl(self, wx.ID_ANY, "320")
+        self.text_raster_accel_4 = TextCtrl(self, wx.ID_ANY, _("infinity"))
 
         self.__set_properties()
         self.__do_layout()

--- a/meerk40t/lihuiyu/gui/lhycontrollergui.py
+++ b/meerk40t/lihuiyu/gui/lhycontrollergui.py
@@ -14,6 +14,7 @@ from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     ScrolledPanel,
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxButton,
     wxCheckBox,
@@ -42,30 +43,30 @@ class LihuiyuControllerPanel(ScrolledPanel):
             connectivity = f"Network: {self.context.address}:{self.context.port}"
         else:
             connectivity = "USB"
-        self.text_connection_status = wx.TextCtrl(
+        self.text_connection_status = TextCtrl(
             self, wx.ID_ANY, connectivity, style=wx.TE_READONLY
         )
         # self.button_controller_control = wxButton(
         #     self, wx.ID_ANY, _("Start Controller")
         # )
         # self.button_controller_control.function = lambda: self.context("start\n")
-        # self.text_controller_status = wx.TextCtrl(
+        # self.text_controller_status = TextCtrl(
         #     self, wx.ID_ANY, "", style=wx.TE_READONLY
         # )
-        self.packet_count_text = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.rejected_packet_count_text = wx.TextCtrl(
+        self.packet_count_text = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.rejected_packet_count_text = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
-        self.text_packet_info = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_0 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_1 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_desc = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_2 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_3 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_4 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_5 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_packet_info = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_0 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_1 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_desc = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_2 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_3 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_4 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_5 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.checkbox_show_usb_log = wxCheckBox(self, wx.ID_ANY, _("Show USB Log"))
-        self.text_usb_log = wx.TextCtrl(
+        self.text_usb_log = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.button_clear_stats = wxButton(self, wx.ID_ANY, _("Reset\nstatistics"))

--- a/meerk40t/lihuiyu/gui/lhyoperationproperties.py
+++ b/meerk40t/lihuiyu/gui/lhyoperationproperties.py
@@ -1,6 +1,6 @@
 import wx
 
-from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, wxCheckBox
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, wxCheckBox, wxComboBox
 
 _ = wx.GetTranslation
 
@@ -113,7 +113,7 @@ class LhyAdvancedPanel(wx.Panel):
         self.text_dot_length.SetToolTip(OPERATION_DOTLENGTH_TOOLTIP)
         sizer_20.Add(self.text_dot_length, 1, wx.EXPAND, 0)
 
-        self.combo_dot_length_units = wx.ComboBox(
+        self.combo_dot_length_units = wxComboBox(
             self,
             wx.ID_ANY,
             choices=["steps", "mm", "cm", "inch", "mil", "%"],

--- a/meerk40t/lihuiyu/gui/tcpcontroller.py
+++ b/meerk40t/lihuiyu/gui/tcpcontroller.py
@@ -25,7 +25,7 @@ class TCPController(MWindow):
 
         self.button_device_connect = wxButton(self, wx.ID_ANY, _("Connection"))
         self.service = self.context.device
-        self.text_status = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
+        self.text_status = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
         self.text_ip_host = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER, check="empty"
         )
@@ -38,8 +38,8 @@ class TCPController(MWindow):
         self.text_port.lower_limit_err = 0
         self.text_port.upper_limit_err = 65535
         self.gauge_buffer = wx.Gauge(self, wx.ID_ANY, 10)
-        self.text_buffer_length = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_buffer_max = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_buffer_length = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_buffer_max = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
 
         self.__set_properties()
         self.__do_layout()

--- a/meerk40t/moshi/gui/moshicontrollergui.py
+++ b/meerk40t/moshi/gui/moshicontrollergui.py
@@ -10,6 +10,7 @@ from meerk40t.gui.icons import (
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxButton,
     wxCheckBox,
@@ -33,33 +34,33 @@ class MoshiControllerPanel(wx.Panel):
         self.SetHelpText("moshicontroller")
 
         self.button_device_connect = wxButton(self, wx.ID_ANY, _("Connection"))
-        self.text_connection_status = wx.TextCtrl(
+        self.text_connection_status = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.checkbox_mock_usb = wxCheckBox(
             self, wx.ID_ANY, _("Mock USB Connection Mode")
         )
-        self.text_device_index = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_device_index = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.spin_device_index = wx.SpinCtrl(self, wx.ID_ANY, "-1", min=-1)
-        self.text_device_address = wx.TextCtrl(
+        self.text_device_address = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.spin_device_address = wx.SpinCtrl(self, wx.ID_ANY, "-1", min=-1)
-        self.text_device_bus = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_device_bus = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.spin_device_bus = wx.SpinCtrl(self, wx.ID_ANY, "-1", min=-1)
-        self.text_device_version = wx.TextCtrl(
+        self.text_device_version = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_READONLY
         )
         self.spin_device_version = wx.SpinCtrl(self, wx.ID_ANY, "-1", min=-1)
-        self.text_byte_0 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_1 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_desc = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_2 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_3 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_4 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
-        self.text_byte_5 = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_0 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_1 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_desc = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_2 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_3 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_4 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
+        self.text_byte_5 = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_READONLY)
         self.checkbox_show_usb_log = wxCheckBox(self, wx.ID_ANY, _("Show USB Log"))
-        self.text_usb_log = wx.TextCtrl(
+        self.text_usb_log = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
 

--- a/meerk40t/newly/gui/newlycontroller.py
+++ b/meerk40t/newly/gui/newlycontroller.py
@@ -8,7 +8,7 @@ from meerk40t.gui.icons import (
     icons8_disconnected,
 )
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import dip_size, wxButton
+from meerk40t.gui.wxutils import TextCtrl, dip_size, wxButton
 from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
@@ -32,7 +32,7 @@ class NewlyControllerPanel(wx.ScrolledWindow):
         self.service = self.context.device
         self._buffer = []
         self._buffer_lock = threading.Lock()
-        self.text_usb_log = wx.TextCtrl(
+        self.text_usb_log = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.text_usb_log.SetFont(font)

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -9,7 +9,7 @@ from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icon_rotary
 from meerk40t.gui.mwindow import MWindow
 
-# from meerk40t.gui.wxutils import wxButton, wxCheckBox, wxStaticText
+# from meerk40t.gui.wxutils import TextCtrl, wxButton, wxCheckBox, wxStaticText
 
 _ = wx.GetTranslation
 
@@ -40,10 +40,10 @@ _ = wx.GetTranslation
 #             nonzero=True,
 #         )
 #         # self.checkbox_rotary_loop = wxCheckBox(self, wx.ID_ANY, _("Field Loop"))
-#         # self.text_rotary_rotation = wx.TextCtrl(self, wx.ID_ANY, "360.0")
+#         # self.text_rotary_rotation = TextCtrl(self, wx.ID_ANY, "360.0")
 #         # self.checkbox_rotary_roller = wxCheckBox(self, wx.ID_ANY, _("Uses Roller"))
-#         # self.text_rotary_roller_circumference = wx.TextCtrl(self, wx.ID_ANY, "50.0")
-#         # self.text_rotary_object_circumference = wx.TextCtrl(self, wx.ID_ANY, "50.0")
+#         # self.text_rotary_roller_circumference = TextCtrl(self, wx.ID_ANY, "50.0")
+#         # self.text_rotary_object_circumference = TextCtrl(self, wx.ID_ANY, "50.0")
 #
 #         self.__set_properties()
 #         self.__do_layout()

--- a/meerk40t/ruida/gui/ruidacontroller.py
+++ b/meerk40t/ruida/gui/ruidacontroller.py
@@ -8,7 +8,7 @@ from meerk40t.gui.icons import (
     icons8_disconnected,
 )
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import dip_size, wxButton
+from meerk40t.gui.wxutils import TextCtrl, dip_size, wxButton
 from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
@@ -31,7 +31,7 @@ class RuidaControllerPanel(wx.ScrolledWindow):
         self.service = self.context.device
         self._buffer = ""
         self._buffer_lock = threading.Lock()
-        self.text_usb_log = wx.TextCtrl(
+        self.text_usb_log = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.text_usb_log.SetFont(font)

--- a/meerk40t/tools/kerftest.py
+++ b/meerk40t/tools/kerftest.py
@@ -178,7 +178,7 @@ class KerfPanel(wx.Panel):
         info_pic = wxStaticBitmap(
             self, wx.ID_ANY, bitmap=icon_kerf.GetBitmap(resize=STD_ICON_SIZE)
         )
-        info_label = wx.TextCtrl(
+        info_label = TextCtrl(
             self, wx.ID_ANY, value=infomsg, style=wx.TE_READONLY | wx.TE_MULTILINE
         )
         info_label.SetBackgroundColour(self.GetBackgroundColour())

--- a/meerk40t/tools/livinghinges.py
+++ b/meerk40t/tools/livinghinges.py
@@ -15,6 +15,7 @@ from meerk40t.gui.wxutils import (
     dip_size,
     wxButton,
     wxCheckBox,
+    wxComboBox,
     wxStaticText,
 )
 from meerk40t.kernel import signal_listener
@@ -74,7 +75,7 @@ class HingePanel(wx.Panel):
         self.text_origin_y = TextCtrl(self, wx.ID_ANY, "")
         self.text_width = TextCtrl(self, wx.ID_ANY, "")
         self.text_height = TextCtrl(self, wx.ID_ANY, "")
-        self.combo_style = wx.ComboBox(
+        self.combo_style = wxComboBox(
             self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN
         )
         self.button_default = wxButton(self, wx.ID_ANY, "D")

--- a/meerk40t/tools/livinghinges.py
+++ b/meerk40t/tools/livinghinges.py
@@ -11,6 +11,7 @@ from meerk40t.gui.laserrender import LaserRender
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
+    TextCtrl,
     dip_size,
     wxButton,
     wxCheckBox,
@@ -69,10 +70,10 @@ class HingePanel(wx.Panel):
         self.last_show_event = 0
         self._Buffer = None
 
-        self.text_origin_x = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_origin_y = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_width = wx.TextCtrl(self, wx.ID_ANY, "")
-        self.text_height = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.text_origin_x = TextCtrl(self, wx.ID_ANY, "")
+        self.text_origin_y = TextCtrl(self, wx.ID_ANY, "")
+        self.text_width = TextCtrl(self, wx.ID_ANY, "")
+        self.text_height = TextCtrl(self, wx.ID_ANY, "")
         self.combo_style = wx.ComboBox(
             self, wx.ID_ANY, choices=[], style=wx.CB_DROPDOWN
         )
@@ -90,7 +91,7 @@ class HingePanel(wx.Panel):
         self.slider_rotate_label.SetFont(
             wx.Font(8, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
-        self.text_rotate = wx.TextCtrl(
+        self.text_rotate = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
 
@@ -109,7 +110,7 @@ class HingePanel(wx.Panel):
         self.slider_width_label.SetFont(
             wx.Font(8, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
-        self.text_cell_width = wx.TextCtrl(
+        self.text_cell_width = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
         self.slider_height = wx.Slider(
@@ -126,7 +127,7 @@ class HingePanel(wx.Panel):
         self.slider_height_label.SetFont(
             wx.Font(8, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
-        self.text_cell_height = wx.TextCtrl(
+        self.text_cell_height = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
         self.slider_offset_x = wx.Slider(
@@ -141,7 +142,7 @@ class HingePanel(wx.Panel):
         self.slider_offx_label.SetFont(
             wx.Font(8, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
-        self.text_cell_offset_x = wx.TextCtrl(
+        self.text_cell_offset_x = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
         self.slider_offset_y = wx.Slider(
@@ -156,7 +157,7 @@ class HingePanel(wx.Panel):
         self.slider_offy_label.SetFont(
             wx.Font(8, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
-        self.text_cell_offset_y = wx.TextCtrl(
+        self.text_cell_offset_y = TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
         )
         # Slider times ten
@@ -810,7 +811,7 @@ class HingePanel(wx.Panel):
                 except ValueError:
                     self.in_change_event = False
                     return
-            elif isinstance(origin, wx.TextCtrl):
+            elif isinstance(origin, TextCtrl):
                 newvalue = origin.GetValue().strip().lower()
                 # Some basic checks:
                 # a) Empty?


### PR DESCRIPTION
- You can not only set a forced dark mode but a forced light mode, too
- Some fixes for forced dark mode

## Summary by Sourcery

Add a new GUI light mode option and fix issues with the dark mode. Refactor the code to use custom TextCtrl and wxComboBox classes for improved consistency and functionality.

New Features:
- Introduce a GUI light mode option, allowing users to force the application to start in light mode regardless of system settings.

Bug Fixes:
- Fix issues related to the forced dark mode, ensuring consistent application of the theme.

Enhancements:
- Refactor the code to replace wx.TextCtrl with a custom TextCtrl class across various modules for consistency and potential customization.
- Replace wx.ComboBox with a custom wxComboBox class to enhance tooltip functionality on Linux systems.