### PR TITLE
Allow limited selection on right click menu

### DIFF
--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -280,7 +280,11 @@ class ContourPanel(wx.Panel):
 
     def pane_hide(self):
         self.list_contours.save_column_widths()
-        self.context.contour_placement = self.combo_placement.GetSelection()
+        try:
+            self.context.contour_placement = self.combo_placement.GetSelection()
+        except RuntimeError:
+            # Might have already been deleted...
+            pass
 
     def pane_deactive(self):
         self._pane_is_active = False

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -62,7 +62,8 @@ class PropertyWindow(MWindow):
         for p in self.panel_instances:
             try:
                 p.pane_hide()
-            except AttributeError:
+            except (AttributeError, RuntimeError):
+                # We don't have one or the underlying pane has already been destroyed
                 pass
             self.remove_module_delegate(p)
         self.panel_instances.clear()


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/ab4ab21f-cb88-41c6-a7b9-0ab1edff11cb)

## Summary by Sourcery

Add a right-click context menu to the contour list, enabling users to perform selective deletion of contours. Refactor the code to separate the logic for populating the contour list, enhancing code clarity.

New Features:
- Introduce a right-click context menu for contour list items, allowing users to delete specific contours, all other contours, or contours based on size comparison.

Enhancements:
- Refactor the contour list population logic into a separate method to improve code organization and readability.