### PR TITLE
Simulation balor fix

### DIFF
--- a/meerk40t/balormk/gui/corscene.py
+++ b/meerk40t/balormk/gui/corscene.py
@@ -16,7 +16,7 @@ import wx
 from meerk40t.gui import icons
 from meerk40t.gui.icons import icons8_detective
 from meerk40t.gui.laserrender import LaserRender
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.scene.scenespacewidget import SceneSpaceWidget
 from meerk40t.gui.scene.widget import Widget
@@ -772,7 +772,7 @@ class CorFileWidget(Widget):
         """
         Draws the background on the scene.
         """
-        mat_fact = gcmatrix_scale(gc)
+        mat_fact = get_gc_scale(gc)
         try:
             linewidth = 2.0 / mat_fact
         except ZeroDivisionError:

--- a/meerk40t/balormk/gui/corscene.py
+++ b/meerk40t/balormk/gui/corscene.py
@@ -16,6 +16,7 @@ import wx
 from meerk40t.gui import icons
 from meerk40t.gui.icons import icons8_detective
 from meerk40t.gui.laserrender import LaserRender
+from meerk40t.gui.wxutils import gcmatrix_scale
 from meerk40t.gui.scene.sceneconst import HITCHAIN_HIT, RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.scene.scenespacewidget import SceneSpaceWidget
 from meerk40t.gui.scene.widget import Widget
@@ -771,11 +772,7 @@ class CorFileWidget(Widget):
         """
         Draws the background on the scene.
         """
-        matrix = gc.GetTransform().Get()
-        # mat.a mat.d
-        mat_fact = max(matrix[0], matrix[3])
-        if mat_fact == 0:
-            mat_fact = 1
+        mat_fact = gcmatrix_scale(gc)
         try:
             linewidth = 2.0 / mat_fact
         except ZeroDivisionError:

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -39,7 +39,7 @@ from ..tools.geomstr import (  # , TYPE_RAMP
 from .fonts import wxfont_to_svg
 from .icons import icons8_image
 from .zmatrix import ZMatrix
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 
 DRAW_MODE_FILLS = 0x000001
 DRAW_MODE_GUIDES = 0x000002
@@ -561,7 +561,7 @@ class LaserRender:
         @param y: offset in y direction
         @return:
         """
-        gcscale = gcmatrix_scale(gc)
+        gcscale = get_gc_scale(gc)
         # print (f"Scale: {gcscale} - {mat_param}")
         highlight_color = Color("magenta")
         wx_color = wx.Colour(swizzlecolor(highlight_color))
@@ -626,7 +626,7 @@ class LaserRender:
                     cut.offset_x + x, cut.offset_y + y
                 )  # Adjust image xy
                 gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(matrix)))
-                _gcscale = gcmatrix_scale(gc)
+                _gcscale = get_gc_scale(gc)
                 try:
                     cache = cut._cache
                     cache_id = cut._cache_id

--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -39,6 +39,7 @@ from ..tools.geomstr import (  # , TYPE_RAMP
 from .fonts import wxfont_to_svg
 from .icons import icons8_image
 from .zmatrix import ZMatrix
+from meerk40t.gui.wxutils import gcmatrix_scale
 
 DRAW_MODE_FILLS = 0x000001
 DRAW_MODE_GUIDES = 0x000002
@@ -560,11 +561,8 @@ class LaserRender:
         @param y: offset in y direction
         @return:
         """
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        gcscale = max(mat_param[0], mat_param[3])
-        if gcscale == 0:
-            gcscale = 1
+        gcscale = gcmatrix_scale(gc)
+        # print (f"Scale: {gcscale} - {mat_param}")
         highlight_color = Color("magenta")
         wx_color = wx.Colour(swizzlecolor(highlight_color))
         highlight_pen = wx.Pen(wx_color)
@@ -628,10 +626,7 @@ class LaserRender:
                     cut.offset_x + x, cut.offset_y + y
                 )  # Adjust image xy
                 gc.ConcatTransform(wx.GraphicsContext.CreateMatrix(gc, ZMatrix(matrix)))
-                _mat_param = gc.GetTransform().Get()
-                _gcscale = max(_mat_param[0], _mat_param[3])
-                if _gcscale == 0:
-                    _gcscale = 1
+                _gcscale = gcmatrix_scale(gc)
                 try:
                     cache = cut._cache
                     cache_id = cut._cache_id

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -24,7 +24,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.scene.scenespacewidget import SceneSpaceWidget
-from meerk40t.gui.wxutils import matrix_scale
+from meerk40t.gui.wxutils import get_matrix_scale
 from meerk40t.kernel import Job, Module
 from meerk40t.svgelements import Matrix, Point
 
@@ -859,7 +859,7 @@ class Scene(Module, Job):
 
                     sdx = new_x_space - space_pos[0]
                     if current_matrix is not None and not current_matrix.is_identity():
-                        sdx *= matrix_scale(current_matrix)
+                        sdx *= get_matrix_scale(current_matrix)
                     snap_x = window_pos[0] + sdx
                     sdy = new_y_space - space_pos[1]
                     if current_matrix is not None and not current_matrix.is_identity():
@@ -1037,7 +1037,7 @@ class Scene(Module, Job):
             self._calculate_attraction_points()
 
         matrix = self.widget_root.scene_widget.matrix
-        length = self.context.show_attract_len / matrix_scale(matrix)
+        length = self.context.show_attract_len / get_matrix_scale(matrix)
 
         if snap_points and self.snap_attraction_points:
             self._calculate_snap_points(my_x, my_y, length)
@@ -1067,7 +1067,7 @@ class Scene(Module, Job):
                     min_delta = delta
             if new_x is not None:
                 matrix = self.widget_root.scene_widget.matrix
-                pixel = self.context.action_attract_len / matrix_scale(matrix)
+                pixel = self.context.action_attract_len / get_matrix_scale(matrix)
                 if abs(new_x - my_x) <= pixel and abs(new_y - my_y) <= pixel:
                     # If the distance is small enough: snap.
                     res_x = new_x

--- a/meerk40t/gui/scenewidgets/attractionwidget.py
+++ b/meerk40t/gui/scenewidgets/attractionwidget.py
@@ -9,7 +9,7 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import HITCHAIN_PRIORITY_HIT, RESPONSE_CHAIN
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.gui.wxutils import matrix_scale
+from meerk40t.gui.wxutils import get_matrix_scale
 
 TYPE_BOUND = 0
 TYPE_POINT = 1
@@ -239,16 +239,16 @@ class AttractionWidget(Widget):
         matrix = self.parent.matrix
         try:
             # Intentionally big to clearly see shape
-            self.symbol_size = 10 / matrix_scale(matrix)
+            self.symbol_size = 10 / get_matrix_scale(matrix)
         except ZeroDivisionError:
             matrix.reset()
             return
         # Anything within a 15 Pixel Radius will be attracted, anything within a 45 Pixel Radius will be displayed
-        local_attract_len = self.context.show_attract_len / matrix_scale(matrix)
-        local_action_attract_len = self.context.action_attract_len / matrix_scale(
+        local_attract_len = self.context.show_attract_len / get_matrix_scale(matrix)
+        local_action_attract_len = self.context.action_attract_len / get_matrix_scale(
             matrix
         )
-        local_grid_attract_len = self.context.grid_attract_len / matrix_scale(matrix)
+        local_grid_attract_len = self.context.grid_attract_len / get_matrix_scale(matrix)
 
         min_delta = float("inf")
         min_x = None

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -16,7 +16,7 @@ from meerk40t.gui.scene.scene import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.gui.wxutils import matrix_scale, gcmatrix_fullscale
+from meerk40t.gui.wxutils import get_matrix_scale, get_gc_full_scale
 from meerk40t.tools.geomstr import NON_GEOMETRY_TYPES
 
 
@@ -284,7 +284,7 @@ class RectSelectWidget(Widget):
                     and "shift" not in modifiers
                     and b is not None
                 ):
-                    gap = self.scene.context.action_attract_len / matrix_scale(matrix)
+                    gap = self.scene.context.action_attract_len / get_matrix_scale(matrix)
                     # We gather all points of non-selected elements,
                     # but only those that lie within the boundaries
                     # of the selected area
@@ -363,7 +363,7 @@ class RectSelectWidget(Widget):
                     and not did_snap_to_point
                 ):
                     # t1 = perf_counter()
-                    gap = self.scene.context.grid_attract_len / matrix_scale(matrix)
+                    gap = self.scene.context.grid_attract_len / get_matrix_scale(matrix)
                     # Check for corner points + center:
                     selected_points = (
                         (b[0], b[1]),
@@ -438,7 +438,7 @@ class RectSelectWidget(Widget):
         # (even if they are dotted on a microscopic level)
         # To circumvent this issue, we scale the gc back
         gc.PushState()
-        sx, sy = gcmatrix_fullscale(gc)
+        sx, sy = get_gc_full_scale(gc)
         gc.Scale(1 / sx, 1 / sy)
         self.selection_pen.SetColour(tcolor)
         self.selection_pen.SetStyle(tstyle)
@@ -461,7 +461,7 @@ class RectSelectWidget(Widget):
         # (even if they are dotted on a microscopic level)
         # To circumvent this issue, we scale the gc back
         gc.PushState()
-        sx, sy = gcmatrix_fullscale(gc)
+        sx, sy = get_gc_full_scale(gc)
         # print (f"sx={sx}, sy={sy}")
         gc.Scale(1 / sx, 1 / sy)
         self.selection_pen.SetColour(tcolor)

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -16,7 +16,7 @@ from meerk40t.gui.scene.scene import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.scene.widget import Widget
-from meerk40t.gui.wxutils import matrix_scale
+from meerk40t.gui.wxutils import matrix_scale, gcmatrix_fullscale
 from meerk40t.tools.geomstr import NON_GEOMETRY_TYPES
 
 
@@ -438,14 +438,7 @@ class RectSelectWidget(Widget):
         # (even if they are dotted on a microscopic level)
         # To circumvent this issue, we scale the gc back
         gc.PushState()
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        sx = mat_param[0]
-        sy = mat_param[3]
-        if sx == 0:
-            sx = 1
-        if sy == 0:
-            sy = 1
+        sx, sy = gcmatrix_fullscale(gc)
         gc.Scale(1 / sx, 1 / sy)
         self.selection_pen.SetColour(tcolor)
         self.selection_pen.SetStyle(tstyle)
@@ -468,14 +461,7 @@ class RectSelectWidget(Widget):
         # (even if they are dotted on a microscopic level)
         # To circumvent this issue, we scale the gc back
         gc.PushState()
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        sx = mat_param[0]
-        sy = mat_param[3]
-        if sx == 0:
-            sx = 1
-        if sy == 0:
-            sy = 1
+        sx, sy = gcmatrix_fullscale(gc)
         # print (f"sx={sx}, sy={sy}")
         gc.Scale(1 / sx, 1 / sy)
         self.selection_pen.SetColour(tcolor)

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -33,8 +33,8 @@ from meerk40t.gui.scene.widget import Widget
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
     create_menu_for_node,
-    gcmatrix_fullscale,
-    matrix_scale,
+    get_gc_full_scale,
+    get_matrix_scale,
     wxButton,
     wxCheckBox,
     wxStaticText,
@@ -233,7 +233,7 @@ class BorderWidget(Widget):
             # (even if they are dotted on a microscopic level)
             # To circumvent this issue, we scale the gc back
             gc.PushState()
-            sx, sy = gcmatrix_fullscale(gc)
+            sx, sy = get_gc_full_scale(gc)
             gc.Scale(1 / sx, 1 / sy)
 
             # Create a copy of the pen
@@ -1634,7 +1634,7 @@ class MoveWidget(Widget):
                 and not "shift" in modifiers
                 and b is not None
             ):
-                gap = self.scene.context.action_attract_len / matrix_scale(matrix)
+                gap = self.scene.context.action_attract_len / get_matrix_scale(matrix)
                 # We gather all points of non-selected elements,
                 # but only those that lie within the boundaries
                 # of the selected area
@@ -1716,7 +1716,7 @@ class MoveWidget(Widget):
                 and not did_snap_to_point
             ):
                 # t1 = perf_counter()
-                gap = self.scene.context.grid_attract_len / matrix_scale(matrix)
+                gap = self.scene.context.grid_attract_len / get_matrix_scale(matrix)
                 # Check for corner points + center:
                 selected_points = (
                     (b[0], b[1]),

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -33,6 +33,7 @@ from meerk40t.gui.scene.widget import Widget
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
     create_menu_for_node,
+    gcmatrix_fullscale,
     matrix_scale,
     wxButton,
     wxCheckBox,
@@ -232,14 +233,7 @@ class BorderWidget(Widget):
             # (even if they are dotted on a microscopic level)
             # To circumvent this issue, we scale the gc back
             gc.PushState()
-            gcmat = gc.GetTransform()
-            mat_param = gcmat.Get()
-            sx = mat_param[0]
-            sy = mat_param[3]
-            if sx == 0:
-                sx = 1
-            if sy == 0:
-                sy = 1
+            sx, sy = gcmatrix_fullscale(gc)
             gc.Scale(1 / sx, 1 / sy)
 
             # Create a copy of the pen

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -53,7 +53,7 @@ from .wxutils import (
     StaticBoxSizer,
     TextCtrl,
     dip_size,
-    gcmatrix_scale,
+    get_gc_scale,
     wxButton,
     wxCheckBox,
     wxListBox,
@@ -2091,7 +2091,7 @@ class SimulationTravelWidget(Widget):
             pos = self.pos[-1]
         if pos < 0:
             return
-        gcscale = gcmatrix_scale(gc)
+        gcscale = get_gc_scale(gc)
         if gcscale == 0:
             gcscale = 1
         linewidth = 1 / gcscale

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -53,6 +53,7 @@ from .wxutils import (
     StaticBoxSizer,
     TextCtrl,
     dip_size,
+    gcmatrix_scale,
     wxButton,
     wxCheckBox,
     wxListBox,
@@ -2090,9 +2091,7 @@ class SimulationTravelWidget(Widget):
             pos = self.pos[-1]
         if pos < 0:
             return
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        gcscale = max(mat_param[0], mat_param[3])
+        gcscale = gcmatrix_scale(gc)
         if gcscale == 0:
             gcscale = 1
         linewidth = 1 / gcscale

--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -9,6 +9,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CHAIN,
     RESPONSE_CONSUME,
 )
+from meerk40t.gui.wxutils import gcmatrix_scale
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
 from meerk40t.svgelements import Ellipse
 
@@ -42,10 +43,7 @@ class CircleTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            matrix = gc.GetTransform().Get()
-            mat_fact = max(matrix[0], matrix[3])
-            if mat_fact == 0:
-                mat_fact = 1
+            mat_fact = gcmatrix_scale(gc)
             pixel = 1.0 / mat_fact
             cx = self.p1.real
             cy = self.p1.imag

--- a/meerk40t/gui/toolwidgets/toolcircle.py
+++ b/meerk40t/gui/toolwidgets/toolcircle.py
@@ -9,7 +9,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CHAIN,
     RESPONSE_CONSUME,
 )
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
 from meerk40t.svgelements import Ellipse
 
@@ -43,7 +43,7 @@ class CircleTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            mat_fact = gcmatrix_scale(gc)
+            mat_fact = get_gc_scale(gc)
             pixel = 1.0 / mat_fact
             cx = self.p1.real
             cy = self.p1.imag

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -8,7 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 
 _ = wx.GetTranslation
 
@@ -30,7 +30,7 @@ class EllipseTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            mat_fact = gcmatrix_scale(gc)
+            mat_fact = get_gc_scale(gc)
             pixel = 1.0 / mat_fact
             # print (f"1 Px = {pixel}, sx = {matrix[0]}")
             if self.creation_mode == 1:

--- a/meerk40t/gui/toolwidgets/toolellipse.py
+++ b/meerk40t/gui/toolwidgets/toolellipse.py
@@ -8,6 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.gui.wxutils import gcmatrix_scale
 
 _ = wx.GetTranslation
 
@@ -29,10 +30,7 @@ class EllipseTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            matrix = gc.GetTransform().Get()
-            mat_fact = max(matrix[0], matrix[3])
-            if mat_fact == 0:
-                mat_fact = 1
+            mat_fact = gcmatrix_scale(gc)
             pixel = 1.0 / mat_fact
             # print (f"1 Px = {pixel}, sx = {matrix[0]}")
             if self.creation_mode == 1:

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -3,7 +3,7 @@ from math import atan2, cos, sin, sqrt, tau
 import wx
 
 from meerk40t.core.units import Length
-from meerk40t.gui.wxutils import matrix_scale
+from meerk40t.gui.wxutils import matrix_scale, gcmatrix_scale
 
 from .toolpointlistbuilder import PointListTool
 
@@ -36,11 +36,7 @@ class MeasureTool(PointListTool):
     def draw_points(self, gc, points):
         if not self.point_series:
             return
-        matrix = gc.GetTransform().Get()
-        # mat.a mat.d
-        mat_fact = max(matrix[0], matrix[3])
-        if mat_fact == 0:
-            mat_fact = 1
+        mat_fact = gcmatrix_scale(gc)
         try:
             font_size = 10.0 / mat_fact
         except ZeroDivisionError:

--- a/meerk40t/gui/toolwidgets/toolmeasure.py
+++ b/meerk40t/gui/toolwidgets/toolmeasure.py
@@ -3,7 +3,7 @@ from math import atan2, cos, sin, sqrt, tau
 import wx
 
 from meerk40t.core.units import Length
-from meerk40t.gui.wxutils import matrix_scale, gcmatrix_scale
+from meerk40t.gui.wxutils import get_matrix_scale, get_gc_scale
 
 from .toolpointlistbuilder import PointListTool
 
@@ -36,7 +36,7 @@ class MeasureTool(PointListTool):
     def draw_points(self, gc, points):
         if not self.point_series:
             return
-        mat_fact = gcmatrix_scale(gc)
+        mat_fact = get_gc_scale(gc)
         try:
             font_size = 10.0 / mat_fact
         except ZeroDivisionError:

--- a/meerk40t/gui/toolwidgets/toolnodeedit.py
+++ b/meerk40t/gui/toolwidgets/toolnodeedit.py
@@ -25,7 +25,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import matrix_scale
+from meerk40t.gui.wxutils import get_matrix_scale
 from meerk40t.svgelements import (
     Arc,
     Close,
@@ -333,7 +333,7 @@ class EditTool(ToolWidget):
                 pass  # Exceeds 32 bit signed integer.
 
         matrix = self.scene.widget_root.scene_widget.matrix
-        linewidth = 1.0 / matrix_scale(matrix)
+        linewidth = 1.0 / get_matrix_scale(matrix)
         if linewidth < 1:
             linewidth = 1
         set_width_pen(self.pen, linewidth)

--- a/meerk40t/gui/toolwidgets/toolparameter.py
+++ b/meerk40t/gui/toolwidgets/toolparameter.py
@@ -4,7 +4,7 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import dip_size, matrix_scale
+from meerk40t.gui.wxutils import dip_size, matrix_scale, gcmatrix_scale
 from meerk40t.tools.geomstr import NON_GEOMETRY_TYPES
 
 _ = wx.GetTranslation
@@ -173,13 +173,7 @@ class SimpleSlider:
         offset = self.magnification * self.pt_offset / s
 
         mypen = wx.Pen(wx.LIGHT_GREY)
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        sx = mat_param[0]
-        sy = mat_param[3]
-        sx = max(sx, sy)
-        if sx == 0:
-            sx = 1
+        sx = gcmatrix_scale(gc)
         linewidth = 1 / sx
         try:
             mypen.SetWidth(linewidth)

--- a/meerk40t/gui/toolwidgets/toolparameter.py
+++ b/meerk40t/gui/toolwidgets/toolparameter.py
@@ -4,7 +4,7 @@ import wx
 
 from meerk40t.gui.scene.sceneconst import RESPONSE_CHAIN, RESPONSE_CONSUME
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import dip_size, matrix_scale, gcmatrix_scale
+from meerk40t.gui.wxutils import dip_size, get_matrix_scale, get_gc_scale
 from meerk40t.tools.geomstr import NON_GEOMETRY_TYPES
 
 _ = wx.GetTranslation
@@ -173,7 +173,7 @@ class SimpleSlider:
         offset = self.magnification * self.pt_offset / s
 
         mypen = wx.Pen(wx.LIGHT_GREY)
-        sx = gcmatrix_scale(gc)
+        sx = get_gc_scale(gc)
         linewidth = 1 / sx
         try:
             mypen.SetWidth(linewidth)
@@ -649,7 +649,7 @@ class ParameterTool(ToolWidget):
             )
             if doit:
                 matrix = self.scene.widget_root.scene_widget.matrix
-                gap = self.scene.context.action_attract_len / matrix_scale(matrix)
+                gap = self.scene.context.action_attract_len / get_matrix_scale(matrix)
                 this_point = (
                     self.params[self.point_index][0]
                     + 1j * self.params[self.point_index][1]

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -8,7 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 
 _ = wx.GetTranslation
 
@@ -30,7 +30,7 @@ class RectTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            mat_fact = gcmatrix_scale(gc)
+            mat_fact = get_gc_scale(gc)
             pixel = 1.0 / mat_fact
             if self.creation_mode == 1:
                 # From center (p1 center, p2 one corner)

--- a/meerk40t/gui/toolwidgets/toolrect.py
+++ b/meerk40t/gui/toolwidgets/toolrect.py
@@ -8,6 +8,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_CONSUME,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.gui.wxutils import gcmatrix_scale
 
 _ = wx.GetTranslation
 
@@ -29,10 +30,7 @@ class RectTool(ToolWidget):
 
     def process_draw(self, gc: wx.GraphicsContext):
         if self.p1 is not None and self.p2 is not None:
-            matrix = gc.GetTransform().Get()
-            mat_fact = max(matrix[0], matrix[3])
-            if mat_fact == 0:
-                mat_fact = 1
+            mat_fact = gcmatrix_scale(gc)
             pixel = 1.0 / mat_fact
             if self.creation_mode == 1:
                 # From center (p1 center, p2 one corner)

--- a/meerk40t/gui/toolwidgets/tooltabedit.py
+++ b/meerk40t/gui/toolwidgets/tooltabedit.py
@@ -11,7 +11,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
-from meerk40t.gui.wxutils import gcmatrix_scale
+from meerk40t.gui.wxutils import get_gc_scale
 
 _ = wx.GetTranslation
 
@@ -80,7 +80,7 @@ class SimpleSlider:
         offset = self.pt_offset / s
 
         mypen = wx.Pen(wx.LIGHT_GREY)
-        sx = gcmatrix_scale(gc)
+        sx = get_gc_scale(gc)
         linewidth = 1 / sx
         try:
             mypen.SetWidth(linewidth)

--- a/meerk40t/gui/toolwidgets/tooltabedit.py
+++ b/meerk40t/gui/toolwidgets/tooltabedit.py
@@ -11,6 +11,7 @@ from meerk40t.gui.scene.sceneconst import (
     RESPONSE_DROP,
 )
 from meerk40t.gui.toolwidgets.toolwidget import ToolWidget
+from meerk40t.gui.wxutils import gcmatrix_scale
 
 _ = wx.GetTranslation
 
@@ -79,13 +80,7 @@ class SimpleSlider:
         offset = self.pt_offset / s
 
         mypen = wx.Pen(wx.LIGHT_GREY)
-        gcmat = gc.GetTransform()
-        mat_param = gcmat.Get()
-        sx = mat_param[0]
-        sy = mat_param[3]
-        sx = max(sx, sy)
-        if sx == 0:
-            sx = 1
+        sx = gcmatrix_scale(gc)
         linewidth = 1 / sx
         try:
             mypen.SetWidth(linewidth)

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -20,7 +20,7 @@ _ = wx.GetTranslation
 ##############
 
 
-def matrix_scale(matrix):
+def get_matrix_scale(matrix):
     # We usually use the value_scale_x to establish a pixel size
     # by counteracting the scene matrix, linewidth = 1 / matrix.value_scale_x()
     # For a rotated scene this crashes, so we need to take
@@ -35,7 +35,7 @@ def matrix_scale(matrix):
         res = 1
     return res
 
-def matrix_fullscale(matrix):
+def get_matrix_full_scale(matrix):
     # We usually use the value_scale_x to establish a pixel size
     # by counteracting the scene matrix, linewidth = 1 / matrix.value_scale_x()
     # For a rotated scene this crashes, so we need to take
@@ -54,7 +54,7 @@ def matrix_fullscale(matrix):
         resy = 1
     return resx, resy
 
-def gcmatrix_scale(gc):
+def get_gc_scale(gc):
     gcmat = gc.GetTransform()
     mat_param = gcmat.Get()
     testmatrix = Matrix(
@@ -65,9 +65,9 @@ def gcmatrix_scale(gc):
         mat_param[4], 
         mat_param[5], 
     )
-    return matrix_scale(testmatrix)
+    return get_matrix_scale(testmatrix)
 
-def gcmatrix_fullscale(gc):
+def get_gc_full_scale(gc):
     gcmat = gc.GetTransform()
     mat_param = gcmat.Get()
     testmatrix = Matrix(
@@ -78,7 +78,7 @@ def gcmatrix_fullscale(gc):
         mat_param[4], 
         mat_param[5], 
     )
-    return matrix_fullscale(testmatrix)
+    return get_matrix_full_scale(testmatrix)
 
 def create_menu_for_choices(gui, choices: List[dict]) -> wx.Menu:
     """

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -8,6 +8,7 @@ import wx
 import wx.lib.mixins.listctrl as listmix
 from wx.lib.scrolledpanel import ScrolledPanel as SP
 
+from meerk40t.svgelements import Matrix
 from meerk40t.core.units import ACCEPTED_ANGLE_UNITS, ACCEPTED_UNITS, Angle, Length
 
 _ = wx.GetTranslation
@@ -34,6 +35,50 @@ def matrix_scale(matrix):
         res = 1
     return res
 
+def matrix_fullscale(matrix):
+    # We usually use the value_scale_x to establish a pixel size
+    # by counteracting the scene matrix, linewidth = 1 / matrix.value_scale_x()
+    # For a rotated scene this crashes, so we need to take
+    # that into consideration, so let's look at the
+    # distance from (1, 0) to (0, 0) and call this our scale
+    from math import sqrt
+
+    x0, y0 = matrix.point_in_matrix_space((0, 0))
+    x1, y1 = matrix.point_in_matrix_space((1, 0))
+    resx = sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2)
+    if resx < 1e-8:
+        resx = 1
+    x1, y1 = matrix.point_in_matrix_space((0, 1))
+    resy = sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2)
+    if resy < 1e-8:
+        resy = 1
+    return resx, resy
+
+def gcmatrix_scale(gc):
+    gcmat = gc.GetTransform()
+    mat_param = gcmat.Get()
+    testmatrix = Matrix(
+        mat_param[0], 
+        mat_param[1], 
+        mat_param[2], 
+        mat_param[3], 
+        mat_param[4], 
+        mat_param[5], 
+    )
+    return matrix_scale(testmatrix)
+
+def gcmatrix_fullscale(gc):
+    gcmat = gc.GetTransform()
+    mat_param = gcmat.Get()
+    testmatrix = Matrix(
+        mat_param[0], 
+        mat_param[1], 
+        mat_param[2], 
+        mat_param[3], 
+        mat_param[4], 
+        mat_param[5], 
+    )
+    return matrix_fullscale(testmatrix)
 
 def create_menu_for_choices(gui, choices: List[dict]) -> wx.Menu:
     """


### PR DESCRIPTION
Simulation view for balor devices was not properly displayed on Darwin (and probably not on Linux either).

Cause: the scale of the current GraphicsContext Transformation Matrix was relying solely on the 'regular' scale values. This fails for rotated / mirrored matrices like the one we need for Balor.