### PR TITLE
Put dc acquisition inside lock

### DIFF
--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -957,18 +957,19 @@ class RibbonBarPanel(wx.Control):
             try:
                 buf = self._set_buffer()
                 dc = wx.MemoryDC()
+                dc.SelectObject(buf)
+                if self._layout_dirty:
+                    self.art.layout(dc, self)
+                    self._layout_dirty = False
+                self.art.paint_main(dc, self)
+                dc.SelectObject(wx.NullBitmap)
+                del dc
+                self._paint_dirty = False
             except (RuntimeError, AssertionError):
+                pass
                 # Shutdown error
-                return
-            dc.SelectObject(buf)
-            if self._layout_dirty:
-                self.art.layout(dc, self)
-                self._layout_dirty = False
-            self.art.paint_main(dc, self)
-            dc.SelectObject(wx.NullBitmap)
-            del dc
-            self._paint_dirty = False
-            self._redraw_lock.release()
+            finally:
+                self._redraw_lock.release()
 
         self.Refresh()  # Paint buffer on screen.
 

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -953,22 +953,22 @@ class RibbonBarPanel(wx.Control):
     def _paint_main_on_buffer(self):
         """Performs redrawing of the data in the UI thread."""
         # print (f"Redraw job started for RibbonBar with {self.visible_pages()} pages")
-        try:
-            buf = self._set_buffer()
-            dc = wx.MemoryDC()
-        except (RuntimeError, AssertionError):
-            # Shutdown error
-            return
-        dc.SelectObject(buf)
         if self._redraw_lock.acquire(timeout=0.2):
+            try:
+                buf = self._set_buffer()
+                dc = wx.MemoryDC()
+            except (RuntimeError, AssertionError):
+                # Shutdown error
+                return
+            dc.SelectObject(buf)
             if self._layout_dirty:
                 self.art.layout(dc, self)
                 self._layout_dirty = False
             self.art.paint_main(dc, self)
-            self._redraw_lock.release()
+            dc.SelectObject(wx.NullBitmap)
+            del dc
             self._paint_dirty = False
-        dc.SelectObject(wx.NullBitmap)
-        del dc
+            self._redraw_lock.release()
 
         self.Refresh()  # Paint buffer on screen.
 


### PR DESCRIPTION
We seem to have every now and then an error, where we try to get the dc, while it's still in use:
```
MeerK40t crash log. Version: 0.9.5202 on Windows: Python 3.9.10: AMD64 - wxPython: 4.1.1 msw (phoenix) wxWidgets 3.1.5
Traceback (most recent call last):
  File "meerk40t\gui\ribbon.py", line 946, in on_paint
  File "meerk40t\gui\ribbon.py", line 962, in _paint_main_on_buffer
wx._core.wxAssertionError: C++ assertion "!bitmap.GetSelectedInto() || (bitmap.GetSelectedInto() == GetOwner())" failed at ..\..\src\msw\dcmemory.cpp(114) in wxMemoryDCImpl::DoSelect(): Bitmap is selected in another wxMemoryDC, delete the first wxMemoryDC or use SelectObject(NULL)
```
This change should cover it