### PR TITLE
Cylinder commands

### DIFF
--- a/meerk40t/balormk/cylindermod.py
+++ b/meerk40t/balormk/cylindermod.py
@@ -26,11 +26,11 @@ class CylinderModifier:
     def convert(self, x, y):
         a = x - 0x8000
         r = self.r_x
-        x_prime = r * math.sin(a / r)
+        x_prime = a if r == 0 else r * math.sin(a / r)
         a = y - 0x8000
         r = self.r_y
-        y_prime = r * math.sin(a / r)
-        return x_prime + 0x8000, y_prime
+        y_prime = a if r == 0 else r * math.sin(a / r)
+        return x_prime + 0x8000, y_prime + 0x8000
 
     def mark(self, x, y, **kwargs):
         x, y = self.convert(x, y)

--- a/meerk40t/balormk/cylindermod.py
+++ b/meerk40t/balormk/cylindermod.py
@@ -1,7 +1,6 @@
 import math
 from functools import lru_cache
 
-
 class CylinderModifier:
     def __init__(self, wrapped_instance, service):
         self._wrapped_instance = wrapped_instance
@@ -23,29 +22,15 @@ class CylinderModifier:
         self.l_x = 0x8000
         self.l_y = 0x8000
 
-        @service.console_command(
-            "cylinder",
-            help="Cylinder base command",
-            output_type="cylinder",
-        )
-        def cylinder(command, channel, _, data=None, **kwargs):
-            channel(
-                f"Cylinder Mode X: {self.x_axis}, {self.x_axis_length}, concave: {self.x_concave}."
-            )
-            channel(
-                f"Cylinder Mode Y: {self.y_axis}, {self.y_axis_length}, concave: {self.y_concave}."
-            )
-            channel(
-                "Only x axis is used. Updates occur only when toggled off and on. Concave is unused."
-            )
-            return "cylinder", None
-
     @lru_cache(maxsize=1024)
     def convert(self, x, y):
         a = x - 0x8000
         r = self.r_x
         x_prime = r * math.sin(a / r)
-        return x_prime + 0x8000, y
+        a = y - 0x8000
+        r = self.r_y
+        y_prime = r * math.sin(a / r)
+        return x_prime + 0x8000, y_prime
 
     def mark(self, x, y, **kwargs):
         x, y = self.convert(x, y)

--- a/meerk40t/cylinder/cylinder.py
+++ b/meerk40t/cylinder/cylinder.py
@@ -177,7 +177,7 @@ class CylinderCorrection:
         @service.console_argument("axis", type=str, help="Axis X or Y")
         @service.console_argument("diam", type=Length, help="Diameter of to be engraved object")
         @service.console_command("axis", help="Sets the to be used axis (X or Y)", input_type="cylinder", output_type="cylinder")
-        def cylinder_x_diameter(command, channel, _, data=None, axis=None, diam=None, **kwargs):
+        def cylinder_axis_parameter(command, channel, _, data=None, axis=None, diam=None, **kwargs):
             if axis is None:
                 channel("You need to provide X or Y as parameter to choose which axis to use")
             if diam is None:

--- a/meerk40t/cylinder/cylinder.py
+++ b/meerk40t/cylinder/cylinder.py
@@ -72,8 +72,10 @@ class CylinderCorrection:
                 "type": bool,
                 "label": _("Cylinder is Concave"),
                 "tip": _("Cylinder is concave rather than convex"),
-                "conditional": (service, "cylinder_x_axis"),
+                # "conditional": (service, "cylinder_x_axis"),
                 "subsection": _("X Axis"),
+                "hidden": True,
+                "enabled": False,
             },
             {
                 "attr": "cylinder_y_axis",
@@ -102,11 +104,102 @@ class CylinderCorrection:
                 "type": bool,
                 "label": _("Cylinder is Concave"),
                 "tip": _("Cylinder is concave rather than convex"),
-                "conditional": (service, "cylinder_y_axis"),
+                # "conditional": (service, "cylinder_y_axis"),
                 "subsection": _("Y Axis"),
+                "hidden": True,
+                "enabled": False,
             },
         ]
         service.register_choices("cylinder", choices)
+        @service.console_command(
+            "cylinder",
+            help="Cylinder base command",
+            output_type="cylinder",
+        )
+        def cylinder(command, channel, _, data=None, remainder=None, **kwargs):
+            if remainder is None:
+                provide_status(channel)
+
+            return "cylinder", None
+
+        def provide_status(channel):
+            if service.cylinder_active:
+                channel(f"Distance from mirror to object: {Length(service.cylinder_mirror_distance).length_mm}")
+                channel(
+                    f"Cylinder Mode X: {'on' if service.cylinder_x_axis else 'off'}, object diameter: {Length(service.cylinder_x_diameter).length_mm}, concave: {'on' if service.cylinder_x_concave else 'off'}."
+                )
+                channel(
+                    f"Cylinder Mode Y: {'on' if service.cylinder_y_axis else 'off'}, object diameter: {Length(service.cylinder_y_diameter).length_mm}, concave: {'on' if service.cylinder_y_concave else 'off'}."
+                )
+                channel(
+                    "Notabene: Updates occur only when toggled off and on. Concave is unused."
+                )
+            else:
+                channel("Cylinder mode is not active, use 'cylinder on' or 'cylinder axis X <object diameter>' to activate it")
+
+        def validate_cylinder_signal():
+            device = service.device
+            device.driver.cylinder_validate()
+            service.signal("cylinder_update")
+
+        @service.console_command("off", help="Turn cylinder correction off", input_type="cylinder", output_type="cylinder")
+        def cylinder_off(command, channel, _, data=None, **kwargs):
+            state = service.cylinder_active
+            service.cylinder_active = False
+            validate_cylinder_signal()
+            provide_status(channel)
+            return "cylinder", None
+
+        @service.console_command("on", help="Turn cylinder correction on", input_type="cylinder", output_type="cylinder")
+        def cylinder_on(command, channel, _, data=None, **kwargs):
+            state = service.cylinder_active
+            service.cylinder_active = True
+            validate_cylinder_signal()
+            provide_status(channel)
+            return "cylinder", None
+
+        @service.console_argument("dist", type=Length, help="Distance between mirror and cylinder")
+        @service.console_command("distance", help="Sets mirror cylinder distance", input_type="cylinder", output_type="cylinder")
+        def cylinder_distance(command, channel, _, data=None, dist=None, **kwargs):
+            if dist is None:
+                channel ("You did not provide a valid distance")
+                return
+            try:
+                c_dist = float(Length(dist))
+            except ValueError:
+                channel ("You did not provide a valid distance")
+                return
+            service.cylinder_mirror_distance = c_dist
+            validate_cylinder_signal()
+            provide_status(channel)
+            return "cylinder", None
+
+        @service.console_argument("axis", type=str, help="Axis X or Y")
+        @service.console_argument("diam", type=Length, help="Diameter of to be engraved object")
+        @service.console_command("axis", help="Sets the to be used axis (X or Y)", input_type="cylinder", output_type="cylinder")
+        def cylinder_x_diameter(command, channel, _, data=None, axis=None, diam=None, **kwargs):
+            if axis is None:
+                channel("You need to provide X or Y as parameter to choose which axis to use")
+            if diam is None:
+                channel ("You did not provide a valid diameter")
+                return
+            use_x = axis.lower() == "x"
+            try:
+                c_dist = float(Length(diam))
+            except ValueError:
+                channel ("You did not provide a valid diameter")
+                return
+            service.cylinder_x_axis = use_x
+            service.cylinder_y_axis = not use_x
+            if use_x:
+                service.cylinder_x_diameter = c_dist
+            else:
+                service.cylinder_y_diameter = c_dist
+            service.cylinder_active = True
+            validate_cylinder_signal()
+            provide_status(channel)
+            return "cylinder", None
+
 
     @lookup_listener("service/device/active")
     @signal_listener("cylinder_active")

--- a/meerk40t/cylinder/gui/cylindersettings.py
+++ b/meerk40t/cylinder/gui/cylindersettings.py
@@ -3,6 +3,7 @@ import wx
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icon_barrel_distortion
 from meerk40t.gui.mwindow import MWindow
+from meerk40t.kernel.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -30,3 +31,7 @@ class CylinderSettings(MWindow):
     @staticmethod
     def submenu():
         return "Device-Settings", "Cylinder-Correction"
+
+    @signal_listener("cylinder_update")
+    def signal_cylinder(self, origin=None, *args, **kwargs):
+        self.panel.reload()

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -1253,10 +1253,15 @@ class ChoicePropertyPanel(ScrolledPanel):
                     nonzero=nonzero,
                 )
                 if isinstance(data, Length):
+                    if not data._preferred_units:
+                        data._preferred_units = "mm"
                     if not data._digits:
                         if data._preferred_units in ("mm", "cm", "in", "inch"):
                             data._digits = 4
-                control.SetValue(str(data))
+                    display_value = data.preferred_length
+                else:
+                    display_value = str(data)
+                control.SetValue(display_value)
                 if ctrl_width > 0:
                     control.SetMaxSize(dip_size(self, ctrl_width, -1))
                 control_sizer.Add(control, 1, wx.EXPAND, 0)
@@ -1540,6 +1545,8 @@ class ChoicePropertyPanel(ScrolledPanel):
                         if float(data) != float(Length(ctrl.GetValue())):
                             update_needed = True
                         if update_needed:
+                            if not isinstance(data, str):
+                                data = Length(data).length_mm
                             ctrl.SetValue(str(data))
                     elif dtype == Angle:
                         if ctrl.GetValue() != str(data):


### PR DESCRIPTION
## Summary by Sourcery

Add new console commands for managing cylinder settings, including enabling/disabling cylinder correction and configuring axis and diameter. Enhance status reporting for cylinder mode.

New Features:
- Introduce a new console command 'cylinder' to manage cylinder settings, including turning cylinder correction on and off, setting mirror distance, and selecting the axis and diameter for engraving.

Enhancements:
- Improve the cylinder mode status reporting by providing detailed information about the cylinder's configuration and status.