### PR TITLE
Greedy operation drag

### DIFF
--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -314,7 +314,11 @@ class HatchEffectNode(Node, Suppressable):
         self.altered()
 
     def can_drop(self, drag_node):
-        if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+        if (
+            hasattr(drag_node, "as_geometry") or
+            drag_node.type in ("effect", "file", "group", "reference") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+        ):
             return True
         return False
 
@@ -349,13 +353,15 @@ class HatchEffectNode(Node, Suppressable):
             return True
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
-            # then we will reverse the game
-            # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect

--- a/meerk40t/core/node/effect_warp.py
+++ b/meerk40t/core/node/effect_warp.py
@@ -297,7 +297,7 @@ class WarpEffectNode(Node, FunctionalParameter):
             self.altered()
 
     def can_drop(self, drag_node):
-        if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+        if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or (drag_node.type.startswith("op ") and drag_node.type != "op dots"):
             return True
         return False
 
@@ -333,9 +333,14 @@ class WarpEffectNode(Node, FunctionalParameter):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -384,7 +384,7 @@ class WobbleEffectNode(Node, Suppressable):
         self.altered()
 
     def can_drop(self, drag_node):
-        if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or drag_node.type.startswith("op "):
+        if hasattr(drag_node, "as_geometry") or drag_node.type in ("effect", "file", "group", "reference") or (drag_node.type.startswith("op ") and drag_node.type != "op dots"):
             return True
         return False
 
@@ -420,9 +420,14 @@ class WobbleEffectNode(Node, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         elif drag_node.type in ("file", "group"):
             # If we drag a group or a file to this node,
             # then we will do it only if this an element effect

--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -263,12 +263,12 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -277,13 +277,18 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
             if modify:
                 self.insert_sibling(drag_node)
             return True
-        
+
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -319,8 +319,7 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         return bool(
             hasattr(drag_node, "as_geometry") or
             hasattr(drag_node, "as_image") or
-            drag_node.type.startswith("op") or
-            drag_node.type in ("file", "group")
+            drag_node.type in ("op image", "op raster", "file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
@@ -334,7 +333,12 @@ class ImageNode(Node, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -203,12 +203,12 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -220,9 +220,14 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -87,12 +87,11 @@ class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            drag_node.type in ("op dots", "file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -104,9 +103,14 @@ class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -234,12 +234,12 @@ class PolylineNode(
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -251,9 +251,14 @@ class PolylineNode(
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -242,12 +242,12 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -259,9 +259,14 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game, but we will take the operations color
-            if hasattr(drag_node, "color") and drag_node.color is not None:
-                self.stroke = drag_node.color
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                if hasattr(drag_node, "color") and drag_node.color is not None:
+                    self.stroke = drag_node.color
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -198,12 +198,11 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            drag_node.type in ("op raster", "file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
@@ -215,7 +214,12 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         elif drag_node.type.startswith("op"):
             # If we drag an operation to this node,
             # then we will reverse the game
-            return drag_node.drop(self, modify=modify, flag=flag)
+            old_references = list(self._references)
+            result = drag_node.drop(self, modify=modify, flag=flag)
+            if result and modify:
+                for ref in old_references:
+                    ref.remove_node()
+            return result
         return False
 
     def revalidate_points(self):

--- a/meerk40t/core/node/image_processed.py
+++ b/meerk40t/core/node/image_processed.py
@@ -165,12 +165,12 @@ class ImageProcessedNode(Node):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):

--- a/meerk40t/core/node/image_raster.py
+++ b/meerk40t/core/node/image_raster.py
@@ -94,12 +94,12 @@ class ImageRasterNode(Node):
     def can_drop(self, drag_node):
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or 
-            hasattr(drag_node, "as_image") or 
-            drag_node.type.startswith("op") or
+            hasattr(drag_node, "as_geometry") or
+            hasattr(drag_node, "as_image") or
+            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
             drag_node.type in ("file", "group")
         )
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):


### PR DESCRIPTION
- Dragging an operation on an element will assign that element to that operation (as before) , but will now remove all other assignments of that element to other operations
- A couple of clearer indicator when an op can't be assigned to an element - before any op was shown as possible nwo only fitting ones will display as feasible (mouse pointer changes when nodes are dragged on top of each other).