### PR TITLE
Add dpi warning

### DIFF
--- a/meerk40t/gui/gui_mixins.py
+++ b/meerk40t/gui/gui_mixins.py
@@ -518,7 +518,7 @@ class Warnings:
                     count += 1
             return flag, count
 
-        def has_low_dpis():
+        def check_dpis(check_type='low'):
             flag = False
             count = 0
             active = self.context.setting(bool, "warning_dpi", True)
@@ -527,6 +527,9 @@ class Warnings:
             threshold = self.context.setting(float, "warning_dpi_low", 1.25)
             if threshold is None:
                 threshold = 2
+            # Compare function based on check type
+            compare = (lambda x, y: x >= y) if check_type == 'high' else (lambda x, y: x <= y)
+
             laserspot = getattr(self.context.device, "laserspot", "0.3mm")
             try:
                 diameter = float(Length(laserspot))
@@ -544,7 +547,7 @@ class Warnings:
                         step_x *= self.context.device.view.native_scale_x
                         step_y *= self.context.device.view.native_scale_y
                         # print (f"Stepx={step_x:.1f}, stepy{step_y:.1f}, diameter={diameter:.1f}")
-                        if step_x >= threshold * diameter or step_y >= threshold * diameter:
+                        if compare(step_x, threshold * diameter) or compare(step_y, threshold * diameter):
                             flag = True
                             count += 1
                             break
@@ -559,55 +562,13 @@ class Warnings:
                             step_x *= self.context.device.view.native_scale_x
                             step_y *= self.context.device.view.native_scale_y
                             # Get steps from individual images
-                            if step_x >= threshold * diameter or step_y >= threshold * diameter:
+                            if compare(step_x, threshold * diameter) or compare(step_y, threshold * diameter):
                                 flag = True
                                 count += 1
                                 break
 
             return flag, count
 
-        def has_high_dpis():
-            flag = False
-            count = 0
-            threshold = self.context.setting(float, "warning_dpi_high", 0.25)
-            if threshold is None:
-                threshold = 0.25
-            laserspot = getattr(self.context.device, "laserspot", "0.3mm")
-            try:
-                diameter = float(Length(laserspot))
-            except ValueError:
-                diameter = float(Length("0.3mm"))
-            for op in self.context.elements.ops():
-                if (
-                    hasattr(op, "output")
-                    and op.output
-                    and op.type in ("op raster", "op image")
-                    and op.children
-                ):
-                    if op.type == "op raster":
-                        step_x, step_y = self.context.device.view.dpi_to_steps(op.dpi)
-                        step_x *= self.context.device.view.native_scale_x
-                        step_y *= self.context.device.view.native_scale_y
-                        if step_x <= threshold * diameter or step_y <= threshold * diameter:
-                            flag = True
-                            count += 1
-                            break
-                    elif op.type == "op image":
-                        useop = op.overrule_dpi and op.dpi
-                        for node in op.children:
-                            image_node = node.node if hasattr(node, "node") else node
-                            if getattr(image_node, "hidden", False):
-                                continue
-                            opdpi = op.dpi if useop else image_node.dpi
-                            step_x, step_y = self.context.device.view.dpi_to_steps(opdpi)
-                            step_x *= self.context.device.view.native_scale_x
-                            step_y *= self.context.device.view.native_scale_y
-                            if step_x <= threshold * diameter or step_y <= threshold * diameter:
-                                flag = True
-                                count += 1
-                                break
-
-            return flag, count
 
         self._concerns.clear()
 
@@ -635,16 +596,15 @@ class Warnings:
                 )
 
         active = self.context.setting(bool, "warning_outside", True)
-        if active:
-            if has_objects_outside():
-                self._concerns.append(
-                    (
-                        _("- Elements are lying outside the burnable area.")
-                        + "\n  "
-                        + _("Could lead to the laserhead bumping into the rails."),
-                        CONCERN_CRITICAL
-                    )
+        if active and has_objects_outside():
+            self._concerns.append(
+                (
+                    _("- Elements are lying outside the burnable area.")
+                    + "\n  "
+                    + _("Could lead to the laserhead bumping into the rails."),
+                    CONCERN_CRITICAL
                 )
+            )
 
         active = self.context.setting(bool, "warning_closetoedge", True)
         if active:
@@ -661,28 +621,27 @@ class Warnings:
                     )
                 )
 
-        active = self.context.setting(bool, "warning_nonassigned", True)
-        if active:
+        active1 = self.context.setting(bool, "warning_nonassigned", True)
+        active2 = self.context.setting(bool, "warning_opdisabled", True)
+        if active1 or active2:
             non_assigned, non_burn = self.context.elements.have_unburnable_elements()
-            if non_assigned:
-                self._concerns.append(
-                    (
-                        _("- Elements aren't assigned to an operation and will not be burnt"),
-                        CONCERN_NORMAL
-                    )
+        if active1 and non_assigned:
+            self._concerns.append(
+                (
+                    _("- Elements aren't assigned to an operation and will not be burnt"),
+                    CONCERN_NORMAL
                 )
+            )
 
-        active = self.context.setting(bool, "warning_opdisabled", True)
-        if active:
-            if non_burn:
-                self._concerns.append(
-                    (
-                        _(
-                            "- Some operations containing elements aren't active, so some elements will not be burnt"
-                        ),
-                        CONCERN_LOW
-                    )
+        if active2 and non_burn:
+            self._concerns.append(
+                (
+                    _(
+                        "- Some operations containing elements aren't active, so some elements will not be burnt"
+                    ),
+                    CONCERN_LOW
                 )
+            )
 
         active = self.context.setting(bool, "warning_hidden", True)
         if active:
@@ -695,24 +654,22 @@ class Warnings:
                     )
                 )
 
-        active = self.context.setting(bool, "warning_dpi", True)
-        if active:
-            low_dpis, info = has_low_dpis()
-            if low_dpis:
-                self._concerns.append(
-                    (
-                        _("- Raster/Images have a low dpi and lines will not overlap") + f" ({info})\n",
-                        CONCERN_LOW
-                    )
+        low_dpis, info = check_dpis(check_type='low')
+        if low_dpis:
+            self._concerns.append(
+                (
+                    _("- Raster/Images have a low dpi and lines will not overlap") + f" ({info})\n",
+                    CONCERN_LOW
                 )
+            )
 
-            high_dpis, info = has_high_dpis()
-            if high_dpis:
-                self._concerns.append(
-                    (
-                        _("- Raster/Images have a high dpi and lines will overlap") + f" ({info})\n",
-                        CONCERN_LOW
-                    )
+        high_dpis, info = check_dpis(check_type='high')
+        if high_dpis:
+            self._concerns.append(
+                (
+                    _("- Raster/Images have a high dpi and lines will overlap") + f" ({info})\n",
+                    CONCERN_LOW
                 )
+            )
 
         self.context.signal("icons")

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -1503,18 +1503,20 @@ class RasterSettingsPanel(wx.Panel):
             self.context.signal(
                 "element_property_reload", self.operation, "text_dpi"
             )
+            self.context.signal("warn_state_update")
 
     def on_text_dpi(self):
         try:
             value = int(self.text_dpi.GetValue())
-            if self.operation.dpi != value:
-                self.operation.dpi = value
-                self.context.signal(
-                    "element_property_reload", self.operation, "text_dpi"
-                )
         except ValueError as e:
             # print (e)
-            pass
+            return
+        if self.operation.dpi != value:
+            self.operation.dpi = value
+            self.context.signal(
+                "element_property_reload", self.operation, "text_dpi"
+            )
+            self.context.signal("warn_state_update")
 
     def on_text_overscan(self):
         try:


### PR DESCRIPTION
## Summary by Sourcery

Add DPI warnings and enhance user feedback by introducing checks for low and high DPI settings, fast operations, and other potential issues in laser operations.

New Features:
- Introduce warnings for low and high DPI settings in raster and image operations to alert users when lines may not overlap or may overlap excessively.

Enhancements:
- Add checks for various conditions such as fast operations, objects outside the burnable area, and unassigned elements to improve user feedback and prevent potential issues during laser operations.