### PR TITLE
Persist settings, add double display

### DIFF
--- a/meerk40t/gui/laserrender.py
+++ b/meerk40t/gui/laserrender.py
@@ -610,7 +610,7 @@ class LaserRender:
                     gc.DrawBitmap(cut._cache, 0, 0, cut._cache_width, cut._cache_height)
                     if cut.highlighted:
                         # gc.SetBrush(wx.RED_BRUSH)
-                        self._penwidth(highlight_pen, 3 / _gcscale)
+                        self._penwidth(highlight_pen, 3 / gcscale)
                         gc.SetPen(highlight_pen)
                         gc.DrawRectangle(0, 0, cut._cache_width, cut._cache_height)
                 else:
@@ -734,6 +734,9 @@ class LaserRender:
 
         gcscale = get_gc_scale(gc)
         pixelwidth = establish_linewidth(gcscale, laserspot_width)
+        defaultwidth = 1 / gcscale
+        if defaultwidth > 0.25 * pixelwidth:
+            defaultwidth = 0
         # print (f"Scale: {gcscale} - {mat_param}")
         highlight_color = Color("magenta")
         wx_color = wx.Colour(swizzlecolor(highlight_color))
@@ -754,19 +757,28 @@ class LaserRender:
             except AttributeError:
                 pass
             if c is not color:
-                color = c
-                last_point = None
                 if p is not None:
                     gc.StrokePath(p)
+                    if defaultwidth:
+                        self._penwidth(self.pen, defaultwidth)
+                        self.set_pen(gc, color, 192)
+                        gc.StrokePath(p)
                     del p
+                color = c
+                last_point = None
                 p = gc.CreatePath()
                 self._penwidth(self.pen, pixelwidth)
-                self.set_pen(gc, c, alpha=127)
+                alphavalue = 192 if laserspot_width is None else 64
+                self.set_pen(gc, c, alpha=alphavalue)
             if p is None:
                 p = gc.CreatePath()
             last_point = process_cut(cut, p, last_point)
         if p is not None:
             gc.StrokePath(p)
+            if defaultwidth:
+                self._penwidth(self.pen, defaultwidth)
+                self.set_pen(gc, c, 192)
+                gc.StrokePath(p)
             del p
 
     def cache_geomstr(self, node, gc):

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -809,8 +809,10 @@ class SimulationPanel(wx.Panel, Job):
         self.auto_clear = auto_clear
         # Display travel paths?
         self.display_travel = True
-        self.raster_as_image = True
+        self.raster_as_image = self.context.setting(bool, "raster_as_image", True)
+        self.laserspot_display = self.context.setting(bool, "laserspot_display", True)
         self.laserspot_width = None
+        self.calc_laser_spot_width()
 
         Job.__init__(self)
         self._playback_cuts = True
@@ -1288,11 +1290,12 @@ class SimulationPanel(wx.Panel, Job):
 
     def toggle_raster_display(self, event):
         self.raster_as_image = not self.raster_as_image
+        self.context.raster_as_image = self.raster_as_image
         self.sim_cutcode.raster_as_image = self.raster_as_image
         self.widget_scene.request_refresh()
 
-    def toggle_laserspot(self, event):
-        if self.laserspot_width is None:
+    def calc_laser_spot_width(self):
+        if self.laserspot_display:
             spot_value = getattr(self.context.device, "laserspot", "0.3mm")
             try:
                 scale = 0.5 * (self.context.device.view.native_scale_x + self.context.device.view.native_scale_y)
@@ -1304,6 +1307,11 @@ class SimulationPanel(wx.Panel, Job):
             self.laserspot_width = spot_width
         else:
             self.laserspot_width = None
+
+    def toggle_laserspot(self, event):
+        self.laserspot_display = not self.laserspot_display
+        self.context.laserspot_display = self.laserspot_display
+        self.calc_laser_spot_width()
         self.sim_cutcode.laserspot_width = self.laserspot_width
         self.widget_scene.request_refresh()
 
@@ -1471,12 +1479,12 @@ class SimulationPanel(wx.Panel, Job):
         menu.Check(id7.GetId(), self.raster_as_image)
         id8 = menu.Append(
             wx.ID_ANY,
-            _("Simplify laser path"),
-            _("Show laser path as simple line / make it as wide as laserspot width"),
+            _("Simulate laser width"),
+            _("Show laser path as wide as laserspot width / as simple line"),
             wx.ITEM_CHECK,
         )
         self.Bind(wx.EVT_MENU, self.toggle_laserspot, id=id8.GetId())
-        menu.Check(id8.GetId(), self.laserspot_width is None)
+        menu.Check(id8.GetId(), self.laserspot_display)
 
         menu.AppendSeparator()
         self.Bind(


### PR DESCRIPTION
## Summary by Sourcery

Persist user settings for 'raster_as_image' and 'laserspot_display', and enhance rendering accuracy by refining pen width and color management.

New Features:
- Introduce a setting to persist the 'raster_as_image' option, allowing users to maintain their preference across sessions.
- Add a new feature to toggle the display of the laser spot width, with the setting being persisted.

Enhancements:
- Improve the handling of pen width and color settings in the rendering process, ensuring more accurate visual representation.