### PR TITLE
Context menu on dpi entry fields

### DIFF
--- a/meerk40t/core/view.py
+++ b/meerk40t/core/view.py
@@ -342,6 +342,26 @@ class View:
             self._matrix = Matrix.map(*self._source, *self._destination)
         return self._matrix
 
+    def get_sensible_dpi_values(self) -> list:
+        # Look for dpis beyond 100 where we have an integer step value.
+        # We assume for this exercise that the x-axis is good enough
+        candidates = []
+        unit_x = UNITS_PER_INCH
+        matrix = self.matrix
+        oneinch_x = abs(complex(*matrix.transform_vector([unit_x, 0])))
+        lastdpi = None
+        for steps in range(1, 100):
+            dpi = int(round(oneinch_x / steps, 0))
+            if dpi < 75:
+                break
+            if dpi>1000:
+                continue
+            if lastdpi is None or dpi % 25 < 5 or dpi % 33 < 3:
+                lastdpi = dpi
+                candidates.append(dpi)
+        # print (candidates)
+        return candidates
+
     def dpi_to_steps(self, dpi):
         """
         Converts a DPI to a given step amount within the device length values. So M2 Nano will have 1 step per mil,

--- a/meerk40t/gui/imagesplitter.py
+++ b/meerk40t/gui/imagesplitter.py
@@ -176,6 +176,14 @@ class SplitterPanel(wx.Panel):
         self.rbox_selection.SetSelection(0)
         self.text_dpi = TextCtrl(self, wx.ID_ANY, limited=True, check="int")
         self.text_dpi.SetValue("500")
+        self.text_dpi.set_default_values(
+            list(
+                (
+                    str(dpi),
+                    _("Set DPI to {value}").format(value=str(dpi))
+                ) for dpi in self.context.device.view.get_sensible_dpi_values()
+            )
+        )
         self.lbl_info = wxStaticText(self, wx.ID_ANY, "")
         self.btn_align = wxButton(self, wx.ID_ANY, _("Create split images"))
         self.btn_align.SetBitmap(
@@ -318,6 +326,12 @@ class KeyholePanel(wx.Panel):
         self.rbox_selection.SetSelection(0)
         self.text_dpi = TextCtrl(self, wx.ID_ANY, limited=True, check="int")
         self.text_dpi.SetValue("500")
+        self.text_dpi.set_default_values(
+            [
+                (str(dpi), _("Set DPI to {value}").format(value=str(dpi)))
+                for dpi in self.context.device.view.get_sensible_dpi_values()
+            ]
+        )
         self.info_panel = InfoPanel(self, wx.ID_ANY, context=self.context)
 
         self.btn_align = wxButton(self, wx.ID_ANY, _("Create keyhole image"))

--- a/meerk40t/gui/imagesplitter.py
+++ b/meerk40t/gui/imagesplitter.py
@@ -177,12 +177,10 @@ class SplitterPanel(wx.Panel):
         self.text_dpi = TextCtrl(self, wx.ID_ANY, limited=True, check="int")
         self.text_dpi.SetValue("500")
         self.text_dpi.set_default_values(
-            list(
-                (
-                    str(dpi),
-                    _("Set DPI to {value}").format(value=str(dpi))
-                ) for dpi in self.context.device.view.get_sensible_dpi_values()
-            )
+            [
+                (str(dpi), _("Set DPI to {value}").format(value=str(dpi)))
+                for dpi in self.context.device.view.get_sensible_dpi_values()
+            ]
         )
         self.lbl_info = wxStaticText(self, wx.ID_ANY, "")
         self.btn_align = wxButton(self, wx.ID_ANY, _("Create split images"))

--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -1694,7 +1694,7 @@ class ImageVectorisationPanel(ScrolledPanel):
             xmin, ymin, xmax, ymax = bounds
             width = xmax - xmin
             height = ymax - ymin
-            dpi = 500
+            dpi = 250
             dots_per_units = dpi / UNITS_PER_INCH
             new_width = width * dots_per_units
             new_height = height * dots_per_units
@@ -1794,7 +1794,6 @@ class ImagePropertyPanel(ScrolledPanel):
         )
         self.SetHelpText("imageproperty")
         self.subpanels.append(self.panel_id)
-
         self.text_dpi = TextCtrl(
             self,
             wx.ID_ANY,
@@ -1803,6 +1802,12 @@ class ImagePropertyPanel(ScrolledPanel):
             check="float",
             limited=True,
             nonzero=True,
+        )
+        self.text_dpi.set_default_values(
+            [
+                (str(dpi), _("Set DPI to {value}").format(value=str(dpi)))
+                for dpi in self.context.device.view.get_sensible_dpi_values()
+            ]
         )
         self.check_keep_size = wxCheckBox(self, wx.ID_ANY, _("Keep size on change"))
         self.check_keep_size.SetValue(True)

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -1305,6 +1305,12 @@ class RasterSettingsPanel(wx.Panel):
             check="int",
             style=wx.TE_PROCESS_ENTER,
         )
+        self.text_dpi.set_default_values(
+            [
+                (str(dpi), _("Set DPI to {value}").format(value=str(dpi)))
+                for dpi in self.context.device.view.get_sensible_dpi_values()
+            ]
+        )
         self.text_dpi.set_error_level(1, 100000)
         OPERATION_DPI_TOOLTIP = (
             _(

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -58,12 +58,12 @@ def get_gc_scale(gc):
     gcmat = gc.GetTransform()
     mat_param = gcmat.Get()
     testmatrix = Matrix(
-        mat_param[0], 
-        mat_param[1], 
-        mat_param[2], 
-        mat_param[3], 
-        mat_param[4], 
-        mat_param[5], 
+        mat_param[0],
+        mat_param[1],
+        mat_param[2],
+        mat_param[3],
+        mat_param[4],
+        mat_param[5],
     )
     return get_matrix_scale(testmatrix)
 
@@ -71,12 +71,12 @@ def get_gc_full_scale(gc):
     gcmat = gc.GetTransform()
     mat_param = gcmat.Get()
     testmatrix = Matrix(
-        mat_param[0], 
-        mat_param[1], 
-        mat_param[2], 
-        mat_param[3], 
-        mat_param[4], 
-        mat_param[5], 
+        mat_param[0],
+        mat_param[1],
+        mat_param[2],
+        mat_param[3],
+        mat_param[4],
+        mat_param[5],
     )
     return get_matrix_full_scale(testmatrix)
 
@@ -596,6 +596,7 @@ class TextCtrl(wx.TextCtrl):
         self._last_valid_value = None
         self._event_generated = None
         self._action_routine = None
+        self._default_values = None
 
         # You can set this to False, if you don't want logic to interfere with text input
         self.execute_action_on_change = True
@@ -605,6 +606,7 @@ class TextCtrl(wx.TextCtrl):
             self.Bind(wx.EVT_KEY_UP, self.on_check)
         self.Bind(wx.EVT_SET_FOCUS, self.on_enter_field)
         self.Bind(wx.EVT_KILL_FOCUS, self.on_leave_field)
+        self.Bind(wx.EVT_RIGHT_DOWN, self.on_right_click)
         if self._style & wx.TE_PROCESS_ENTER != 0:
             self.Bind(wx.EVT_TEXT_ENTER, self.on_enter)
         _MIN_WIDTH, _MAX_WIDTH = self.validate_widths()
@@ -673,6 +675,9 @@ class TextCtrl(wx.TextCtrl):
         or None in any other case
         """
         return self._event_generated
+
+    def set_default_values(self, def_values):
+        self._default_values = def_values
 
     def get_warn_status(self, txt):
         status = ""
@@ -828,6 +833,26 @@ class TextCtrl(wx.TextCtrl):
         # We assume it's been dealt with, so we recolor...
         self.SetModified(False)
         self.warn_status = self._warn_status
+
+    def on_right_click(self, event):
+        def set_menu_value(to_be_set):
+            def handler(event):
+                self.SetValue(to_be_set)
+            return handler
+
+        if not self._default_values:
+            event.Skip()
+            return
+        menu = wx.Menu()
+        has_info = isinstance(self._default_values[0], (list, tuple))
+        item : wx.MenuItem = menu.Append(wx.ID_ANY, _("Default values..."), "")
+        item.Enable(False)
+        for info in self._default_values:
+            item = menu.Append(wx.ID_ANY, info[0] if has_info else info, info[1] if has_info else "")
+            self.Bind(wx.EVT_MENU, set_menu_value(info[0] if has_info else info), id=item.GetId())
+        self.PopupMenu(menu)
+        menu.Destroy()
+
 
     @property
     def warn_status(self):


### PR DESCRIPTION
Will provide a list of "sensible" dpis, ie those that will end up in an integer scaling factor to the device intrinsic units

## Summary by Sourcery

Introduce a context menu for DPI entry fields that allows users to select from a list of sensible DPI values, enhancing usability by providing predefined options that result in integer scaling factors.

New Features:
- Add a context menu to DPI entry fields that provides a list of sensible DPI values for selection.

Enhancements:
- Implement a method to calculate sensible DPI values based on integer scaling factors.