### PR TITLE
Fix behaviour for hidden raster elements

### DIFF
--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -398,7 +398,16 @@ class RasterOpNode(Node, Parameters):
             step_x, step_y = context.device.view.dpi_to_steps(self.dpi)
             bounds = self.paint_bounds
             img_mx = Matrix.scale(step_x, step_y)
-            data = list(self.flat())
+            data = []
+            for node in self.flat():
+                if node.type == "reference":
+                    node = node.node
+                if getattr(node, 'hidden', False):
+                    continue
+                data.append(node)
+            if not data:
+                self.children.clear()
+                return
             reverse = context.elements.classify_reverse
             if reverse:
                 data = list(reversed(data))
@@ -422,6 +431,7 @@ class RasterOpNode(Node, Parameters):
             image_node.step_x = step_x
             image_node.step_y = step_y
             image_node.process_image()
+
         msx = matrix.value_scale_x()
         msy = matrix.value_scale_y()
         rotated = False
@@ -502,6 +512,7 @@ class RasterOpNode(Node, Parameters):
                 image_node = image_node.node
             if getattr(image_node, "hidden", False):
                 continue
+            print (f"Image_node: {image_node.type} - hidden: {image_node.hidden}")
             if image_node.type != "elem image":
                 continue
 

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -400,6 +400,8 @@ class RasterOpNode(Node, Parameters):
             img_mx = Matrix.scale(step_x, step_y)
             data = []
             for node in self.flat():
+                if node.type not in self._allowed_elements_dnd:
+                    continue
                 if node.type == "reference":
                     node = node.node
                 if getattr(node, 'hidden', False):

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -396,7 +396,6 @@ class RasterOpNode(Node, Parameters):
             self.set_dirty_bounds()
 
             step_x, step_y = context.device.view.dpi_to_steps(self.dpi)
-            bounds = self.paint_bounds
             img_mx = Matrix.scale(step_x, step_y)
             data = []
             for node in self.flat():
@@ -410,6 +409,7 @@ class RasterOpNode(Node, Parameters):
             if not data:
                 self.children.clear()
                 return
+            bounds = Node.union_bounds(data, attr="paint_bounds")
             reverse = context.elements.classify_reverse
             if reverse:
                 data = list(reversed(data))

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -512,7 +512,6 @@ class RasterOpNode(Node, Parameters):
                 image_node = image_node.node
             if getattr(image_node, "hidden", False):
                 continue
-            print (f"Image_node: {image_node.type} - hidden: {image_node.hidden}")
             if image_node.type != "elem image":
                 continue
 


### PR DESCRIPTION
Contrary to all other operations hidden elements under a raster node did still influence the raster creation. That has been addressed.

## Summary by Sourcery

Bug Fixes:
- Fix the issue where hidden elements under a raster node still influenced raster creation by ensuring they are excluded from the data used for raster generation.