### PR TITLE
Fix invalid persistence of coolant attribute

### DIFF
--- a/meerk40t/core/node/op_cut.py
+++ b/meerk40t/core/node/op_cut.py
@@ -29,7 +29,6 @@ class CutOpNode(Node, Parameters):
         # int("2180.534") throws a value error.
         self.kerf = 0.0
         self._device_factor = 1.0
-        self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
 
         # Which elements can be added to an operation (manually via DND)?
         self._allowed_elements_dnd = (

--- a/meerk40t/core/node/op_dots.py
+++ b/meerk40t/core/node/op_dots.py
@@ -23,7 +23,6 @@ class DotsOpNode(Node, Parameters):
         self._allowed_elements = ("elem point",)
         # Is this op out of useful bounds?
         self.dangerous = False
-        self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
         self.stopop = True
         self.label = "Dots"
 

--- a/meerk40t/core/node/op_engrave.py
+++ b/meerk40t/core/node/op_engrave.py
@@ -22,7 +22,6 @@ class EngraveOpNode(Node, Parameters):
 
         # Is this op out of useful bounds?
         self.dangerous = False
-        self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
 
         self.label = "Engrave"
         # We may want to add more advanced logic at a later time

--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -44,7 +44,6 @@ class ImageOpNode(Node, Parameters):
 
         # Is this op out of useful bounds?
         self.dangerous = False
-        self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
         self.stopop = True
         self.label = "Image"
         self.overrule_dpi = False

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -45,7 +45,6 @@ class RasterOpNode(Node, Parameters):
         # self.allowed_attributes.append("fill")
         # Is this op out of useful bounds?
         self.dangerous = False
-        self.coolant = 0  # Nothing to do (0/None = keep, 1=turn on, 2=turn off)
         self.stopop = False
         self.label = "Raster"
         self.use_grayscale = False

--- a/meerk40t/core/parameters.py
+++ b/meerk40t/core/parameters.py
@@ -20,6 +20,7 @@ INT_PARAMETERS = (
     "input_value",
     "output_mask",
     "output_value",
+    "coolant",
 )
 
 FLOAT_PARAMETERS = (
@@ -50,7 +51,6 @@ BOOL_PARAMETERS = (
     "advanced",
     "stopop",
     "effect",
-    "air_assist",
 )
 
 STRING_PARAMETERS = (
@@ -720,10 +720,10 @@ class Parameters:
         self.__dict__["output_message"] = value
 
     @property
-    def air_assist(self):
-        return self.settings.get("air_assist", True)
+    def coolant(self):
+        return self.settings.get("coolant", True)
 
-    @air_assist.setter
-    def air_assist(self, value):
-        self.settings["air_assist"] = value
-        self.__dict__["air_assist"] = value
+    @coolant.setter
+    def coolant(self, value):
+        self.settings["coolant"] = value
+        self.__dict__["coolant"] = value


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix invalid persistence of the coolant attribute by replacing the air_assist attribute with coolant in the parameters module.