### PR TITLE
Immediately set default value

### DIFF
--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -814,8 +814,10 @@ class TextCtrl(wx.TextCtrl):
         self.prevalidate("leave")
         if self._action_routine is not None:
             self._event_generated = wx.EVT_KILL_FOCUS
-            self._action_routine()
-            self._event_generated = None
+            try:
+                self._action_routine()
+            finally:
+                self._event_generated = None
         self.SelectNone()
         # We assume it's been dealt with, so we recolor...
         self.SetModified(False)
@@ -827,8 +829,10 @@ class TextCtrl(wx.TextCtrl):
         self.prevalidate("enter")
         if self._action_routine is not None:
             self._event_generated = wx.EVT_TEXT_ENTER
-            self._action_routine()
-            self._event_generated = None
+            try:
+                self._action_routine()
+            finally:
+                self._event_generated = None
         self.SelectNone()
         # We assume it's been dealt with, so we recolor...
         self.SetModified(False)
@@ -841,8 +845,10 @@ class TextCtrl(wx.TextCtrl):
                 self.prevalidate("enter")
                 if self._action_routine is not None:
                     self._event_generated = wx.EVT_TEXT_ENTER
-                    self._action_routine()
-                    self._event_generated = None
+                    try:
+                        self._action_routine()
+                    finally:
+                        self._event_generated = None
             return handler
 
         if not self._default_values:
@@ -935,8 +941,10 @@ class TextCtrl(wx.TextCtrl):
             if getattr(self.parent.context.root, "process_while_typing", False):
                 if self._action_routine is not None:
                     self._event_generated = wx.EVT_TEXT
-                    self._action_routine()
-                    self._event_generated = None
+                    try:
+                        self._action_routine()
+                    finally:
+                        self._event_generated = None
 
     @property
     def is_changed(self):

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -838,6 +838,11 @@ class TextCtrl(wx.TextCtrl):
         def set_menu_value(to_be_set):
             def handler(event):
                 self.SetValue(to_be_set)
+                self.prevalidate("enter")
+                if self._action_routine is not None:
+                    self._event_generated = wx.EVT_TEXT_ENTER
+                    self._action_routine()
+                    self._event_generated = None
             return handler
 
         if not self._default_values:


### PR DESCRIPTION
Making sure that a context menu choice from default values will be immediately processed

## Summary by Sourcery

Bug Fixes:
- Ensure that context menu choices from default values are immediately processed by triggering pre-validation and executing the action routine if defined.