### PR TITLE
Remove IRC from list of supported interactions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,6 @@ or comments against other people's Pull Requests or Issues.
 
 If your thoughts are not firmed up enough to make a formal submission,
 please come and find us for an informal discussion on:
-*   [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
 *   [Discord](https://discord.gg/vkDD3HdQq6)
 
 Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -8,7 +8,6 @@ or make fully formed suggestions for improvements.
 
 If you are not ready to make a formal report, then do please come and discuss it with the MeerK40t team
 using one of the following links:
-*   [IRC](http://kiwiirc.com/client/irc.libera.chat/meerk40t)
 *   [Discord](https://discord.gg/vkDD3HdQq6)
 
 Please see also the [Contribution Guidelines](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/meerk40t/core/webhelp.py
+++ b/meerk40t/core/webhelp.py
@@ -11,7 +11,7 @@ MEERK40T_RELEASES = "https://github.com/meerk40t/meerk40t/releases"
 FACEBOOK_MEERK40T = "https://www.facebook.com/groups/716000085655097"
 DISCORD_MEERK40T = "https://discord.gg/vkDD3HdQq6"
 MAKERS_FORUM_MEERK40T = "https://forum.makerforums.info/c/k40/meerk40t/120"
-IRC_CLIENT = "http://kiwiirc.com/client/irc.libera.chat/meerk40t"
+# IRC_CLIENT = "http://kiwiirc.com/client/irc.libera.chat/meerk40t"
 MEERK40T_FEATURE = "https://github.com/meerk40t/meerk40t/discussions/new/choose"
 
 
@@ -58,5 +58,5 @@ def plugin(kernel, lifecycle):
         kernel.register("webhelp/facebook", FACEBOOK_MEERK40T)
         kernel.register("webhelp/discord", DISCORD_MEERK40T)
         kernel.register("webhelp/makers", MAKERS_FORUM_MEERK40T)
-        kernel.register("webhelp/irc", IRC_CLIENT)
+        # kernel.register("webhelp/irc", IRC_CLIENT)
         kernel.register("webhelp/featurerequest", MEERK40T_FEATURE)


### PR DESCRIPTION
## Summary by Sourcery

Remove IRC as a supported interaction platform from the webhelp module and update documentation to reflect this change.

Enhancements:
- Remove IRC from the list of supported interaction platforms in the webhelp module.

Documentation:
- Update CONTRIBUTING.md and SUPPORT.md to remove references to IRC as a communication channel.