### PR TITLE
Balor serial

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -256,6 +256,31 @@ class BalorDevice(Service, Status):
                     "Which machine should we connect to? -- Leave at 0 if you have 1 machine."
                 ),
                 "section": "_00_General",
+                "subsection": "_10_Device Selection",
+            },
+            {   "attr": "serial_enable",
+                "object": self,
+                "default": False,
+                "type": bool,
+                "label": _("Check serial no"),
+                "tip": _(
+                    "Does the machine need to have a specific serial number?"
+                ),
+                "section": "_00_General",
+                "subsection": "_10_Device Selection",
+            },
+            {
+                "attr": "serial",
+                "object": self,
+                "default": "",
+                "type": str,
+                "tip": _(
+                    "Does the machine need to have a specific serial number?"
+                ),
+                "label": "",
+                "section": "_00_General",
+                "subsection": "_10_Device Selection",
+                "conditional": (self, "serial_enable")
             },
             {
                 "attr": "footpedal_pin",

--- a/meerk40t/balormk/mock_connection.py
+++ b/meerk40t/balormk/mock_connection.py
@@ -18,6 +18,7 @@ class MockConnection:
         self.interface = {}
         self.backend_error_code = None
         self.timeout = 500
+        self._implied_response = None
 
     def is_open(self, index=0):
         try:
@@ -46,12 +47,16 @@ class MockConnection:
             del self.devices[index]
 
     def write(self, index=0, packet=None):
+        from meerk40t.balormk.controller import GetSerialNo
         packet_length = len(packet)
         assert packet_length == 0xC or packet_length == 0xC00
         if packet is not None:
             device = self.devices[index]
             if not device:
                 raise ConnectionError
+            b = packet[0]
+            if b == GetSerialNo:
+                self.set_implied_response("meerk40t")
             if self.send:
                 if packet_length == 0xC:
                     self.send(self._parse_single(packet))
@@ -83,7 +88,6 @@ class MockConnection:
 
     def _parse_single(self, packet):
         from meerk40t.balormk.controller import single_command_lookup
-
         b0 = packet[1] << 8 | packet[0]
         b1 = packet[3] << 8 | packet[2]
         b2 = packet[5] << 8 | packet[4]
@@ -93,10 +97,27 @@ class MockConnection:
         string_value = single_command_lookup.get(b0, "Unknown")
         return f"{b0:04x}:{b1:04x}:{b2:04x}:{b3:04x}:{b4:04x}:{b5:04x} {string_value}"
 
+    def set_implied_response(self, data):
+        if data is None:
+            self._implied_response = None
+        else:
+            self._implied_response = bytearray(8)
+            if isinstance(data, str):
+                for idx in range(min(8, len(data))):
+                    self._implied_response[idx] = int(ord(data[idx]))
+            else:
+                for idx in range(min(8, len(data))):
+                    self._implied_response[idx] = int(data[idx])
+            for idx in range(len(data), 8):
+                self._implied_response[idx] = 0
+
     def read(self, index=0):
-        read = bytearray(8)
-        for r in range(len(read)):
-            read[r] = random.randint(0, 255)
+        if self._implied_response is None:
+            read = bytearray(8)
+            for r in range(len(read)):
+                read[r] = random.randint(0, 255)
+        else:
+            read = self._implied_response
         read = struct.pack("8B", *read)
         device = self.devices[index]
         if not device:
@@ -106,4 +127,5 @@ class MockConnection:
                 f"{read[0]:02x}:{read[1]:02x}:{read[2]:02x}:{read[3]:02x}"
                 f"{read[4]:02x}:{read[5]:02x}:{read[6]:02x}:{read[7]:02x}"
             )
+        self.set_implied_response(None)
         return read

--- a/meerk40t/balormk/mock_connection.py
+++ b/meerk40t/balormk/mock_connection.py
@@ -100,16 +100,16 @@ class MockConnection:
     def set_implied_response(self, data):
         if data is None:
             self._implied_response = None
-        else:
-            self._implied_response = bytearray(8)
-            if isinstance(data, str):
-                for idx in range(min(8, len(data))):
-                    self._implied_response[idx] = int(ord(data[idx]))
-            else:
-                for idx in range(min(8, len(data))):
-                    self._implied_response[idx] = int(data[idx])
-            for idx in range(len(data), 8):
-                self._implied_response[idx] = 0
+            return
+
+        # Convert input to bytes early
+        if isinstance(data, str):
+            data = data.encode('ascii')
+
+        # Create fixed-size response with padding
+        self._implied_response = bytearray(8)
+        self._implied_response[:len(data)] = data[:8]
+
 
     def read(self, index=0):
         if self._implied_response is None:

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -738,13 +738,17 @@ class ChoicePropertyPanel(ScrolledPanel):
                 current_sizer.Add(control_sizer, expansion_flag * weight, wx.EXPAND, 0)
             elif data_type in (str, int, float) and data_style == "combosmall":
                 control_sizer = wx.BoxSizer(wx.HORIZONTAL)
+                exclusive = c.get("exclusive", True)
+                cb_style = wx.CB_DROPDOWN
+                if exclusive:
+                    cb_style = cb_style | wx.CB_READONLY
 
                 choice_list = list(map(str, c.get("choices", [c.get("default")])))
                 control = wxComboBox(
                     self,
                     wx.ID_ANY,
                     choices=choice_list,
-                    style=wx.CB_DROPDOWN | wx.CB_READONLY,
+                    style = cb_style,
                 )
                 # Constrain the width
                 testsize = control.GetBestSize()
@@ -772,6 +776,7 @@ class ChoicePropertyPanel(ScrolledPanel):
                         v = dtype(ctrl.GetValue())
                         current_value = getattr(obj, param)
                         if current_value != v:
+                            # print (f"Setting it to {v}")
                             setattr(obj, param, v)
                             self.context.signal(param, v, obj)
                             for _sig in addsig:
@@ -794,6 +799,14 @@ class ChoicePropertyPanel(ScrolledPanel):
                         attr, control, obj, data_type, additional_signal
                     ),
                 )
+                if not exclusive:
+                    control.Bind(
+                        wx.EVT_TEXT,
+                        on_combosmall_text(
+                            attr, control, obj, data_type, additional_signal
+                        ),
+                    )
+
                 current_sizer.Add(control_sizer, expansion_flag * weight, wx.EXPAND, 0)
             elif data_type == int and data_style == "binary":
                 mask = c.get("mask")


### PR DESCRIPTION
Add serial number check

## Summary by Sourcery

Implement a serial number verification feature to ensure device authenticity before connection. Enhance the mock connection with implied response handling for testing, and update the GUI to support non-exclusive combo box options.

New Features:
- Introduce a serial number check feature that allows the system to verify the serial number of a device before establishing a connection.

Enhancements:
- Add a mechanism to set and use an implied response in the mock connection for testing purposes.
- Enhance the GUI to support non-exclusive combo boxes, allowing more flexible user input.