### PR TITLE
Version bump

### DIFF
--- a/.github/workflows/win/file_version.txt
+++ b/.github/workflows/win/file_version.txt
@@ -8,7 +8,7 @@ VSVersionInfo(
     # Set not needed items to zero 0.
     filevers=(0, 9, 6010, 0),
     prodvers=(0, 9, 6010, 0),
-    # Contains a bitmask that specifies the valid bits 'flags'r
+    # Contains a bitmask that specifies the valid bits 'flags'
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
     flags=0x0,

--- a/.github/workflows/win/file_version.txt
+++ b/.github/workflows/win/file_version.txt
@@ -6,8 +6,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(0, 9, 6000, 0),
-    prodvers=(0, 9, 6000, 0),
+    filevers=(0, 9, 6010, 0),
+    prodvers=(0, 9, 6010, 0),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'MeerK40t'),
         StringStruct(u'FileDescription', u'MeerK40t Laser Control Software'),
-        StringStruct(u'FileVersion', u'0.9.6000.0'),
+        StringStruct(u'FileVersion', u'0.9.6010.0'),
         StringStruct(u'InternalName', u'MeerK40t.exe'),
         StringStruct(u'LegalCopyright', u'MeerK40t, MIT License'),
         StringStruct(u'OriginalFilename', u'MeerK40t.exe'),
         StringStruct(u'ProductName', u'MeerK40t'),
-        StringStruct(u'ProductVersion', u'0.9.6000')])
+        StringStruct(u'ProductVersion', u'0.9.6010')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1031, 2058])])
   ]

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -11,7 +11,7 @@ import os.path
 import sys
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.6000"
+APPLICATION_VERSION = "0.9.6010"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = meerk40t
-version = 0.9.6000
+version = 0.9.6010
 description = MeerK40t LaserCutter Software
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/tools/build_icon.cmd
+++ b/tools/build_icon.cmd
@@ -1,5 +1,5 @@
 @echo off
-set ver=0.9.6
+set ver=0.9.7a1
 echo Converting master image to a couple of smaller images
 echo This requires imagemagick (https://imagemagick.org)
 echo Superimposing Version information: '%ver%'

--- a/tools/build_icon.sh
+++ b/tools/build_icon.sh
@@ -1,4 +1,4 @@
-VER=0.9.6
+VER=0.9.7a1
 echo Converting master image to a couple of smaller images
 echo This requires imagemagick \(https://imagemagick.org\)
 echo Superimposing Version information: "$VER"


### PR DESCRIPTION
## Summary by Sourcery

Bump the application version to 0.9.6010 and update version information in build scripts and configuration files.

Build:
- Update version number in setup configuration to 0.9.6010.

CI:
- Update version information in build scripts for Windows and Unix to 0.9.7a1.