### PR TITLE
invert image with transparency

### DIFF
--- a/meerk40t/image/imagetools.py
+++ b/meerk40t/image/imagetools.py
@@ -1261,7 +1261,7 @@ def plugin(kernel, lifecycle=None):
                 img_array[:, :, :3] = 255 - img_array[:, :, :3]
                 inode.image = Image.fromarray(img_array)
 
-                inode.image.convert(original_mode)
+                inode.image = inode.image.convert(original_mode)
                 update_image_node(inode)
                 channel(_("Image Inverted."))
             except OSError:


### PR DESCRIPTION
Using the Invert Image operation currently converts transparency as white and converts it to black.  This is not usually the desired result.  This change inverts the r, g, b and keeps the alpha.

Before Change
![Before Change](https://github.com/user-attachments/assets/bc5888d5-6172-4d8a-8625-ce63d0bf869c)

After Change
![After Cjamge](https://github.com/user-attachments/assets/84dbfe61-f106-46fe-8446-bdeb28c44b32)

The visualization on the screen in meerk40t seems to treat white as transparency which make sense for rastering but this change highlights that as you can't tell visually which parts are white and which ones are transparent until the inversion is done.

## Summary by Sourcery

Bug Fixes:
- Fix the issue where inverting an image with transparency incorrectly converted transparent areas to black.