### PR TITLE
Resync image property panel display after script application

### DIFF
--- a/meerk40t/gui/propertypanels/imageproperty.py
+++ b/meerk40t/gui/propertypanels/imageproperty.py
@@ -1247,8 +1247,8 @@ class ImageModificationPanel(ScrolledPanel):
     def update_node(self):
         self.context.elements.emphasized()
         self.context.elements.do_image_update(self.node, self.context)
-        self.context.signal("element_property_update", self.node)
-        self.context.signal("selected", self.node)
+        self.context.signal("element_property_force", self.node)
+        # self.context.signal("selected", self.node)
         self.fill_operations()
 
     def on_apply_replace(self, event):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the image property panel display is resynced after applying a script by introducing a forced reload mechanism.