### PR TITLE
GRBL custom operation startup commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
 
         {
-            "name": "Python Debugger: Current File",
+            "name": "Python Debugger: Run MeerK40t",
             "type": "debugpy",
             "request": "launch",
             "program": "meerk40t.py",


### PR DESCRIPTION
Specific for GRBL driver
- Fixes incomplete treatment of z-Axis
- Adds option to include custom commands to be executed at the start of an operation:
   
Usecase (as described in issue https://github.com/meerk40t/meerk40t/issues/2764 ):
Switch between M3 and M4 mode for cut / raster 
- M3=used to cut as gantry acceleration doesn't matter on a cut.
- M4=used for Raster/Engrave operations, as grblHAL will adjust power based on gantry speed including acceleration.

## Summary by Sourcery

Introduce custom GRBL command execution at the start of operations and fix z-axis handling in the GRBL driver.

New Features:
- Add option to include custom GRBL commands to be executed at the start of an operation.

Bug Fixes:
- Fix incomplete treatment of the z-axis in the GRBL driver.