### PR TITLE
Raster fixes

### DIFF
--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -44,7 +44,7 @@ class BalorDriver:
         self._queue_current = 0
         self._queue_total = 0
         self.plot_planner = PlotPlanner(
-            dict(), single=True, ppi=False, shift=False, group=True
+            dict(), single=True, ppi=False, shift=False, group=True, require_uniform_movement = False,
         )
         self.value_penbox = None
         self.plot_planner.settings_then_jog = True

--- a/meerk40t/core/plotplanner.py
+++ b/meerk40t/core/plotplanner.py
@@ -47,6 +47,7 @@ class PlotPlanner(Parameters):
         ppi=True,
         shift=True,
         group=True,
+        require_uniform_movement = True,
         **kwargs,
     ):
         super().__init__(settings, **kwargs)
@@ -57,6 +58,7 @@ class PlotPlanner(Parameters):
         self.group_enabled = True  # Grouped Output Required for Lhymicro-gl.
         self.phase_type = 0  # Sequential, random, progressive, static.
         self.phase_value = 0
+        self.require_uniform_movement = require_uniform_movement
 
         self.queue = []
 
@@ -306,6 +308,7 @@ class PlotManipulation:
 class Single(PlotManipulation):
     def __init__(self, planner: PlotPlanner):
         super().__init__(planner)
+        self.planner = planner
         self.single_default = 1
         self.single_x = None
         self.single_y = None
@@ -346,7 +349,7 @@ class Single(PlotManipulation):
             dx = 1 if total_dx > 0 else 0 if total_dx == 0 else -1
             dy = 1 if total_dy > 0 else 0 if total_dy == 0 else -1
 
-            if total_dy * dx != total_dx * dy:
+            if total_dy * dx != total_dx * dy and self.planner.require_uniform_movement:
                 # Check for cross-equality.
                 raise ValueError(
                     f"Must be uniformly diagonal or orthogonal: ({total_dx}, {total_dy}) is not."

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -47,7 +47,7 @@ class GRBLDriver(Parameters):
         self.stepper_step_size = UNITS_PER_MIL
 
         self.plot_planner = PlotPlanner(
-            self.settings, single=True, ppi=False, shift=False, group=True
+            self.settings, single=True, ppi=False, shift=False, group=True, require_uniform_movement = False,
         )
         self.queue = []
         self._queue_current = 0

--- a/meerk40t/image/imagetools.py
+++ b/meerk40t/image/imagetools.py
@@ -2265,7 +2265,7 @@ class RasterImagePreprocessor:
                 else:
                     was_covered = True
                 e.direction = RASTER_T2B if idx % 2 == 0 else RASTER_B2T
-            if not was_covered:
+            if not was_covered and data_out:
                 inode.remove_node()
 
         operation.raster_direction = RASTER_T2B

--- a/meerk40t/newly/driver.py
+++ b/meerk40t/newly/driver.py
@@ -39,7 +39,7 @@ class NewlyDriver:
         self._queue_total = 0
 
         self.plot_planner = PlotPlanner(
-            dict(), single=True, ppi=False, shift=False, group=True
+            dict(), single=True, ppi=False, shift=False, group=True, require_uniform_movement = False,
         )
         self._aborting = False
         self._list_bits = None


### PR DESCRIPTION
- Remove the dreaded (and unnecessary) uniform requirement for more capable devices
- Fix the split among white areas feature for those images that haven't any

## Summary by Sourcery

Remove the uniform movement requirement for plot planning on capable devices and fix the image processing issue related to splitting among white areas.

Bug Fixes:
- Fix the issue with splitting among white areas in images that do not contain any white areas.

Enhancements:
- Remove the requirement for uniform movement in plot planning for more capable devices.