### PR TITLE
Suppress hidden nodes

### DIFF
--- a/meerk40t/core/node/effect_hatch.py
+++ b/meerk40t/core/node/effect_hatch.py
@@ -239,6 +239,8 @@ class HatchEffectNode(Node, Suppressable):
                 if e._children:
                     subs = right_types(e)
                     res.extend(subs)
+                elif hasattr(e, "hidden") and e.hidden:
+                    continue
                 elif e.type.startswith("elem"):
                     res.append(e)
             return res

--- a/meerk40t/core/node/effect_warp.py
+++ b/meerk40t/core/node/effect_warp.py
@@ -228,6 +228,8 @@ class WarpEffectNode(Node, FunctionalParameter):
                 if e._children:
                     subs = right_types(e)
                     res.extend(subs)
+                elif hasattr(e, "hidden") and e.hidden:
+                    continue
                 elif e.type.startswith("elem"):
                     res.append(e)
             return res

--- a/meerk40t/core/node/effect_wobble.py
+++ b/meerk40t/core/node/effect_wobble.py
@@ -224,6 +224,8 @@ class WobbleEffectNode(Node, Suppressable):
                 if e._children:
                     subs = right_types(e)
                     res.extend(subs)
+                elif hasattr(e, "hidden") and e.hidden:
+                    continue
                 elif e.type.startswith("elem"):
                     res.append(e)
             return res


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Suppress processing of nodes marked as hidden in the right_types function across multiple modules.