### PR TITLE
Custom commands bugfix

### DIFF
--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -412,9 +412,9 @@ class GRBLDriver(Parameters):
             #   M4=used for Raster/Engrave operations, as grblHAL will 
             #   adjust power based on gantry speed including acceleration. 
 
-            cmd_string = q.settings.get("custom_commands", "")
-            for cmd in cmd_string.splitlines():
-                self(f"{cmd}{self.line_end}")
+            if cmd_string := q.settings.get("custom_commands", ""):
+                for cmd in cmd_string.splitlines():
+                    self(f"{cmd}{self.line_end}")
 
             current += 1
             self._set_queue_status(current, total)

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -412,7 +412,8 @@ class GRBLDriver(Parameters):
             #   M4=used for Raster/Engrave operations, as grblHAL will 
             #   adjust power based on gantry speed including acceleration. 
 
-            if cmd_string := q.settings.get("custom_commands", ""):
+            cmd_string = q.settings.get("custom_commands", "")
+            if cmd_string:
                 for cmd in cmd_string.splitlines():
                     self(f"{cmd}{self.line_end}")
 

--- a/meerk40t/grbl/gui/grbloperationconfig.py
+++ b/meerk40t/grbl/gui/grbloperationconfig.py
@@ -82,6 +82,8 @@ class GRBLAdvancedPanel(wx.Panel):
         self.text_zaxis.SetValue(value)
         self.text_zaxis.Enable(flag)
         value = getattr(self.operation, "custom_commands", "")
+        if value is None:
+            value = ""
         self.text_commands.SetValue(value)
 
     def on_check_zaxis(self, event=None):


### PR DESCRIPTION
In the on_text_commands function custom_commands is set to None if text is empty. So the get function will return None instead of using the default value.
Therefore the value has to be checked if it is None before usage.
Another solution could be to instead let it get set to an empty string,

## Summary by Sourcery

Bug Fixes:
- Handle the case where the "custom_commands" setting is empty, preventing potential issues.