### PR TITLE
Accelerate deletion (and other operations)

### DIFF
--- a/meerk40t/core/elements/undo_redo.py
+++ b/meerk40t/core/elements/undo_redo.py
@@ -63,7 +63,9 @@ def init_commands(kernel):
         "redo",
     )
     def undo_redo(command, channel, _, data=None, **kwgs):
-        if not self.undo.redo():
+        with self.static("redo"):
+            redo_done = self.undo.redo()
+        if not redo_done:
             channel("No redo available.")
             return
         channel(f"Redo: {self.undo}")


### PR DESCRIPTION
A couple of changes:
a) Add the visual update context to the undoscope context (so most operations will refrain from multiple tree updates)
b) Element deletion will cause a (time-intensive) deletion of the associated tree node. If we are deleting more than 100 elements at once we will suppress the tree synchronisation and rebuild the tree instead. That is most of the times much faster

## Summary by Sourcery

Improve performance of element deletion, especially when deleting more than 100 elements at once. Update the undoscope context to reduce redundant tree updates during operations.

New Features:
- Added a "fast" deletion mode that rebuilds the tree instead of deleting individual nodes when deleting a large number of elements.

Enhancements:
- Reduce redundant tree updates by adding visual update context to the undoscope context.