### PR TITLE
Selective tree rebuild

### DIFF
--- a/meerk40t/core/elements/branches.py
+++ b/meerk40t/core/elements/branches.py
@@ -597,7 +597,7 @@ def init_commands(kernel):
                 name = f"{select_piece} {i}: {str(item)}"
                 channel(f"{name}: {len(item.children)}")
                 item.remove_all_children()
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @self.console_command(
         "list",

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -353,7 +353,7 @@ def init_tree(kernel):
                 keep_children=True,
                 label=_("Content of {filenode}").format(filenode=node.name),
             )
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "elements")
 
     @tree_conditional(lambda node: not is_regmark(node))
     @tree_operation(
@@ -419,7 +419,7 @@ def init_tree(kernel):
         with self.undoscope("Simplify group"):
             res = straighten(node)
         if res > 0:
-            self.signal("rebuild_tree")
+            self.signal("rebuild_tree", "elements")
 
     # @tree_conditional(lambda node: len(list(self.elems(emphasized=True))) > 0)
     # @tree_operation(
@@ -689,7 +689,7 @@ def init_tree(kernel):
         #     print (f"threw an error: {e}")
         #     return
         # print (f"Index is now {idx}")
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Burning sequence"))
     @tree_operation(
@@ -749,7 +749,7 @@ def init_tree(kernel):
                 new_settings = dict(n.settings)
                 new_settings["type"] = "op image"
                 n.replace_node(keep_children=True, **new_settings)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Convert operation"))
     @tree_operation(
@@ -767,7 +767,7 @@ def init_tree(kernel):
                 new_settings = dict(n.settings)
                 new_settings["type"] = "op raster"
                 n.replace_node(keep_children=True, **new_settings)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Convert operation"))
     @tree_operation(
@@ -785,7 +785,7 @@ def init_tree(kernel):
                 new_settings = dict(n.settings)
                 new_settings["type"] = "op engrave"
                 n.replace_node(keep_children=True, **new_settings)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Convert operation"))
     @tree_operation(
@@ -803,7 +803,7 @@ def init_tree(kernel):
                 new_settings = dict(n.settings)
                 new_settings["type"] = "op cut"
                 n.replace_node(keep_children=True, **new_settings)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Convert operation"))
     @tree_operation(
@@ -821,7 +821,7 @@ def init_tree(kernel):
                 new_settings = dict(n.settings)
                 new_settings["type"] = "op dots"
                 n.replace_node(keep_children=True, **new_settings)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
 
     @tree_submenu(_("Raster-Wizard"))
     @tree_operation(
@@ -1151,7 +1151,7 @@ def init_tree(kernel):
             return
         with self.undoscope("Remove placements"):
             self.remove_operations(data)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "operations")
         self.signal("refresh_scene", "Scene")
 
 
@@ -1671,7 +1671,7 @@ def init_tree(kernel):
             for enode in data:
                 enode.remove_node()
 
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "elements")
 
     # ==========
     # Remove Operations (If No Tree Selected)
@@ -3656,7 +3656,7 @@ def init_tree(kernel):
                 self.classify(data)
         self.set_node_emphasis(node, True)
         self.signal("refresh_scene", "Scene")
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "elements")
         node.focus()
 
     def has_vectorize(node):
@@ -3872,7 +3872,7 @@ def init_tree(kernel):
             if data:
                 if self.classify_new:
                     self.classify(data)
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "elements")
         self.signal("refresh_scene", "Scene")
 
     @tree_conditional(

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -353,7 +353,7 @@ def init_tree(kernel):
                 keep_children=True,
                 label=_("Content of {filenode}").format(filenode=node.name),
             )
-        self.signal("rebuild_tree", "elements")
+        # self.signal("rebuild_tree", "elements")
 
     @tree_conditional(lambda node: not is_regmark(node))
     @tree_operation(

--- a/meerk40t/core/elements/undo_redo.py
+++ b/meerk40t/core/elements/undo_redo.py
@@ -57,7 +57,7 @@ def init_commands(kernel):
         self.validate_selected_area()
         channel(f"Undo: {self.undo}")
         self.signal("refresh_scene", "Scene")
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "all")
 
     @self.console_command(
         "redo",
@@ -71,7 +71,7 @@ def init_commands(kernel):
         channel(f"Redo: {self.undo}")
         self.validate_selected_area()
         self.signal("refresh_scene", "Scene")
-        self.signal("rebuild_tree")
+        self.signal("rebuild_tree", "all")
 
     @self.console_command(
         "undolist",

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -156,7 +156,7 @@ class TreePanel(wx.Panel):
         self.wxtree.Bind(wx.EVT_KEY_DOWN, self.on_key_down)
         self._keybind_channel = self.context.channel("keybinds")
 
-        self.context.signal("rebuild_tree")
+        self.context.signal("rebuild_tree", "all")
 
     def setup_warn_panel(self):
         def fix_unassigned_create(event):
@@ -453,7 +453,9 @@ class TreePanel(wx.Panel):
         #     self.shadow_tree.wxtree.Expand(startnode)
         # else:
         #     self.shadow_tree.rebuild_tree()
-        self.shadow_tree.rebuild_tree("signal")
+        if target is None:
+            target = "all"
+        self.shadow_tree.rebuild_tree(source="signal", target=target)
 
     @signal_listener("refresh_tree")
     def on_refresh_tree_signal(self, origin, nodes=None, *args):
@@ -729,7 +731,7 @@ class ShadowTree:
     def check_validity(self, item):
         if item is None or not item.IsOk():
             # raise ValueError("Bad Item")
-            self.rebuild_tree("validity")
+            self.rebuild_tree(source="validity", target="all")
             self.elements.signal("refresh_scene", "Scene")
             return False
         return True
@@ -937,7 +939,20 @@ class ShadowTree:
         @param node:
         @return:
         """
-        self.rebuild_tree("reorder")
+        target = "all"
+        while node.parent is not None:
+            if node.parent.type == "branch reg":
+                target = "regmarks"
+                break
+            if node.parent.type == "branch elem":
+                target = "elements"
+                break
+            if node.parent.type == "branch ops":
+                target = "operations"
+                break
+            node = node.parent
+        
+        self.rebuild_tree("reorder", target=target)
 
     def update(self, node):
         """
@@ -1179,7 +1194,7 @@ class ShadowTree:
         self.dragging_nodes = None
         self.wxtree.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
 
-    def rebuild_tree(self, source):
+    def rebuild_tree(self, source:str, target:str="all" ):
         """
         Tree requires being deleted and completely rebuilt.
 
@@ -1188,7 +1203,7 @@ class ShadowTree:
         # print (f"Rebuild called from {source}")
         # let's try to remember which branches were expanded:
         busy = wx.BusyCursor()
-        self.context.elements.set_start_time("rebuild_tree")
+        self.context.elements.set_start_time(f"rebuild_tree_{target}")
         self.freeze_tree(True)
 
         # self.reset_expanded()
@@ -1201,71 +1216,85 @@ class ShadowTree:
 
         # self.parse_tree(self.wxtree.GetRootItem(), 0)
         # Rebuild tree destroys the emphasis, so let's store it...
+        def delete_items(target):
+            if target == "regmarks":
+                node = self.elements.reg_branch
+                item = node._item
+                self.wxtree.DeleteChildren(item)
+            elif target == "operations":
+                node = self.elements.op_branch
+                item = node._item
+                self.wxtree.DeleteChildren(item)
+            elif target == "elements":
+                node = self.elements.elem_branch
+                item = node._item
+                self.wxtree.DeleteChildren(item)
+            else:
+                self.wxtree.DeleteAllItems()
+        
+        def rebuild_items(target):
+            if target == "all":
+                if self.tree_images is not None:
+                    self.tree_images.Destroy()
+                    self.image_cache = []
+                self.tree_images = wx.ImageList()
+                self.tree_images.Create(width=self.iconsize, height=self.iconsize)
+
+                self.wxtree.SetImageList(self.tree_images)
+            if target == "regmarks":
+                elemtree = self.elements.reg_branch
+            elif target == "operations":
+                elemtree = self.elements.op_branch
+            elif target == "elements":
+                elemtree = self.elements.elem_branch
+            else:
+                elemtree = self.elements._tree
+                elemtree._item = self.wxtree.AddRoot(self.name)
+                self.wxtree.SetItemData(elemtree._item, elemtree)
+                self.set_icon(
+                    elemtree,
+                    icon_meerk40t.GetBitmap(
+                        False,
+                        resize=(self.iconsize, self.iconsize),
+                        noadjustment=True,
+                        buffer=1,
+                    ),
+                )
+            self.register_children(elemtree)
+            branch_list = (
+                ("branch ops", "operations", icons8_laser_beam),
+                ("branch reg", "regmarks", icon_regmarks),
+                ("branch elems", "elements", icon_canvas),
+            )
+            for branch_name, branch_type, icon in branch_list:
+                if target not in ("all", branch_type):
+                    continue
+                node_branch = elemtree.get(type=branch_name)
+                self.set_icon(
+                    node_branch,
+                    icon.GetBitmap(
+                        resize=(self.iconsize, self.iconsize),
+                        noadjustment=True,
+                        buffer=1,
+                    ),
+                )
+                for n in node_branch.children:
+                    self.set_icon(n, force=True)
+            if target in {"all", "operations"}:
+                self.update_op_labels()
+            if target in {"all", "elements"}:
+                self.update_group_labels("rebuild_tree")
+
         emphasized_list = list(self.elements.elems(emphasized=True))
-        elemtree = self.elements._tree
-        self.wxtree.DeleteAllItems()
-        if self.tree_images is not None:
-            self.tree_images.Destroy()
-            self.image_cache = []
 
-        self.tree_images = wx.ImageList()
-        self.tree_images.Create(width=self.iconsize, height=self.iconsize)
+        delete_items(target)
+        rebuild_items(target)
 
-        self.wxtree.SetImageList(self.tree_images)
-        elemtree._item = self.wxtree.AddRoot(self.name)
-
-        self.wxtree.SetItemData(elemtree._item, elemtree)
-
-        self.set_icon(
-            elemtree,
-            icon_meerk40t.GetBitmap(
-                False,
-                resize=(self.iconsize, self.iconsize),
-                noadjustment=True,
-                buffer=1,
-            ),
-        )
-        self.register_children(elemtree)
-
-        node_operations = elemtree.get(type="branch ops")
-        self.set_icon(
-            node_operations,
-            icons8_laser_beam.GetBitmap(
-                resize=(self.iconsize, self.iconsize),
-                noadjustment=True,
-                buffer=1,
-            ),
-        )
-
-        for n in node_operations.children:
-            self.set_icon(n, force=True)
-
-        node_elements = elemtree.get(type="branch elems")
-        self.set_icon(
-            node_elements,
-            icon_canvas.GetBitmap(
-                resize=(self.iconsize, self.iconsize),
-                noadjustment=True,
-                buffer=1,
-            ),
-        )
-
-        node_registration = elemtree.get(type="branch reg")
-        self.set_icon(
-            node_registration,
-            icon_regmarks.GetBitmap(
-                resize=(self.iconsize, self.iconsize),
-                noadjustment=True,
-                buffer=1,
-            ),
-        )
-        self.update_op_labels()
-        self.update_group_labels("rebuild_tree")
         # Expand Ops, Element, and Regmarks nodes only
-        self.wxtree.CollapseAll()
-        self.wxtree.Expand(node_operations._item)
-        self.wxtree.Expand(node_elements._item)
-        self.wxtree.Expand(node_registration._item)
+        # self.wxtree.CollapseAll()
+        self.wxtree.Expand(self.elements.op_branch._item)
+        self.wxtree.Expand(self.elements.elem_branch._item)
+        self.wxtree.Expand(self.elements.reg_branch._item)
         self.elements.signal("warn_state_update")
 
         # Restore emphasis
@@ -1273,7 +1302,7 @@ class ShadowTree:
             e.emphasized = True
         # self.restore_tree(self.wxtree.GetRootItem(), 0)
         self.freeze_tree(False)
-        self.context.elements.set_end_time("rebuild_tree", display=True)
+        self.context.elements.set_end_time(f"rebuild_tree_{target}", display=True)
         # print(f"Rebuild done for {source}")
         del busy
 
@@ -1736,7 +1765,7 @@ class ShadowTree:
             force = False
         if node._item is None:
             # This node is not registered the tree has desynced.
-            self.rebuild_tree("desync")
+            self.rebuild_tree(source="desync", target="all")
             return
 
         self.set_icon(node, force=force)


### PR DESCRIPTION
We have been rebuilding the complete tree too often. This PR introduces a more selective approach by recreating only affected main branches (op, elem, reg).

## Summary by Sourcery

Optimize tree rebuilding to only rebuild affected branches (operations, elements, or registration marks) instead of the entire tree.

New Features:
- Add selective tree rebuilding based on the type of change.

Enhancements:
- Reduce unnecessary tree rebuilds for improved performance.