### PR TITLE
Support partial ellipses in dxf-import

### DIFF
--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -194,7 +194,7 @@ def init_commands(kernel):
         output_type="elements",
         all_arguments_required=True,
     )
-    def element_ellipse(
+    def element_arc(
         channel, _, x_pos, y_pos, rx, ry=None, start_angle=None, end_angle=None, rotation=None, data=None, post=None, **kwargs
     ):
         if start_angle is None:

--- a/meerk40t/dxf/dxf_io.py
+++ b/meerk40t/dxf/dxf_io.py
@@ -157,22 +157,22 @@ class DXFProcessor:
                 color = Color("black")
             node.stroke = color
 
-    def debug_entity(self, entity):
-        print (f"Entitity: {entity.dxftype()}")
-        for key in dir(entity):
-            if key.startswith("_"):
-                continue
-            var = getattr(entity, key)
-            if callable(var):
-                continue
-            print (f"e.{key}={var}")
-        for key in dir(entity.dxf):
-            if key.startswith("_"):
-                continue
-            var = getattr(entity.dxf, key)
-            if callable(var):
-                continue
-            print (f"e.dxf.{key}={var}")
+    # def debug_entity(self, entity):
+    #     print (f"Entity: {entity.dxftype()}")
+    #     for key in dir(entity):
+    #         if key.startswith("_"):
+    #             continue
+    #         var = getattr(entity, key)
+    #         if callable(var):
+    #             continue
+    #         print (f"e.{key}={var}")
+    #     for key in dir(entity.dxf):
+    #         if key.startswith("_"):
+    #             continue
+    #         var = getattr(entity.dxf, key)
+    #         if callable(var):
+    #             continue
+    #         print (f"e.dxf.{key}={var}")
 
     def parse(self, entity, context_node, e_list):
 

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -2647,7 +2647,7 @@ class Geomstr:
     #######################
 
     def arc_as_quads(
-        self, start_t, end_t, rx, ry, cx, cy, rotation=0, slices=12, settings=0
+        self, start_t, end_t, rx, ry, cx, cy, rotation=0, slices=None, settings=0
     ):
         """
         Creates a rotated elliptical arc using quads. This is a helper for creating a more complex arc-like shape from
@@ -2665,6 +2665,10 @@ class Geomstr:
         @return:
         """
         sweep = start_t - end_t
+        if slices is None:
+            # A full ellipse can be properly represented with 12 slices - we err on the side of caution here...
+            slices = int(1.5 * 12 * sweep / math.tau)
+            slices = max(2, slices)
         t_slice = sweep / float(slices)
         alpha_mid = (4.0 - math.cos(t_slice)) / 3.0
         current_t = start_t
@@ -2723,6 +2727,7 @@ class Geomstr:
         if slices is None:
             # A full ellipse can be properly represented with 12 slices - we err on the side of caution here...
             slices = int(1.5 * 12 * sweep / math.tau)
+            slices = max(2, slices)
         t_slice = sweep / float(slices)
         alpha = (
             math.sin(t_slice)

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -2719,7 +2719,7 @@ class Geomstr:
 
         @return:
         """
-        sweep = start_t - end_t
+        sweep = end_t - start_t 
         t_slice = sweep / float(slices)
         alpha = (
             math.sin(t_slice)
@@ -2768,7 +2768,6 @@ class Geomstr:
             p_c2 = complex(
                 p_end.real - alpha * ePrimen2x, p_end.imag - alpha * ePrimen2y
             )
-
             self.cubic(p_start, p_c1, p_c2, p_end)
             p_start = p_end
             current_t = next_t

--- a/meerk40t/tools/geomstr.py
+++ b/meerk40t/tools/geomstr.py
@@ -2701,7 +2701,7 @@ class Geomstr:
             current_t = next_t
 
     def arc_as_cubics(
-        self, start_t, end_t, rx, ry, cx, cy, rotation=0, slices=12, settings=0
+        self, start_t, end_t, rx, ry, cx, cy, rotation=0, slices=None, settings=0
     ):
         """
         Creates a rotated elliptical arc using quads. This is a helper for creating a more complex arc-like shape from
@@ -2720,6 +2720,9 @@ class Geomstr:
         @return:
         """
         sweep = end_t - start_t 
+        if slices is None:
+            # A full ellipse can be properly represented with 12 slices - we err on the side of caution here...
+            slices = int(1.5 * 12 * sweep / math.tau)
         t_slice = sweep / float(slices)
         alpha = (
             math.sin(t_slice)


### PR DESCRIPTION
Original:
<img width="357" alt="2025-02-08 11_00_19-LibreCAD -  test_drawing dxf" src="https://github.com/user-attachments/assets/6efb3e07-2269-4a26-923b-1249d41d2ed9" />

Import:
![grafik](https://github.com/user-attachments/assets/2b7abfad-e379-4589-ad1e-5cb8d0dd947c)

## Summary by Sourcery

Add support for partial ellipses in DXF import, enhancing the ability to accurately render arcs and elliptical shapes by handling start and end angles. Refactor the parsing logic to improve shape rendering flexibility.

New Features:
- Add support for importing partial ellipses from DXF files, allowing for more accurate representation of arcs and elliptical shapes.

Enhancements:
- Refactor the ellipse and arc parsing logic to handle start and end angles, improving the flexibility of shape rendering.