### PR TITLE
Smaller fixes

### DIFF
--- a/meerk40t/core/elements/branches.py
+++ b/meerk40t/core/elements/branches.py
@@ -187,7 +187,7 @@ def init_commands(kernel):
             return
         try:
             channel(_("loading..."))
-            result = self.load(new_file)
+            result = self.load(new_file, svg_ppi=self.svg_ppi)
             if result:
                 channel(_("Done."))
         except AttributeError:

--- a/meerk40t/extra/inkscape.py
+++ b/meerk40t/extra/inkscape.py
@@ -228,7 +228,7 @@ def plugin(kernel, lifecycle):
             inkscape_path, filename = data
             channel(_("inkscape load - loading the previous conversion..."))
             try:
-                kernel.elements.load(filename)
+                kernel.elements.load(filename, svg_ppi=kernel.elements.svg_ppi)
             except BadFileError as e:
                 channel(_("File is Malformed."))
                 channel(str(e))

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -78,7 +78,7 @@ def register_panel_console(window, context):
         aui.AuiPaneInfo()
         .Bottom()
         .Layer(2)
-        .MinSize(600, 100)
+        .MinSize(100, 100)
         .FloatingSize(600, 230)
         .Caption(_("Console"))
         .Name("console")

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -18,7 +18,7 @@ from meerk40t.gui.icons import (
     icons8_pentagon,
     icons8_save,
 )
-from meerk40t.gui.navigationpanels import Drag, Jog, MovePanel
+from meerk40t.gui.navigationpanels import Drag, Jog, MovePanel, JogDistancePanel
 from meerk40t.gui.wxutils import (
     HoverButton,
     ScrolledPanel,
@@ -47,10 +47,14 @@ def register_panel_laser(window, context):
     jog_drag.SetupScrolling()
     jog_panel = Jog(jog_drag, wx.ID_ANY, context=context)
     drag_panel = Drag(jog_drag, wx.ID_ANY, context=context)
-    main_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    distance_panel = JogDistancePanel(jog_drag, wx.ID_ANY, context=context)
+    main_sizer = wx.BoxSizer(wx.VERTICAL)
+    sub_sizer = wx.BoxSizer(wx.HORIZONTAL)
     # main_sizer.AddStretchSpacer()
-    main_sizer.Add(jog_panel, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-    main_sizer.Add(drag_panel, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+    sub_sizer.Add(jog_panel, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+    sub_sizer.Add(drag_panel, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+    main_sizer.Add(sub_sizer, 1, wx.EXPAND, 0)
+    main_sizer.Add(distance_panel, 0, wx.EXPAND, 0)
     # main_sizer.AddStretchSpacer()
     jog_drag.SetSizer(main_sizer)
     jog_drag.Layout()
@@ -97,7 +101,7 @@ def register_panel_laser(window, context):
         page = notebook.GetCurrentPage()
         if page is None:
             return
-        pages = [jog_panel, drag_panel] if page is jog_drag else [page]
+        pages = [jog_panel, drag_panel, distance_panel] if page is jog_drag else [page]
         for p in pages:
             if hasattr(p, "pane_show"):
                 p.pane_show()
@@ -127,8 +131,9 @@ def register_panel_laser(window, context):
         else:
             panel_size = (wb_size[0] / 2, wb_size[1])
 
-        jog_panel.set_icons(dimension=panel_size)
-        drag_panel.set_icons(dimension=panel_size)
+        for panel in (jog_panel, drag_panel, distance_panel):
+            if hasattr(panel, "set_icons"):
+                panel.set_icons(dimension=panel_size)
 
     jog_drag.Bind(wx.EVT_SIZE, on_resize)
 

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -560,15 +560,17 @@ class wxMeerK40t(wx.App, Module):
     def MacOpenFile(self, filename):
         try:
             if self.context is not None:
-                self.context.elements.load(os.path.realpath(filename))
+                channel = self.context.kernel.channel("console")
+                self.context.elements.load(os.path.realpath(filename), svg_ppi=self.context.elements.svg_ppi, channel=channel)
         except AttributeError:
             pass
 
     def MacOpenFiles(self, filenames):
         try:
             if self.context is not None:
+                channel = self.context.kernel.channel("console")
                 for filename in filenames:
-                    self.context.elements.load(os.path.realpath(filename))
+                    self.context.elements.load(os.path.realpath(filename), svg_ppi=self.context.elements.svg_ppi, channel=channel)
         except AttributeError:
             pass
 


### PR DESCRIPTION
- Adding jog distance panel to laserpanel Jog tab
- Passing the svg_ppi value to all invocations of elements.load

## Summary by Sourcery

Add a jog distance panel to the Laser panel and pass the `svg_ppi` value consistently to the `elements.load` function. Also, adjust the minimum height of the console panel.

Enhancements:
- Pass the `svg_ppi` value to the `elements.load` function, ensuring consistent scaling across different load methods.
- Add a jog distance panel to the laser panel's Jog tab, providing more control over jog movements.
- Adjust the minimum height of the console panel to 100 pixels for better usability.