### PR TITLE
Linux busyinfo changes

### DIFF
--- a/meerk40t/gui/busy.py
+++ b/meerk40t/gui/busy.py
@@ -62,19 +62,10 @@ class SimpleBusyInfo:
         if "keep" in kwds:
             keep = int(kwds["keep"])
         if "msg" in kwds:
-            newmsg = ""
-            if self._msg:
-                old = self._msg.split("\n")
-                idx = 0
-                while (idx < keep) and (idx < len(old)):
-                    if newmsg:
-                        newmsg += "\n"
-                    newmsg += old[idx]
-                    idx += 1
-            if newmsg:
-                newmsg += "\n"
-            newmsg += kwds["msg"]
-            self._msg = newmsg
+            old_lines = self._msg.split("\n") if self._msg else []
+            new_lines = old_lines[:keep]
+            new_lines.append(kwds["msg"])
+            self._msg = "\n".join(new_lines)            
 
     @property
     def msg(self):
@@ -135,19 +126,10 @@ class BusyInfo:
             if keep == 0:
                 self.image = None
         if "msg" in kwds:
-            newmsg = ""
-            if self.msg:
-                old = self.msg.split("\n")
-                idx = 0
-                while (idx < keep) and (idx < len(old)):
-                    if newmsg:
-                        newmsg += "\n"
-                    newmsg += old[idx]
-                    idx += 1
-            if newmsg:
-                newmsg += "\n"
-            newmsg += kwds["msg"]
-            self.msg = newmsg
+            old_lines = self.msg.split("\n") if self.msg else []
+            new_lines = old_lines[:keep]
+            new_lines.append(kwds["msg"])
+            self.msg = "\n".join(new_lines)            
         if "bgcolor" in kwds:
             self.bgcolor = kwds["bgcolor"]
         if "fgcolor" in kwds:

--- a/meerk40t/gui/busy.py
+++ b/meerk40t/gui/busy.py
@@ -8,6 +8,86 @@ import wx
 
 DEFAULT_SIZE = 14
 
+class SimpleBusyInfo:
+    """
+    Create a simplified BusyInfo class that uses the main window title as canvas. 
+    Just used for Linux as the wxWidgets implementation sucks big time regarding
+    the controlled update of a window. So the full-featured implementation below
+    does not only produce nothing visible but seems to have severe side effects
+    that may caus segmenation faults.
+
+    :param string `msg`:     a string to be displayed in the BusyInfo window.
+    """
+    def __init__(self, **kwds):
+        self.kernel = kwds.get("kernel", None)
+        self.shown = False
+        self._old_title = ""
+        self._msg = ""
+
+    def start(self, **kwds):
+        if self.shown:
+            self.end()
+        self.update_keywords(kwds)
+        self.shown = True
+        self._old_title = ""
+        try:
+            win:wx.Window = self.kernel.root.gui
+            win.SetCursor(wx.Cursor(wx.CURSOR_WAIT))
+            self._old_title = win.GetTitle()
+        except (TypeError, AttributeError) as e:
+            return
+
+    def end(self):
+        self.shown = False
+        self._msg = ""
+        try:
+            win = self.kernel.root.gui
+            win.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
+        except (TypeError, AttributeError):
+            return
+        if self._old_title:
+            win.SetTitle(self._old_title)
+
+    def change(self, **kwds):
+        self.update_keywords(kwds)
+        if self.msg:
+            try:
+                win = self.kernel.root.gui
+                win.SetTitle(self.msg)
+            except (TypeError, AttributeError):
+                return
+
+    def update_keywords(self, kwds):
+        keep = 0
+        if "keep" in kwds:
+            keep = int(kwds["keep"])
+        if "msg" in kwds:
+            newmsg = ""
+            if self._msg:
+                old = self._msg.split("\n")
+                idx = 0
+                while (idx < keep) and (idx < len(old)):
+                    if newmsg:
+                        newmsg += "\n"
+                    newmsg += old[idx]
+                    idx += 1
+            if newmsg:
+                newmsg += "\n"
+            newmsg += kwds["msg"]
+            self._msg = newmsg
+
+    @property
+    def msg(self):
+        return self._msg.replace("\n", " - ")
+
+    def hide(self):
+        self.shown = False
+        return
+
+    def show(self):
+        self.shown = True
+        return
+
 
 class BusyInfo:
     """

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -327,13 +327,19 @@ and a wxpython version <= 4.1.1."""
 
         kernel.yesno = yesno_popup
 
-        from meerk40t.gui.busy import BusyInfo
+        from meerk40t.gui.busy import SimpleBusyInfo, BusyInfo
 
-        kargs = {}
+        kargs = {"kernel": kernel,}
         if kernel.themes.dark:
             kargs["bgcolor"] = kernel.themes.get("win_bg")
             kargs["fgcolor"] = kernel.themes.get("win_fg")
-        kernel.busyinfo = BusyInfo(**kargs)
+        if kernel.os_information["OS_NAME"] != "Linux":
+            # The Linux implementation of wxWidgets 
+            # cannot properly update controls (n idea why,
+            # any hint to circumvent this would be welcome)
+            kernel.busyinfo = BusyInfo(**kargs)
+        else:
+            kernel.busyinfo = SimpleBusyInfo(**kargs)
 
         @kernel.console_argument("message")
         @kernel.console_command("notify", hidden=True)


### PR DESCRIPTION
Under Linux the busyinfo aka the panel with the progress indicator is not only not updating the screen due to some wxWidgets shortcomings re window refresh logic, but does seem as well impose some unwanted side effects (as seen in issue #2822 ).
This change uses a simpler method that will update the main window title (which will at least update more often alsas not necessarily fully consistent)

## Summary by Sourcery

Improves the busyinfo panel functionality on Linux systems by replacing the standard `BusyInfo` class with a simplified `SimpleBusyInfo` class that updates the main window title instead of using a separate panel. This resolves issues with window refresh logic and potential segmentation faults caused by the original implementation.

Bug Fixes:
- Fixes an issue on Linux where the busyinfo panel was not updating correctly due to wxWidgets limitations, and was causing unwanted side effects, possibly segmentation faults.

Enhancements:
- Improves the user experience on Linux by using the main window title to display progress information when the busyinfo panel fails to update.