### PR TITLE
Harmonize airassist setting for ruida

### DIFF
--- a/meerk40t/ruida/gui/gui.py
+++ b/meerk40t/ruida/gui/gui.py
@@ -48,7 +48,7 @@ def plugin(service, lifecycle):
 
         from meerk40t.ruida.gui.ruidaconfig import RuidaConfiguration
         from meerk40t.ruida.gui.ruidacontroller import RuidaController
-        from meerk40t.ruida.gui.ruidaoperationproperties import RuidaOperationPanel
+        # from meerk40t.ruida.gui.ruidaoperationproperties import RuidaOperationPanel
 
         service.register("window/Controller", RuidaController)
         service.register("window/Configuration", RuidaConfiguration)
@@ -56,11 +56,11 @@ def plugin(service, lifecycle):
         service.register("winpath/Controller", service)
         service.register("winpath/Configuration", service)
 
-        service.register("property/RasterOpNode/Ruida", RuidaOperationPanel)
-        service.register("property/CutOpNode/Ruida", RuidaOperationPanel)
-        service.register("property/EngraveOpNode/Ruida", RuidaOperationPanel)
-        service.register("property/ImageOpNode/Ruida", RuidaOperationPanel)
-        service.register("property/DotsOpNode/Ruida", RuidaOperationPanel)
+        # service.register("property/RasterOpNode/Ruida", RuidaOperationPanel)
+        # service.register("property/CutOpNode/Ruida", RuidaOperationPanel)
+        # service.register("property/EngraveOpNode/Ruida", RuidaOperationPanel)
+        # service.register("property/ImageOpNode/Ruida", RuidaOperationPanel)
+        # service.register("property/DotsOpNode/Ruida", RuidaOperationPanel)
 
         service.add_service_delegate(RuidaGui(service))
 

--- a/meerk40t/ruida/gui/ruidaoperationproperties.py
+++ b/meerk40t/ruida/gui/ruidaoperationproperties.py
@@ -17,16 +17,7 @@ class RuidaOperationPanel(ScrolledPanel):
         self.parent = args[0]
         self.operation = node
 
-        choices = [
-            {
-                "attr": "air_assist",
-                "object": node,
-                "default": True,
-                "type": bool,
-                "label": _("Air Assist"),
-                "tip": _("Trigger the per element air assist"),
-            },
-        ]
+        choices = []
 
         self.panel = ChoicePropertyPanel(
             self, wx.ID_ANY, context=self.context, choices=choices, scrolling=False

--- a/meerk40t/ruida/rdjob.py
+++ b/meerk40t/ruida/rdjob.py
@@ -1376,13 +1376,13 @@ class RDJob:
         part = current_settings.get("part", 0)
         speed = current_settings.get("speed", 0)
         power = current_settings.get("power", 0) / 10.0
-        air = current_settings.get("air_assist", True)
+        air = current_settings.get("coolant", 0)
         self.layer_end()
         self.layer_number_part(part)
         self.laser_device_0()
-        if air:
+        if air == 1:
             self.air_assist_on()
-        else:
+        elif air==2:
             self.air_assist_off()
         self.speed_laser_1(speed)
         self.laser_on_delay(0)


### PR DESCRIPTION
## Summary by Sourcery

This PR harmonizes the air assist setting for Ruida devices by renaming `air_assist` to `coolant` and adjusting the logic to align with the new naming.

Enhancements:
- Renames `air_assist` to `coolant` to better reflect the functionality.
- Updates the logic for air assist control based on the `coolant` setting.