### PR TITLE
Stitches

### DIFF
--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -2651,14 +2651,14 @@ def init_commands(kernel):
                         # append
                         if dist_e_s > 0:
                             g2.line(lp2, fp1)
-                        g2.append(g1)
+                        g2.append(g1, end=False)
                         was_stitched = True
                     elif dist_e_e <= tolerance:
                         # append reverse
                         g1.reverse()
                         if dist_e_e > 0:
                             g2.line(lp2, lp1)
-                        g2.append(g1)
+                        g2.append(g1, end=False)
                         was_stitched = True
                     elif dist_s_s <= tolerance:
                         # insert reverse
@@ -2675,6 +2675,7 @@ def init_commands(kernel):
                         was_stitched = True
                     if was_stitched:
                         # print ("stitched")
+                        # g2.debug_me()
                         anychanges = True
                         start_points[idx] = g2.first_point
                         end_points[idx] = g2.last_point

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -2649,20 +2649,28 @@ def init_commands(kernel):
                     # print (f"Gaps: e -> s: {dist_e_s:.3f}, e -> e: {dist_e_e:.3f}, s -> s: {dist_s_s:.3f},s -> e: {dist_s_e:.3f},")
                     if dist_e_s <= tolerance:
                         # append
+                        if dist_e_s > 0:
+                            g2.line(lp2, fp1)
                         g2.append(g1)
                         was_stitched = True
                     elif dist_e_e <= tolerance:
                         # append reverse
                         g1.reverse()
+                        if dist_e_e > 0:
+                            g2.line(lp2, lp1)
                         g2.append(g1)
                         was_stitched = True
                     elif dist_s_s <= tolerance:
                         # insert reverse
                         g1.reverse()
+                        if dist_s_s > 0:
+                            g1.line(fp1, fp2)
                         g2.insert(0, g1.segments[0 : g1.index])
                         was_stitched = True
                     elif dist_s_e <= tolerance:
                         # insert
+                        if dist_s_e > 0:
+                            g1.line(lp1, fp2)
                         g2.insert(0, g1.segments[0 : g1.index])
                         was_stitched = True
                     if was_stitched:
@@ -2683,6 +2691,12 @@ def init_commands(kernel):
                 result_list.clear()
                 start_points.clear()
                 end_points.clear()
+        for g1 in result_list:
+            fp1 = g1.first_point
+            lp1 = g1.last_point
+            dist_e_s = abs(lp1 - fp1)
+            if 0 < dist_e_s <= tolerance:
+                g1.line(lp1, fp1)
         return result_list
 
 

--- a/meerk40t/core/elements/shapes.py
+++ b/meerk40t/core/elements/shapes.py
@@ -2624,20 +2624,28 @@ def init_commands(kernel):
         output_type="elements",
     )
     def stitched(command, channel, _, data=None, tolerance=None, keep=None, post=None, **kwargs):
-        if data is None:
-            data = list(self.elems(emphasized=True))
-        if len(data) == 0:
-            channel("There is nothing to be stitched together")
-            return    
-        if keep is None:
-            keep = False
-        if tolerance is None:
-            tolerance = 0
-        else:
-            try:
-                tolerance = float(Length(tolerance))
-            except ValueError:
-                tolerance = 0
+        def _prepare_stitching_params(channel, data, tolerance, keep):
+            if data is None:
+                data = list(self.elems(emphasized=True))
+            if len(data) == 0:
+                channel("There is nothing to be stitched together")
+                return data, tolerance, keep, False
+            if keep is None:
+                keep = False
+            if tolerance is None:
+                tolerance_val = 0
+            else:
+                try:
+                    tolerance_val = float(Length(tolerance))
+                except ValueError as e:
+                    channel(f"Invalid tolerance value: {tolerance}")
+                    return data, tolerance, keep, False
+            return data, tolerance_val, keep, True
+
+        data, tolerance, keep, valid = _prepare_stitching_params(channel, data, tolerance, keep)
+        if not valid:
+            return
+
         geoms = []
         data_out = []
         to_be_deleted = []

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -182,6 +182,29 @@ def plugin(kernel, lifecycle=None):
                 "conditional": (context, "opt_reduce_travel"),
             },
             {
+                "attr": "opt_stitching",
+                "object": context,
+                "default": False,
+                "type": bool,
+                "label": _("Combine path segments"),
+                "tip": 
+                    _("Stitch segments together that are very close (ideally having joint start/end points).") + "\n" +
+                    _("Only inside a single cut/engrave operation."),
+                "page": "Optimisations",
+                "section": "_05_Stitching",
+            },
+            {
+                "attr": "opt_stitch_tolerance",
+                "object": context,
+                "default": "0",
+                "type": Length,
+                "label": _("Tolerance"),
+                "tip": _("Tolerance to decide whether two path segements should be joined."),
+                "page": "Optimisations",
+                "section": "_05_Stitching",
+                "conditional": (context, "opt_stitching"),
+            },
+            {
                 "attr": "opt_inner_first",
                 "object": context,
                 "default": True,

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -199,7 +199,7 @@ def plugin(kernel, lifecycle=None):
                 "default": "0",
                 "type": Length,
                 "label": _("Tolerance"),
-                "tip": _("Tolerance to decide whether two path segements should be joined."),
+                "tip": _("Tolerance to decide whether two path segments should be joined."),
                 "page": "Optimisations",
                 "section": "_05_Stitching",
                 "conditional": (context, "opt_stitching"),

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -24,6 +24,7 @@ from meerk40t.gui.wxmscene import SceneWindow
 from meerk40t.gui.wxutils import TextCtrl, wxButton, wxStaticText
 from meerk40t.kernel import CommandSyntaxError, Module, get_safe_path
 from meerk40t.kernel.kernel import Job
+from meerk40t.core.units import Length
 
 from ..main import APPLICATION_NAME, APPLICATION_VERSION
 from ..tools.kerftest import KerfTool
@@ -834,6 +835,31 @@ class wxMeerK40t(wx.App, Module):
             else:
                 dialog.cancel_it()
             dialog.Destroy()
+
+        @kernel.console_argument("info", type=str, help=_("Unit to translate"))
+        @kernel.console_command("unit", help=_("Translate units"))
+        def show_unit_info(command, channel, _, info=None, **kwargs):
+            if info is None:
+                channel(_("You need to provide a value to translate"))
+            device = kernel.root.device
+            try:
+                valuex = Length(info, relative_length=device.view.width, digits=4)
+            except ValueError:
+                channel(f"Invalid value: '{info}'")
+                return
+            channel(f"{info} translates to:")
+            channel(f"tat          :  {float(valuex):.4f}")
+            channel(f"mil          :  {valuex.mil}")
+            channel(f"um           :  {valuex.um}")
+            channel(f"nm           :  {valuex.nm}")
+            channel(f"mm           :  {valuex.mm}")
+            channel(f"cm           :  {valuex.cm}")
+            channel(f"Pixels       :  {valuex.pixels}")
+            channel(f"Point        :  {valuex.pt}")
+            channel(f"spx (screen) :  {valuex.spx}")
+            channel(f"inch         :  {valuex.inches}")
+            channel(f"Device units :  {float(valuex) / device.view.native_scale_x:.4f}")
+            
 
     def module_open(self, *args, **kwargs):
         context = self.context


### PR DESCRIPTION
- Add a ``stitch`` command to join individual paths together 
- Add stitching as an option for preprocessing (ie optimizing) a design at cutplan stage.

This is required to make the "burn inner" functionality work with disjoint(line segments). A rectangle will be treated as a "closed" element and consequently "inner" elements will be burnt first. The same design but this time with 4 separate lines forming the rectangle will not be treated as a closed element and the burn inner first logic won't be triggered.
![stitches](https://github.com/user-attachments/assets/73588d01-b9c1-41ca-9e7d-5d4323ed39b8)

## Summary by Sourcery

Add stitching functionality to join and optimize path segments in the laser cutting software

New Features:
- Implement a new 'stitch' command to join individual path segments together
- Add stitching as an optimization option during cut planning preprocessing

Enhancements:
- Create a flexible geometry stitching algorithm that can connect path segments within a tolerance
- Add user-configurable tolerance for path segment joining

Chores:
- Update configuration options to support new stitching functionality
- Add new optimization settings in the application preferences