### PR TITLE
Lhyserver (and others) fix

### DIFF
--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -1242,7 +1242,7 @@ class Kernel(Settings):
 
                     line = await loop.run_in_executor(None, sys.stdin.readline)
                     line = line.strip()
-                    if line in ("quit", "shutdown", "restart"):
+                    if line in ("quit", "shutdown", "exit", "restart"):
                         self._quit = True
                         if line == "restart":
                             self._restart = True

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -227,8 +227,9 @@ def _exe(restarted, args):
     console = hasattr(kernel.args, "console") and kernel.args.console
     daemon = hasattr(kernel.args, "daemon") and kernel.args.daemon
     server_mode = False
-    for c in command:
-        server_mode = server_mode or any(substring in c for substring in ("lhyserver", "grblserver", "ruidacontrol", "grblcontrol", "webserver"))
+    if command:
+        for c in command:
+            server_mode = server_mode or any(substring in c for substring in ("lhyserver", "grblserver", "ruidacontrol", "grblcontrol", "webserver"))
     nogui = (
         (hasattr(kernel.args, "gui_suppress") and kernel.args.gui_suppress) or
         (hasattr(kernel.args, "no_gui") and kernel.args.no_gui) 


### PR DESCRIPTION
Fixing an issue that crept in with 0.9.3020: 
we introduced an extended kernel lifecycle management with 0.9.3020. Prior to this version the kernel more or less looped forever. Now the default is an immediate exit unless a service prevents it by looping in its main cycle. The console or the GUI are two examples of such a plugin/module.

So the invocation of a lhyserver (ie a network proxy for the K40) with ``python3 meerk40t.py -e 'lhyserver -p 1024' -Z``  (-Z = headless = no console / no GUI) failed as meerk40t was exiting immediately.

Meerk40t will now recognize any of the "server" commands (lhyserver, grblserver, ruidacontrol, grblcontrol, webserver) and won't exit immediately if they have been mentioned as a command argument (-e/--execute). Alternatively you can issue -d/--daemon as argument, which will have the same effect but for any command given.
