### PR TITLE
Additional z-control tweaks

### DIFF
--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -661,7 +661,7 @@ class GRBLDevice(Service, Status):
             self._register_console_serial()
 
         @self.console_command(
-            "home_z",
+            "z_home",
             help=_("Homes the z-Axis"),
             input_type=None,
         )
@@ -678,11 +678,11 @@ class GRBLDevice(Service, Status):
 
         @self.console_argument("step", type=Length, help=_("Amount to move the z-axis"))
         @self.console_command(
-            "move_z",
+            "z_move",
             help=_("Moves the z-Axis by the given amount"),
             input_type=None,
         )
-        def command_zmove(command, channel, _, data=None, step=None, **kwgs):
+        def command_zmove_rel(command, channel, _, data=None, step=None, **kwgs):
             if not self.supports_z_axis:
                 channel(_("This device does not support a z-axis."))
                 return
@@ -691,6 +691,23 @@ class GRBLDevice(Service, Status):
                 return
             # relative movement in mm
             gcode = f"G91 G21 Z{step.mm:.3f}"
+            self.driver(gcode + self.driver.line_end)
+
+        @self.console_argument("step", type=Length, help=_("New z-axis position"))
+        @self.console_command(
+            "z_move_to",
+            help=_("Moves the z-Axis to the given position"),
+            input_type=None,
+        )
+        def command_zmove_abs(command, channel, _, data=None, step=None, **kwgs):
+            if not self.supports_z_axis:
+                channel(_("This device does not support a z-axis."))
+                return
+            if step is None:
+                channel(_("No z-movement defined"))
+                return
+            # absolute movement in mm
+            gcode = f"G91 G20 Z{step.mm:.3f}"
             self.driver(gcode + self.driver.line_end)
 
         @self.console_command(

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -18,7 +18,7 @@ from meerk40t.gui.icons import (
     icons8_pentagon,
     icons8_save,
 )
-from meerk40t.gui.navigationpanels import Drag, Jog, MovePanel, JogDistancePanel
+from meerk40t.gui.navigationpanels import Drag, Jog, JogDistancePanel, MovePanel
 from meerk40t.gui.wxutils import (
     HoverButton,
     ScrolledPanel,
@@ -45,7 +45,7 @@ def register_panel_laser(window, context):
     # jog_drag = wx.Panel(window, wx.ID_ANY)
     jog_drag = ScrolledPanel(window, wx.ID_ANY)
     jog_drag.SetupScrolling()
-    jog_panel = Jog(jog_drag, wx.ID_ANY, context=context)
+    jog_panel = Jog(jog_drag, wx.ID_ANY, context=context, suppress_z_controls=True)
     drag_panel = Drag(jog_drag, wx.ID_ANY, context=context)
     distance_panel = JogDistancePanel(jog_drag, wx.ID_ANY, context=context)
     main_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -95,7 +95,7 @@ def register_panel_laser(window, context):
     notebook.AddPage(plan_panel, _("Plan"))
     notebook.AddPage(optimize_panel, _("Optimize"))
     notebook.AddPage(move_panel, _("Move"))
-    
+
     def on_page_change(event):
         event.Skip()
         page = notebook.GetCurrentPage()

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -483,17 +483,17 @@ class ZMovePanel(wx.Panel):
         self.Layout()
 
     def z_home(self, event=None):
-        self.context("home_z\n")
+        self.context("z_home\n")
 
     def z_move_down(self, distance):
         def handler():
-            self.context(f"move_z -{distance*0.1:.2f}mm")
+            self.context(f"z_move -{distance*0.1:.2f}mm")
 
         return handler
 
     def z_move_up(self, distance):
         def handler():
-            self.context(f"move_z {distance*0.1:.2f}mm")
+            self.context(f"z_move {distance*0.1:.2f}mm")
 
         return handler
 
@@ -522,7 +522,7 @@ class ZMovePanel(wx.Panel):
         self.Layout()
 
     def on_update(self, origin, *args):
-        has_home = self.context.kernel.has_command("home_z")
+        has_home = self.context.kernel.has_command("z_home")
         # print (f"Has_home for {self.context.device.name}: {has_home}")
         self.button_z_home.Show(has_home)
         self.navigation_sizer.Show(self.button_z_home, has_home)


### PR DESCRIPTION
Some visual tweaking and renaming the underlying commands to make them more similar to the rotary commands
- ``z_home``: homing z-axis
- ``z_move``: relative z-movement
- ``z_move_to``: absolute z-movement
(for now only GRBL-devices are supported, ruida to follow)

## Summary by Sourcery

Unify Z-axis command naming and behavior to match rotary controls, add absolute Z movement and autofocus support, and update the GUI to dynamically display and bind these new commands based on device capabilities

New Features:
- Rename Z-axis commands to z_home, z_move (relative), and introduce z_move_to (absolute)
- Add autofocus command z_focus for supported devices

Enhancements:
- Update GUI to dynamically show/hide and bind right-click autofocus on Z controls based on device support
- Add suppress_z_controls flag to disable Z controls in specific panels
- Implement kernel.has_command API to detect available console commands

Chores:
- Clean up whitespace and formatting in kernel and layout adjustments