### PR TITLE
Fix group on children drag and drop issue

### DIFF
--- a/meerk40t/core/node/elem_ellipse.py
+++ b/meerk40t/core/node/elem_ellipse.py
@@ -3,8 +3,8 @@ from math import cos, sin, sqrt, tau
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Fillrule, Node
@@ -171,12 +171,16 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
         tablen = self.mktablength
         numtabs = self.mktabpositions
         if tablen and numtabs:
-            path = Geomstr.wobble_tab(path, tablen, resolution, numtabs, unit_factor=unit_factor)
+            path = Geomstr.wobble_tab(
+                path, tablen, resolution, numtabs, unit_factor=unit_factor
+            )
         # Is there a dash/dot pattern to apply?
         dashlen = self.stroke_dash
         irrelevant = 50
         if dashlen:
-            path = Geomstr.wobble_dash(path, dashlen, resolution, irrelevant, unit_factor=unit_factor)
+            path = Geomstr.wobble_dash(
+                path, dashlen, resolution, irrelevant, unit_factor=unit_factor
+            )
 
         return path
 
@@ -261,19 +265,25 @@ class EllipseNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_line.py
+++ b/meerk40t/core/node/elem_line.py
@@ -2,8 +2,8 @@ from copy import copy
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
@@ -150,12 +150,16 @@ class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         numtabs = 4
         numtabs = 0
         if tablen and numtabs:
-            path = Geomstr.wobble_tab(path, tablen, resolution, numtabs, unit_factor=unit_factor)
+            path = Geomstr.wobble_tab(
+                path, tablen, resolution, numtabs, unit_factor=unit_factor
+            )
         # Is there a dash/dot pattern to apply?
         dashlen = self.stroke_dash
         irrelevant = 50
         if dashlen:
-            path = Geomstr.wobble_dash(path, dashlen, resolution, irrelevant, unit_factor=unit_factor)
+            path = Geomstr.wobble_dash(
+                path, dashlen, resolution, irrelevant, unit_factor=unit_factor
+            )
         return path
 
     def scaled(self, sx, sy, ox, oy, interim=False):
@@ -235,19 +239,25 @@ class LineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -2,8 +2,8 @@ from copy import copy
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
@@ -122,12 +122,16 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         tablen = self.mktablength
         numtabs = self.mktabpositions
         if tablen and numtabs:
-            path = Geomstr.wobble_tab(path, tablen, resolution, numtabs, unit_factor=unit_factor)
+            path = Geomstr.wobble_tab(
+                path, tablen, resolution, numtabs, unit_factor=unit_factor
+            )
         # Is there a dash/dot pattern to apply?
         dashlen = self.stroke_dash
         irrelevant = 50
         if dashlen:
-            path = Geomstr.wobble_dash(path, dashlen, resolution, irrelevant, unit_factor=unit_factor)
+            path = Geomstr.wobble_dash(
+                path, dashlen, resolution, irrelevant, unit_factor=unit_factor
+            )
         return path
 
     def scaled(self, sx, sy, ox, oy, interim=False):
@@ -201,19 +205,25 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_point.py
+++ b/meerk40t/core/node/elem_point.py
@@ -85,18 +85,24 @@ class PointNode(Node, FunctionalParameter, LabelDisplay, Suppressable):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            drag_node.type in ("op dots", "file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("op dots", "file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_polyline.py
+++ b/meerk40t/core/node/elem_polyline.py
@@ -2,8 +2,8 @@ from copy import copy
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Fillrule, Linecap, Linejoin, Node
@@ -18,9 +18,7 @@ from meerk40t.svgelements import (
 from meerk40t.tools.geomstr import Geomstr
 
 
-class PolylineNode(
-    Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable
-):
+class PolylineNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
     """
     PolylineNode is the bootstrapped node type for the 'elem polyline' type.
     """
@@ -152,12 +150,16 @@ class PolylineNode(
         tablen = self.mktablength
         numtabs = self.mktabpositions
         if tablen and numtabs:
-            path = Geomstr.wobble_tab(path, tablen, resolution, numtabs, unit_factor=unit_factor)
+            path = Geomstr.wobble_tab(
+                path, tablen, resolution, numtabs, unit_factor=unit_factor
+            )
         # Is there a dash/dot pattern to apply?
         dashlen = self.stroke_dash
         irrelevant = 50
         if dashlen:
-            path = Geomstr.wobble_dash(path, dashlen, resolution, irrelevant, unit_factor=unit_factor)
+            path = Geomstr.wobble_dash(
+                path, dashlen, resolution, irrelevant, unit_factor=unit_factor
+            )
         return path
 
     def scaled(self, sx, sy, ox, oy, interim=False):
@@ -232,19 +234,25 @@ class PolylineNode(
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_rect.py
+++ b/meerk40t/core/node/elem_rect.py
@@ -2,8 +2,8 @@ from copy import copy
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Fillrule, Linejoin, Node
@@ -157,12 +157,16 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         tablen = self.mktablength
         numtabs = self.mktabpositions
         if tablen and numtabs:
-            path = Geomstr.wobble_tab(path, tablen, resolution, numtabs, unit_factor=unit_factor)
+            path = Geomstr.wobble_tab(
+                path, tablen, resolution, numtabs, unit_factor=unit_factor
+            )
         # Is there a dash/dot pattern to apply?
         dashlen = self.stroke_dash
         irrelevant = 50
         if dashlen:
-            path = Geomstr.wobble_dash(path, dashlen, resolution, irrelevant, unit_factor=unit_factor)
+            path = Geomstr.wobble_dash(
+                path, dashlen, resolution, irrelevant, unit_factor=unit_factor
+            )
         return path
 
     def scaled(self, sx, sy, ox, oy, interim=False):
@@ -241,18 +245,24 @@ class RectNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
 
     def can_drop(self, drag_node):
         # Dragging element into element.
+        if self.is_a_child_of(drag_node):
+            return False
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/elem_text.py
+++ b/meerk40t/core/node/elem_text.py
@@ -4,8 +4,8 @@ from math import tau
 
 from meerk40t.core.node.mixins import (
     FunctionalParameter,
-    Stroked,
     LabelDisplay,
+    Stroked,
     Suppressable,
 )
 from meerk40t.core.node.node import Node
@@ -196,18 +196,24 @@ class TextNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            drag_node.type in ("op raster", "file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("op raster", "file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/filenode.py
+++ b/meerk40t/core/node/filenode.py
@@ -25,21 +25,15 @@ class FileNode(Node):
         default_map["filename"] = s
         return default_map
 
-    def is_a_child_of(self, node):
-        candidate = self
-        while candidate is not None:
-            if candidate is node:
-                return True
-            candidate = candidate.parent
         return False
-    
+
     def can_drop(self, drag_node):
         if self.is_a_child_of(drag_node):
             return False
         if drag_node.type == "group":
             return True
         return False
-    
+
     def drop(self, drag_node, modify=True, flag=False):
         # Do not allow dragging onto children
         if not self.can_drop(drag_node):

--- a/meerk40t/core/node/groupnode.py
+++ b/meerk40t/core/node/groupnode.py
@@ -1,5 +1,5 @@
-from meerk40t.core.node.node import Node
 from meerk40t.core.node.mixins import LabelDisplay
+from meerk40t.core.node.node import Node
 
 
 class GroupNode(Node, LabelDisplay):
@@ -76,18 +76,14 @@ class GroupNode(Node, LabelDisplay):
         default_map["id"] = str(self.id)
         return default_map
 
-    def is_a_child_of(self, node):
-        candidate = self
-        while candidate is not None:
-            if candidate is node:
-                return True
-            candidate = candidate.parent
-        return False
-
     def can_drop(self, drag_node):
         if self.is_a_child_of(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type == "group":
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type == "group"
+        ):
             # Move a group
             return True
         elif drag_node.type.startswith("op"):
@@ -121,7 +117,11 @@ class GroupNode(Node, LabelDisplay):
             if result and modify:
                 # changed = []
                 for e in self.flat():
-                    if hasattr(drag_node, "color") and drag_node.color is not None and hasattr(e, "stroke"):
+                    if (
+                        hasattr(drag_node, "color")
+                        and drag_node.color is not None
+                        and hasattr(e, "stroke")
+                    ):
                         e.stroke = drag_node.color
                         # changed.append(e)
                 for ref in old_references:

--- a/meerk40t/core/node/image_processed.py
+++ b/meerk40t/core/node/image_processed.py
@@ -163,19 +163,25 @@ class ImageProcessedNode(Node):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/image_raster.py
+++ b/meerk40t/core/node/image_raster.py
@@ -92,19 +92,25 @@ class ImageRasterNode(Node):
         return default_map
 
     def can_drop(self, drag_node):
+        if self.is_a_child_of(drag_node):
+            return False
         # Dragging element into element.
         return bool(
-            hasattr(drag_node, "as_geometry") or
-            hasattr(drag_node, "as_image") or
-            (drag_node.type.startswith("op ") and drag_node.type != "op dots") or
-            drag_node.type in ("file", "group")
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or (drag_node.type.startswith("op ") and drag_node.type != "op dots")
+            or drag_node.type in ("file", "group")
         )
 
     def drop(self, drag_node, modify=True, flag=False):
         # Dragging element into element.
         if not self.can_drop(drag_node):
             return False
-        if hasattr(drag_node, "as_geometry") or hasattr(drag_node, "as_image") or drag_node.type in ("file", "group"):
+        if (
+            hasattr(drag_node, "as_geometry")
+            or hasattr(drag_node, "as_image")
+            or drag_node.type in ("file", "group")
+        ):
             if modify:
                 self.insert_sibling(drag_node)
             return True

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -1389,6 +1389,14 @@ class Node:
             child.remove_all_children(fast=fast, destroy=destroy)
             child.remove_node(fast=fast, destroy=destroy)
 
+    def is_a_child_of(self, node):
+        candidate = self
+        while candidate is not None:
+            if candidate is node:
+                return True
+            candidate = candidate.parent
+        return False
+
     def has_ancestor(self, type):
         """
         Return whether this node has an ancestor node that matches the given type, or matches the major type.


### PR DESCRIPTION
Dragging a group/file node on one of its children lead to a crash

## Summary by Sourcery

Prevent dragging a node onto its own descendant to fix crash in group/file drag-and-drop

Bug Fixes:
- Block drop operations when a node is dragged onto one of its own children to avoid crashes

Enhancements:
- Centralize is_a_child_of logic into the base Node class and remove duplicate implementations
- Reformat argument lists, adjust import ordering, and clean up whitespace across node modules