### PR TITLE
Honor rapid mode

### DIFF
--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -496,6 +496,19 @@ class GRBLDevice(Service, Status):
                 "subsection": "_10_",
             },
             {
+                "attr": "rapid_speed",
+                "object": self,
+                "default": 600,
+                "type": float,
+                "label": _("Travel speed"),
+                "trailer": "mm/s",
+                "tip": _(
+                    "What is the travel speed for your device to move from point to another."
+                ),
+                "section": "_25_" + _("Travel"),
+                "subsection": "_10_",
+            },
+            {
                 "attr": "limit_buffer",
                 "object": self,
                 "default": True,
@@ -900,7 +913,8 @@ class GRBLDevice(Service, Status):
                 # self.redlight_preferred = True
                 # self.driver.set("power", int(self.red_dot_level / 100 * 1000))
                 self.driver._clean()
-                self.driver.laser_on(power=int(self.red_dot_level), speed=1000)
+                rapid_speed = self.setting(float, "rapid_speed", 600.0)
+                self.driver.laser_on(power=int(self.red_dot_level), speed=rapid_speed)
                 # By default, any move is a G0 move which will not activate the laser,
                 # so we need to switch to G1 mode:
                 self.driver.move_mode = 1

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -262,7 +262,6 @@ class GRBLDriver(Parameters):
             self.power = power
             self.power_dirty = False
         if speed is not None:
-            print(f"Laser on with speed={speed}")
             sspeed = f"G1 F{speed}{self.line_end}"
             self.speed = speed
             self.speed_dirty = False


### PR DESCRIPTION
The rapid mode setting for a grbl device was ignored so far, it moved with the same speed as previously set. This speed setting has now be made user configurable

## Summary by Sourcery

Introduce a user-configurable rapid (travel) speed and apply it consistently across rapid moves and red-dot operations

New Features:
- Add a new `rapid_speed` setting to configure travel speed on Grbl devices

Enhancements:
- Modify `rapid_mode()` to fetch and apply the user-defined `rapid_speed`
- Update red-dot and laser-on routines to use the configurable rapid travel speed