### PR TITLE
Device property panels

### DIFF
--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -235,3 +235,9 @@ class BalorConfiguration(MWindow):
     @staticmethod
     def helptext():
         return _("Display and edit device configuration")
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'balor':
+            wx.CallAfter(self.Close)

--- a/meerk40t/grbl/gui/grblconfiguration.py
+++ b/meerk40t/grbl/gui/grblconfiguration.py
@@ -371,3 +371,9 @@ class GRBLConfiguration(MWindow):
         else:
             # Different command
             pass
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'GRBLDevice':
+            wx.CallAfter(self.Close)

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -243,9 +243,7 @@ class DevicePanel(wx.Panel):
         sizer_1.Add(sizer_3, 1, wx.EXPAND, 0)
         # All devices
         self.devices = []
-        # Active item in list
-        self.current_item = 0
-
+    
         self.button_create_device = wxButton(self, wx.ID_ANY, _("Create New Device"))
         sizer_3.Add(self.button_create_device, 0, 0, 0)
 
@@ -305,12 +303,16 @@ class DevicePanel(wx.Panel):
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.on_end_edit, self.devices_list)
         # end wxGlade
 
+    @property
+    def current_item(self):
+        if self.devices_list.GetSelectedItemCount() > 0:
+            return self.devices_list.GetFirstSelected()
+        return -1
+    
     def pane_show(self, *args):
         self.refresh_device_tree()
         if len(self.devices) > 0:
             self.devices_list.Select(0, 1)
-        else:
-            self.current_item = -1
         self.enable_controls()
 
     def pane_hide(self, *args):
@@ -453,17 +455,14 @@ class DevicePanel(wx.Panel):
         return label
 
     def on_item_selected(self, event):
-        if event is None:
-            self.current_item = self.devices_list.GetFirstSelected()
-        else:
-            self.current_item = event.Index
+        if event:
             event.Skip()
         self.enable_controls()
 
     def on_item_deselected(self, event):
-        self.current_item = -1
+        if event:
+            event.Skip()
         self.enable_controls()
-        event.Skip()
 
     def enable_controls(self):
         if self.current_item < 0:
@@ -608,15 +607,25 @@ class DevicePanel(wx.Panel):
         self.duplicate_device(service)
 
     def on_button_activate_device(self, event):  # wxGlade: DevicePanel.<event_handler>
+        def reselect(idx):
+            def handler():
+                if idx >= 0:
+                    self.devices_list.Select(idx, 1)
+                    self.devices_list.Focus(idx)
+
+            return handler
+        
+        idx = self.current_item
+        if idx < 0:
+            return
         service = self.get_selected_device()
         if service is not None:
             service.kernel.activate_service_path("device", service.path)
             self.recolor_device_items()
+            wx.CallLater(750, reselect(idx))    
 
     def on_button_config_device(self, event):  # wxGlade: DevicePanel.<event_handler>
-        service = self.get_selected_device()
-        if service is not None:
-            service("window toggle Configuration\n")
+        self.context("window toggle Configuration\n")
 
     def on_button_rename_device(self, event):  # wxGlade: DevicePanel.<event_handler>
         service = self.get_selected_device()

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -468,3 +468,9 @@ class LihuiyuDriverGui(MWindow):
     @staticmethod
     def helptext():
         return _("Display the device configuration window")
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'LihuiyuDevice':
+            wx.CallAfter(self.Close)

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -7,6 +7,7 @@ from meerk40t.device.gui.effectspanel import EffectsPanel
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -85,3 +86,9 @@ class MoshiDriverGui(MWindow):
     @staticmethod
     def helptext():
         return _("Display the device configuration window")
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'MoshiDevice':
+            wx.CallAfter(self.Close)

--- a/meerk40t/newly/gui/newlyconfig.py
+++ b/meerk40t/newly/gui/newlyconfig.py
@@ -114,3 +114,9 @@ class NewlyConfiguration(MWindow):
     @staticmethod
     def submenu():
         return "Device-Settings", "Configuration"
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'newly':
+            wx.CallAfter(self.Close)

--- a/meerk40t/ruida/gui/ruidaconfig.py
+++ b/meerk40t/ruida/gui/ruidaconfig.py
@@ -8,6 +8,7 @@ from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icons8_administrative_tools
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer, TextCtrl, dip_size
+from meerk40t.kernel import signal_listener
 
 _ = wx.GetTranslation
 
@@ -237,3 +238,9 @@ class RuidaConfiguration(MWindow):
     @staticmethod
     def helptext():
         return _("Display the device configuration window")
+
+    @signal_listener("activate;device")
+    def on_device_changes(self, *args):
+        # Device activated, make sure we are still fine...
+        if self.context.device.name != 'RuidaDevice':
+            wx.CallAfter(self.Close)


### PR DESCRIPTION
When a device is changed all contexts receive the new device as self.context.device.
This could cause erroneous behaviour in an open (different) device configuration dialog. So all device config dialogs close now on a device change.