### PR TITLE
Speed up lightjob execution

### DIFF
--- a/meerk40t/balormk/controller.py
+++ b/meerk40t/balormk/controller.py
@@ -288,7 +288,7 @@ class GalvoController:
         self._list_executing = False
         self._number_of_list_packets = 0
         self.paused = False
-        self._signal_updates = self.service.setting(bool, "signal_updates", True)
+        self.service.setting(bool, "signal_updates", True)
 
     def define_pins(self):
         self._light_bit = self.service.setting(int, "light_pin", 8)
@@ -1090,7 +1090,7 @@ class GalvoController:
         x = int(x)
         y = int(y)
         self._list_write(listJumpTo, x, y, angle, distance)
-        if self._signal_updates:
+        if self.service.signal_updates:
             view = self.service.view
             l_x, l_y = view.iposition(self._last_x, self._last_y)
             n_x, n_y = view.iposition(x, y)
@@ -1125,7 +1125,7 @@ class GalvoController:
         y = int(y)
         self._list_write(listMarkTo, x, y, angle, distance)
 
-        if self._signal_updates:
+        if self.service.signal_updates:
             view = self.service.view
             l_x, l_y = view.iposition(self._last_x, self._last_y)
             n_x, n_y = view.iposition(x, y)

--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -57,6 +57,7 @@ class BalorDriver:
         self.plot_planner.settings_then_jog = True
         self._aborting = False
         self._list_bits = None
+        self.service.setting(bool, "signal_updates", True)
 
     def __repr__(self):
         return f"BalorDriver({self.name})"
@@ -552,11 +553,12 @@ class BalorDriver:
         if self.native_y < 0:
             self.native_y = 0
         self.connection.set_xy(self.native_x, self.native_y)
-        new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self.service.signal_updates:
+            new_current = self.service.current
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def move_rel(self, dx, dy):
         """
@@ -581,11 +583,12 @@ class BalorDriver:
         if self.native_y < 0:
             self.native_y = 0
         self.connection.set_xy(self.native_x, self.native_y)
-        new_current = self.service.current
-        self.service.signal(
-            "driver;position",
-            (old_current[0], old_current[1], new_current[0], new_current[1]),
-        )
+        if self.service.signal_updates:
+            new_current = self.service.current
+            self.service.signal(
+                "driver;position",
+                (old_current[0], old_current[1], new_current[0], new_current[1]),
+            )
 
     def home(self):
         """


### PR DESCRIPTION
Run just a single looping job instead of repeating single execution ones

## Summary by Sourcery

Optimize livelightjob execution by replacing repeated single-interval jobs with a single continuous loop and suppressing redundant position update signals to improve performance.

Enhancements:
- Run the redlight job in a persistent loop instead of repeatedly scheduling single executions
- Introduce a service.signal_updates flag to disable driver and controller position signals during lightjob execution
- Expose signal_updates as a configurable setting in the driver and controller
- Add update_group_labels to the set of listened events for livelightjob updates