### PR TITLE
Fix pwm pulse crash

### DIFF
--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -1851,13 +1851,17 @@ class PulsePanel(wx.Panel):
                     # Convert percent to ppi
                     power = power * 10
                 power = max(0, min(1000, int(power)))
+                self.context.device.setting(int, "last_pulse_duration", 50)
                 self.context.device.setting(float, "last_pulse_power", 1000)
+                self.context.device.last_pulse_duration = value
                 self.context.device.last_pulse_power = power
                 powerstr = f" -p {power}"
         self.context(f"pulse {value}{powerstr}\n")
 
     def on_spin_pulse_duration(self, event=None):  # wxGlade: Navigation.<event_handler>
-        self.context.navigate_pulse = float(self.spin_pulse_duration.GetValue())
+        dval = self.spin_pulse_duration.GetValue()
+        self.context.device.setting(int, "last_pulse_duration", 50)
+        self.context.device.last_pulse_duration = dval
 
     def pane_show(self, *args):
         # Is the current device pwm pulse capable?
@@ -1877,6 +1881,10 @@ class PulsePanel(wx.Panel):
         pval = self.context.device.setting(float, "last_pulse_power", 1000)
         if pval is None:
             pval = 1000
+        dval = self.context.device.setting(float, "last_pulse_duration", 50)
+        if dval is None:
+            dval = 50
+        self.spin_pulse_duration.SetValue(dval)
         if self.context.device.setting(bool, "use_percent_for_power_display", False):
             self.text_power.SetValue(f"{pval/10.0:.1f}")
             self.text_power.set_range(0, 100)

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -1881,7 +1881,7 @@ class PulsePanel(wx.Panel):
         pval = self.context.device.setting(float, "last_pulse_power", 1000)
         if pval is None:
             pval = 1000
-        dval = self.context.device.setting(float, "last_pulse_duration", 50)
+        dval = self.context.device.setting(int, "last_pulse_duration", 50)
         if dval is None:
             dval = 50
         self.spin_pulse_duration.SetValue(dval)

--- a/meerk40t/lihuiyu/driver.py
+++ b/meerk40t/lihuiyu/driver.py
@@ -446,7 +446,7 @@ class LihuiyuDriver(Parameters):
         if self.laser:
             return False
         if power is not None and self.service.supports_pwm:
-            self.send_at_pwm_code(power, "laser_on")
+            self.send_at_pwm_code(power)
 
         if self.state == DRIVER_STATE_RAPID:
             self(b"I")


### PR DESCRIPTION
## Summary by Sourcery

Fix crashes related to PWM pulse commands by initializing and persisting pulse duration settings in the navigation UI and aligning driver code with the updated send_at_pwm_code signature.

Bug Fixes:
- Prevent crashes by initializing and storing the last pulse duration setting before use in the navigation panel.
- Fix lihuiyu driver send_at_pwm_code call to use the correct single-argument signature.

Enhancements:
- Load and display the persisted pulse duration in the spin control to maintain user settings between sessions.