### PR TITLE
Livelight fixes

### DIFF
--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -370,7 +370,7 @@ class SpoolerJob:
 
         @return:
         """
-        if self.is_running:
+        if self.is_running():
             return "Running"
         else:
             return "Queued"

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -4837,9 +4837,12 @@ class MeerK40t(MWindow):
             if answer == wx.CANCEL:
                 return True  # VETO
         for job in self.context.device.spooler.queue:
-            print(f"{job.label} is running: {job.is_running()}")
             if job.is_running():
-                job.stop()
+                print(f"{job.label} was still running, stopping...")
+                try:
+                    job.stop()
+                except Exception as e:
+                    print(f"Error stopping job {job.label}: {e}")
         return False
 
     def window_close(self):

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -4836,6 +4836,10 @@ class MeerK40t(MWindow):
                 return True
             if answer == wx.CANCEL:
                 return True  # VETO
+        for job in self.context.device.spooler.queue:
+            print(f"{job.label} is running: {job.is_running()}")
+            if job.is_running():
+                job.stop()
         return False
 
     def window_close(self):


### PR DESCRIPTION
- proper display of (partial) out of bound geometries
- fix invalid is_running invocations
- stop running jobs at end of program

## Summary by Sourcery

Improve livelight job handling by fixing status checks, clamping geometry, stopping running jobs on exit, and enhancing the out-of-bound fallback with a new lightning visualization

New Features:
- Add a lightning fallback visualization for out-of-bound redlight paths

Bug Fixes:
- Clamp out-of-bound redlight geometry coordinates to the valid range instead of wrapping
- Fix invalid is_running property accesses by invoking is_running() correctly
- Stop any running spooler jobs when the application is closing

Enhancements:
- Replace the crosshair fallback with the new lightning pattern
- Correct the livelight crosshair docstring typo