### PR TITLE
Use physical home for emulators if available

### DIFF
--- a/meerk40t/grbl/emulator.py
+++ b/meerk40t/grbl/emulator.py
@@ -368,6 +368,15 @@ class GRBLEmulator:
             else:
                 self._buffer.append(chr(c))
 
+    def _home_device(self):
+        if hasattr(self.device.driver, "physical_home"):
+            # If the driver has a physical home, we can use that.
+            self.device.driver.physical_home()
+        elif hasattr(self.device.driver, "home"):
+            self.device.driver.home()
+        else:
+            self.device.driver.move_abs(0, 0)
+
     def _grbl_special(self, data):
         """
         GRBL special commands are commands beginning with $ that do purely grbl specific things.
@@ -458,14 +467,7 @@ class GRBLEmulator:
         elif data == "$H":
             if not self.settings["homing_cycle_enable"]:
                 return 5  # Homing cycle not enabled by settings.
-            try:
-                self.device.driver.physical_home()
-            except AttributeError:
-                pass
-            try:
-                self.device.driver.move_abs(0, 0)
-            except AttributeError:
-                pass
+            self._home_device()
             return 0
         elif data.startswith("$J="):
             """

--- a/meerk40t/ruida/emulator.py
+++ b/meerk40t/ruida/emulator.py
@@ -161,6 +161,15 @@ class RuidaEmulator:
                 if self.channel:
                     self.channel(f"Process Failure: {str(bytes(array).hex())}")
 
+    def _home_device(self):
+        if hasattr(self.device.driver, "physical_home"):
+            # If the driver has a physical home, we can use that.
+            self.device.driver.physical_home()
+        elif hasattr(self.device.driver, "home"):
+            self.device.driver.home()
+        else:
+            self.device.driver.move_abs(0, 0)
+
     def _channel(self, text):
         if self.channel:
             self.channel(text)
@@ -357,7 +366,7 @@ class RuidaEmulator:
                 self._describe(array, "Stop Process")
                 try:
                     self.device.driver.reset()
-                    self.device.driver.home()
+                    self._home_device()
                 except AttributeError:
                     pass
                 return True
@@ -383,10 +392,7 @@ class RuidaEmulator:
                 return True
             elif array[1] == 0x2A:
                 self._describe(array, "Home XY")
-                try:
-                    self.device.driver.home()
-                except AttributeError:
-                    pass
+                self._home_device()
                 return True
             elif array[1] == 0x2E:
                 self._describe(array, "FocusZ")
@@ -637,10 +643,7 @@ class RuidaEmulator:
                         except AttributeError:
                             pass
                     else:
-                        try:
-                            self.device.driver.home()
-                        except AttributeError:
-                            pass
+                        self._home_device()
                 elif array[1] == 0x30 or array[1] == 0x70:
                     x = abscoord(array[3:8])
                     y = abscoord(array[8:13])


### PR DESCRIPTION
## Summary by Sourcery

Unify and improve homing behavior in Ruida and GRBL emulators by introducing a helper that uses physical homing when available and falls back to default methods.

Enhancements:
- Introduce a `_home_device` helper in Ruida and GRBL emulators to prefer `physical_home`, then `home`, then absolute move
- Replace direct `home` and manual move calls with the new `_home_device` method in real-time and `$H` homing routines