### PR TITLE
Add option to restore main window state

### DIFF
--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -112,6 +112,18 @@ and a wxpython version <= 4.1.1."""
                 "section": "General",
             },
             {
+                "attr": "remember_main_pos",
+                "object": kernel.root,
+                "default": True,
+                "type": bool,
+                "label": _("Remember main window position"),
+                "tip": _(
+                    "Should MeerK40t remember its last position on the screen?"
+                ),
+                "page": "Gui",
+                "section": "General",
+            },
+            {
                 "attr": "windows_save",
                 "object": kernel.root,
                 "default": True,


### PR DESCRIPTION
## Summary by Sourcery

Implement persistent main window state with a new preference to remember and restore its position, size, and window state across sessions.

New Features:
- Add a "Remember main window position" setting and GUI option.
- Persist main window position, size, maximized, and minimized state on application close.
- Restore main window geometry and state on startup, honoring the remember setting and CLI flags.

Enhancements:
- Validate restored window position against all connected screens and fallback to default position and size if invalid.