### PR TITLE
Fix margin usage in view

### DIFF
--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -2,6 +2,9 @@
 This module contains panels that display internal developer information.
 They will become visible if you type 'set debug_mode True' in the
 console and restart the program.
+
+The module provides a set of wxPython panels for debugging, including device view, color, icon, window, and raster plotter panels.
+These panels are intended for developers to inspect internal state, test shutdown scenarios, and visualize system resources.
 """
 
 import time
@@ -77,6 +80,7 @@ def register_panel_color(window, context):
     window.on_pane_create(pane)
     context.register("pane/debug_color", pane)
 
+
 def register_panel_view(window, context):
     pane = (
         aui.AuiPaneInfo()
@@ -94,6 +98,7 @@ def register_panel_view(window, context):
     pane.helptext = _("Display information about device view")
     window.on_pane_create(pane)
     context.register("pane/debug_view", pane)
+
 
 def register_panel_icon(window, context):
     pane = (
@@ -358,7 +363,15 @@ class DebugTreePanel(wx.Panel):
 
         self.txt_first.SetValue(txt3)
 
+
 class DebugViewPanel(ScrolledPanel):
+    """
+    Displays information about the device view and provides coordinate conversion tools.
+
+    This panel shows device-specific information and allows users to convert between
+    workspace and device coordinates.
+    """
+
     def __init__(self, *args, context=None, **kwds):
         # begin wxGlade: PositionPanel.__init__
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
@@ -368,26 +381,40 @@ class DebugViewPanel(ScrolledPanel):
         self.context.themes.set_window_colors(self)
 
         sizer_main = wx.BoxSizer(wx.VERTICAL)
-        self.info_device = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY |wx.TE_MULTILINE)
+        self.info_device = wx.TextCtrl(
+            self, wx.ID_ANY, style=wx.TE_READONLY | wx.TE_MULTILINE
+        )
+        # Set teletype (monospace) font
+        mono_font = wx.Font(
+            10, wx.FONTFAMILY_TELETYPE, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL
+        )
+        self.info_device.SetFont(mono_font)
+
         sizer_main.Add(self.info_device, 1, wx.EXPAND, 0)
-        pos_sizer = StaticBoxSizer(self,wx.ID_ANY, _("Coordinates to Device"), wx.HORIZONTAL)
+        pos_sizer = StaticBoxSizer(
+            self, wx.ID_ANY, _("Coordinates to Device"), wx.HORIZONTAL
+        )
         self.text_x = wx.TextCtrl(self, wx.ID_ANY)
         self.text_y = wx.TextCtrl(self, wx.ID_ANY)
         self.check_vector = wx.CheckBox(self, wx.ID_ANY, "V")
+        self.check_vector.SetToolTip(_("Vector-mode: only transition"))
         self.button_test = wx.Button(self, wx.ID_ANY, _("Convert"))
-        self.info_position = wx.StaticText(self,wx.ID_ANY)
+        self.info_position = wx.StaticText(self, wx.ID_ANY)
         pos_sizer.Add(self.text_x, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         pos_sizer.Add(self.text_y, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         pos_sizer.Add(self.check_vector, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         pos_sizer.Add(self.button_test, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         pos_sizer.Add(self.info_position, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         sizer_main.Add(pos_sizer, 0, wx.EXPAND, 0)
-        ipos_sizer = StaticBoxSizer(self,wx.ID_ANY, _("Device to Coordinates"), wx.HORIZONTAL)
+        ipos_sizer = StaticBoxSizer(
+            self, wx.ID_ANY, _("Device to Coordinates"), wx.HORIZONTAL
+        )
         self.text_ix = wx.TextCtrl(self, wx.ID_ANY)
         self.text_iy = wx.TextCtrl(self, wx.ID_ANY)
         self.check_ivector = wx.CheckBox(self, wx.ID_ANY, "V")
+        self.check_ivector.SetToolTip(_("Vector-mode: only transition"))
         self.button_itest = wx.Button(self, wx.ID_ANY, _("Convert"))
-        self.info_iposition = wx.StaticText(self,wx.ID_ANY)
+        self.info_iposition = wx.StaticText(self, wx.ID_ANY)
         ipos_sizer.Add(self.text_ix, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         ipos_sizer.Add(self.text_iy, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         ipos_sizer.Add(self.check_ivector, 0, wx.ALIGN_CENTER_VERTICAL, 0)
@@ -399,7 +426,7 @@ class DebugViewPanel(ScrolledPanel):
         self.SetupScrolling()
         self.SetSizer(sizer_main)
         self.Layout()
-        
+
     def on_test_position(self, event):
         try:
             x = float(Length(self.text_x.GetValue()))
@@ -408,13 +435,14 @@ class DebugViewPanel(ScrolledPanel):
             self.info_position.SetLabel(_("Invalid length value"))
             return
         from meerk40t.core.view import View
-        dview : View = self.context.device.view
+
+        dview: View = self.context.device.view
         vector = bool(self.check_vector.GetValue())
-        mx, my  = dview.position(x, y, vector=vector)
+        mx, my = dview.position(x, y, vector=vector)
         self.info_position.SetLabel(f"x={mx:.2f}, y={my:.2f}")
         if event is not None:
-            self.text_ix.SetValue(str(mx)) 
-            self.text_iy.SetValue(str(my)) 
+            self.text_ix.SetValue(str(mx))
+            self.text_iy.SetValue(str(my))
 
     def on_test_iposition(self, event):
         try:
@@ -424,52 +452,72 @@ class DebugViewPanel(ScrolledPanel):
             self.info_iposition.SetLabel(_("Invalid length value"))
             return
         from meerk40t.core.view import View
-        dview : View = self.context.device.view
+
+        dview: View = self.context.device.view
         vector = bool(self.check_ivector.GetValue())
-        mx, my  = dview.iposition(x, y, vector=vector)
-        self.info_iposition.SetLabel(f"x={Length(mx).length_mm}, y={Length(my).length_mm}")
+        mx, my = dview.iposition(x, y, vector=vector)
+        self.info_iposition.SetLabel(
+            f"x={Length(mx).length_mm}, y={Length(my).length_mm}"
+        )
         if event is not None:
-            self.text_x.SetValue(Length(mx).length_mm) 
-            self.text_y.SetValue(Length(my).length_mm) 
-        
+            self.text_x.SetValue(Length(mx).length_mm)
+            self.text_y.SetValue(Length(my).length_mm)
+
     def refresh_info(self):
         def sc(coord):
             return f"({coord[0]:.1f}, {coord[1]:.1f})"
+
         def disp(source):
             top_left, top_right, bottom_right, bottom_left = source
             return f"TL: {sc(top_left)}, TR: {sc(top_right)}, BL: {sc(bottom_left)}, BR: {sc(bottom_right)}"
 
-
         from meerk40t.core.view import View
+
         infomsg = ""
         dev = self.context.device
-        dview : View = dev.view
-        infomsg = f"{infomsg}Device  : {dev.label}\n"
-        infomsg = f"{infomsg}Offset-X: {Length(dview.margin_x).length_mm}\n"
-        infomsg = f"{infomsg}Offset-Y: {Length(dview.margin_y).length_mm}\n"
-        
-        infomsg = f"{infomsg}Width   : {Length(dview.width).length_mm}\n"
-        infomsg = f"{infomsg}Height  : {Length(dview.height).length_mm}\n"
+        dview: View = dev.view
+        infomsg = f"{infomsg}Device     : {dev.label}\n"
+        infomsg = f"{infomsg}Offset-X   : {Length(dview.margin_x).length_mm}\n"
+        infomsg = f"{infomsg}Offset-Y   : {Length(dview.margin_y).length_mm}\n"
+
+        infomsg = f"{infomsg}Width      : {Length(dview.width).length_mm}\n"
+        infomsg = f"{infomsg}Height     : {Length(dview.height).length_mm}\n"
         if dview._source is not None:
             infomsg = f"{infomsg}Source     : {disp(dview._source)}\n"
         if dview._destination is not None:
             infomsg = f"{infomsg}Destination: {disp(dview._destination)}\n"
-            
-        # infomsg = f"{infomsg}Flipped : X:{'yes' if dview.flip_x else 'no'}, Y:{'yes' if dview.flip_y else 'no'}\n"
+            tl, tr, br, bl = dview._destination
+            if tl[0] > bl[0]:
+                infomsg = f"{infomsg}Flip-X : X-Axis appears flipped.\n"
+            if tl[1] > bl[1]:
+                infomsg = f"{infomsg}Flip-Y : Y-Axis appears flipped.\n"
+
+        def devinfo(attrib):
+            if hasattr(dev, attrib):
+                info = "yes" if getattr(dev, attrib) else "no"
+            else:
+                info = "undef"
+            return info
+
+        xflip = devinfo("flip_x")
+        yflip = devinfo("flip_y")
+        xyswap = devinfo("swap_xy")
+        infomsg = f"{infomsg}Device-Flip : X:{xflip}, Y:{yflip}, swap xy: {xyswap}\n"
         self.info_device.SetValue(infomsg)
-    
+
     @signal_listener("view;realized")
     @signal_listener("device;modified")
     def on_view_change(self, origin, *args):
         self.refresh_info()
         self.on_test_position(None)
-        
+
     def pane_show(self, *args):
         self.refresh_info()
 
     def pane_hide(self, *args):
         return
-    
+
+
 class DebugColorPanel(ScrolledPanel):
     """
     Displays system defined (OS and wxpython) colors to simplify identifying / choosing them
@@ -849,7 +897,7 @@ class DebugRasterPlotterPanel(wx.Panel):
             self, wx.ID_ANY, _("Raster Properties"), wx.VERTICAL
         )
         raster_type_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        raster_sizer.Add(raster_type_sizer, 0, wx.EXPAND, 0)    
+        raster_sizer.Add(raster_type_sizer, 0, wx.EXPAND, 0)
         self.raster_terms = [
             (RASTER_T2B, "Top To Bottom"),
             (RASTER_B2T, "Bottom To Top"),
@@ -949,7 +997,7 @@ class DebugRasterPlotterPanel(wx.Panel):
         for key, info in self.raster_terms:
             if raster_string == info:
                 raster_direction = key
-                break   
+                break
         if raster_direction < 0:
             self.text_result.SetValue("Invalid raster direction selected.")
             return
@@ -958,7 +1006,9 @@ class DebugRasterPlotterPanel(wx.Panel):
         # Notabene: a black pixel is a non-burnt one, so we invert the logic here
         image = Image.new("RGBA", (x, y), "white")
         image = image.convert("L")
-        plotter = RasterPlotter(image.load(), x, y, direction=raster_direction, bidirectional=bidir)  
+        plotter = RasterPlotter(
+            image.load(), x, y, direction=raster_direction, bidirectional=bidir
+        )
         t = time.time()
         i = 0
         res = []
@@ -1002,7 +1052,7 @@ class DebugRasterPlotterPanel(wx.Panel):
         for key, info in self.raster_terms:
             if raster_string == info:
                 raster_direction = key
-                break   
+                break
         if raster_direction < 0:
             self.text_result.SetValue("Invalid raster direction selected.")
             return
@@ -1011,8 +1061,10 @@ class DebugRasterPlotterPanel(wx.Panel):
         # Notabene: a black pixel is a non-burnt one, so we invert the logic here
         image = Image.new("RGBA", (x, y), "black")
         image = image.convert("L")
-        
-        plotter = RasterPlotter(image.load(), x, y, direction=raster_direction, bidirectional=bidir)   
+
+        plotter = RasterPlotter(
+            image.load(), x, y, direction=raster_direction, bidirectional=bidir
+        )
         t = time.time()
         i = 0
         res = []

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1089,6 +1089,7 @@ class wxMeerK40t(wx.App, Module):
                 register_panel_icon,
                 register_panel_plotter,
                 register_panel_window,
+                register_panel_view,
             )
 
             kernel.register("wxpane/debug_tree", register_panel_debugger)
@@ -1097,6 +1098,7 @@ class wxMeerK40t(wx.App, Module):
             kernel.register("wxpane/debug_shutdown", register_panel_crash)
             kernel.register("wxpane/debug_window", register_panel_window)
             kernel.register("wxpane/debug_plotter", register_panel_plotter)
+            kernel.register("wxpane/debug_view", register_panel_view)
 
             from meerk40t.gui.utilitywidgets.debugwidgets import register_widget_icon
 

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -1,0 +1,182 @@
+import unittest
+from meerk40t.core.view import View
+from meerk40t.core.units import UNITS_PER_INCH, MM_PER_INCH, Length
+from meerk40t.svgelements import Matrix, Point
+
+
+class TestView(unittest.TestCase):
+    def test_init_and_properties(self):
+        # Arrange
+
+        # Act
+        v = View(100, 200, 96)
+        # Assert
+        self.assertEqual(v.width, 100)
+        self.assertEqual(v.height, 200)
+        self.assertIsNotNone(v._source)
+        self.assertIsNotNone(v._destination)
+        self.assertTrue(isinstance(str(v), str))
+        self.assertGreater(v.native_scale_x, 0)
+        self.assertGreater(v.native_scale_y, 0)
+        self.assertGreater(v.mm, 0)
+
+    def test_set_native_scale_and_set_dims_and_set_margins(self):
+        # Arrange
+        v = View(100, 200)
+        # Act
+        v.set_native_scale(2, 4)
+        v.set_dims(300, 400)
+        v.set_margins(10, 20)
+        # Assert
+        self.assertEqual(v.dpi_x, UNITS_PER_INCH / 2)
+        self.assertEqual(v.dpi_y, UNITS_PER_INCH / 4)
+        self.assertEqual(v.width, 300)
+        self.assertEqual(v.height, 400)
+        self.assertEqual(v.margin_x, 10)
+        self.assertEqual(v.margin_y, 20)
+
+    def test_reset_and_scale_and_origin_and_flip_and_swap(self):
+        # Arrange
+        v = View(100, 200)
+        # Act
+        v.reset()
+        v.scale(2, 0.5)
+        v.origin(0.1, 0.2)
+        v.flip_x()
+        v.flip_y()
+        v.swap_xy()
+        v.rotate_ccw()
+        v.rotate_cw()
+        # Assert
+        self.assertIsNotNone(v._destination)
+        self.assertEqual(len(v._destination), 4)
+
+    def test_destination_contains_and_source_contains(self):
+        # Arrange
+        v = View(100, 200)
+        # Act & Assert
+        self.assertTrue(v.destination_contains(50, 100))
+        self.assertTrue(v.destination_contains(0, 0))
+        self.assertFalse(v.destination_contains(200, 400))
+        self.assertTrue(v.source_contains(50, 100))
+        self.assertTrue(v.source_contains(0, 0))
+        self.assertFalse(v.source_contains(200, 400))
+
+    def test_destination_bbox_and_source_bbox(self):
+        # Arrange
+        v = View(100, 200)
+        # Act
+        dbbox = v.destination_bbox()
+        sbbox = v.source_bbox()
+        # Assert
+        self.assertEqual(dbbox, (0, 0, 100, 200))
+        self.assertEqual(sbbox, (0, 0, 100, 200))
+
+    def test_transform_all_options(self):
+        # Arrange
+        v = View(100, 200)
+        # Act
+        v.transform(
+            user_scale_x=2.0,
+            user_scale_y=0.5,
+            flip_x=True,
+            flip_y=True,
+            swap_xy=True,
+            origin_x=0.1,
+            origin_y=0.2,
+        )
+        # Assert
+        self.assertIsNotNone(v._destination)
+
+    def test_position_and_iposition_and_scene_position(self):
+        # Arrange
+        v = View(100, 200)
+        v.set_margins(5, 10)
+        # Act
+        pos = v.position(10, 20)
+        self.assertEqual(pos, (15, 30))
+        pos_vec = v.position(10, 20, vector=True)
+        pos_nomargin = v.position(10, 20, margins=False)
+        scene = v.scene_position("30", "40")
+        ipos = v.iposition(15, 30)
+        self.assertEqual(ipos, (10, 20))
+        ipos_vec = v.iposition(10, 20, vector=True)
+        # Assert
+        self.assertIsInstance(pos, (Point, tuple, list))
+        self.assertIsInstance(pos_vec, (Point, tuple, list))
+        self.assertIsInstance(pos_nomargin, (Point, tuple, list))
+        self.assertEqual(scene, (30, 40))
+        self.assertIsInstance(ipos, (Point, tuple, list))
+        self.assertIsInstance(ipos_vec, (Point, tuple, list))
+
+    def test_position_invalid_margins(self):
+        # Arrange
+        v = View(100, 200)
+        v.margin_x = "notanumber"
+        v.margin_y = 10
+        # Act
+        pos = v.position(10, 20)
+        # Assert
+        self.assertIsInstance(pos, (Point, tuple, list))
+
+        # Arrange
+        v.margin_x = 5
+        v.margin_y = "notanumber"
+        # Act
+        pos = v.position(10, 20)
+        # Assert
+        self.assertIsInstance(pos, (Point, tuple, list))
+
+    def test_iposition_invalid_margins(self):
+        # Arrange
+        v = View(100, 200)
+        v.margin_x = "notanumber"
+        v.margin_y = 10
+        # Act
+        ipos = v.iposition(10, 20)
+        # Assert
+        self.assertIsInstance(ipos, (Point, tuple, list))
+
+        # Arrange
+        v.margin_x = 5
+        v.margin_y = "notanumber"
+        # Act
+        ipos = v.iposition(10, 20)
+        # Assert
+        self.assertIsInstance(ipos, (Point, tuple, list))
+
+    def test_matrix_property_and_lazy_init(self):
+        # Arrange
+        v = View(100, 200)
+        v._matrix = None
+        # Act
+        m = v.matrix
+        # Assert
+        self.assertIsInstance(m, Matrix)
+
+    def test_get_sensible_dpi_values_and_dpi_to_steps(self):
+        # Arrange
+        v = View(100, 200)
+        # Act
+        dpis = v.get_sensible_dpi_values()
+        step_x, step_y = v.dpi_to_steps(100)
+        # Assert
+        self.assertIsInstance(dpis, list)
+        for d in dpis:
+            self.assertIsInstance(d, int)
+        self.assertIsInstance(step_x, float)
+        self.assertIsInstance(step_y, float)
+
+    def test_unit_width_and_unit_height(self):
+        # Arrange
+        v = View("100mm", "200mm")
+        # Act
+        uw = v.unit_width
+        uh = v.unit_height
+        # Assert
+        self.assertEqual(uw, float(Length("100mm")))
+        self.assertEqual(uh, float(Length("200mm")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary by Sourcery

Add a new Debug View panel to inspect and convert between workspace and device coordinates, simplify margin offset logic in the core view code, and bolster coverage with View class unit tests.

New Features:
- Add a DebugViewPanel with coordinate conversion tools for device view debugging in the GUI
- Add register_panel_view to integrate the new DebugViewPanel into the AUI pane system

Bug Fixes:
- Fix minor whitespace and formatting issues in raster testing routines

Enhancements:
- Refactor View.position and View.iposition to handle margins inline and remove the private _get_offset method
- Automatically refresh the DebugViewPanel on view realization and device modification signals

Tests:
- Add comprehensive unit tests for the View class covering initialization, transformations, margin handling, and invalid inputs