### PR TITLE
Remove user offset for now

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -212,6 +212,7 @@ class BalorDevice(Service, Status):
                 "section": "_10_Parameters",
                 # _("User Offset")
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "user_margin_y",
@@ -224,6 +225,7 @@ class BalorDevice(Service, Status):
                 ),
                 "section": "_10_Parameters",
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "interp",

--- a/meerk40t/core/view.py
+++ b/meerk40t/core/view.py
@@ -3,6 +3,9 @@ from meerk40t.svgelements import Matrix
 
 
 class View:
+    
+    MARGIN_NONWORKING = True
+
     def __init__(
         self,
         width,
@@ -82,6 +85,10 @@ class View:
         self.reset()
 
     def set_margins(self, offset_x, offset_y):
+        # Not working yet, so disable
+        if self.MARGIN_NONWORKING:
+            offset_x = 0
+            offset_y = 0
         self.margin_x = offset_x
         self.margin_y = offset_y
         # print (f"Margins were set to {offset_x}, {offset_y}")
@@ -275,6 +282,8 @@ class View:
     def calc_margins(self, vector=False, margins=True):
         off_x = 0.0
         off_y = 0.0
+        if self.MARGIN_NONWORKING:
+            return 0.0, 0.0
         if vector or not margins:
             return 0.0, 0.0
         try:

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -118,6 +118,7 @@ class GRBLDevice(Service, Status):
                     "Margin for the X-axis. This will be a kind of unused space at the left side."
                 ),
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "user_margin_y",
@@ -129,6 +130,7 @@ class GRBLDevice(Service, Status):
                     "Margin for the Y-axis. This will be a kind of unused space at the top."
                 ),
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "flip_x",

--- a/meerk40t/gui/choicepropertypanel.py
+++ b/meerk40t/gui/choicepropertypanel.py
@@ -91,6 +91,7 @@ class ChoicePropertyPanel(ScrolledPanel):
             developer-mode has been set
         "enabled": Is the control enabled (default yes, so does not need to be
             provided)
+        "ignored": As the name implies...
         "conditional": if given as tuple (cond_obj, cond_prop) then the (boolean)
             value of the property cond_obj.cond_prop will decide if the element
             will be enabled or not. (If a third value then the value must equal that value).
@@ -693,6 +694,12 @@ class ChoicePropertyPanel(ScrolledPanel):
                 weight = 0
             developer_mode = self.context.root.setting(bool, "developer_mode", False)
             if not developer_mode and hidden:
+                continue
+            ignore = c.get("ignore", False)
+            ignore = (
+                bool(ignore) if ignore != "False" else False
+            )  # bool("False") = True
+            if ignore:
                 continue
             # get default value
             if hasattr(obj, attr):

--- a/meerk40t/lihuiyu/device.py
+++ b/meerk40t/lihuiyu/device.py
@@ -113,6 +113,7 @@ class LihuiyuDevice(Service, Status):
                 "section": "_30_" + _("Laser Parameters"),
                 # _("User Offset")
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "user_margin_y",
@@ -125,6 +126,7 @@ class LihuiyuDevice(Service, Status):
                 ),
                 "section": "_30_" + _("Laser Parameters"),
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
         ]
         self.register_choices("bed_dim", choices)

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -120,6 +120,7 @@ class RuidaDevice(Service):
                 # _("User Offset")
                 "section": "_10_" + _("Configuration"),
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "user_margin_y",
@@ -132,6 +133,7 @@ class RuidaDevice(Service):
                 ),
                 "section": "_10_" + _("Configuration"),
                 "subsection": "_30_User Offset",
+                "ignore": True, # Does not work yet, so don't show
             },
             {
                 "attr": "flip_x",

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -26,14 +26,16 @@ class TestView(unittest.TestCase):
         # Act
         v.set_native_scale(2, 4)
         v.set_dims(300, 400)
-        v.set_margins(10, 20)
+        if not getattr(v, "MARGIN_NONWORKING", False):
+            v.set_margins(10, 20)
         # Assert
         self.assertEqual(v.dpi_x, UNITS_PER_INCH / 2)
         self.assertEqual(v.dpi_y, UNITS_PER_INCH / 4)
         self.assertEqual(v.width, 300)
         self.assertEqual(v.height, 400)
-        self.assertEqual(v.margin_x, 10)
-        self.assertEqual(v.margin_y, 20)
+        if not getattr(v, "MARGIN_NONWORKING", False):
+            self.assertEqual(v.margin_x, 10)
+            self.assertEqual(v.margin_y, 20)
 
     def test_reset_and_scale_and_origin_and_flip_and_swap(self):
         # Arrange
@@ -102,6 +104,9 @@ class TestView(unittest.TestCase):
         SX = 2
         SY = 3
         v = View(100, 200, native_scale_x=SX, native_scale_y=SY)
+        if getattr(v, "MARGIN_NONWORKING", False):
+            MX = 0
+            MY = 0
         v.set_margins(MX, MY)
         v.realize()
         # Act


### PR DESCRIPTION
The approach cannot be done with this simplistic approach, either the plotplanner that creates the cutcode need to become driver aware or each and every driver needs to adjusted....
So disable and hide from view for now.

## Summary by Sourcery

Temporarily disable the user offset (margin) feature by zeroing out margin values and hiding related controls across the core view, GUI, and device drivers, and adjust tests to conditionally skip margin behavior when disabled

Enhancements:
- Introduce a MARGIN_NONWORKING flag in View to force margins to zero and bypass margin calculations

Tests:
- Update view tests to skip margin setting and assertions when MARGIN_NONWORKING is enabled

Chores:
- Add an “ignore” property in ChoicePropertyPanel to filter out hidden controls
- Mark user_margin_x and user_margin_y settings as ignored in balormk, grbl, lihuiyu, and ruida device drivers