### PR TITLE
Add secondary unit display for element selection box

### DIFF
--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -13,7 +13,6 @@ LockWidget: Widget to lock and unlock the given object.
 
 """
 
-
 import math
 
 import numpy as np
@@ -211,7 +210,12 @@ class BorderWidget(Widget):
             self.master.bottom,
         )
         self.update()
-        coord_display_mode = self.scene.context.root.setting(int, "coord_display", 0)
+        context = self.scene.context
+        # Make sure we have the correct display unit
+        display_unit = context.setting(str, "_display_unit", context.units_name)
+        if display_unit is None or display_unit == "":
+            context._display_unit = context.units_name
+        coord_display_mode = context.root.setting(int, "coord_display", 0)
         # 0 = all, 1 = to mk 0,0 only, 2=suppress
         self.show_lt = coord_display_mode in (0, 1)
         self.show_rb = coord_display_mode == 0
@@ -291,7 +295,9 @@ class BorderWidget(Widget):
 
             # print ("Inner Drawmode=%d (logic=%s)" % ( draw_mode ,(draw_mode & DRAW_MODE_SELECTION) ))
             # if draw_mode & DRAW_MODE_SELECTION == 0:
-            units = context.units_name
+            units = (
+                context._display_unit if context._display_unit else context.units_name
+            )
             try:
                 font = wx.Font(
                     self.master.font_size,
@@ -309,7 +315,14 @@ class BorderWidget(Widget):
             gc.SetFont(font, self.scene.colors.color_manipulation)
             if self.show_lt:
                 # Show Y-Value
-                s_txt = str(Length(amount=self.top, digits=2, preferred_units=units))
+                s_txt = str(
+                    Length(
+                        amount=self.top,
+                        digits=2,
+                        preferred_units=units,
+                        relative_length=self.scene.context.device.view.height,
+                    )
+                )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 distance = (
                     0.25 * t_height
@@ -320,7 +333,14 @@ class BorderWidget(Widget):
                 gc.DrawText(s_txt, center_x - t_width / 2, pos)
 
                 # Display X-Coordinate from left
-                s_txt = str(Length(amount=self.left, digits=2, preferred_units=units))
+                s_txt = str(
+                    Length(
+                        amount=self.left,
+                        digits=2,
+                        preferred_units=units,
+                        relative_length=self.scene.context.device.view.width,
+                    )
+                )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 pos = self.left / 2.0 - t_width / 2
                 if pos + t_width + distance >= self.left:
@@ -328,7 +348,14 @@ class BorderWidget(Widget):
                 gc.DrawText(s_txt, pos, center_y)
             if self.show_rb:
                 rpos = bed_h - self.bottom
-                s_txt = str(Length(amount=rpos, digits=2, preferred_units=units))
+                s_txt = str(
+                    Length(
+                        amount=rpos,
+                        digits=2,
+                        preferred_units=units,
+                        relative_length=self.scene.context.device.view.height,
+                    )
+                )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 distance = 1.5 * t_height  # There's text in the way
                 pos = self.bottom + rpos / 2 - t_height / 2
@@ -338,7 +365,14 @@ class BorderWidget(Widget):
 
                 # Display X-Coordinate from right
                 rpos = bed_w - self.right
-                s_txt = str(Length(amount=rpos, digits=2, preferred_units=units))
+                s_txt = str(
+                    Length(
+                        amount=rpos,
+                        digits=2,
+                        preferred_units=units,
+                        relative_length=self.scene.context.device.view.width,
+                    )
+                )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 pos = self.right + rpos / 2.0 - t_width / 2
                 if pos - distance <= self.right:
@@ -347,7 +381,12 @@ class BorderWidget(Widget):
 
             # Display height
             s_txt = str(
-                Length(amount=(self.bottom - self.top), digits=2, preferred_units=units)
+                Length(
+                    amount=(self.bottom - self.top),
+                    digits=2,
+                    preferred_units=units,
+                    relative_length=self.scene.context.device.view.height,
+                )
             )
             (t_width, t_height) = gc.GetTextExtent(s_txt)
             gc.DrawText(
@@ -359,7 +398,12 @@ class BorderWidget(Widget):
 
             # Display width
             s_txt = str(
-                Length(amount=(self.right - self.left), digits=2, preferred_units=units)
+                Length(
+                    amount=(self.right - self.left),
+                    digits=2,
+                    preferred_units=units,
+                    relative_length=self.scene.context.device.view.width,
+                )
             )
             (t_width, t_height) = gc.GetTextExtent(s_txt)
             gc.DrawText(s_txt, center_x - 0.5 * t_width, self.bottom + 0.5 * t_height)

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -298,6 +298,7 @@ class BorderWidget(Widget):
             units = (
                 context._display_unit if context._display_unit else context.units_name
             )
+            secondary_units = context.units_name
             try:
                 font = wx.Font(
                     self.master.font_size,
@@ -323,6 +324,15 @@ class BorderWidget(Widget):
                         relative_length=self.scene.context.device.view.height,
                     )
                 )
+                if units != secondary_units:
+                    s_txt += "/" + str(
+                        Length(
+                            amount=self.top,
+                            digits=2,
+                            preferred_units=secondary_units,
+                            relative_length=self.scene.context.device.view.height,
+                        )
+                    )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 distance = (
                     0.25 * t_height
@@ -341,6 +351,15 @@ class BorderWidget(Widget):
                         relative_length=self.scene.context.device.view.width,
                     )
                 )
+                if units != secondary_units:
+                    s_txt += "/" + str(
+                        Length(
+                            amount=self.left,
+                            digits=2,
+                            preferred_units=secondary_units,
+                            relative_length=self.scene.context.device.view.width,
+                        )
+                    )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 pos = self.left / 2.0 - t_width / 2
                 if pos + t_width + distance >= self.left:
@@ -356,6 +375,15 @@ class BorderWidget(Widget):
                         relative_length=self.scene.context.device.view.height,
                     )
                 )
+                if units != secondary_units:
+                    s_txt += "/" + str(
+                        Length(
+                            amount=rpos,
+                            digits=2,
+                            preferred_units=secondary_units,
+                            relative_length=self.scene.context.device.view.height,
+                        )
+                    )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 distance = 1.5 * t_height  # There's text in the way
                 pos = self.bottom + rpos / 2 - t_height / 2
@@ -373,6 +401,15 @@ class BorderWidget(Widget):
                         relative_length=self.scene.context.device.view.width,
                     )
                 )
+                if units != secondary_units:
+                    s_txt += "/" + str(
+                        Length(
+                            amount=rpos,
+                            digits=2,
+                            preferred_units=secondary_units,
+                            relative_length=self.scene.context.device.view.width,
+                        )
+                    )
                 (t_width, t_height) = gc.GetTextExtent(s_txt)
                 pos = self.right + rpos / 2.0 - t_width / 2
                 if pos - distance <= self.right:
@@ -388,6 +425,15 @@ class BorderWidget(Widget):
                     relative_length=self.scene.context.device.view.height,
                 )
             )
+            if units != secondary_units:
+                s_txt += "/" + str(
+                    Length(
+                        amount=(self.bottom - self.top),
+                        digits=2,
+                        preferred_units=secondary_units,
+                        relative_length=self.scene.context.device.view.height,
+                    )
+                )
             (t_width, t_height) = gc.GetTextExtent(s_txt)
             gc.DrawText(
                 s_txt,
@@ -405,6 +451,15 @@ class BorderWidget(Widget):
                     relative_length=self.scene.context.device.view.width,
                 )
             )
+            if units != secondary_units:
+                s_txt += "/" + str(
+                    Length(
+                        amount=(self.right - self.left),
+                        digits=2,
+                        preferred_units=secondary_units,
+                        relative_length=self.scene.context.device.view.width,
+                    )
+                )   
             (t_width, t_height) = gc.GetTextExtent(s_txt)
             gc.DrawText(s_txt, center_x - 0.5 * t_width, self.bottom + 0.5 * t_height)
         # But show the angle

--- a/meerk40t/gui/statusbarwidgets/shapepropwidget.py
+++ b/meerk40t/gui/statusbarwidgets/shapepropwidget.py
@@ -458,7 +458,10 @@ class PositionWidget(StatusBarWidget):
             self.unit_index = 0
         if self.unit_index < 0:
             self.unit_index = len(self.units) - 1
-        self.unit_lbl.SetLabel(self.units[self.unit_index])
+        new_unit = self.units[self.unit_index]
+        self.unit_lbl.SetLabel(new_unit)
+        self.context._display_unit = new_unit
+        self.context.signal("refresh_scene", "Scene")
         self.update_position(True)
 
     def on_click_units_l(self, event):


### PR DESCRIPTION

![second_unit](https://github.com/user-attachments/assets/f389d046-2bf9-4773-b07b-31e464a31013)

## Summary by Sourcery

Add dual‐unit support for selection box measurements, allow users to switch and persist display units on the shape properties widget, refactor the drawing flow for clarity, and correct the rotation tool’s scaling fallback.

New Features:
- Show primary and secondary units concurrently in the selection border labels
- Persist the chosen display unit and refresh the scene when the unit selector is clicked

Bug Fixes:
- Fix zero‐division fallback in rotation tool by assigning the correct scale variable

Enhancements:
- Refactor selection widget drawing logic and factor out unit text measurement
- Restructure angle and border rendering order in the selection widget