### PR TITLE
Drag: Align laserposition to selection even on selection drag

### DIFF
--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -904,9 +904,6 @@ class Drag(wx.Panel):
 
     def align_per_pos(self, value):
         bbox = self.get_bbox()
-        print(
-            f"Aligning to position {value} with bbox {'---' if bbox is None else bbox}"
-        )
         if bbox is None:
             return
         if value == 1:


### PR DESCRIPTION
When locked drag is active (right click on one of the directional icons in the middle panel) then the selection and the laser head position will be synced:
- (already in place) moving the laser head will align the selection to the physical laser head position
- (new) when dragging the selection around then the physical laser head position will be synced to the scene position after the drag operation has finished
![dragging](https://github.com/user-attachments/assets/72300a31-da2d-4388-9902-5cd2eeccd788)

## Summary by Sourcery

Realign the laser position when selection is dragged by listening for selection modification events and invoking the existing alignment logic

Enhancements:
- Register and unregister an on_modified handler to listen for 'modified_by_tool' events in the navigation pane
- Invoke align_per_pos in on_modified to maintain laser alignment during selection drags