### PR TITLE
Add option to abort program during gui interrupt message

### DIFF
--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -418,13 +418,11 @@ and a wxpython version <= 4.1.1."""
             lock.acquire(True)
 
             def message_dialog(*args):
+                msg_continue = _("Press OK to Continue.")
+                msg_abort = _("Press Cancel to abort the Program.")
                 dlg = wx.MessageDialog(
                     None,
-                    message
-                    + "\n\n"
-                    + _("Press OK to Continue.")
-                    + "\n"
-                    + _("Press Cancel to abort the Program."),
+                    f"{message}\n\n{msg_continue}\n{msg_abort}",
                     _("Interrupt"),
                     wx.OK | wx.CANCEL | wx.ICON_INFORMATION,
                 )


### PR DESCRIPTION
## Summary by Sourcery

Add an option to abort the application from the GUI interrupt dialog and clean up code formatting throughout the plugin module.

New Features:
- Allow users to cancel the interrupt dialog to trigger an emergency stop (estop) of the program.

Enhancements:
- Include an information icon in the interrupt dialog and update its layout for clarity.
- Standardize multi-line string formatting and reorder imports for consistency in plugin.py