### PR TITLE
add multi-plan management and background task tracking

### DIFF
--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -268,7 +268,7 @@ DEFAULT_ALIAS = {
     "+up": (".timerup 0 0.1 up 1mm",),
     "+down": (".timerdown 0 0.1 down 1mm",),
     "burn": ("planz clear copy preprocess validate blob preopt optimize spool",),
-    "simulate": ("planz clear copy preprocess validate blob preopt optimize\nwindow open Simulation",),
+    "simulate": ("planz clear copy preprocess validate blob preopt optimize finish\nwindow open Simulation",),
     "-scale_up": (".timerscale_up off",),
     "-scale_down": (".timerscale_down off",),
     "-rotate_cw": (".timerrotate_cw off",),

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1405,8 +1405,9 @@ def init_tree(kernel):
     )
     def compile_and_simulate(node, **kwargs):
         self.set_node_emphasis(node, True)
-        self("plan0 copy-selected preprocess validate blob preopt optimize\n")
-        self("window open Simulation 0 1 1\n")  # Plan Name, Auto-Clear, Optimise
+        last_plan, new_plan = self.kernel.planner.get_free_plan()
+        self(f"plan{new_plan} copy-selected preprocess validate blob preopt optimize\n")
+        self(f"window open Simulation {new_plan} 1 1\n")  # Plan Name, Auto-Clear, Optimise
 
     # ==========
     # General menu-entries for operation branch

--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1406,7 +1406,7 @@ def init_tree(kernel):
     def compile_and_simulate(node, **kwargs):
         self.set_node_emphasis(node, True)
         last_plan, new_plan = self.kernel.planner.get_free_plan()
-        self(f"plan{new_plan} copy-selected preprocess validate blob preopt optimize\n")
+        self(f"plan{new_plan} copy-selected preprocess validate blob preopt optimize finish\n")
         self(f"window open Simulation {new_plan} 1 1\n")  # Plan Name, Auto-Clear, Optimise
 
     # ==========

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -974,6 +974,14 @@ class Planner(Service):
     def finish_plan(self, plan_name):
         self.update_stage(plan_name, STAGE_PLAN_FINISHED)
 
+    def has_content(self, plan_name):
+        """
+        Checks if the specified plan has any content.
+        """
+        if plan_name not in self._plan:
+            return False
+        return len(self._plan[plan_name].plan) > 0
+
     def get_free_plan(self):
         """
         Finds and returns a unique plan name not currently in use.

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -443,8 +443,9 @@ class Planner(Service):
         try:
             return self._plan[plan_name]
         except KeyError:
-            self._plan[plan_name] = CutPlan(plan_name, self)
-            self._states[plan_name] = STAGE_PLAN_INIT
+            with self._plan_lock:
+                self._plan[plan_name] = CutPlan(plan_name, self)
+                self._states[plan_name] = STAGE_PLAN_INIT
             return self._plan[plan_name]
 
     @property
@@ -1011,7 +1012,8 @@ class Planner(Service):
             self.console(f"Couldn't update plan {plan_name}: not found")
             return
         if not noset:
-            self._states[plan_name] = stage
+            with self._plan_lock:
+                self._states[plan_name] = stage
         self.signal("plan", plan_name, stage)
 
     def get_plan_stage(self, plan_name):

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -501,8 +501,11 @@ class Planner(Service):
             if remainder is None:
                 channel(_("----------"))
                 channel(_("Plan:") + self._default_plan)
-                for i, plan_name in enumerate(cutplan.name):
-                    channel(f"{i + 1}: {plan_name}")
+                if isinstance(cutplan.name, str):
+                    channel(f"{1}: {cutplan.name}")
+                else:
+                    for i, plan_name in enumerate(cutplan.name):
+                        channel(f"{i + 1}: {plan_name}")
                 channel(_("----------"))
                 channel(_("Plan {plan}:").format(plan=self._default_plan))
                 for i, op_name in enumerate(cutplan.plan):

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -866,6 +866,17 @@ class Planner(Service):
             return data_type, data
 
         @self.console_command(
+            "finish",
+            help=_("plan<?> finish"),
+            input_type="plan",
+            output_type="plan",
+        )
+        def plan_finish(data_type=None, data=None, **kwgs):
+            # Update Info-panel if displayed
+            self.update_stage(data.name, STAGE_PLAN_FINISHED)
+            return data_type, data
+
+        @self.console_command(
             "return",
             help=_("plan<?> return"),
             input_type="plan",

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -50,7 +50,7 @@ def plugin(kernel, lifecycle):
                     data.plan, loops=loops, label=label, outline=data.outline
                 )
                 channel(_("Spooled Plan."))
-                kernel.root.signal("plan", data.name, 6)
+                kernel.planner.finish_plan(data.name)
 
             if remainder is None:
                 channel(_("----------"))

--- a/meerk40t/gui/busy.py
+++ b/meerk40t/gui/busy.py
@@ -208,20 +208,7 @@ class BusyInfo():
 
     def update_message(self, **kwds):
         if self.kernel is not None:
+            thread_name = getattr(self.kernel.thread_local, "thread_name", "")
             message = kwds.get("msg", "")
-            # We need to update the message for the active job, 
-            # unfortunately the context is not easily established
-            # job_name = self.kernel.active_job
-            # if job_name.startswith("threaded") and job_name in self.kernel.jobs:
-            #     self.kernel.jobs[job_name].message = message
-
-    def debug_busy(self, info:str):
-        import inspect
-        tname = threading.current_thread().name
-        state = "" if self.kernel is None else self.kernel.active_job
-        print(f"Debug busy: {info}, state: {state}, thread: {tname}")
-        for idx, s in enumerate(inspect.stack()):
-            print (f"  Caller {idx}: {s}")
-        # caller = inspect.stack()[1]
-        # for prop in caller.__dict__:
-        #     print(f"  {prop}: {caller.__dict__[prop]}")
+            self.kernel.set_thread_message(thread_name, message)
+            self.kernel.signal("thread_update", "/", thread_name, message)

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -871,8 +871,11 @@ class JobPanel(wx.Panel):
         has_content = False
         if can_update:
             plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
-            plan = self.context.planner._plan[plan_name]
-            has_content = len(plan.plan) != 0
+            try:
+                plan = self.context.planner._plan[plan_name]
+                has_content = len(plan.plan) != 0
+            except KeyError:
+                can_update = False
         can_export = has_content and hasattr(self.context.device, "extension")
         self.btn_update.Enable(can_update)
         self.btn_export.Enable(can_export)

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -152,6 +152,8 @@ class LaserPanel(wx.Panel):
         self.context.themes.set_window_colors(self)
         self.SetHelpText("laserpanel")
         self.context.root.setting(bool, "laserpane_arm", True)
+        self.context.setting(bool, "laserpane_hold", False)
+        self.context.setting(str, "laserpane_plan", "z")
 
         sizer_main = wx.BoxSizer(wx.VERTICAL)
         self.icon_size = 0.5 * get_default_icon_size(self.context)
@@ -705,15 +707,16 @@ class LaserPanel(wx.Panel):
 
         busy = self.context.kernel.busyinfo
         busy.start(msg=_("Preparing Laserjob..."))
-        last_plan, new_plan = self.context.planner.get_free_plan()
-        self.context.setting(bool, "laserpane_hold", False)
-        if last_plan is not None and self.context.laserpane_hold:
+        last_plan = self.context.laserpane_plan
+        if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             self.context(f"plan{last_plan} spool\n")
         elif self.checkbox_optimize.GetValue():
+            last_plan, new_plan = self.context.planner.get_free_plan()
             self.context(
                 f"threaded plan{new_plan} clear copy preprocess validate blob preopt optimize spool\nwindow open ThreadInfo\n"
             )
         else:
+            last_plan, new_plan = self.context.planner.get_free_plan()
             self.context(f"plan{new_plan} clear copy preprocess validate blob spool\n")
         self.armed = False
         self.check_laser_arm()
@@ -741,9 +744,11 @@ class LaserPanel(wx.Panel):
         self.context.kernel.busyinfo.start(msg=_("Preparing simulation..."))
         last_plan, new_plan = self.context.planner.get_free_plan()
         param = "0"
-        if last_plan is not None and self.context.laserpane_hold:
+        last_plan = self.context.laserpane_plan
+        if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             plan = last_plan
         else:
+            last_plan, new_plan = self.context.planner.get_free_plan()
             plan = new_plan
             if self.checkbox_optimize.GetValue():
                 self.context(
@@ -775,8 +780,8 @@ class LaserPanel(wx.Panel):
     def on_config_button(self, event):
         self.context.device("window toggle Configuration\n")
 
-class JobPanel(wx.Panel):
 
+class JobPanel(wx.Panel):
     def __init__(self, *args, context=None, **kwds):
         # begin wxGlade: MovePanel.__init__
         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
@@ -792,21 +797,47 @@ class JobPanel(wx.Panel):
         )
         self.list_plan.SetToolTip(_("List of prepared cutplans"))
         self.list_plan.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=48)
-        self.list_plan.AppendColumn(
-            _("Plan"), format=wx.LIST_FORMAT_LEFT, width=113
-        )
-        self.list_plan.AppendColumn(
-            _("Status"), format=wx.LIST_FORMAT_LEFT, width=73
-        )
-        self.list_plan.AppendColumn(
-            _("Content"), format=wx.LIST_FORMAT_LEFT, width=73
-        )
+        self.list_plan.AppendColumn(_("Plan"), format=wx.LIST_FORMAT_LEFT, width=113)
+        self.list_plan.AppendColumn(_("Status"), format=wx.LIST_FORMAT_LEFT, width=73)
+        self.list_plan.AppendColumn(_("Content"), format=wx.LIST_FORMAT_LEFT, width=73)
         self.list_plan.resize_columns()
+        # self.btn_clear = wx.Button(self, wx.ID_ANY, _("Clear"))
+        # self.btn_clear.SetToolTip(_("Clear selected plan"))
+        self.btn_update = wx.Button(self, wx.ID_ANY, _("Update"))
+        self.btn_update.SetToolTip(_("Update selected plan"))
+        self.btn_export = wx.Button(self, wx.ID_ANY, _("Export"))
+        self.btn_export.SetToolTip(_("Export selected plan"))
+        self.btn_spool = wx.Button(self, wx.ID_ANY, _("Spool"))
+        self.btn_spool.SetToolTip(_("Spool selected plan"))
+        self.context.setting(bool, "laserpane_hold", False)
+        self.context.setting(str, "laserpane_plan", "z")
+        self.checkbox_hold = wxCheckBox(self, wx.ID_ANY, _("Hold"))
+        self.checkbox_hold.SetToolTip(
+            _("Preserve the job between running, rerunning, and execution")
+        )
+        self.checkbox_hold.SetValue(self.context.laserpane_hold)
         sizer_main = wx.BoxSizer(wx.VERTICAL)
         sizer_main.Add(self.list_plan, 1, wx.EXPAND, 0)
+        hsizer_buttons = wx.BoxSizer(wx.HORIZONTAL)
+        # hsizer.Add(self.btn_clear, 0, wx.EXPAND, 0)
+        hsizer_buttons.Add(self.btn_update, 0, wx.EXPAND, 0)
+        hsizer_buttons.Add(self.btn_export, 0, wx.EXPAND, 0)
+        hsizer_buttons.Add(self.btn_spool, 0, wx.EXPAND, 0)
+        hsizer_controls = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer_controls.Add(self.checkbox_hold, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        sizer_main.Add(hsizer_buttons, 0, wx.EXPAND, 0)
+        sizer_main.Add(hsizer_controls, 0, wx.EXPAND, 0)
         self.SetSizer(sizer_main)
         self.Layout()
         self.shown = False
+        self.list_plan.Bind(wx.EVT_RIGHT_DOWN, self.on_right_click)
+        self.list_plan.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_selection)
+        # self.btn_clear.Bind(wx.EVT_BUTTON, self.on_clear_plan)
+        self.btn_update.Bind(wx.EVT_BUTTON, self.on_update_plan)
+        self.btn_export.Bind(wx.EVT_BUTTON, self.on_export_plan)
+        self.btn_spool.Bind(wx.EVT_BUTTON, self.on_spool_plan)
+        self.checkbox_hold.Bind(wx.EVT_CHECKBOX, self.on_hold)
+        self.on_selection(None)
 
     def refresh_plan_list(self):
         self.list_plan.DeleteAllItems()
@@ -825,84 +856,56 @@ class JobPanel(wx.Panel):
         if self.shown:
             self.refresh_plan_list()
 
-    def pane_show(self):
-        self.shown = True
-        self.list_plan.load_column_widths()
-        self.refresh_plan_list()
+    def on_selection(self, event):
+        can_update = self.list_plan.GetFirstSelected() != -1
+        has_content = False
+        if can_update:
+            plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
+            plan = self.context.planner._plan[plan_name]
+            has_content = len(plan.plan) != 0
+        can_export = has_content and hasattr(self.context.device, "extension")
+        self.btn_update.Enable(can_update)
+        self.btn_export.Enable(can_export)
+        self.btn_spool.Enable(has_content)
 
-    def pane_hide(self):
-        self.shown = False
-        self.list_plan.save_column_widths()
+    def on_spool_plan(self, event):
+        if self.list_plan.GetFirstSelected() == -1:
+            return
+        plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
+        self.context.laserpane_plan = plan_name
+        plan = self.context.planner._plan[plan_name]
+        if len(plan.plan) == 0:
+            wx.MessageBox(
+                _("No items to spool"), _("Spool Plan"), wx.OK | wx.ICON_INFORMATION
+            )
+            return
+        self.context(f"plan{plan_name} spool\n")
 
-class JobPanelOld(wx.Panel):
-    """
-    Contains all elements to plan and save the job
-    """
+    def on_clear_plan(self, event):
+        if self.list_plan.GetFirstSelected() == -1:
+            return
+        plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
+        self.context(f"plan{plan_name} clear finish\n")
 
-    def __init__(self, *args, context=None, **kwds):
-        # begin wxGlade: MovePanel.__init__
-        kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
-        wx.Panel.__init__(self, *args, **kwds)
-        self.context = context
-        self.context.themes.set_window_colors(self)
+    def on_update_plan(self, event):
+        if self.list_plan.GetFirstSelected() == -1:
+            return
+        plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
+        self.context.kernel.busyinfo.start(msg=_("Updating Plan..."))
+        if self.context.planner.do_optimization:
+            self.context(
+                f"plan{plan_name} clear copy preprocess validate blob preopt optimize finish\n"
+            )
+        else:
+            self.context(
+                f"plan{plan_name} clear copy preprocess validate blob finish\n"
+            )
+        self.context.kernel.busyinfo.end()
 
-        sizer_main = wx.BoxSizer(wx.VERTICAL)
-        self._optimize = True
-        self.icon_size = 0.5 * get_default_icon_size(self.context)
-        sizer_control_update = wx.BoxSizer(wx.HORIZONTAL)
-        sizer_main.Add(sizer_control_update, 0, wx.EXPAND, 0)
-
-        self.button_clear = wxButton(self, wx.ID_ANY, _("Clear"))
-        self.button_clear.SetToolTip(_("Clear locally defined plan"))
-        self.button_clear.SetBitmap(icons8_delete.GetBitmap(resize=self.icon_size))
-        sizer_control_update.Add(self.button_clear, 1, 0, 0)
-
-        self.button_update = wxButton(self, wx.ID_ANY, _("Update"))
-        self.button_update.SetToolTip(_("Update the Plan"))
-        self.button_update.SetBitmap(icon_update_plan.GetBitmap(resize=self.icon_size))
-        sizer_control_update.Add(self.button_update, 1, 0, 0)
-
-        self.button_save_file = wxButton(self, wx.ID_ANY, _("Save"))
-        self.button_save_file.SetToolTip(_("Save the job"))
-        self.button_save_file.SetBitmap(icons8_save.GetBitmap(resize=self.icon_size))
-        sizer_control_update.Add(self.button_save_file, 1, 0, 0)
-
-        sizer_source = wx.BoxSizer(wx.HORIZONTAL)
-        sizer_main.Add(sizer_source, 0, wx.EXPAND, 0)
-
-        self.text_plan = TextCtrl(
-            self, wx.ID_ANY, _("--- Empty ---"), style=wx.TE_READONLY
-        )
-        sizer_source.Add(self.text_plan, 2, 0, 0)
-
-        self.context.setting(bool, "laserpane_hold", False)
-        self.checkbox_hold = wxCheckBox(self, wx.ID_ANY, _("Hold"))
-        self.checkbox_hold.SetToolTip(
-            _("Preserve the job between running, rerunning, and execution")
-        )
-        self.checkbox_hold.SetValue(self.context.laserpane_hold)
-        sizer_source.Add(self.checkbox_hold, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-
-        self.SetSizer(sizer_main)
-        self.Layout()
-
-        self.Bind(wx.EVT_CHECKBOX, self.on_check_hold, self.checkbox_hold)
-        self.Bind(wx.EVT_BUTTON, self.on_button_save, self.button_save_file)
-        # self.Bind(wx.EVT_BUTTON, self.on_button_load, self.button_load)
-        self.Bind(wx.EVT_BUTTON, self.on_button_clear, self.button_clear)
-        self.Bind(wx.EVT_BUTTON, self.on_button_update, self.button_update)
-
-    @signal_listener("plan")
-    def plan_update(self, origin, *message):
-        plan_name, stage = message[0], message[1]
-        if plan_name == "z":
-            plan = self.context.planner.get_or_make_plan("z")
-            if not len(plan.plan):
-                self.text_plan.SetValue(_("--- Empty ---"))
-            else:
-                self.text_plan.SetValue(f"{str(stage)}: {str(plan)}")
-
-    def on_button_save(self, event):  # wxGlade: LaserPanel.<event_handler>
+    def on_export_plan(self, event):
+        if self.list_plan.GetFirstSelected() == -1:
+            return
+        plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
         gui = self.context.gui
         extension = "txt"
         if hasattr(self.context.device, "extension"):
@@ -920,33 +923,40 @@ class JobPanelOld(wx.Panel):
 
             if not pathname.lower().endswith(f".{extension}"):
                 pathname += f".{extension}"
-            optpart = "preopt optimize " if self.context.planner.do_optimization else ""
-            self.context(
-                f'planz clear copy preprocess validate blob {optpart}save_job "{pathname}"\n'
-            )
+            self.context(f'plan{plan_name} save_job "{pathname}"\n')
 
-    def on_button_load(self, event):  # wxGlade: LaserPanel.<event_handler>
-        pass
-
-    def on_button_clear(self, event):  # wxGlade: LaserPanel.<event_handler>
-        self.context("planz clear\n")
-
-    def on_button_update(self, event):  # wxGlade: LaserPanel.<event_handler>
-        self.context.kernel.busyinfo.start(msg=_("Updating Plan..."))
-        if self.context.planner.do_optimization:
-            self.context("planz clear copy preprocess validate blob preopt optimize\n")
-        else:
-            self.context("planz clear copy preprocess validate blob\n")
-        self.context.kernel.busyinfo.end()
-
-    def on_check_hold(self, event):
+    def on_hold(self, event):
         self.context.laserpane_hold = self.checkbox_hold.GetValue()
 
-    def pane_show(self, *args):
-        self.button_save_file.Enable(hasattr(self.context.device, "extension"))
+    def on_right_click(self, event):
+        # Select the item under the mouse cursor
+        event.Skip()
+        item, flags = self.list_plan.HitTest(event.GetPosition())
+        if item >= 0:
+            self.list_plan.Select(item)
+        item = self.list_plan.GetFirstSelected()
+        if item < 0:
+            return
+        menu = wx.Menu()
+        item = menu.Append(wx.ID_ANY, _("Clear"))
+        self.Bind(wx.EVT_MENU, self.on_clear_plan, item)
+        item = menu.Append(wx.ID_ANY, _("Update"))
+        self.Bind(wx.EVT_MENU, self.on_update_plan, item)
+        item = menu.Append(wx.ID_ANY, _("Export"))
+        self.Bind(wx.EVT_MENU, self.on_export_plan, item)
+        item = menu.Append(wx.ID_ANY, _("Spool"))
+        self.Bind(wx.EVT_MENU, self.on_spool_plan, item)
+        self.PopupMenu(menu)
+        menu.Destroy()
 
-    def pane_hide(self, *args):
-        pass
+    def pane_show(self):
+        self.shown = True
+        self.list_plan.load_column_widths()
+        self.refresh_plan_list()
+
+    def pane_hide(self):
+        self.shown = False
+        self.list_plan.save_column_widths()
 
 
 class OptimizePanel(wx.Panel):

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -1858,7 +1858,7 @@ class SimulationPanel(wx.Panel, Job):
             self.context.planner.do_optimization = False
         self.context.signal("optimize", self.context.planner.do_optimization)
         self.context(
-            f"plan{plan} clear\nplan{plan} copy preprocess validate blob{opt}\n"
+            f"plan{plan} clear\nplan{plan} copy preprocess validate blob{opt} finish\n"
         )
         busy.end()
         self._refresh_simulated_plan()
@@ -1880,7 +1880,7 @@ class SimulationPanel(wx.Panel, Job):
 
     def pane_hide(self):
         if self.auto_clear:
-            self.context(f"plan{self.plan_name} clear\n")
+            self.context(f"plan{self.plan_name} clear finish\n")
         self.context.close("SimScene")
         self.context.unschedule(self)
         self.running = False
@@ -2396,7 +2396,7 @@ class Simulation(MWindow):
             last_plan, new_plan = kernel.planner.get_free_plan()
 
             kernel.console(
-                f"plan{new_plan} clear copy preprocess validate blob{optpart}\nwindow toggle Simulation {new_plan}\n"
+                f"plan{new_plan} clear copy preprocess validate blob{optpart} finish\nwindow open Simulation {new_plan}\n"
             )
             busy.end()
 

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -2393,9 +2393,10 @@ class Simulation(MWindow):
             busy = kernel.busyinfo
             busy.change(msg=_("Preparing simulation..."))
             busy.start()
+            last_plan, new_plan = kernel.planner.get_free_plan()
 
             kernel.console(
-                f"planz clear copy preprocess validate blob{optpart}\nwindow toggle Simulation z\n"
+                f"plan{new_plan} clear copy preprocess validate blob{optpart}\nwindow toggle Simulation {new_plan}\n"
             )
             busy.end()
 

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -7,7 +7,6 @@ import wx
 
 # import wx.lib.mixins.listctrl as listmix
 from wx import aui
-from wx.lib.splitter import MultiSplitterWindow
 
 from meerk40t.gui.icons import (
     get_default_icon_size,
@@ -73,6 +72,19 @@ def register_panel_spooler(window, context):
     window.on_pane_create(pane)
     context.register("pane/spooler", pane)
 
+
+# class EditableListCtrl(wx.ListCtrl, listmix.TextEditMixin):
+#     """TextEditMixin allows any column to be edited."""
+
+#     # ----------------------------------------------------------------------
+#     def __init__(
+#         self, parent, ID=wx.ID_ANY, pos=wx.DefaultPosition, size=wx.DefaultSize, style=0
+#     ):
+#         """Constructor"""
+#         wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
+#         listmix.TextEditMixin.__init__(self)
+
+
 class SpoolerPanel(wx.Panel):
     def __init__(self, *args, context=None, selected_device=None, **kwds):
         # begin wxGlade: SpoolerPanel.__init__
@@ -89,20 +101,19 @@ class SpoolerPanel(wx.Panel):
         spools.insert(0, _("-- All available devices --"))
         self.queue_entries = []
         self.context.setting(int, "spooler_sash_position", 0)
-        self.context.setting(int, "spooler_sash2_position", 0)
         self.context.setting(bool, "spool_history_clear_on_start", False)
         self.context.setting(bool, "spool_ignore_helper_jobs", True)
         self.context.setting(bool, "silent_mode", False)
         self.context(f".silent {'on' if self.context.silent_mode else 'off'}\n")
-        
-        self.splitter = MultiSplitterWindow(self, wx.ID_ANY)
-        self.splitter.SetOrientation(wx.VERTICAL)
 
+        self.splitter = wx.SplitterWindow(self, id=wx.ID_ANY, style=wx.SP_LIVE_UPDATE)
         sty = wx.BORDER_SUNKEN
-        self.win_top = wx.Window(self, wx.ID_ANY, style=sty)
-        self.win_middle = wx.Window(self, wx.ID_ANY, style=sty)
-        self.win_bottom = wx.Window(self, wx.ID_ANY, style=sty)
 
+        self.win_top = wx.Window(self.splitter, style=sty)
+        self.win_bottom = wx.Window(self.splitter, style=sty)
+        self.splitter.SetMinimumPaneSize(50)
+        self.splitter.SplitHorizontally(self.win_top, self.win_bottom, -100)
+        self.splitter.SetSashPosition(self.context.spooler_sash_position)
         self.combo_device = wxComboBox(
             self.win_top, wx.ID_ANY, choices=spools, style=wx.CB_DROPDOWN
         )
@@ -143,13 +154,6 @@ class SpoolerPanel(wx.Panel):
             style=wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES | wx.LC_SINGLE_SEL,
             context=self.context,
             list_name="list_spoolerjobs",
-        )
-        self.list_job_threads = wxListCtrl(
-            self.win_middle,
-            wx.ID_ANY,
-            style=wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES | wx.LC_SINGLE_SEL,
-            context=self.context,
-            list_name="list_threads",
         )
 
         self.info_label = wxStaticText(self.win_bottom, wx.ID_ANY, _("Completed jobs:"))
@@ -294,56 +298,30 @@ class SpoolerPanel(wx.Panel):
         self.list_job_history.resize_columns()
         # end wxGlade
 
-
-        self.list_job_threads.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=48)
-        self.list_job_threads.AppendColumn(
-            _("Task"), format=wx.LIST_FORMAT_LEFT, width=113
-        )
-        self.list_job_threads.AppendColumn(
-            _("Status"), format=wx.LIST_FORMAT_LEFT, width=73
-        )
-        self.list_job_threads.AppendColumn(
-            _("Runtime"), format=wx.LIST_FORMAT_LEFT, width=73
-        )
-        self.list_job_threads.resize_columns()
-
     def __do_layout(self):
-        self.sizer_top = wx.BoxSizer(wx.VERTICAL)
-        self.sizer_middle = wx.BoxSizer(wx.VERTICAL)
-        self.sizer_bottom = wx.BoxSizer(wx.VERTICAL)
+        sizer_main = wx.BoxSizer(wx.VERTICAL)
 
+        sizer_top = wx.BoxSizer(wx.VERTICAL)
+        sizer_bottom = wx.BoxSizer(wx.VERTICAL)
         sizer_combo_cmds = wx.BoxSizer(wx.HORIZONTAL)
         sizer_combo_cmds.Add(self.combo_device, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         sizer_combo_cmds.Add(self.button_pause, 0, wx.EXPAND, 0)
         sizer_combo_cmds.Add(self.button_stop, 0, wx.EXPAND, 0)
         sizer_combo_cmds.Add(self.check_silent, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
-        self.sizer_top.Add(sizer_combo_cmds, 0, wx.EXPAND, 0)
-        self.sizer_top.Add(self.list_job_spool, 2, wx.EXPAND, 0)
-        
-        self.sizer_middle.Add(self.list_job_threads, 1, wx.EXPAND, 0)
+        sizer_top.Add(sizer_combo_cmds, 0, wx.EXPAND, 0)
+        sizer_top.Add(self.list_job_spool, 4, wx.EXPAND, 0)
+        self.win_top.SetSizer(sizer_top)
+        sizer_top.Fit(self.win_top)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         hsizer.Add(self.info_label, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         hsizer.Add(self.button_clear_history, 0, wx.EXPAND, 0)
-        self.sizer_bottom.Add(hsizer, 0, wx.EXPAND, 0)
-        self.sizer_bottom.Add(self.list_job_history, 2, wx.EXPAND, 0)
+        sizer_bottom.Add(hsizer, 0, wx.EXPAND, 0)
+        sizer_bottom.Add(self.list_job_history, 2, wx.EXPAND, 0)
+        self.win_bottom.SetSizer(sizer_bottom)
+        sizer_bottom.Fit(self.win_bottom)
 
-        self.win_top.SetSizer(self.sizer_top)
-        self.win_middle.SetSizer(self.sizer_middle)
-        self.win_bottom.SetSizer(self.sizer_bottom)
-
-        self.sizer_top.Fit(self.win_top)
-        self.sizer_middle.Fit(self.win_middle)
-        self.sizer_bottom.Fit(self.win_bottom)
-
-        self.splitter.AppendWindow(self.win_top)
-        self.splitter.AppendWindow(self.win_middle)
-        self.splitter.AppendWindow(self.win_bottom)
-        self.splitter.SetSashPosition(0, self.context.spooler_sash_position)
-        self.splitter.SetSashPosition(1, self.context.spooler_sash2_position)
-
-        sizer_main = wx.BoxSizer(wx.VERTICAL)
         sizer_main.Add(self.splitter, 1, wx.EXPAND, 0)
         self.SetSizer(sizer_main)
         sizer_main.Fit(self)
@@ -354,26 +332,13 @@ class SpoolerPanel(wx.Panel):
         self.context.silent_mode = self.check_silent.GetValue()
         self.context(f".silent {'on' if self.context.silent_mode else 'off'}\n")
 
-    def _refresh_layout(self):
-        for win in (self.win_top, self.win_middle, self.win_bottom):    
-            sizer = win.GetSizer()
-            sizer.Layout()
-            win.Refresh()
-
     def on_sash_changed(self, event):
-        position1 = self.splitter.GetSashPosition(0)
-        position2 = self.splitter.GetSashPosition(1)
-        self.context.spooler_sash_position = position1
-        self.context.spooler_sash2_position = position2
-        self._refresh_layout()
+        position = self.splitter.GetSashPosition()
+        self.context.spooler_sash_position = position
 
     def on_sash_double(self, event):
-        total_size = int(self.splitter.GetSize().GetHeight() / 3)
-        self.splitter.SetSashPosition(0, 1 * total_size)
-        self.splitter.SetSashPosition(1, 2 * total_size)
-        self.context.spooler_sash_position = 1 * total_size
-        self.context.spooler_sash2_position = 2 * total_size
-        self._refresh_layout()
+        self.splitter.SetSashPosition(0, True)
+        self.context.spooler_sash_position = 0
 
     def on_item_selected(self, event):
         self.current_item = event.Index
@@ -728,30 +693,6 @@ class SpoolerPanel(wx.Panel):
             return named_obj.__name__
         except AttributeError:
             return str(named_obj)
-
-    def refresh_thread_list(self):
-        if not self.update_spooler:
-            return
-        try:
-            self.list_job_threads.DeleteAllItems()
-        except RuntimeError:
-            return
-        idx = 0 
-        with self.context.kernel.thread_lock:
-            thread_items = list(self.context.kernel.threads.items())
-        for thread_name, thread_info in thread_items:
-            thread, message, user_type, info, started = thread_info
-            if not user_type:
-                continue
-            idx += 1
-            elapsed = time.time() - started
-            hours, remainder = divmod(elapsed, 3600)
-            minutes, seconds = divmod(remainder, 60)
-            runtime = f"{int(hours)}:{str(int(minutes)).zfill(2)}:{str(int(seconds)).zfill(2)}"
-            m = self.list_job_threads.InsertItem(idx, f"#{idx}")
-            self.list_job_threads.SetItem(m, 1, info)
-            self.list_job_threads.SetItem(m, 2, message)
-            self.list_job_threads.SetItem(m, 3, runtime)
 
     def refresh_spooler_list(self):
         if not self.update_spooler:
@@ -1132,10 +1073,6 @@ class SpoolerPanel(wx.Panel):
         self.update_spooler = True
         self.refresh_spooler_list()
 
-    @signal_listener("thread_update")
-    def on_thread_signal(self, origin, *args):
-        self.refresh_thread_list()
-
     @signal_listener("driver;position")
     @signal_listener("emulator;position")
     @signal_listener("pipe;usb_status")
@@ -1239,12 +1176,10 @@ class SpoolerPanel(wx.Panel):
         if refresh_needed:
             self.refresh_spooler_list()
             self.refresh_history()
-            self.refresh_thread_list()
 
     def update_queue(self):
         if self.shown:
             self.on_device_update(None)
-            self.refresh_thread_list()
 
     def pane_show(self):
         self.shown = True
@@ -1252,7 +1187,6 @@ class SpoolerPanel(wx.Panel):
         self.list_job_spool.load_column_widths()
         self.context.schedule(self.timerjob)
         self.refresh_spooler_list()
-        self.refresh_thread_list()
 
     def pane_hide(self):
         self.context.unschedule(self.timerjob)

--- a/meerk40t/gui/thread_info.py
+++ b/meerk40t/gui/thread_info.py
@@ -1,0 +1,191 @@
+import threading
+import time
+import wx
+from wx import aui
+from meerk40t.gui.icons import icons8_route
+from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import (
+    wxListCtrl, wxStaticText,
+)
+from meerk40t.kernel import Job, signal_listener
+
+_ = wx.GetTranslation
+
+
+def register_panel_thread_info(window, context):
+    panel = ThreadPanel(window, wx.ID_ANY, context=context)
+    pane = (
+        aui.AuiPaneInfo()
+        .Bottom()
+        .Layer(1)
+        .MinSize(600, 100)
+        .FloatingSize(600, 230)
+        .Caption(_("Tasks"))
+        .Name("tasks")
+        .CaptionVisible(not context.pane_lock)
+        .Hide()
+    )
+    pane.dock_proportion = 600
+    pane.control = panel
+    pane.helptext = _("Opens the tasks window with all background task information")
+
+    window.on_pane_create(pane)
+    context.register("pane/tasks", pane)
+
+
+class ThreadPanel(wx.Panel):
+    def __init__(self, *args, context=None, **kwds):
+        # begin wxGlade: SpoolerPanel.__init__
+        kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
+        wx.Panel.__init__(self, *args, **kwds)
+        self.context = context
+        self.context.themes.set_window_colors(self)
+        self.SetHelpText("threadinfo")
+
+        self.sizer_main = wx.BoxSizer(wx.VERTICAL)
+        infomsg = _("Background Tasks are preparatory jobs issued with the 'threaded' command,\nlike burn preparation and others.")
+        self.info = wxStaticText(self, wx.ID_ANY, infomsg)
+
+        self.list_job_threads = wxListCtrl(
+            self,
+            wx.ID_ANY,
+            style=wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES | wx.LC_SINGLE_SEL,
+            context=self.context,
+            list_name="list_threads",
+        )
+        self.list_job_threads.SetToolTip(_("List of background tasks"))
+        self.list_job_threads.AppendColumn(_("#"), format=wx.LIST_FORMAT_LEFT, width=48)
+        self.list_job_threads.AppendColumn(
+            _("Task"), format=wx.LIST_FORMAT_LEFT, width=113
+        )
+        self.list_job_threads.AppendColumn(
+            _("Status"), format=wx.LIST_FORMAT_LEFT, width=73
+        )
+        self.list_job_threads.AppendColumn(
+            _("Runtime"), format=wx.LIST_FORMAT_LEFT, width=73
+        )
+        self.list_job_threads.resize_columns()
+
+        self.sizer_main.Add(self.info, 0, wx.EXPAND)
+        self.sizer_main.Add(self.list_job_threads, 1, wx.EXPAND)
+
+        self.SetSizer(self.sizer_main)
+        self.Layout()
+
+        # We set a timer job that will periodically check the spooler queue
+        # in case no signal was received
+        self.show_system_tasks = False
+        self._last_invokation = 0
+        self.shown = False
+        self.update_lock = threading.Lock()
+        self.timerjob = Job(
+            process=self.update_queue,
+            job_name="spooler-update",
+            interval=5,
+            run_main=True,
+        )
+        self.list_job_threads.Bind(wx.EVT_RIGHT_DOWN, self.show_context_menu)
+
+    def on_show_system_tasks(self, event):
+        self.show_system_tasks = not self.show_system_tasks
+        self.refresh_thread_list()
+
+    def show_context_menu(self, event):
+        menu = wx.Menu()
+        item = menu.AppendCheckItem(wx.ID_ANY, _("Show System Tasks"))
+        item.Check(self.show_system_tasks)
+        menu.Bind(wx.EVT_MENU, self.on_show_system_tasks, id=item.GetId())
+        self.PopupMenu(menu)
+        menu.Destroy()
+
+    def refresh_thread_list(self):
+        try:
+            self.list_job_threads.DeleteAllItems()
+        except RuntimeError:
+            return
+        idx = 0
+        with self.context.kernel.thread_lock:
+            thread_items = list(self.context.kernel.threads.items())
+        for thread_name, thread_info in thread_items:
+            thread, message, user_type, info, started = thread_info
+            # Skip system tasks when not showing them
+            if not (user_type or self.show_system_tasks):
+                continue
+            if not info:
+                info = thread_name
+            idx += 1
+            elapsed = time.time() - started
+            hours, remainder = divmod(elapsed, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            runtime = f"{int(hours)}:{str(int(minutes)).zfill(2)}:{str(int(seconds)).zfill(2)}"
+            m = self.list_job_threads.InsertItem(idx, f"#{idx}")
+            self.list_job_threads.SetItem(m, 1, info)
+            self.list_job_threads.SetItem(m, 2, message)
+            self.list_job_threads.SetItem(m, 3, runtime)
+
+    @signal_listener("thread_update")
+    def on_thread_signal(self, origin, *args):
+        doit = True
+        with self.update_lock:
+            # Only update every 2 seconds or so
+            dtime = time.time()
+            if dtime - self._last_invokation < 2:
+                doit = False
+            else:
+                self._last_invokation = dtime
+        if not doit:
+            return
+        self.refresh_thread_list()
+
+    def pane_show(self):
+        self.shown = True
+        self.list_job_threads.load_column_widths()
+        self.context.schedule(self.timerjob)
+        self.refresh_thread_list()
+
+    def pane_hide(self):
+        self.context.unschedule(self.timerjob)
+        self.shown = False
+
+        self.list_job_threads.save_column_widths()
+
+    def update_queue(self):
+        if self.shown:
+            self.refresh_thread_list()
+
+
+class ThreadInfo(MWindow):
+    def __init__(self, *args, **kwds):
+        super().__init__(600, 400, *args, **kwds)
+        self.panel = ThreadPanel(
+            self,
+            wx.ID_ANY,
+            context=self.context,
+        )
+        self.sizer.Add(self.panel, 1, wx.EXPAND, 0)
+        self.add_module_delegate(self.panel)
+        _icon = wx.NullIcon
+        _icon.CopyFromBitmap(icons8_route.GetBitmap())
+        self.SetIcon(_icon)
+        self.SetTitle(_("Background Tasks"))
+        self.Layout()
+        self.restore_aspect(honor_initial_values=True)
+
+    @staticmethod
+    def sub_register(kernel):
+        kernel.register("wxpane/ThreadInfo", register_panel_thread_info)
+
+    def window_open(self):
+        self.panel.pane_show()
+
+    def window_close(self):
+        self.panel.pane_hide()
+
+    @staticmethod
+    def submenu():
+        # Hint for translation:  _("Tasks")
+        return "", "Tasks"
+
+    @staticmethod
+    def helptext():
+        return _("Opens the window with all background task information")

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -11,6 +11,7 @@ from meerk40t.core.units import Length
 from meerk40t.gui.consolepanel import Console
 from meerk40t.gui.navigationpanels import Navigation
 from meerk40t.gui.spoolerpanel import JobSpooler
+from meerk40t.gui.thread_info import ThreadInfo
 
 # try:
 #     # According to https://docs.wxpython.org/wx.richtext.1moduleindex.html
@@ -255,11 +256,14 @@ class GoPanel(ActionPanel):
             return
 
         self.button_go.Enable(False)
-        self.context.kernel.busyinfo.start(msg=_("Processing and sending..."))
+        last_plan, new_plan = self.context.planner.get_free_plan()
+
         self.context(
-            "planz clear copy preprocess validate blob preopt optimize spool\n"
+            f"threaded plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
         )
-        self.context.kernel.busyinfo.end()
+        self.context(
+            f"window open JobSpooler\nwindow open ThreadInfo\n"
+        )
         self.button_go.Enable(True)
         # Reset...
         # Deliberately at the end, as clicks queue...
@@ -1000,6 +1004,7 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("window/Notes", Notes)
         kernel.register("window/AutoExec", AutoExec)
         kernel.register("window/JobSpooler", JobSpooler)
+        kernel.register("window/ThreadInfo", ThreadInfo)
         kernel.register("window/Simulation", Simulation)
         kernel.register("window/Tips", Tips)
         kernel.register("window/ExecuteJob", ExecuteJob)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1833,21 +1833,21 @@ class MeerK40t(MWindow):
             return handler
 
         def run_job(*args):
+            context.setting(bool, "laserpane_hold", False)
             busy = kernel.busyinfo
             context = kernel.root
             opt = kernel.planner.do_optimization
             busy.start(msg=_("Preparing Laserjob..."))
-            plan = kernel.planner.get_or_make_plan("z")
-            context.setting(bool, "laserpane_hold", False)
-            if plan.plan and context.laserpane_hold:
-                context("planz spool\n")
+            last_plan, new_plan = kernel.planner.get_free_plan()
+            if last_plan is not None and context.laserpane_hold:
+                context(f"plan{last_plan} spool\n")
             else:
                 if opt:
                     context(
-                        "planz clear copy preprocess validate blob preopt optimize spool\n"
+                        f"plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
                     )
                 else:
-                    context("planz clear copy preprocess validate blob spool\n")
+                    context(f"plan{new_plan} clear copy preprocess validate blob spool\n")
             if context.auto_spooler:
                 context("window open JobSpooler\n")
             # And we disarm again

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1833,6 +1833,7 @@ class MeerK40t(MWindow):
             return handler
 
         def run_job(*args):
+            context = kernel.root
             context.setting(bool, "laserpane_hold", False)
             busy = kernel.busyinfo
             context = kernel.root


### PR DESCRIPTION
# Overview
Introduces support for managing multiple laser job plans, including plan selection, status tracking, and improved plan lifecycle management.
- Adds a new "ThreadInfo" panel and related infrastructure to monitor simulation and and display job execution handling. background tasks and threaded job status.
- Refactors job preparation, simulation, and spooling workflows to utilize named plans and background processing, improving user feedback and concurrency.
- Enhances the planner and kernel to track plan states, thread metadata, and provide richer status updates throughout the application.
- Updates UI components to reflect these changes, including new controls for plan management and task monitoring.

## Summary by Sourcery

Add multi-plan management and background task tracking by extending the planner service, kernel threading, and UI panels to support named plans, plan state tracking, and background task monitoring.

New Features:
- Introduce a Job Plan panel listing multiple plans with controls to update, export, spool, and hold individual named plans
- Add a ThreadInfo panel to display and filter background task threads with status and runtime
- Expose new planner commands and methods (list-plans, finish, get_free_plan, has_content) for multi-plan handling
- Extend kernel threading to track thread metadata, messages, user/system types, and emit thread_update signals

Enhancements:
- Refactor job preparation, simulation, and spooling workflows to use named plans and threaded operations for improved concurrency
- Implement plan stage tracking in the Planner with state enums and update signals for richer status updates
- Update BusyPanel to relay thread messages and tie into thread_update events for real-time feedback