### PR TITLE
Update Plan lock and plan state mechanism

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -1405,12 +1405,14 @@ def init_tree(kernel):
     )
     def compile_and_simulate(node, **kwargs):
         self.set_node_emphasis(node, True)
-        last_plan, new_plan = self.kernel.planner.get_free_plan()
+        new_plan = self.kernel.planner.get_free_plan()
         opt = self.kernel.planner.do_optimization
         optstr = " preopt optimize" if opt else ""
 
         self(f"plan{new_plan} copy-selected preprocess validate blob{optstr} finish\n")
-        self(f"window open Simulation {new_plan} 1 1\n")  # Plan Name, Auto-Clear, Optimise
+        self(
+            f"window open Simulation {new_plan} 1 1\n"
+        )  # Plan Name, Auto-Clear, Optimise
 
     # ==========
     # General menu-entries for operation branch

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -992,7 +992,7 @@ class Planner(Service):
         Finds and returns a unique plan name that can be reused as work as has been done on it
         """
         last = None
-        with self, _plan_lock:
+        with self._plan_lock:
             for candidate in self._plan:
                 plan = self._plan[candidate]
                 state, info = self.get_plan_stage(candidate)

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -874,8 +874,7 @@ class JobPanel(wx.Panel):
         if can_update:
             plan_name = self.list_plan.GetItemText(self.list_plan.GetFirstSelected(), 1)
             try:
-                plan = self.context.planner._plan[plan_name]
-                has_content = len(plan.plan) != 0
+                has_content = self.context.planner.has_content(plan_name)
             except KeyError:
                 can_update = False
         can_export = has_content and hasattr(self.context.device, "extension")

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -709,7 +709,7 @@ class LaserPanel(wx.Panel):
 
         busy = self.context.kernel.busyinfo
         busy.start(msg=_("Preparing Laserjob..."))
-        last_plan = self.context.laserpane_plan
+        last_plan = self.context.laserpane_plan or self.context.planner.get_last_plan()
         if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             self.context(f"plan{last_plan} spool\n")
         elif self.checkbox_optimize.GetValue():

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -29,8 +29,8 @@ from meerk40t.gui.wxutils import (
     wxButton,
     wxCheckBox,
     wxComboBox,
-    wxStaticText,
     wxListCtrl,
+    wxStaticText,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
 
@@ -713,13 +713,15 @@ class LaserPanel(wx.Panel):
         if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             self.context(f"plan{last_plan} spool\n")
         elif self.checkbox_optimize.GetValue():
-            last_plan, new_plan = self.context.planner.get_free_plan()
+            new_plan = self.context.planner.get_free_plan()
             self.context(
                 f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\nwindow open ThreadInfo\n"
             )
         else:
-            last_plan, new_plan = self.context.planner.get_free_plan()
-            self.context(f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n")
+            new_plan = self.context.planner.get_free_plan()
+            self.context(
+                f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n"
+            )
         self.armed = False
         self.check_laser_arm()
         if self.context.auto_spooler:
@@ -744,14 +746,14 @@ class LaserPanel(wx.Panel):
 
     def on_button_simulate(self, event):  # wxGlade: LaserPanel.<event_handler>
         self.context.kernel.busyinfo.start(msg=_("Preparing simulation..."))
-        last_plan, new_plan = self.context.planner.get_free_plan()
         param = "0"
         last_plan = self.context.laserpane_plan
+        if not last_plan:
+            last_plan = self.context.planner.get_last_plan()
         if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             plan = last_plan
         else:
-            last_plan, new_plan = self.context.planner.get_free_plan()
-            plan = new_plan
+            plan = self.context.planner.get_free_plan()
             if self.checkbox_optimize.GetValue():
                 self.context(
                     f"plan{plan} clear copy preprocess validate blob preopt optimize finish\n"

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -747,9 +747,7 @@ class LaserPanel(wx.Panel):
     def on_button_simulate(self, event):  # wxGlade: LaserPanel.<event_handler>
         self.context.kernel.busyinfo.start(msg=_("Preparing simulation..."))
         param = "0"
-        last_plan = self.context.laserpane_plan
-        if not last_plan:
-            last_plan = self.context.planner.get_last_plan()
+        last_plan = self.context.laserpane_plan or self.context.planner.get_last_plan()
         if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
             plan = last_plan
         else:

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -2393,7 +2393,7 @@ class Simulation(MWindow):
             busy = kernel.busyinfo
             busy.change(msg=_("Preparing simulation..."))
             busy.start()
-            last_plan, new_plan = kernel.planner.get_free_plan()
+            new_plan = kernel.planner.get_free_plan()
 
             kernel.console(
                 f"plan{new_plan} clear copy preprocess validate blob{optpart} finish\nwindow open Simulation {new_plan}\n"

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -2389,15 +2389,20 @@ class Simulation(MWindow):
     def sub_register(kernel):
         def handler(opt):
             optpart = " preopt optimize" if opt else ""
-
+            hold = kernel.root.setting(bool, "laserpane_hold", False)
+            plan_name = (
+                kernel.root.setting(str, "laserpane_plan", "z")
+                or kernel.planner.get_last_plan()
+            )
             busy = kernel.busyinfo
             busy.change(msg=_("Preparing simulation..."))
             busy.start()
-            new_plan = kernel.planner.get_free_plan()
-
-            kernel.console(
-                f"plan{new_plan} clear copy preprocess validate blob{optpart} finish\nwindow open Simulation {new_plan}\n"
-            )
+            if not (hold and kernel.planner.has_content(plan_name)):
+                plan_name = kernel.planner.get_free_plan()
+                kernel.console(
+                    f"plan{plan_name} clear copy preprocess validate blob{optpart} finish\n"
+                )
+            kernel.console(f"window open Simulation {plan_name}\n")
             busy.end()
 
         def open_simulator(*args):

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -11,7 +11,6 @@ from meerk40t.core.units import Length
 from meerk40t.gui.consolepanel import Console
 from meerk40t.gui.navigationpanels import Navigation
 from meerk40t.gui.spoolerpanel import JobSpooler
-from meerk40t.gui.thread_info import ThreadInfo
 
 # try:
 #     # According to https://docs.wxpython.org/wx.richtext.1moduleindex.html
@@ -22,6 +21,7 @@ from meerk40t.gui.thread_info import ThreadInfo
 # except ImportError:
 #     pass
 from meerk40t.gui.themes import Themes
+from meerk40t.gui.thread_info import ThreadInfo
 from meerk40t.gui.wxmscene import SceneWindow
 from meerk40t.gui.wxutils import TextCtrl, wxButton, wxStaticText
 from meerk40t.kernel import CommandSyntaxError, Module, get_safe_path
@@ -256,7 +256,7 @@ class GoPanel(ActionPanel):
             return
 
         self.button_go.Enable(False)
-        last_plan, new_plan = self.context.planner.get_free_plan()
+        new_plan = self.context.planner.get_free_plan()
         prefer_threaded = self.context.setting(bool, "prefer_threaded_mode", True)
         prefix = "threaded " if prefer_threaded else ""
         busy = self.context.kernel.busyinfo
@@ -267,14 +267,10 @@ class GoPanel(ActionPanel):
             f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
         )
         if prefer_threaded:
-            self.context(
-                f"window open JobSpooler\nwindow open ThreadInfo\n"
-            )
+            self.context(f"window open JobSpooler\nwindow open ThreadInfo\n")
         else:
             busy.end()
-            self.context(
-                f"window open JobSpooler\n"
-            )
+            self.context(f"window open JobSpooler\n")
 
         self.button_go.Enable(True)
         # Reset...
@@ -1104,8 +1100,8 @@ class wxMeerK40t(wx.App, Module):
                 register_panel_debugger,
                 register_panel_icon,
                 register_panel_plotter,
-                register_panel_window,
                 register_panel_view,
+                register_panel_window,
             )
 
             kernel.register("wxpane/debug_tree", register_panel_debugger)

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1841,10 +1841,11 @@ class MeerK40t(MWindow):
             busy = kernel.busyinfo
             context = kernel.root
             opt = kernel.planner.do_optimization
-            last_plan, new_plan = kernel.planner.get_free_plan()
+            last_plan = kernel.planner.get_last_plan()
             if last_plan is not None and hold:
                 context(f"plan{last_plan} spool\n")
             else:
+                new_plan = kernel.planner.get_free_plan()
                 if not prefer_threaded:
                     busy.start(msg=_("Preparing Laserjob..."))
                 if opt:
@@ -1852,7 +1853,9 @@ class MeerK40t(MWindow):
                         f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
                     )
                 else:
-                    context(f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n")
+                    context(
+                        f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n"
+                    )
                 if not prefer_threaded:
                     busy.end()
             if context.auto_spooler:


### PR DESCRIPTION
## Summary by Sourcery

Enhance the Planner service to use a timestamped, multi-stage state mechanism with proper thread safety, and update all consumers (console commands and GUI) to the new single-value get_free_plan API and newly added get_last_plan function.

New Features:
- Introduce get_last_plan to retrieve the most recently finished plan with content

Enhancements:
- Refactor plan state tracking to use timestamped dictionaries for multiple stages
- Provide thread-safe plan creation via private __get_or_make_plan and public get_or_make_plan with locking
- Update get_free_plan to reuse finished plans and return a single new plan name
- Improve update_stage to record and clear multiple stages and emit plan signals
- Revise get_plan_stage to return a comma-separated list of all reached stage descriptions