### PR TITLE
Independent redlight delay settings

### DIFF
--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -397,6 +397,28 @@ class BalorDevice(Service, Status):
                 "tip": _("Speed of the galvo when using the red laser."),
             },
             {
+                "attr": "redlight_delay_dark",
+                "object": self,
+                "default": 10,
+                "type": int,
+                "trailer": "µs",
+                "label": _("Dark"),
+                "tip": _("Delay for dark movement."),
+                # Hint for translation _("Delays")
+                "subsection": "Delays",
+            },
+            {
+                "attr": "redlight_delay_light",
+                "object": self,
+                "default": 10,
+                "type": int,
+                "trailer": "µs",
+                "label": _("Light"),
+                "tip": _("Delay for light movement."),
+                # Hint for translation _("Delays")
+                "subsection": "Delays",
+            },
+            {
                 "attr": "redlight_offset_x",
                 "object": self,
                 "default": "0mm",

--- a/meerk40t/balormk/device.py
+++ b/meerk40t/balormk/device.py
@@ -399,7 +399,7 @@ class BalorDevice(Service, Status):
             {
                 "attr": "redlight_delay_dark",
                 "object": self,
-                "default": 10,
+                "default": 1,
                 "type": int,
                 "trailer": "µs",
                 "label": _("Dark"),
@@ -410,7 +410,7 @@ class BalorDevice(Service, Status):
             {
                 "attr": "redlight_delay_light",
                 "object": self,
-                "default": 10,
+                "default": 1,
                 "type": int,
                 "trailer": "µs",
                 "label": _("Light"),

--- a/meerk40t/balormk/livelightjob.py
+++ b/meerk40t/balormk/livelightjob.py
@@ -208,8 +208,8 @@ class LiveLightJob:
             con: The connection to the laser controller.
         """
         con.light_mode()
-        delay_dark = self.service.delay_jump_long
-        delay_between = self.service.delay_jump_short
+        delay_dark = self.service.redlight_delay_dark
+        delay_between = self.service.redlight_delay_light
         move = True
         # We need to jump back to the first point
         first = True


### PR DESCRIPTION
## Summary by Sourcery

Introduce independent µs delay settings for dark and light redlight movements and apply them in the live redlight tracing routine.

New Features:
- Add separate configuration settings for redlight dark and light delays in the BalorMK laser device.

Enhancements:
- Update trace_redlight method to use the new redlight_delay_dark and redlight_delay_light settings instead of generic jump delays.