### PR TITLE
Update documentation / add more locks

### DIFF
--- a/meerk40t/moshi/controller.py
+++ b/meerk40t/moshi/controller.py
@@ -1,7 +1,28 @@
 """
-Moshiboard Controller
+Moshiboard Controller Module
 
-Tasked with sending data to usb connection.
+This module provides the MoshiController class, which manages communication with Moshiboard
+laser controllers via USB connection. The controller handles the complex protocol for sending
+laser cutting/engraving data to Moshiboard devices.
+
+Key Features:
+- Thread-safe data transmission with proper synchronization
+- Automatic connection management and error recovery
+- Real-time command processing (including emergency stop)
+- Buffer management for queuing multiple programs
+- Status monitoring and device state tracking
+- Support for both libusb and windll drivers
+
+The controller implements a three-stage protocol:
+1. Send program data with preamble/epilogue framing
+2. Monitor processing status and wait for completion
+3. Send completion confirmation
+
+Threading Model:
+- Main processing thread handles data transmission
+- Real-time commands can interrupt normal processing
+- All buffer/program access is protected by a central lock
+- Connection operations are thread-safe
 """
 
 import threading
@@ -10,15 +31,30 @@ import time
 from ..ch341 import get_ch341_interface
 from .builder import MoshiBuilder
 
-STATUS_OK = 205  # Seen before file send. And after file send.
-STATUS_PROCESSING = 207  # PROCESSING
-STATUS_ERROR = 237  # ERROR
-STATUS_RESET = 239  # Seen during reset
+# Status codes returned by the Moshiboard device
+STATUS_OK = 205  # Device is ready to accept commands
+STATUS_PROCESSING = 207  # Device is currently processing data
+STATUS_ERROR = 237  # An error occurred during processing
+STATUS_RESET = 239  # Device has been reset
 
 
 def get_code_string_from_moshicode(code):
     """
-    Moshiboard CH341 codes into code strings.
+    Convert Moshiboard status codes to human-readable strings.
+
+    Args:
+        code (int): The status code returned by the Moshiboard device
+
+    Returns:
+        str: Human-readable description of the status code
+
+    Status Codes:
+        205 (STATUS_OK): Device is ready to accept commands
+        207 (STATUS_PROCESSING): Device is currently processing data
+        237 (STATUS_ERROR): An error occurred during processing
+        239 (STATUS_RESET): Device has been reset
+        0: USB connection failed
+        Other: Unknown status code in hex format
     """
     if code == STATUS_OK:
         return "OK"
@@ -36,94 +72,188 @@ def get_code_string_from_moshicode(code):
 
 class MoshiController:
     """
-    The Moshiboard Controller takes data programs built by the MoshiDriver and sends to the Moshiboard
-    according to established moshi protocols.
+    Moshiboard Controller for managing laser device communication.
 
-    The output device is concerned with sending the moshibuilder.data to the control board and control events and
-    to the CH341 chip on the Moshiboard. We use the same ch341 driver as the Lihuiyu boards. Giving us
-    access to both libusb drivers and windll drivers.
+    This controller handles the complete lifecycle of sending laser cutting/engraving
+    programs to Moshiboard devices. It manages USB connections, buffers data safely
+    across threads, and implements the Moshiboard communication protocol.
 
-    The protocol for sending rasters is as follows:
-    Check processing-state of board, seeking 205
-    Send Preamble.
-    Check processing-state of board, seeking 205
-    Send bulk data of moshibuilder. No checks between packets.
-    Send Epilogue.
-    While Check processing-state is 207:
-        wait 0.2 seconds
-    Send Preamble
-    Send 0,0 offset 0,0 move.
-    Send Epilogue
+    Key Responsibilities:
+    - Establish and maintain USB connection to Moshiboard device
+    - Queue and transmit laser programs in proper protocol format
+    - Handle real-time commands (including emergency stop)
+    - Monitor device status and manage connection recovery
+    - Provide thread-safe access to buffer and program data
 
-    Checks done before the Epilogue will have 205 state.
+    Threading and Synchronization:
+    - Uses a single central lock (_program_lock) to protect all buffer/program access
+    - Main processing runs in a dedicated thread (_thread_data_send)
+    - Real-time commands can interrupt normal processing safely
+    - All state changes are properly synchronized
+
+    Protocol Implementation:
+    The controller implements a three-stage protocol for each program:
+
+    Stage 0 - Program Preparation:
+        - Wait for device ready status (STATUS_OK = 205)
+        - Send protocol preamble via MoshiBuilder.prologue()
+        - Load program data into transmission buffer
+
+    Stage 1 - Data Transmission:
+        - Send program data in 32-byte packets
+        - No status checks between packets for efficiency
+        - Send protocol epilogue via MoshiBuilder.epilogue()
+
+    Stage 2 - Completion Verification:
+        - Monitor device status until processing complete
+        - Wait for STATUS_OK (205) indicating successful completion
+        - Handle timeout and error conditions gracefully
+
+    Error Handling:
+    - Automatic connection recovery on temporary failures
+    - Exponential backoff for repeated connection attempts
+    - Graceful handling of device disconnection/reconnection
+    - Comprehensive logging of all operations and errors
+
+    Attributes:
+        _programs (list): Queue of programs waiting to be sent
+        _buffer (bytearray): Current program being transmitted
+        _program_lock (threading.Lock): Central lock protecting buffer/program access
+        connection: USB connection to the Moshiboard device
+        state (str): Current controller state (unknown, init, active, idle, etc.)
+        context: Service context for logging and signaling
     """
 
     def __init__(self, service, channel=None, force_mock=False, *args, **kwargs):
+        """
+        Initialize the MoshiController.
+
+        Args:
+            service: The service context providing logging, threading, and configuration
+            channel: Optional channel for communication (unused)
+            force_mock (bool): Force use of mock connection for testing
+            *args: Additional positional arguments (unused)
+            **kwargs: Additional keyword arguments (unused)
+        """
         self.context = service
         self.state = "unknown"
 
-        self._programs = []  # Programs to execute.
-        self._buffer = (
-            bytearray()
-        )  # Threadsafe buffered commands to be sent to controller.
+        # Thread-safe data structures protected by _program_lock
+        self._programs = []  # Queue of programs waiting to be processed
+        self._buffer = bytearray()  # Current program being transmitted
+        self._program_lock = (
+            threading.Lock()
+        )  # Central lock for all buffer/program access
 
+        # Threading state
         self._thread = None
         self.is_shutdown = False
-        self._program_lock = threading.Lock()
 
-        self._status = [0] * 6
+        # Device status and connection
+        self._status = [0] * 6  # Device status array
         self._usb_state = -1
-
         self.connection = None
         self.force_mock = force_mock
 
+        # Error handling and retry logic
         self.max_attempts = 5
-        self.refuse_counts = 0
-        self.connection_errors = 0
-        self.count = 0
-        self.abort_waiting = False
+        self.refuse_counts = 0  # Count of consecutive connection refusals
+        self.connection_errors = 0  # Count of connection errors
+        self.count = 0  # General purpose counter for backoff logic
+        self.abort_waiting = False  # Flag to abort wait operations
 
+        # Communication channels
         name = service.safe_label
-        self.pipe_channel = service.channel(f"{name}/events")
-        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)
-        self.usb_send_channel = service.channel(f"{name}/usb_send")
-        self.recv_channel = service.channel(f"{name}/recv")
+        self.pipe_channel = service.channel(f"{name}/events")  # General events
+        self.usb_log = service.channel(f"{name}/usb", buffer_size=500)  # USB operations
+        self.usb_send_channel = service.channel(f"{name}/usb_send")  # Data being sent
+        self.recv_channel = service.channel(f"{name}/recv")  # Data received
 
     def usb_signal_update(self, e):
+        """
+        Handle USB status updates from the connection.
+
+        This method is registered as a callback for USB status changes
+        and forwards them to the service context for broader notification.
+
+        Args:
+            e: The USB status event/message
+        """
         self.context.signal("pipe;usb_status", e)
 
     def viewbuffer(self):
         """
-        Viewbuffer is used by the BufferView class if such a value exists it provides a view of the
-        buffered data. Without this class the BufferView displays nothing. This is optional for any output
-        device.
+        Get a string representation of the current buffer and program queue.
+
+        This method is used by debugging and monitoring tools to inspect
+        the current state of queued programs and transmission buffer.
+
+        Returns:
+            str: Formatted string showing buffer contents and queued programs
         """
-        buffer = f"Current Working Buffer: {str(self._buffer)}\n"
-        for p in self._programs:
-            if hasattr(p, "data"):
-                buffer += f"{str(p.data)}\n"
-            else:
-                buffer += f"{str(p)} [dataless]\n"
+        with self._program_lock:
+            buffer = f"Current Working Buffer: {str(self._buffer)}\n"
+            for p in self._programs:
+                if hasattr(p, "data"):
+                    buffer += f"{str(p.data)}\n"
+                else:
+                    buffer += f"{str(p)} [dataless]\n"
         return buffer
 
     def added(self, *args, **kwargs):
+        """
+        Called when the controller is added to the service.
+
+        Sets up the USB logging callback and starts the controller.
+        """
         self.start()
         self.usb_log.watch(self.usb_signal_update)
 
     def shutdown(self, *args, **kwargs):
+        """
+        Shut down the controller and clean up resources.
+
+        Stops the USB logging callback, terminates processing,
+        and signals the processing thread to stop.
+        """
         self.usb_log.unwatch(self.usb_signal_update)
         self.update_state("terminate")
         if self._thread is not None:
             self.is_shutdown = True
 
     def __repr__(self):
+        """Return a string representation of the controller."""
         return "MoshiController()"
 
     def __len__(self):
-        """Provides the length of the buffer of this device."""
-        return len(self._buffer) + sum(map(len, self._programs))
+        """
+        Get the total length of buffered data.
+
+        Returns the combined length of the current transmission buffer
+        and all queued programs.
+
+        Returns:
+            int: Total bytes of data in buffer and queue
+        """
+        with self._program_lock:
+            return len(self._buffer) + sum(map(len, self._programs))
 
     def open(self):
+        """
+        Establish connection to the Moshiboard device.
+
+        Attempts to find and connect to a compatible Moshiboard device by:
+        1. Enumerating available CH341 interfaces
+        2. Trying each interface at configured USB indices
+        3. Validating device compatibility (bus, address, version)
+
+        Raises:
+            ConnectionRefusedError: If no compatible device is found
+            PermissionError: If USB access is denied (logged, not raised)
+
+        The method implements robust error handling with detailed logging
+        for troubleshooting connection issues.
+        """
         _ = self.usb_log._
         if self.connection is not None and self.connection.is_connected():
             return  # Already connected.
@@ -152,15 +282,15 @@ class MoshiController:
                         self._open_at_index(i)
                         return  # Opened successfully.
                     except ConnectionRefusedError as e:
-                        self.usb_log(str(e))
+                        self.usb_log(f"Failed to open connection at index {i}: {e}")
                         if self.connection is not None:
                             self.connection.close()
-                    except IndexError:
-                        self.usb_log(_("Connection failed."))
+                    except IndexError as e:
+                        self.usb_log(f"Failed to open connection at index {i}: {e}")
                         self.connection = None
                         break
         except PermissionError as e:
-            self.usb_log(str(e))
+            self.usb_log(f"Failed to open connection: {e}")
             return  # OS denied permissions, no point checking anything else.
         if self.connection:
             self.close()
@@ -169,6 +299,15 @@ class MoshiController:
         )
 
     def _open_at_index(self, usb_index):
+        """
+        Open connection at a specific USB index with validation.
+
+        Args:
+            usb_index (int): The USB device index to attempt connection
+
+        Raises:
+            ConnectionRefusedError: If device validation fails
+        """
         _ = self.context.kernel.translation
         self.connection.open(usb_index=usb_index)
         if not self.connection.is_connected():
@@ -195,6 +334,15 @@ class MoshiController:
                 )
 
     def close(self):
+        """
+        Close the current USB connection.
+
+        Safely closes the connection to the Moshiboard device and
+        cleans up the connection reference.
+
+        Raises:
+            ConnectionError: If no connection exists to close
+        """
         self.pipe_channel("close()")
         if self.connection is not None:
             self.connection.close()
@@ -203,11 +351,30 @@ class MoshiController:
             raise ConnectionError
 
     def write(self, data):
+        """
+        Queue a program for transmission to the device.
+
+        Adds the program data to the processing queue and ensures
+        the processing thread is running.
+
+        Args:
+            data: The program data to be sent to the device
+        """
         with self._program_lock:
             self._programs.append(data)
         self.start()
 
     def realtime(self, data):
+        """
+        Send a real-time command to the device.
+
+        Real-time commands can interrupt normal processing and are
+        sent immediately. Special handling for emergency stop commands
+        which clear all buffers and terminate current processing.
+
+        Args:
+            data: The real-time command data to send
+        """
         if MoshiBuilder.is_estop(data):
             self.context.signal("pipe;buffer", 0)
             self.update_state("terminate")
@@ -217,15 +384,23 @@ class MoshiController:
         try:
             self.open()
             self.connection.write_addr(data)
-        except ConnectionRefusedError:
-            pass  # could not open connection.
-        except ConnectionError:
-            pass  # Connection did not return success.
+        except ConnectionRefusedError as e:
+            self.usb_log(f"Failed to open connection for realtime command: {e}")
+        except ConnectionError as e:
+            self.usb_log(f"Failed to open connection for realtime command: {e}")
 
     def start(self):
         """
-        Controller state change to `Started`.
-        @return:
+        Start the data transmission thread.
+
+        Creates and starts a new thread for processing queued programs
+        if one is not already running. The thread will process programs
+        from the queue and transmit them to the device.
+
+        Thread Safety:
+        - Safe to call from any thread
+        - Will not create duplicate threads
+        - Thread creation is handled by the service context
         """
         if self._thread is None or not self._thread.is_alive():
             self._thread = self.context.threaded(
@@ -237,10 +412,15 @@ class MoshiController:
 
     def pause(self):
         """
-        Pause simply holds the controller from sending any additional packets.
+        Pause the current data transmission.
 
-        If this state change is done from INITIALIZE it will start the processing.
-        Otherwise, it must be done from ACTIVE or IDLE.
+        If called during initialization, this will start processing.
+        If called during active processing or idle state, this will
+        pause the transmission until resume() is called.
+
+        State Transitions:
+        - init → pause (starts processing)
+        - active/idle → pause (pauses processing)
         """
         if self.state == "init":
             self.start()
@@ -250,14 +430,29 @@ class MoshiController:
 
     def resume(self):
         """
-        Resume can only be called from PAUSE.
+        Resume paused data transmission.
+
+        Can only be called when the controller is in the 'pause' state.
+        Transitions the controller back to 'active' state to continue
+        processing queued programs.
+
+        Raises:
+            No explicit errors, but has no effect if not in pause state
         """
         if self.state == "pause":
             self.update_state("active")
 
     def stop(self, *args):
         """
-        Start the shutdown of the local send thread.
+        Stop the data transmission thread.
+
+        Waits for the current thread to complete its work before
+        returning. This ensures clean shutdown of processing.
+
+        Thread Safety:
+        - Safe to call from any thread
+        - Will block until thread completes
+        - Handles RuntimeError if called from within the thread
         """
         if self._thread is not None:
             try:
@@ -268,7 +463,13 @@ class MoshiController:
 
     def update_state(self, state):
         """
-        Update the local state for the output device
+        Update the controller's current state.
+
+        Manages state transitions and notifies listeners of state changes.
+        Only updates and signals if the state actually changes.
+
+        Args:
+            state (str): New state ('unknown', 'init', 'active', 'idle', 'pause', etc.)
         """
         if state == self.state:
             return
@@ -278,13 +479,23 @@ class MoshiController:
 
     def update_buffer(self):
         """
-        Notify listening processes that the buffer size of this output has changed.
+        Signal that the buffer size has changed.
+
+        Notifies all listeners about the current buffer size.
+        Used by UI components to update buffer displays.
         """
-        self.context.signal("pipe;buffer", len(self._buffer))
+        with self._program_lock:
+            self.context.signal("pipe;buffer", len(self._buffer))
 
     def update_packet(self, packet):
         """
-        Notify listening processes that the last sent packet has changed.
+        Signal that a packet has been sent.
+
+        Notifies listeners about the most recently transmitted packet
+        and logs it to the USB send channel.
+
+        Args:
+            packet: The packet data that was just sent
         """
         if self.context is not None:
             self.context.signal("pipe;packet_text", packet)
@@ -292,10 +503,27 @@ class MoshiController:
 
     def _send_buffer(self):
         """
-        Send the current Moshiboard buffer
+        Send the current transmission buffer to the device.
+
+        Processes the transmission buffer by sending data in chunks and
+        managing the transmission state. Implements exponential backoff
+        for handling transmission delays.
+
+        Processing Logic:
+        - Sends packets until buffer is empty
+        - Resets backoff counter on successful sends
+        - Increases wait time on failed sends (up to 1 second)
+        - Updates controller state based on transmission success
+
+        Thread Safety:
+        - Called only from the main processing thread
+        - Uses _program_lock for buffer access
         """
         self.pipe_channel("Sending Buffer...")
-        while len(self._buffer) != 0:
+        while True:
+            with self._program_lock:
+                if len(self._buffer) == 0:
+                    break
             queue_processed = self.process_buffer()
             self.refuse_counts = 0
 
@@ -317,18 +545,38 @@ class MoshiController:
                     "terminate",
                 ):
                     self.update_state("idle")
-                if self.count > 50:
-                    self.count = 50
-                time.sleep(0.02 * self.count)
+                wait_length = 0.02 * min(50, self.count)
+                time.sleep(wait_length)
                 # will tick up to 1 second waits if there's never a queue.
                 self.count += 1
 
     def _thread_data_send(self):
         """
-        Main threaded function to send data. While the controller is working the thread
-        will be doing work in this function.
+        Main data transmission thread function.
+
+        This is the core processing loop that handles the complete lifecycle
+        of sending programs to the Moshiboard device. Implements the three-stage
+        protocol for each program and handles all error conditions.
+
+        Processing Stages:
+        1. Wait for work and establish connection
+        2. Prepare program (load into buffer, send preamble)
+        3. Send data and wait for completion
+        4. Send epilogue and verify success
+
+        Error Handling:
+        - Connection errors trigger reconnection attempts
+        - Multiple refusal errors trigger failure state
+        - Graceful shutdown on termination signals
+
+        Thread Safety:
+        - This is the only thread that modifies _buffer
+        - Uses _program_lock for all buffer/program access
+        - Handles shutdown signals properly
         """
-        self.pipe_channel(f"Send Thread Start... {len(self._programs)}")
+        with self._program_lock:
+            program_count = len(self._programs)
+        self.pipe_channel(f"Send Thread Start... {program_count}")
         self.count = 0
         self.is_shutdown = False
 
@@ -340,25 +588,34 @@ class MoshiController:
                     self.update_state("active")
                 if self.is_shutdown:
                     break
-                if len(self._buffer) == 0 and len(self._programs) == 0:
+                with self._program_lock:
+                    has_work = len(self._buffer) > 0 or len(self._programs) > 0
+                if not has_work:
                     self.pipe_channel("Nothing to process")
                     break  # There is nothing to run.
                 if self.connection is None:
                     self.open()
                 # Stage 0: New Program send.
-                if len(self._buffer) == 0:
+                with self._program_lock:
+                    buffer_empty = len(self._buffer) == 0
+                if buffer_empty:
                     self.context.laser_status = "active"
                     self.pipe_channel("New Program")
                     self.wait_until_accepting_packets()
                     MoshiBuilder.prologue(self.connection.write_addr, self.pipe_channel)
                     with self._program_lock:
-                        self._buffer += self._programs.pop(0)
-                    if len(self._buffer) == 0:
-                        continue
+                        if self._programs:
+                            self._buffer += self._programs.pop(0)
+                with self._program_lock:
+                    buffer_still_empty = len(self._buffer) == 0
+                if buffer_still_empty:
+                    continue
 
                 # Stage 1: Send Program.
                 self.context.laser_status = "active"
-                self.pipe_channel(f"Sending Data... {len(self._buffer)} bytes")
+                with self._program_lock:
+                    buffer_size = len(self._buffer)
+                self.pipe_channel(f"Sending Data... {buffer_size} bytes")
                 self._send_buffer()
                 self.update_status()
                 MoshiBuilder.epilogue(self.connection.write_addr, self.pipe_channel)
@@ -367,7 +624,9 @@ class MoshiController:
 
                 # Stage 2: Wait for Program to Finish.
                 self.pipe_channel("Waiting for finish processing.")
-                if len(self._buffer) == 0:
+                with self._program_lock:
+                    buffer_finished = len(self._buffer) == 0
+                if buffer_finished:
                     self.wait_finished()
                 self.context.laser_status = "idle"
 
@@ -402,14 +661,23 @@ class MoshiController:
 
     def process_buffer(self):
         """
-        Attempts to process the program send from the buffer.
+        Process and send the next packet from the transmission buffer.
 
-        @return: queue process success.
+        Extracts the next 32-byte chunk from the buffer, sends it to the device,
+        and removes the sent data from the buffer.
+
+        Returns:
+            bool: True if a packet was successfully sent, False otherwise
+
+        Thread Safety:
+        - Called only from _send_buffer() in the main processing thread
+        - Uses _program_lock for buffer modifications
         """
-        if len(self._buffer) > 0:
-            buffer = self._buffer
-        else:
-            return False
+        with self._program_lock:
+            if len(self._buffer) > 0:
+                buffer = self._buffer
+            else:
+                return False
 
         length = min(32, len(buffer))
         packet = buffer[:length]
@@ -420,13 +688,20 @@ class MoshiController:
         self.context.packet_count += 1
 
         # Packet was processed. Remove that data.
-        self._buffer = self._buffer[length:]
+        with self._program_lock:
+            self._buffer = self._buffer[length:]
         self.update_buffer()
         return True  # A packet was prepped and sent correctly.
 
     def send_packet(self, packet):
         """
-        Send packet to the CH341 connection.
+        Send a packet to the USB connection.
+
+        Args:
+            packet: The data packet to send
+
+        Raises:
+            ConnectionError: If no connection is available
         """
         if self.connection is None:
             raise ConnectionError
@@ -436,6 +711,13 @@ class MoshiController:
     def update_status(self):
         """
         Request a status update from the CH341 connection.
+
+        Retrieves the current device status and broadcasts it to all
+        listeners. Updates the internal status array and signals
+        status changes to the application.
+
+        Raises:
+            ConnectionError: If no connection is available
         """
         if self.connection is None:
             raise ConnectionError
@@ -454,6 +736,18 @@ class MoshiController:
     def wait_until_accepting_packets(self):
         """
         Wait until the device can accept packets.
+
+        Polls the device status until it reports STATUS_OK (205),
+        indicating it's ready to receive data. Implements timeout
+        and abort handling for robust operation.
+
+        Raises:
+            ConnectionError: If USB connection fails
+            ConnectionRefusedError: If device reports error status
+
+        Thread Safety:
+        - Can be interrupted by setting abort_waiting flag
+        - Updates status during wait loop
         """
         i = 0
         while self.state != "terminate":
@@ -474,6 +768,20 @@ class MoshiController:
     def wait_finished(self):
         """
         Wait until the device has finished the current sending buffer.
+
+        Monitors device status until processing is complete (STATUS_OK).
+        Handles connection recovery and abort signals during the wait.
+
+        Processing States:
+        - STATUS_PROCESSING (207): Device is still working
+        - STATUS_OK (205): Processing complete
+        - STATUS_ERROR (237): Error occurred
+        - Status 0: Connection lost
+
+        Thread Safety:
+        - Can be interrupted by setting abort_waiting flag
+        - Automatically attempts reconnection on connection loss
+        - Updates controller state appropriately
         """
         self.pipe_channel("Wait Finished")
         i = 0


### PR DESCRIPTION
## Summary by Sourcery

Improve documentation and thread safety in MoshiController by adding detailed docstrings, centralizing and enforcing locks for shared data access, and enhancing status code handling and logging.

Enhancements:
- Add comprehensive docstrings for MoshiController class and all its methods, clarifying arguments, returns, exceptions, and threading behavior
- Introduce a central threading lock (_program_lock) to protect the program queue and transmission buffer from concurrent access
- Wrap buffer and program queue interactions in lock contexts within viewbuffer, __len__, process_buffer, _send_buffer, and the main thread loop
- Enhance status code definitions and expand get_code_string_from_moshicode documentation to list all recognized codes
- Improve USB connection error logging with descriptive f-strings for failure messages