### PR TITLE
Angle div fix for /=

### DIFF
--- a/meerk40t/core/units.py
+++ b/meerk40t/core/units.py
@@ -538,6 +538,10 @@ class Angle:
     def __eq__(self, other):
         if hasattr(other, "angle"):
             other = other.angle
+        try:
+            other = float(other)
+        except (TypeError, ValueError):
+            return False
         c1 = abs((self.angle % tau) - (other % tau)) <= 1e-11
         return c1
 
@@ -599,6 +603,12 @@ class Angle:
         return self
 
     def __idiv__(self, other):
+        if isinstance(other, Angle):
+            other = other.angle
+        self.angle /= other
+        return self
+
+    def __itruediv__(self, other):
         if isinstance(other, Angle):
             other = other.angle
         self.angle /= other


### PR DESCRIPTION
## Summary by Sourcery

Enable robust in-place division and comparison for Angle objects

Bug Fixes:
- Add __itruediv__ to support true in-place division ('/=') for Angle instances
- Modify __eq__ to catch invalid type conversions and return False instead of raising errors