### PR TITLE
Add feedback within plan stages

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -122,12 +122,19 @@ class CutPlan:
         Final is called during at the time of spool. Just before the laserjob is created.
         @return:
         """
+        busy = self.context.kernel.busyinfo
+        _ = self.context.kernel.translation
         # Using copy of commands, so commands can add ops.
+        c_count = 0
         while self.spool_commands:
             # Executing command can add a command, complete them all.
             commands = self.spool_commands[:]
             self.spool_commands.clear()
             for command in commands:
+                c_count += 1
+                if busy.shown:
+                    busy.change(msg=_("Spooling data {count}").format(count=c_count), keep=2)
+                    busy.show()
                 command()
 
     def preprocess(self):

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -716,7 +716,13 @@ class Planner(Service):
             #     "place point"
             #     "blob",
             # )
+            c_count = 0
             for c in operations:
+                c_count += 1
+                if busy.shown:
+                    busy.change(msg=_("Copying data {count}").format(count=c_count), keep=2)
+                    busy.show()
+
                 isactive = True
                 try:
                     if not c.output:

--- a/meerk40t/core/planner.py
+++ b/meerk40t/core/planner.py
@@ -699,6 +699,9 @@ class Planner(Service):
             init_settings()
 
             # Add default start ops
+            if busy.shown:
+                busy.change(msg=_("Adding trailing operations"), keep=1)
+                busy.show()
             add_ops(True)
             # types = (
             #     "op cut",
@@ -717,9 +720,10 @@ class Planner(Service):
             #     "blob",
             # )
             c_count = 0
+            update_interval = 10  # Update busy indicator every 10 commands
             for c in operations:
                 c_count += 1
-                if busy.shown:
+                if busy.shown and (c_count % update_interval) == 0:
                     busy.change(msg=_("Copying data {count}").format(count=c_count), keep=2)
                     busy.show()
 
@@ -754,6 +758,9 @@ class Planner(Service):
                 data.plan.append(copy_c)
 
             # Add default trailing ops
+            if busy.shown:
+                busy.change(msg=_("Adding trailing operations"), keep=1)
+                busy.show()
             add_ops(False)
             channel(_("Copied Operations."))
             self.update_stage(data.name, STAGE_PLAN_COPY)


### PR DESCRIPTION
## Summary by Sourcery

Add busyinfo feedback to spooling and copying stages in the plan pipeline to inform users of processing progress.

New Features:
- Display spooling progress messages during cut plan finalization
- Display copying progress messages during planner operation preprocessing