### PR TITLE
Make timeout for EPP-write longer in libusb.py

### DIFF
--- a/meerk40t/ch341/libusb.py
+++ b/meerk40t/ch341/libusb.py
@@ -54,6 +54,7 @@ class Ch341LibusbDriver:
         self.channel = channel
         self.backend_error_code = None
         self.timeout = 1500
+        self.timeoutEPPWrite = 60000
         self.bulk = bulk
 
     def find_device(self, index=0):
@@ -437,7 +438,7 @@ class Ch341LibusbDriver:
             data.insert(i, p)
         try:
             # endpoint, data, timeout
-            device.write(endpoint=BULK_WRITE_ENDPOINT, data=data, timeout=self.timeout)
+            device.write(endpoint=BULK_WRITE_ENDPOINT, data=data, timeout=self.timeoutEPPWrite)
         except usb.core.USBError as e:
             self.backend_error_code = e.backend_error_code
 


### PR DESCRIPTION
This change aims not to make K40 with Moshiboard run away. 

Moshiboard has a 32kB buffer on the board. The CH341 on the moshiboard makes the PC waits when the buffer is full until the buffer become available. This waiting time might be long enough to make device.write() in the line 440 of libusb.py give timeout exception; 
            device.write(endpoint=BULK_WRITE_ENDPOINT, data=data, timeout=self.timeout)
The waiting time can be easily long. For example, it is three seconds if the laser travels 30mm at 10mm/s. When timeout happens, disconnect_reset() function is repeatedly called to reset CH341 and the laser runs away in the end.

So this commit changes the timeout for EPP write to be 60 seconds.

## Summary by Sourcery

Extend the CH341 driver’s USB write timeout for EPP transfers to 60 seconds to prevent premature timeouts, repeated resets, and unintended laser movement when the Moshiboard’s buffer is full.

Bug Fixes:
- Use the extended timeoutEPPWrite for EPP write operations to avoid USB write timeout errors and subsequent device resets.

Enhancements:
- Introduce a new timeoutEPPWrite attribute in the CH341 libusb driver set to 60000 ms.