### PR TITLE
Prevent over-simplification during optimisation

### DIFF
--- a/test/test_geomstr.py
+++ b/test/test_geomstr.py
@@ -2569,7 +2569,10 @@ class TestGeomstr(unittest.TestCase):
         poly = Polygon(*pg)
         geometry = poly.geomstr
         simplified = geometry.simplify(0.01)
-        self.assertEqual(len(simplified), 32)
+        # With enhanced geometric shape protection, circular shapes preserve more points
+        # to maintain proper circular geometry
+        self.assertLessEqual(len(simplified), 100)  # Still simplified, but preserves circular shape
+        self.assertGreater(len(simplified), 5)  # More than a simple polygon
 
     def test_simplify_disjoint(self):
         """
@@ -2590,7 +2593,10 @@ class TestGeomstr(unittest.TestCase):
         g.translate(20, 20)
         geometry.append(g, end=False)
         simplified = geometry.simplify(0.01)
-        self.assertEqual(len(simplified), 64 + 1)
+        # With enhanced geometric shape protection, circular shapes preserve more points
+        # to maintain proper circular geometry for both circles
+        self.assertLessEqual(len(simplified), 200)  # Still simplified, but preserves circular shapes
+        self.assertGreater(len(simplified), 10)  # More than simple polygons
         self.assertIsNot(simplified, geometry)
 
     def test_simplify_settings(self):
@@ -2612,9 +2618,15 @@ class TestGeomstr(unittest.TestCase):
         g.flag_settings(1)
         geometry.append(g, end=False)
         simplified = geometry.simplify(0.01, inplace=True)
-        self.assertEqual(len(simplified), 64 + 1)
-        self.assertEqual(simplified.segments[16][2].imag, 0)
-        self.assertEqual(simplified.segments[48][2].imag, 1)
+        # With enhanced geometric shape protection, circular shapes preserve more points
+        # to maintain proper circular geometry for both circles
+        self.assertLessEqual(len(simplified), 200)  # Still simplified, but preserves circular shapes
+        self.assertGreater(len(simplified), 10)  # More than simple polygons
+        # The settings flags should still be preserved for the appropriate segments
+        # Check that we have segments with different settings flags
+        settings_flags = [seg[2].imag for seg in simplified.segments if len(seg) > 2]
+        self.assertTrue(any(flag == 0 for flag in settings_flags))
+        self.assertTrue(any(flag == 1 for flag in settings_flags))
         self.assertIs(simplified, geometry)
 
     def test_point_towards_numpy(self):

--- a/test/test_geomstr.py
+++ b/test/test_geomstr.py
@@ -2574,6 +2574,111 @@ class TestGeomstr(unittest.TestCase):
         self.assertLessEqual(len(simplified), 100)  # Still simplified, but preserves circular shape
         self.assertGreater(len(simplified), 5)  # More than a simple polygon
 
+    def test_simplify_rectangle(self):
+        """Test rectangle protection from over-simplification."""
+        # Rectangle: 4 points, should remain 4 after simplification
+        rectangle_points = np.array([(0.0, 0.0), (10.0, 0.0), (10.0, 5.0), (0.0, 5.0)], dtype=np.float32)
+        rectangle_complex = rectangle_points[:, 0] + rectangle_points[:, 1] * 1j
+        
+        # Create a polygon and manually close it
+        poly = Polygon(*rectangle_complex)
+        poly.geomstr.close()  # Explicitly close the polygon
+        geometry = poly.geomstr
+        
+        simplified = geometry.simplify(1.0)  # High tolerance to test protection
+        self.assertEqual(len(simplified), 4, "Rectangle should preserve all 4 vertices")
+
+    def test_simplify_triangle(self):
+        """Test triangle protection from over-simplification."""
+        # Triangle: 3 points, should remain 3 after simplification
+        triangle_points = np.array([(0.0, 0.0), (5.0, 10.0), (10.0, 0.0)], dtype=np.float32)
+        triangle_complex = triangle_points[:, 0] + triangle_points[:, 1] * 1j
+        
+        # Create a polygon and manually close it
+        poly = Polygon(*triangle_complex)
+        poly.geomstr.close()  # Explicitly close the polygon
+        geometry = poly.geomstr
+        
+        simplified = geometry.simplify(1.0)  # High tolerance to test protection
+        self.assertEqual(len(simplified), 3, "Triangle should preserve all 3 vertices")
+
+    def test_simplify_regular_polygon(self):
+        """Test regular polygon protection from over-simplification."""
+        # Use the built-in regular_polygon method (already creates closed polygon)
+        geometry = Geomstr.regular_polygon(6, 0 + 0j, radius=10)
+        
+        simplified = geometry.simplify(1.0)  # High tolerance to test protection
+        self.assertEqual(len(simplified), 6, "Regular hexagon should preserve all 6 vertices")
+
+    def test_simplify_small_shape_high_tolerance(self):
+        """Test protection of small shapes with high tolerance values."""
+        # Small rectangle that would normally be over-simplified
+        small_rect = np.array([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)], dtype=np.float32)
+        small_rect_complex = small_rect[:, 0] + small_rect[:, 1] * 1j
+        
+        # Create a polygon and manually close it
+        poly = Polygon(*small_rect_complex)
+        poly.geomstr.close()  # Explicitly close the polygon
+        geometry = poly.geomstr
+        
+        simplified = geometry.simplify(10.0)  # Very high tolerance - would normally over-simplify
+        self.assertGreaterEqual(len(simplified), 4, "Small rectangle should be protected even with high tolerance")
+
+    def test_simplify_star_shape(self):
+        """Test star shape protection from over-simplification."""
+        # Create a 5-pointed star
+        import math
+        n = 5
+        outer_r = 10
+        inner_r = 4
+        star_points = []
+        for i in range(n):
+            # Outer point
+            angle = 2 * math.pi * i / n - math.pi / 2
+            star_points.append((outer_r * math.cos(angle), outer_r * math.sin(angle)))
+            # Inner point
+            angle += math.pi / n
+            star_points.append((inner_r * math.cos(angle), inner_r * math.sin(angle)))
+        
+        star_array = np.array(star_points, dtype=np.float32)
+        star_complex = star_array[:, 0] + star_array[:, 1] * 1j
+        
+        # Create a polygon and manually close it
+        poly = Polygon(*star_complex)
+        poly.geomstr.close()  # Explicitly close the polygon
+        geometry = poly.geomstr
+        
+        simplified = geometry.simplify(1.0)  # High tolerance to test protection
+        self.assertEqual(len(simplified), 10, "Star should preserve all 10 vertices")
+
+    def test_simplify_large_shape_low_tolerance(self):
+        """Test that large shapes with low tolerance still get simplified appropriately."""
+        # Large rectangle with many extra points that should be simplified
+        base_rect = np.array([(0.0, 0.0), (100.0, 0.0), (100.0, 50.0), (0.0, 50.0)], dtype=np.float32)
+        # Add noise points that should be simplified away
+        noisy_points = []
+        for i, point in enumerate(base_rect):
+            noisy_points.append(point)
+            if i < len(base_rect) - 1:  # Don't add noise after last point
+                # Add multiple points with tiny deviations
+                for j in range(3):
+                    noise_x = point[0] + (0.01 * (j + 1))
+                    noise_y = point[1] + (0.01 * (j + 1) if j % 2 else -0.01 * (j + 1))
+                    noisy_points.append((noise_x, noise_y))
+        
+        noisy_array = np.array(noisy_points, dtype=np.float32)
+        noisy_complex = noisy_array[:, 0] + noisy_array[:, 1] * 1j
+        
+        # Create a polygon and manually close it
+        poly = Polygon(*noisy_complex)
+        poly.geomstr.close()  # Explicitly close the polygon
+        geometry = poly.geomstr
+        
+        simplified = geometry.simplify(0.1)  # Low tolerance - should still simplify noise
+        # Should recognize rectangle and simplify to 4 core vertices while removing noise
+        self.assertGreaterEqual(len(simplified), 4, "Should preserve at least the 4 core rectangle vertices")
+        self.assertLess(len(simplified), len(noisy_points), "Should simplify some noise points")
+
     def test_simplify_disjoint(self):
         """
         Simplify of 2 large circles. The circles are not denoted with an `END` but only by their disjoint.
@@ -2625,8 +2730,8 @@ class TestGeomstr(unittest.TestCase):
         # The settings flags should still be preserved for the appropriate segments
         # Check that we have segments with different settings flags
         settings_flags = [seg[2].imag for seg in simplified.segments if len(seg) > 2]
-        self.assertTrue(any(flag == 0 for flag in settings_flags))
-        self.assertTrue(any(flag == 1 for flag in settings_flags))
+        self.assertTrue(0 in settings_flags)
+        self.assertTrue(1 in settings_flags)
         self.assertIs(simplified, geometry)
 
     def test_point_towards_numpy(self):


### PR DESCRIPTION
Optimisation has an option to reduce the resolution of curves to avoid flooding of the controller.

The Problem: Rectangular shapes are being reduced to just 2 diagonal cuts instead of maintaining their proper 4-sided structure

The algorithm uses (RDP) draws a line from A to C (diagonal), it calculates the distance from points B and D to this diagonal line AC. If the rectangle is small enough relative to the tolerance, points B and D might be considered "close enough" to the line AC and get removed, leaving only the diagonal A→C.

The fix now protects multiple types of geometric shapes from over-simplification:

1. Rectangles & Squares
Detects 4-point shapes with parallel opposite sides
Maintains all 4 segments even with high tolerance values
2. Triangles
Protects all 3-point closed shapes that form valid triangles
Prevents degenerate triangle reduction
3. Regular Polygons
Detects pentagons, hexagons, octagons, etc. (5-12 sides)
Identifies shapes with equal distances from center and equal angles
Protects architectural and decorative geometric patterns
4. Ellipses & Circles
Detects circular and elliptical patterns (up to 3:1 axis ratio)
Analyzes distance patterns from center for smoothness
Protects curved shapes approximated by line segments
5. Star Patterns
Identifies alternating peak/valley distance patterns from center
Protects decorative star shapes and similar radial patterns
Handles 5-point, 6-point, and other star configurations
6. General Closed Shapes
Any closed shape with ≤8 points gets basic protection
Prevents over-simplification of intentional small geometric features
Adaptive Protection Strategy
Size-based tolerance: Larger shapes get less aggressive protection to avoid performance issues
Conservative reduction: Protected shapes use 5% of the original tolerance (vs 100%)
Minimum/maximum bounds: Protection tolerance ranges from 0.1 to 5.0 units
Fallback safety: If shape detection fails, normal simplification proceeds

## Summary by Sourcery

Prevent key vertices from being removed during curve optimisation by detecting common geometric shapes and applying a conservative, adaptive tolerance in the Ramer–Douglas–Peucker simplification routine.

Bug Fixes:
- Fix the oversimplification bug that reduced rectangles and other shapes to minimal diagonal representations.

Enhancements:
- Add shape-protection logic to detect closed shapes (rectangles, triangles, regular polygons, ellipses/circles, star patterns, and small geometries) before simplification.
- Apply an adaptive, much lower tolerance for protected shapes in the RDP algorithm to preserve their structural vertices.

Tests:
- Relax simplify tests to assert point-count ranges for protected shapes and verify that segment settings flags are retained.