### PR TITLE
Ruida UDP comms hardening.

### DIFF
--- a/meerk40t/ruida/controller.py
+++ b/meerk40t/ruida/controller.py
@@ -22,7 +22,6 @@ class RuidaController:
 
         self.job = RDJob()
         self._send_queue = []
-        self._send_lock = threading.Condition()
         self._send_thread = None
         self.events = service.channel(f"{service.safe_label}/events")
 
@@ -50,10 +49,6 @@ class RuidaController:
         while self._send_queue:
             data = self._send_queue.pop(0)
             self.write(data)
-            with self._send_lock:
-                if not self._send_lock.wait(5):
-                    self.service.signal("warning", "Connection Problem.", "Timeout")
-                    return
         self._send_queue.clear()
         self._send_thread = None
         self.events("File Sent.")

--- a/meerk40t/ruida/controller.py
+++ b/meerk40t/ruida/controller.py
@@ -59,11 +59,13 @@ class RuidaController:
         self.events("File Sent.")
 
     def recv(self, reply):
-        e = self.job.unswizzle(reply)
-        if e == ACK:
-            with self._send_lock:
-                self._send_lock.notify()
-        self.events(f"-->: {e}")
+        '''Receive reply from the controller.
+
+        The only reason this will be called is in response to a command
+        which requires reply data from the controller. Forward to the
+        RDJob for parsing.'''
+        _decoded = self.job.decode_reply(reply)
+        self.events(f"-->: {_decoded}")
 
     def start_record(self):
         self.job.get_setting(MEM_CARD_ID, output=self.write)

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -411,6 +411,9 @@ class RuidaDevice(Service, Status):
             elif self.interface == "usb":
                 self.active_interface = self.interface_usb
                 self.driver.controller.write = self.interface_usb.write
+            _swizzle = self.driver.controller.job.swizzle
+            _unswizzle = self.driver.controller.job.unswizzle
+            self.active_interface.set_swizzles(_swizzle, _unswizzle)
 
         @self.console_command(("estop", "abort"), help=_("Abort Job"))
         def pipe_abort(command, channel, _, data=None, **kwargs):

--- a/meerk40t/ruida/udp_connection.py
+++ b/meerk40t/ruida/udp_connection.py
@@ -3,8 +3,10 @@ UDP Connection handles Ruida UDP data sending and receiving and the Ruida protoc
 """
 
 import socket
+import queue
 import struct
 
+from meerk40t.ruida.rdjob import ACK, ERR
 
 class UDPConnection:
     def __init__(self, service):
@@ -15,7 +17,20 @@ class UDPConnection:
         self.events = service.channel(f"{name}/events", pure=True)
         self.is_shutdown = False
         self.recv_address = None
+        self.send_port = 50200
+        self.listen_port = 40200
+        self.ctrl_port = 50207
+        self.ctrl_listen_port = 40207
         self.socket = None
+        self.swizzle = None
+        self.unswizzle = None
+        self.send_q = queue.Queue(2 ** 18) # Power of 2 for efficiency.
+        self._to = 0.25
+
+    # Should verify type is a callable method.
+    def set_swizzles(self, swizzle, unswizzle):
+        self.swizzle = swizzle
+        self.unswizzle = unswizzle
 
     def shutdown(self, *args, **kwargs):
         self.is_shutdown = True
@@ -24,13 +39,16 @@ class UDPConnection:
         if self.connected:
             return
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # TODO: Want non-blocking. Handling send/rcv using states and blocking
+        # on the send queue.
         self.socket.settimeout(4)
-        self.socket.bind(("", 40200))
+        self.socket.bind(("", self.listen_port))
 
         name = self.service.safe_label
         self.service.threaded(
-            self._run_udp_listener, thread_name=f"thread-{name}", daemon=True
+            self._ruida_handshaker, thread_name=f"thread-{name}", daemon=True
         )
+        # TODO: usb_status is a misnomer.
         self.service.signal("pipe;usb_status", "connected")
         self.events("Connected")
 
@@ -54,20 +72,145 @@ class UDPConnection:
         pass
 
     def write(self, data):
-        self.open()
-        data = struct.pack(">H", sum(data) & 0xFFFF) + data
-        self.socket.sendto(data, (self.service.address, 50200))
-        self.send(data)
+        '''Provide double buffered data transmission.
 
-    def _run_udp_listener(self):
+        This blocks for a short time when the queue is full and retries a number
+        of times for a total of approximately 4 seconds before giving up.
+
+        TODO: What does the calling method do in the case of timeout? How to
+        inform the calling method a timeout occurred?
+        '''
+        self.open()
+        # Blocks when queue is full.
+        _tries = 12 # Approximately 4 seconds.
+        while _tries:
+            try:
+                self.send_q.put(data, timeout=self._to)
+                _tries -= 1
+            except queue.Full:
+                if _tries == 0:
+                    self.events('Ruida send queue FULL.')
+                continue
+        self.send(data) # TODO: Where this goes is not known at this time.
+
+    def _ruida_handshaker(self):
+        '''This is a thread which handles the SEND - ACK - REPLY handshake.
+
+        The purpose is to guarantee message sync and graceful failure handling.
+        Sync is required because UDP is a fire and forget protocol and does
+        not support sequence numbers.
+
+        The Ruida protocol is a speak only when spoken to protocol meaning
+        the Ruida controller doesn't send anything unless it receives a command.
+        In most cases the response is a simple ACK but with some commands the
+        controller follows the ACK with data.
+
+        Because it is necessary to know when reply data is expected, swizzling
+        occurs in this thread.
+
+        This is a brute force state machine containing 3 states:
+            IDLE            Waiting for data to be sent.
+            ACK_PENDING     Data has been sent and need an acknowledge.
+            REPLY_PENDING   A command was sent which requires a reply from the
+                            controller.
+
+        Some internal stats are maintained to aid failure diagnosis.
+            sends   Number of messages sent.
+            acks    Number of ACKs received in reply
+            naks    The number of NAKs triggering a resend of a message.
+            replies The number of reply data packets received.
+        '''
+        self.sends = 0
+        self.acks = 0
+        self.naks = 0
+        self.replies = 0
+        _ack_pending = False
+        _reply_pending = False
         try:
-            while self.connected:
-                try:
-                    message, address = self.socket.recvfrom(1024)
-                except (socket.timeout, AttributeError):
-                    continue
-                if address is not None:
-                    self.recv_address = address
-                self.recv(message)
+            while True: # Run forever -- until shutdown externally.
+                # Be sure to allow context switching so the GUI remains
+                # responsive.
+
+                # IDLE
+                while True: # Block here for IDLE state.
+                    try: # NOTE: The queue will be empty if not connected.
+                        # Don't block forever because some earlier versions
+                        # of Python and on Windows (yuck) will not respond to
+                        # a keyboard interrupt.
+                        _message = self.send_q.get(timeout=self._to)
+                        break
+                    except queue.Empty:
+                        # TODO: Could add a keep-alive here.
+                        continue
+                    # TODO: Could add a sanity check on connect state.
+
+                # Transition
+                # Check for only KNOWN command expecting a reply.
+                if (_message[0] == 0xDA and
+                    _message[1] != 0x01): # 0x01 is a memory set -- no reply.
+                    _reply_pending = True
+                    self.events('Expecting reply data.')
+                _data = self.swizzle(_message)
+                _data = struct.pack(">H", sum(_data) & 0xFFFF) + _data
+                self.socket.sendto(_data,
+                                   (self.service.address, self.send_port))
+                _ack_pending = True
+
+                # ACK_PENDING
+                _tries = 4
+                while _ack_pending:
+                    try:
+                        _data, _address = self.socket.recvfrom(1024)
+                    except (socket.timeout, AttributeError):
+                        # Handle a receive timeout. This may be the result of a
+                        # loss of sync or the controller is no longer responding.
+                        _tries -= 1
+                        if _tries:
+                            continue
+                        else:
+                            self.events(f'Timeout on message: {self.sends}')
+                            _ack_pending = False
+                            _reply_pending = False
+                            break
+                    if _address is not None:
+                        # TODO: Need to understand how the address can be used
+                        # further connection sanity checking.
+                        self.recv_address = _address
+                    _ack = self.unswizzle(_data)
+                    if len(_ack) == 1:
+                        if _ack == ACK:
+                            # Signal that the next message can be sent.
+                            _ack_pending = False
+                            self.acks += 1
+                        # TODO: Add resend of _message if not ACK.
+                    else:
+                        self.events('Reply data when expecting ACK.')
+                        # Reply data in response to a command. Forward to be
+                        # processed.
+                        self.replies += 1
+                        _reply_pending = False
+                        # TODO: May need a way to restore sync.
+                        self.recv(_reply) # Just in case
+
+                # REPLY_PENDING
+                _tries = 4
+                while _reply_pending:
+                    try:
+                        _data, _address = self.socket.recvfrom(timeout=self._to)
+                        self.recv_address = _address
+                        # TODO: Add address sanity check?
+                        _reply_pending = False
+                        self.replies += 1
+                        _reply = self.unswizzle(_data)
+                        self.recv(_reply) # Forward to client.
+                    except socket.error as e:
+                        if (e.errno == socket.EWOULDBLOCK or
+                            e.errno == socket.EAGAIN):
+                            _tries -= 1
+                        if _tries:
+                            continue
+                        else:
+                            self.events('Time out when expecting data.')
+                            break
         except OSError:
             pass


### PR DESCRIPTION
This PR represents the next step in comms hardening for UDP communications with a Ruida controller. It replaces the receive thread with a state driven send and receive (handshake) thread to more gracefully handle failure conditions and reply data from the controller. And, because it is necessary for the handshake to know whether or not a reply is expected, the swizzle has been moved to the handshake thread.

Sending data to the controller is now double buffered by virtue of a queue between the write method and the handshake thread. This queue also serves to provide sync and locks until space is available. The queue size is large enough to avoid locking in most cases so the mechanism is mostly precautionary.

The new handshake thread has been tested and performs as expected. There may be a corner case or two which may reveal a problem but otherwise it is solid. Simple cut files are working with no problems. On the other hand, complex files such as a material tests are now triggering a new manifestation of the "invalid file" problem which has been determined to be unrelated to comms.

NOTE: Current testing has been with the laser disabled so power setting and speed parameters are not yet known to be correct.

NOTE: Some of these changes may be applicable to other interfaces (e.g. USB/serial) but have not been considered at this time.