### PR TITLE
Split image into rectangular subimages of connected non-white regions

### DIFF
--- a/meerk40t/core/elements/element_treeops.py
+++ b/meerk40t/core/elements/element_treeops.py
@@ -4829,12 +4829,12 @@ def init_tree(kernel):
     @tree_operation(
         _("Split image into subimages"),
         node_type="elem image",
-        help=_("Split image into rectangular subimages of connected non-white regions"),
+        help=_("Split image into rectangular subimages of connected non-white regions (not lossless)"),
         grouping="70_ELEM_IMAGES",
     )
     def image_split_subimages(node, **kwargs):
         # Language hint "Split image"
-        self("split_subimages\n")
+        self("split_subimages --morphology\n")
 
     @tree_submenu(_("Image"))
     ## @tree_separator_before()


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic segmentation of images into separate connected non-white region subimages and integrate the feature into both console commands and the element tree context menu

New Features:
- Add split_image_into_subimages function to extract connected non-white regions as separate rectangular subimages
- Introduce console command 'split_subimages' to replace an image node with multiple subimage nodes preserving their offsets and transforms
- Add a tree operation menu entry for image elements to invoke the split_subimages command from the context menu