### PR TITLE
Give macros a name

### DIFF
--- a/meerk40t/grbl/gui/grblcontroller.py
+++ b/meerk40t/grbl/gui/grblcontroller.py
@@ -27,6 +27,69 @@ realtime_commands = (
 )
 
 
+class MacroEditDialog(wx.Dialog):
+    def __init__(self, parent, title, current_title, current_macro, context=None):
+        super().__init__(parent, title=title, size=wx.Size(400, 300))
+        self.current_title = current_title
+        self.current_macro = current_macro
+        self.context = context
+        if context:
+            context.themes.set_window_colors(self)
+        self.SetHelpText("grblmacroedit")
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Title field
+        title_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        title_label = wx.StaticText(self, label=_("Title:"))
+        self.title_ctrl = wx.TextCtrl(self, value=current_title)
+        title_sizer.Add(title_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        title_sizer.Add(self.title_ctrl, 1, wx.EXPAND)
+        sizer.Add(title_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        # Content field
+        content_label = wx.StaticText(self, label=_("Content:"))
+        sizer.Add(content_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        self.content_ctrl = wx.TextCtrl(
+            self,
+            value=current_macro,
+            style=wx.TE_MULTILINE | wx.TE_PROCESS_ENTER
+        )
+        self.content_ctrl.SetMinSize(wx.Size(-1, 150))
+        sizer.Add(self.content_ctrl, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        # Buttons
+        button_sizer = wx.StdDialogButtonSizer()
+        self.ok_button = wx.Button(self, wx.ID_OK)
+        self.cancel_button = wx.Button(self, wx.ID_CANCEL)
+        button_sizer.AddButton(self.ok_button)
+        button_sizer.AddButton(self.cancel_button)
+        button_sizer.Realize()
+        sizer.Add(button_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 10)
+
+        self.SetSizer(sizer)
+        self.Layout()
+
+        # Center the dialog
+        self.Centre()
+
+        # Bind events
+        self.ok_button.Bind(wx.EVT_BUTTON, self.on_ok)
+        self.cancel_button.Bind(wx.EVT_BUTTON, self.on_cancel)
+
+    def on_ok(self, event):
+        self.EndModal(wx.ID_OK)
+
+    def on_cancel(self, event):
+        self.EndModal(wx.ID_CANCEL)
+
+    def get_title(self):
+        return self.title_ctrl.GetValue()
+
+    def get_macro(self):
+        return self.content_ctrl.GetValue()
+
+
 class GRBLControllerPanel(wx.Panel):
     """
     GRBL Controller Panel - Real-time communication interface for GRBL laser devices.
@@ -141,10 +204,13 @@ class GRBLControllerPanel(wx.Panel):
 
         sizer_3 = wx.BoxSizer(wx.HORIZONTAL)
         self.macros = []
+        self.macro_titles = []
         for idx in range(5):
             macrotext = self.service.setting(str, f"macro_{idx}", "")
             self.macros.append(macrotext)
-            btn = wxButton(self, wx.ID_ANY, f"Macro {idx+1}")
+            macrotitle = self.service.setting(str, f"macro_title_{idx}", "")
+            self.macro_titles.append(macrotitle)
+            btn = wxButton(self, wx.ID_ANY, f"Macro {idx+1}" if macrotitle == "" else macrotitle)
             btn.Bind(wx.EVT_BUTTON, self.send_macro(idx))
             btn.Bind(wx.EVT_RIGHT_DOWN, self.edit_macro(idx))
             btn.SetToolTip(_("Send list of commands to device. Right click to edit."))
@@ -300,22 +366,29 @@ class GRBLControllerPanel(wx.Panel):
     def edit_macro(self, idx):
         def handler(event):
             macro = str(self.macros[idx])
-            dlg = wx.TextEntryDialog(
+            title = str(self.macro_titles[idx])
+            # open a simple dialog to edit the macro: both title and content
+            dlg = MacroEditDialog(
                 self,
-                _("Content for macro {index}").format(index=idx + 1),
-                value=macro,
-                style=wx.TE_MULTILINE
-                | wx.OK
-                | wx.CANCEL
-                | wx.CENTRE
-                | wx.ICON_QUESTION,
+                _("Edit Macro {index}").format(index=idx + 1),
+                title,
+                macro,
+                context=self.service,
             )
-            dlg.ShowModal()
-            newmacro = dlg.GetValue()
+            if dlg.ShowModal() == wx.ID_OK:
+                new_title = dlg.get_title()
+                new_macro = dlg.get_macro()
+                if new_title != title:
+                    self.macro_titles[idx] = new_title
+                    setattr(self.service, f"macro_title_{idx}", new_title)
+                    # Update button label
+                    button = self.FindWindowById(event.GetId())
+                    if button:
+                        button.SetLabel(f"Macro {idx+1}" if new_title == "" else new_title)
+                if new_macro != macro:
+                    self.macros[idx] = new_macro
+                    setattr(self.service, f"macro_{idx}", new_macro)
             dlg.Destroy()
-            if newmacro != macro:
-                self.macros[idx] = newmacro
-                setattr(self.service, f"macro_{idx}", newmacro)
 
         return handler
 


### PR DESCRIPTION
## Summary by Sourcery

Allow users to assign and edit names for GRBL macros alongside their content.

Enhancements:
- Add MacroEditDialog to edit both the title and content of macros.
- Store macro titles in the service and maintain a macro_titles list in the panel.
- Display custom macro titles on buttons, falling back to default labels if unnamed.
- Update edit_macro handler to persist title and content changes and refresh button labels.