### PR TITLE
Add keep-alive flags to socket communication

### DIFF
--- a/meerk40t/lihuiyu/tcp_connection.py
+++ b/meerk40t/lihuiyu/tcp_connection.py
@@ -24,6 +24,15 @@ class TCPOutput:
     def connect(self):
         try:
             self._stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # Enable TCP keep-alive to prevent connection timeouts
+            self._stream.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            # Set keep-alive parameters (platform-dependent)
+            try:
+                self._stream.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPIDLE", 60), 60)
+                self._stream.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPINTVL", 30), 30)
+                self._stream.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPCNT", 3), 3)
+            except (AttributeError, OSError):
+                pass  # Not all platforms support these options
             # Make sure port is in a valid range...
             port = min(65535, max(0, self.service.port))
             self._stream.connect((self.service.address, port))

--- a/meerk40t/ruida/tcp_connection.py
+++ b/meerk40t/ruida/tcp_connection.py
@@ -40,6 +40,15 @@ class TCPConnection:
             return
         try:
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # Enable TCP keep-alive to prevent connection timeouts
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            # Set keep-alive parameters (platform-dependent)
+            try:
+                self.socket.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPIDLE", 60), 60)
+                self.socket.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPINTVL", 30), 30)
+                self.socket.setsockopt(socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPCNT", 3), 3)
+            except (AttributeError, OSError):
+                pass  # Not all platforms support these options
             # Make sure port is in a valid range...
             port = min(65535, max(0, self.service.port))
             self.socket.connect((self.service.address, port))


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable SO_KEEPALIVE on the TCP sockets and configure platform-dependent keep-alive timers with safe fallbacks