### PR TITLE
Fix crosshatch sequence for 3d depthmap

### DIFF
--- a/meerk40t/core/node/op_image.py
+++ b/meerk40t/core/node/op_image.py
@@ -597,7 +597,7 @@ class ImageOpNode(Node, Parameters):
                         settings=cutsettings,
                         passes=passes,
                         post_filter=image_filter,
-                        label=f"Pass {gray}: cutoff={skip_pixel}",
+                        label=f"Pass {gray}: cutoff={skip_pixel} {'h' if horizontal else 'v'}",
                         laserspot=dotwidth,
                         special=self._instructions,
                     )
@@ -635,13 +635,14 @@ class ImageOpNode(Node, Parameters):
                             settings=cutsettings,
                             passes=passes,
                             post_filter=image_filter,
-                            label=f"Pass {gray}.2: cutoff={skip_pixel}",
+                            label=f"Pass {gray}.2: cutoff={skip_pixel} {'h' if horizontal else 'v'}",
                             laserspot=dotwidth,
                             special=self._instructions,
                         )
                         cut.path = path
                         cut.original_op = self.type
                         cutcodes.append(cut)
+                        horizontal = not horizontal # revert back for next main pass
             else:
                 # Create Cut Object for regular image
                 image_filter = None


### PR DESCRIPTION
## Summary by Sourcery

Fix crosshatch sequence for 3D depthmap threshold filtering by adding orientation markers to pass labels and toggling the horizontal flag between passes.

Bug Fixes:
- Annotate threshold filter pass labels with orientation ('h' or 'v')
- Toggle the horizontal flag after each main pass to maintain the correct crosshatch sequence