### PR TITLE
Ruida - Raster raster layers.

### DIFF
--- a/meerk40t/ruida/driver.py
+++ b/meerk40t/ruida/driver.py
@@ -173,7 +173,6 @@ class RuidaDriver(Parameters):
                     self.controller.job.write_settings(
                         current_settings, _raster)
                     last_settings = current_settings
-
             x = self.native_x
             y = self.native_y
             start_x, start_y = q.start


### PR DESCRIPTION
This PR corrects several issues preventing proper handling of raster layers and switching between cut and raster layers when using a Ruida controller. At this point, the Ruida driver is capable of producing clean engraves and cuts. Power levels are handled properly and overscan modes are properly selected. Transitions from cut layers to raster layers and back are working with proper overscan modes. 

NOTE: For proper raster overscan the overscan should  be set to 0 in the layer properties. Not doing so will still work but not as efficiently and can result in enlargement of the object in the direction of the overscan (see tc-7 below). For most objects be sure to set the stroke width to 0. Setting the object stroke width to something other than 0 will result in a burn area larger than the object dimensions.

NOTE: Exhaustive testing is still ongoing and some features remain untested. For example, attempting to engrave a photographic image has not been attempted. Text font anti-aliasing has not been tested. Also, dimensional precision for raster layers has not been verified. However, this version should work as expected in most situations.

I will be using this for a couple of real world projects and will fix problems as I encounter them.

Test projects are attached:
![tc-7-mk](https://github.com/user-attachments/assets/bff81f8f-1034-4bda-9ccc-4c7f99086212)
<img width="1131" height="1131" alt="tc-7" src="https://github.com/user-attachments/assets/5e905095-e7da-49ef-b6b1-be0558f15ac7" />
![tc-8-mk](https://github.com/user-attachments/assets/abc4f0c3-582f-4f44-8624-d411a073c20f)
<img width="1050" height="1050" alt="tc-8" src="https://github.com/user-attachments/assets/f63b2190-c325-4a2c-ac43-2321cb18e590" />

## Summary by Sourcery

Improve the Ruida driver by adding robust raster layer support, correcting bounds and frequency encoding, and enhancing layer transition and power command logic

New Features:
- Add raster layer support including detection of RasterCut items and selection of raster work modes for proper overscan handling

Bug Fixes:
- Fix encode_frequency unit scaling
- Correct layer bounds calculation and header coordinate ordering for accurate job dimensions
- Skip zero-length moves to avoid redundant commands

Enhancements:
- Implement first_layer flag to properly end and start layers in the Ruida job stream
- Track and optimize power settings by caching current power level and enforcing non-zero cut power
- Disable unused frequency_part commands to prevent incorrect laser frequency calls