### PR TITLE
Ruida user experience improvements.

### DIFF
--- a/meerk40t/ruida/controller.py
+++ b/meerk40t/ruida/controller.py
@@ -4,8 +4,18 @@ Ruida Encoder
 The Ruida Encoder is responsible for turning function calls into binary ruida data.
 """
 import threading
+import time
 
-from meerk40t.ruida.rdjob import ACK, MEM_CARD_ID, RDJob
+from meerk40t.ruida.rdjob import (
+    MEM_CARD_ID,
+    MEM_BED_SIZE_X,
+    MEM_BED_SIZE_Y,
+    MEM_CURRENT_X,
+    MEM_CURRENT_Y,
+    MEM_CURRENT_Z,
+    MEM_CURRENT_U,
+    STATUS_ADDRESSES,
+    RDJob)
 
 
 class RuidaController:
@@ -24,6 +34,27 @@ class RuidaController:
         self._send_queue = []
         self._send_thread = None
         self.events = service.channel(f"{service.safe_label}/events")
+        self._status_thread_sleep = 0.25 # Time between polls.
+        self._connected = False
+        self._job_lock = threading.Lock() # To allow running a job.
+        self._status_thread = threading.Thread(
+            target=self._status_monitor, daemon=True)
+        self._status_thread.start()
+        self._expect_status = None
+        self.card_id = b''
+        self.bed_x = -1.0
+        self.bed_y = -1.0
+        self.x = -1.0
+        self.y = -1.0
+        self.z = -1.0
+        self.u = -1.0
+        self._last_card_id = b''
+        self._last_bed_x = -1.0
+        self._last_bed_y = -1.0
+        self._last_x = 0.0
+        self._last_y = 0.0
+        self._last_z = 0.0
+        self._last_u = 0.0
 
     def start_sending(self):
         self._send_thread = threading.Thread(target=self._data_sender, daemon=True)
@@ -45,13 +76,147 @@ class RuidaController:
         if last != len(data):
             self._send_queue.append(self.job.get_contents(last))
 
+    @property
+    def busy(self):
+        return self._expect_status is not None
+
+    def sync_coords(self):
+        '''
+        Sync native coordinates with device coordinates.
+
+        This is typically used after actions such as physical home.'''
+        while self.busy:
+            time.sleep(self._status_thread_sleep)
+        self.service.driver.native_x = self.service.driver.device_x
+        self.service.driver.native_y = self.service.driver.device_y
+
     def _data_sender(self):
+        '''Data send thread.
+
+        This is a transient thread which is created after job data has been
+        queued. This runs until the queue is empty at which point it
+        terminates.'''
+        self._job_lock.acquire()
         while self._send_queue:
             data = self._send_queue.pop(0)
             self.write(data)
         self._send_queue.clear()
         self._send_thread = None
         self.events("File Sent.")
+        self._job_lock.release()
+
+    def _status_monitor(self):
+        '''Status monitoring thread.
+
+        The thread runs continually to monitor connection status with a
+        Ruida controller. It also updates the UI when status changes.
+
+        NOTE: This thread is blocked while _data_sender is running.'''
+        self._expect_status = None
+        _next = 0
+        try:
+            while True:
+                if self._expect_status is None:
+                    self._job_lock.acquire() # Wait if running a job.
+                    # Step through a series of commands and send/recv each one
+                    # by one. When received, recv will update the UI.
+                    _status = STATUS_ADDRESSES[_next]
+                    self.job.get_setting(
+                        _status, output=self.write)
+                    self._expect_status = _status
+                    _next += 1
+                    if _next >= len(STATUS_ADDRESSES):
+                        _next = 0
+                    self._job_lock.release()
+                time.sleep(self._status_thread_sleep)
+        except OSError:
+            pass
+
+    def update_card_id(self, card_id):
+        if self._expect_status == MEM_CARD_ID:
+            self._expect_status = None
+        if card_id != self.card_id:
+            self.card_id = card_id
+            # Signal the GUI update.
+
+    def update_bed_x(self, bed_x):
+        if self._expect_status == MEM_BED_SIZE_X:
+            self._expect_status = None
+        _bed_x = bed_x / 1000
+        if _bed_x != self.bed_x:
+            self.bed_x = _bed_x
+            # Signal the GUI update.
+            # TODO: The GUI should define the format and presentation units.
+            self.service.bedwidth = f'{_bed_x:.1f}mm'
+            self.service.signal('bedwidth', self.service.bedwidth)
+
+    def update_bed_y(self, bed_y):
+        if self._expect_status == MEM_BED_SIZE_Y:
+            self._expect_status = None
+        _bed_y = bed_y / 1000
+        if _bed_y != self.bed_y:
+            self.bed_y = _bed_y
+            # Signal the GUI update.
+            # TODO: The GUI should define the format and presentation units.
+            self.service.bedheight = f'{_bed_y:.1f}mm'
+            self.service.signal('bedheight', self.service.bedheight)
+
+    def update_x(self, x):
+        if self._expect_status == MEM_CURRENT_X:
+            self._expect_status = None
+        # TODO: Factor discovered by trial and error -- why necessary?
+        # _x = x * 2.58
+        _x = (self.bed_x * 1000 - x) * 2.58
+        if True or _x != self.x:
+            self.x = _x
+            # Signal the GUI update.
+            self.service.signal(
+                "driver;position",
+                (self._last_x, self._last_y, self.x, self.y))
+            self._last_x = self.x
+            # TODO: Updating native_x here causes intermittent move
+            # behavior.
+            self.service.driver.device_x = x
+
+    def update_y(self, y):
+        if self._expect_status == MEM_CURRENT_Y:
+            self._expect_status = None
+        # TODO: Factor discovered by trial and error -- why necessary?
+        _y = y * 2.58
+        if True or _y != self.y:
+            self.y = _y
+            # Signal the GUI update.
+            self.service.signal(
+                "driver;position",
+                (self._last_x, self._last_y, self.x, self.y))
+            self._last_y = self.y
+            # TODO: Updating native_y here causes intermittent move
+            # behavior.
+            self.service.driver.device_y = y
+
+    def update_z(self, z):
+        if self._expect_status == MEM_CURRENT_Z:
+            self._expect_status = None
+        if z != self.z:
+            self.z = z
+            # Signal the GUI update.
+
+    def update_u(self, u):
+        if self._expect_status == MEM_CURRENT_U:
+            self._expect_status = None
+        if u != self.u:
+            self.u = u
+            # Signal the GUI update.
+
+    _dispatch_lut = {
+        MEM_CARD_ID: update_card_id,
+        MEM_BED_SIZE_X: update_bed_x,
+        MEM_BED_SIZE_Y: update_bed_y,
+        MEM_CURRENT_X: update_x,
+        MEM_CURRENT_Y: update_y,
+        MEM_CURRENT_Z: update_z,
+        MEM_CURRENT_U: update_u,
+    }
 
     def recv(self, reply):
         '''Receive reply from the controller.
@@ -59,8 +224,19 @@ class RuidaController:
         The only reason this will be called is in response to a command
         which requires reply data from the controller. Forward to the
         RDJob for parsing.'''
-        _decoded = self.job.decode_reply(reply)
-        self.events(f"-->: {_decoded}")
+        if reply is not None:
+            _mem, _value, _decoded = self.job.decode_reply(reply)
+            if _mem is not None:
+                if _mem in self._dispatch_lut:
+                    # Dispatch to the corresponding updater.
+                    self._dispatch_lut[_mem](self, _value)
+                self.events(
+                    f"-->:Addr: {int.from_bytes(_mem):04X}={_value:08X}: {_decoded}")
+                self._connected = True
+        else:
+            # Comm failure -- timeout.
+            self._connected = False
+            pass
 
     def start_record(self):
         self.job.get_setting(MEM_CARD_ID, output=self.write)

--- a/meerk40t/ruida/device.py
+++ b/meerk40t/ruida/device.py
@@ -4,6 +4,8 @@ Ruida Device
 Ruida device interfacing. We do not send or interpret ruida code, but we can emulate ruidacode into cutcode and read
 ruida files (*.rd) and turn them likewise into cutcode.
 """
+import inspect
+
 from meerk40t.core.view import View
 from meerk40t.device.devicechoices import get_effect_choices, get_operation_choices
 from meerk40t.kernel import CommandSyntaxError, Service, signal_listener
@@ -721,7 +723,13 @@ class RuidaDevice(Service, Status):
         """
         @return: the location in units for the current known position.
         """
+        # This is a kludge because current is used for multiple moves and
+        # the navigation window/panel calls current. This conflicts with
+        # constant update of coordinates from the Ruida controller.
+        if inspect.stack()[1].function == 'on_label_dclick':
+            return self.view.iposition(self.driver.device_x, self.driver.device_y)
         return self.view.iposition(self.driver.native_x, self.driver.native_y)
+        # return self.view.iposition(self.driver.device_x, self.driver.device_y)
 
     @property
     def native(self):

--- a/meerk40t/ruida/driver.py
+++ b/meerk40t/ruida/driver.py
@@ -29,6 +29,11 @@ class RuidaDriver(Parameters):
         self.service = service
         self.native_x = 0
         self.native_y = 0
+        # Coordinates reported by the device. These are set by the
+        # controller updaters.
+        self.device_x = 0
+        self.device_y = 0
+
         self.name = str(self.service)
 
         name = self.service.safe_label
@@ -113,6 +118,7 @@ class RuidaDriver(Parameters):
         @param value:
         @return:
         """
+        pass
 
     def status(self):
         """
@@ -291,7 +297,7 @@ class RuidaDriver(Parameters):
         old_current = self.service.current
         job = self.controller.job
         out = self.controller.write
-        job.speed_laser_1(100.0, output=out)
+        job.speed_laser_1(400.0, output=out)
 
         x, y = self.service.view.position(x, y)
 
@@ -370,6 +376,9 @@ class RuidaDriver(Parameters):
         job = self.controller.job
         out = self.controller.write
         job.home_xy(output=out)
+        self.controller.sync_coords()
+        self.move_abs(10, 10)
+        self.home()
 
     def rapid_mode(self):
         """


### PR DESCRIPTION
This PR is for a number of changes to improve user experience when using a Ruida controller.
- Added a status monitor to continually check whether or not it is responding and to retrieve current coordinates
- Added a signal to inform the upper layers of connection status.
- Added signals to update the bed width and height as read from the controller. These coordinates are then displayed in the Ruida-Configuration window. Currently, they are in mm only. In the future this will be changed to use the mm/inches setting.
- Added signals to update the current X and Y coordinates so that the navigation window will display correct coordinates and double clicking on the displayed coordinates will correctly update the "Move Laser to:" settings. This works even after using the move buttons on the Ruida controller.
- Added sync logic for when a physical home (right click home button on nav window) is used. The Ruida controller goes completely silent while this is happening so the logic holds messages until the controller is once again responding. When the controller is responding again the head is moved to the MK home (far left corner) to ensure correct sync.

TODO: The connection status logic is currently slow to respond (approximately 40 seconds) because of allowing time for physical home to complete. Some logic needs to be added to use this long timeout only when physical home is running. Otherwise, use a short timeout to improve connection status update response.

WARNING: Correct coordinate update requires that Flip X in Axis corrections (Ruida-Configuration) be be checked. This should be default but can be unchecked by mistake.

NOTE: This works but may have undiscovered flaws. Also, there is room for improvement in the code. A lot of experimentation was required to characterize Ruida controller behavior under different conditions. This experimentation may have left a bit of residue or confusing structure. At the moment I'm out of time but plan to do some clean up when I once again have some time.

## Summary by Sourcery

Add continuous status monitoring and real-time UI signaling for Ruida controller connection and coordinate updates, extend protocol decoding for bed size and position, enhance UDP handshake robustness, and synchronize coordinates after physical home

New Features:
- Introduce a status monitor thread in RuidaController to poll connection health and retrieve bed size and current coordinates
- Emit service signals for connection status, bed dimensions, and current X/Y positions to keep the UI in sync
- Add sync logic after physical home to realign native and device coordinates automatically

Enhancements:
- Extend rdjob protocol support to decode additional memory addresses for bed size and axes positions
- Enhance UDPConnection handshake with configurable timeouts, NAK retries, keep-alive responses, and explicit connected/disconnected signaling
- Expose device_x/device_y in the driver and adjust device.current logic to enable correct coordinate display on double-click

Chores:
- Refactor get_setting and set_setting to use raw memory address bytes
- Increase default laser speed in move_abs to speed up absolute moves