### PR TITLE
Use proper move method within rasterplot

### DIFF
--- a/meerk40t/balormk/driver.py
+++ b/meerk40t/balormk/driver.py
@@ -20,9 +20,9 @@ from meerk40t.core.cutcode.outputcut import OutputCut
 from meerk40t.core.cutcode.plotcut import PlotCut
 from meerk40t.core.cutcode.quadcut import QuadCut
 from meerk40t.core.cutcode.waitcut import WaitCut
+from meerk40t.core.geomstr import Geomstr
 from meerk40t.core.plotplanner import PlotPlanner
 from meerk40t.device.basedevice import PLOT_FINISH, PLOT_JOG, PLOT_RAPID, PLOT_SETTING
-from meerk40t.core.geomstr import Geomstr
 
 
 class BalorDriver:
@@ -407,30 +407,33 @@ class BalorDriver:
                         time.sleep(0.05)
 
                     # q.plot can have different on values, these are parsed
-                    if last_on is None or on != last_on:
-                        # No power change.
-                        last_on = on
-                        if self.value_penbox:
-                            # There is an active value_penbox
-                            settings = dict(q.settings)
-                            limit = len(self.value_penbox) - 1
-                            m = int(round(on * limit))
-                            try:
-                                pen = self.value_penbox[m]
-                                settings.update(pen)
-                            except IndexError:
-                                pass
-                            # Power scaling is exclusive to this penbox. on is used as a lookup and does not scale power.
-                            con.set_settings(settings)
-                        else:
-                            # We are using traditional power-scaling
-                            max_power = float(
-                                q.settings.get("power", self.service.default_power)
-                            )
-                            percent_power = max_power / 10.0
-                            # Max power is the percent max power, scaled by the pixel power.
-                            con.power(percent_power * on)
-                    con.mark(x, y)
+                    if on == 0:
+                        con.goto(x, y)
+                    else:
+                        if last_on is None or on != last_on:
+                            # No power change.
+                            last_on = on
+                            if self.value_penbox:
+                                # There is an active value_penbox
+                                settings = dict(q.settings)
+                                limit = len(self.value_penbox) - 1
+                                m = int(round(on * limit))
+                                try:
+                                    pen = self.value_penbox[m]
+                                    settings.update(pen)
+                                except IndexError:
+                                    pass
+                                # Power scaling is exclusive to this penbox. on is used as a lookup and does not scale power.
+                                con.set_settings(settings)
+                            else:
+                                # We are using traditional power-scaling
+                                max_power = float(
+                                    q.settings.get("power", self.service.default_power)
+                                )
+                                percent_power = max_power / 10.0
+                                # Max power is the percent max power, scaled by the pixel power.
+                                con.power(percent_power * on)
+                        con.mark(x, y)
             elif isinstance(q, DwellCut):
                 start = q.start
                 con.goto(start[0], start[1])

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -17,12 +17,12 @@ from meerk40t.core.cutcode.plotcut import PlotCut
 from meerk40t.core.cutcode.quadcut import QuadCut
 from meerk40t.core.cutcode.waitcut import WaitCut
 
+from ..core.geomstr import Geomstr
 from ..core.parameters import Parameters
 from ..core.plotplanner import PlotPlanner
 from ..core.units import UNITS_PER_INCH, UNITS_PER_MIL, UNITS_PER_MM, Length
 from ..device.basedevice import PLOT_FINISH, PLOT_JOG, PLOT_RAPID, PLOT_SETTING
 from ..kernel import signal_listener
-from ..core.geomstr import Geomstr
 
 
 class GRBLDriver(Parameters):
@@ -206,13 +206,19 @@ class GRBLDriver(Parameters):
             new_x = self.native_x * self.service.view.native_scale_x + dx
             new_y = self.native_y * self.service.view.native_scale_y + dy
             if new_x < 0:
-                dx = - self.native_x * self.service.view.native_scale_x
+                dx = -self.native_x * self.service.view.native_scale_x
             elif new_x > self.service.view.width:
-                dx = self.service.view.width - self.native_x * self.service.view.native_scale_x 
+                dx = (
+                    self.service.view.width
+                    - self.native_x * self.service.view.native_scale_x
+                )
             if new_y < 0:
-                dy = - self.native_y * self.service.view.native_scale_y
+                dy = -self.native_y * self.service.view.native_scale_y
             elif new_y > self.service.view.height:
-                dy = self.service.view.height - self.native_y * self.service.view.native_scale_y
+                dy = (
+                    self.service.view.height
+                    - self.native_y * self.service.view.native_scale_y
+                )
         self._g91_relative()
         self._clean()
         old_current = self.service.current
@@ -526,6 +532,10 @@ class GRBLDriver(Parameters):
                     if self.on_value != on:
                         self.power_dirty = True
                     self.on_value = on
+                    if on == 0:
+                        self.move_mode = 0
+                    else:
+                        self.move_mode = 1
                     self._move(x, y)
             else:
                 #  Rastercut

--- a/meerk40t/newly/driver.py
+++ b/meerk40t/newly/driver.py
@@ -14,9 +14,9 @@ from meerk40t.core.cutcode.outputcut import OutputCut
 from meerk40t.core.cutcode.plotcut import PlotCut
 from meerk40t.core.cutcode.quadcut import QuadCut
 from meerk40t.core.cutcode.waitcut import WaitCut
+from meerk40t.core.geomstr import Geomstr
 from meerk40t.core.plotplanner import PlotPlanner
 from meerk40t.newly.controller import NewlyController
-from meerk40t.core.geomstr import Geomstr
 
 
 class NewlyDriver:
@@ -325,7 +325,10 @@ class NewlyDriver:
 
                     # q.plot can have different on values, these are parsed
                     # Max power is the percent max power, scaled by the pixel power.
-                    con.mark(x, y, settings=q.settings, power=percent_power * on)
+                    if on == 0:
+                        con.goto(x, y)
+                    else:
+                        con.mark(x, y, settings=q.settings, power=percent_power * on)
                     con.update()
             elif isinstance(q, DwellCut):
                 last_x, last_y = con.get_last_xy()
@@ -379,13 +382,19 @@ class NewlyDriver:
             new_x = self.native_x * self.service.view.native_scale_x + dx
             new_y = self.native_y * self.service.view.native_scale_y + dy
             if new_x < 0:
-                dx = - self.native_x * self.service.view.native_scale_x
+                dx = -self.native_x * self.service.view.native_scale_x
             elif new_x > self.service.view.width:
-                dx = self.service.view.width - self.native_x * self.service.view.native_scale_x 
+                dx = (
+                    self.service.view.width
+                    - self.native_x * self.service.view.native_scale_x
+                )
             if new_y < 0:
-                dy = - self.native_y * self.service.view.native_scale_y
+                dy = -self.native_y * self.service.view.native_scale_y
             elif new_y > self.service.view.height:
-                dy = self.service.view.height - self.native_y * self.service.view.native_scale_y
+                dy = (
+                    self.service.view.height
+                    - self.native_y * self.service.view.native_scale_y
+                )
 
         unit_dx, unit_dy = self.service.view.position(dx, dy, vector=True)
 


### PR DESCRIPTION
## Summary by Sourcery

Handle zero-power raster moves correctly across multiple drivers to improve raster plotting behavior.

Bug Fixes:
- Prevent lasers from issuing mark operations for zero-intensity raster pixels by using motion-only moves instead in Balor and Newly drivers.
- Ensure GRBL raster moves switch between move and mark modes based on per-pixel power, avoiding incorrect marking on off pixels.

Enhancements:
- Align move clamping logic formatting and clean up geomstr imports across drivers for consistency.