### PR TITLE
Add job type labels

### DIFF
--- a/meerk40t/grbl/gcodejob.py
+++ b/meerk40t/grbl/gcodejob.py
@@ -124,6 +124,7 @@ class GcodeJob:
         self._driver = driver
         self.channel = channel
         self.reply = None
+        self.label = "Gcode Job"
         self.buffer = list()
 
         self.priority = priority

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -4983,11 +4983,11 @@ class MeerK40t(MWindow):
                 return True  # VETO
         for job in self.context.device.spooler.queue:
             if job.is_running():
-                print(f"{job.label} was still running, stopping...")
+                print(f"{job.label if hasattr(job, 'label') else 'Unknown Job'} was still running, stopping...")
                 try:
                     job.stop()
                 except Exception as e:
-                    print(f"Error stopping job {job.label}: {e}")
+                    print(f"Error stopping job {job.label if hasattr(job, 'label') else 'Unknown Job'}: {e}")
         return False
 
     def window_close(self):

--- a/meerk40t/ruida/rdjob.py
+++ b/meerk40t/ruida/rdjob.py
@@ -517,6 +517,7 @@ class RDJob:
         self.units_to_device_matrix = units_to_device_matrix
         self._driver = driver
         self.channel = channel
+        self.label = "Ruida Job"
         self.reply = None
         self.buffer = list()
         self.plotcut = None


### PR DESCRIPTION
## Summary by Sourcery

Add descriptive labels to GRBL and Ruida jobs and make window close handling robust when job labels are missing.

Enhancements:
- Assign human-readable labels to GRBL G-code jobs and Ruida jobs for clearer logging and identification.
- Guard window close logging against jobs that do not define a label attribute to prevent errors during shutdown.