### PR TITLE
Additional attempt to prevent duplicate events in position updates

### DIFF
--- a/meerk40t/gui/position.py
+++ b/meerk40t/gui/position.py
@@ -123,7 +123,7 @@ class PositionPanel(PositionDimensionMixin, wx.Panel):
         # This matches the pattern used in other GUI panels where numeric entry fields
         # should not trigger global accelerators or higher-level handlers while editing.
         for ctl in (self.text_x, self.text_y, self.text_w, self.text_h):
-            ctl._prevent_propagation = True
+            ctl.prevent_propagation = True
         self.text_x.execute_action_on_change = False
         self.text_y.execute_action_on_change = False
         self.text_w.execute_action_on_change = False

--- a/meerk40t/gui/propertypanels/attributes.py
+++ b/meerk40t/gui/propertypanels/attributes.py
@@ -1018,7 +1018,7 @@ class PositionSizePanel(PositionDimensionMixin, wx.Panel):
         # position/dimension fields from propagating to parent panels or global handlers.
         # This avoids architectural event-propagation conflicts with higher-level shortcuts.
         for ctl in (self.text_x, self.text_y, self.text_w, self.text_h):
-            ctl._prevent_propagation = True
+            ctl.prevent_propagation = True
         self.btn_lock_ratio.Bind(wx.EVT_TOGGLEBUTTON, self.on_toggle_ratio)
 
         self.set_widgets(self.node)

--- a/meerk40t/gui/statusbarwidgets/shapepropwidget.py
+++ b/meerk40t/gui/statusbarwidgets/shapepropwidget.py
@@ -287,7 +287,7 @@ class PositionWidget(PositionDimensionMixin, StatusBarWidget):
         # for these position/size fields. This avoids accidental double-handling when
         # a parent also binds EVT_TEXT_ENTER.
         for ctl in (self.text_x, self.text_y, self.text_w, self.text_h):
-            ctl._prevent_propagation = True
+            ctl.prevent_propagation = True
         self.unit_lbl = wxStaticText(
             self.parent, wx.ID_ANY, label=self.units[self.unit_index]
         )

--- a/test/test_textctrl.py
+++ b/test/test_textctrl.py
@@ -1,0 +1,68 @@
+import time
+import unittest
+
+import wx
+
+from meerk40t.gui.wxutils import TextCtrl
+
+
+class TestTextCtrl(unittest.TestCase):
+    def setUp(self):
+        # Ensure a wx App exists
+        if not hasattr(wx, "GetApp") or wx.GetApp() is None:
+            self._app = wx.App(False)
+        else:
+            self._app = None
+        self.frame = wx.Frame(None)
+        self.txt = TextCtrl(
+            self.frame, id=wx.ID_ANY, value="", style=wx.TE_PROCESS_ENTER
+        )
+
+    def tearDown(self):
+        try:
+            self.frame.Destroy()
+        except Exception:
+            pass
+        if self._app:
+            try:
+                self._app.Destroy()
+            except Exception:
+                pass
+
+    def test_set_action_routine_none(self):
+        # Set a real action first
+        self.txt.SetActionRoutine(lambda: None)
+        self.assertIsNotNone(self.txt._action_routine)
+        # Now clear it
+        self.txt.SetActionRoutine(None)
+        self.assertIsNone(self.txt._action_routine)
+        self.assertIsNone(getattr(self.txt, "_user_action", None))
+        # Calling event handlers should not raise even when action is disabled
+        e = wx.CommandEvent(wx.EVT_TEXT.typeId)
+        self.txt.on_enter(e)  # should not raise
+
+    def test_context_menu_action_runs(self):
+        counter = {"c": 0}
+
+        def action():
+            counter["c"] += 1
+
+        self.txt.SetActionRoutine(action)
+        # Simulate the steps performed by the context-menu handler but without
+        # setting _last_action_called_time here (the guarded wrapper should
+        # perform debounce timing itself).
+        self.txt.SetValue("10")
+        self.txt.prevalidate("enter")
+        self.txt._event_generated = wx.EVT_TEXT_ENTER
+        now = time.time()
+        self.txt._last_action_time = now
+        self.txt._last_action_type = wx.EVT_TEXT_ENTER
+        try:
+            self.txt._action_routine()
+        finally:
+            self.txt._event_generated = None
+        self.assertEqual(counter["c"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary by Sourcery

Improve TextCtrl action handling to avoid duplicate event-triggered updates and unintended propagation from position/size fields.

Bug Fixes:
- Prevent duplicate position update actions caused by overlapping EVT_TEXT_ENTER and EVT_KILL_FOCUS events firing in quick succession.
- Debounce rapid, repeated invocations of TextCtrl actions across different event handlers to avoid re-entrancy and double-processing.

Enhancements:
- Wrap user-supplied TextCtrl action routines in a guarded caller that centralizes debounce and event-origin tracking.
- Track last action time and event type within TextCtrl to support smarter suppression of redundant actions.
- Introduce an opt-out flag on TextCtrls to stop Enter and focus events from propagating to parent/global handlers for position and size fields in attributes, status bar, and position panels.