### PR TITLE
Circumvent Linux Xfce enter behaviour

### DIFF
--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -1,4 +1,8 @@
 import datetime
+import os
+import platform
+import shutil
+import socket
 from platform import system
 
 import wx
@@ -1583,10 +1587,6 @@ class InformationPanel(ScrolledPanel):
 
     def __set_properties(self):
         # Fill the content...
-        import os
-        import platform
-        import socket
-
         uname = platform.uname()
         info = ""
         info += f"System: {uname.system}" + "\n"
@@ -1628,17 +1628,16 @@ class InformationPanel(ScrolledPanel):
                 except (FileNotFoundError, IOError):
                     pass
             
-            # Window manager
+            # Desktop session
             wm = os.environ.get("XDG_SESSION_DESKTOP") or os.environ.get("DESKTOP_SESSION") or "Unknown"
-            info += f"\nWindow Manager: {wm}"
+            info += f"\nDesktop Session: {wm}"
             
             # Free disk space
             try:
-                import shutil
                 total, used, free = shutil.disk_usage("/")
                 free_gb = free / (1024**3)
                 info += f"\nFree Disk Space: {free_gb:.2f} GB"
-            except ImportError:
+            except (ImportError, OSError):
                 pass
         
         self.os_version.SetValue(info)


### PR DESCRIPTION
Issue #3147 indicated an unexpected behaviour in Linux distributions using the XFCE window manager: Text controls with the TE_PROCESS_ENTER style set not only emit an enter key event but also a focus lost event. This results in duplicate event handlers.

## Summary by Sourcery

Address duplicate text control action triggers on Linux and enrich the About dialog with additional Linux system diagnostics.

New Features:
- Show Linux distribution, window manager, and free disk space details in the About dialog when running on Linux.

Bug Fixes:
- Prevent duplicate action routines from firing when Enter causes both focus-lost and text-enter events on some Linux window managers by introducing a short cooldown between triggers.

Enhancements:
- Add internal cooldown and reset handling for text control action routines to centralize duplicate-event protection logic.