### PR TITLE
Add a sudo/admin warning

### DIFF
--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -307,6 +307,21 @@ and a wxpython version <= 4.1.1."""
                 "signals": ("icons", "warn_state_update"),
             },
         ]
+        if platform.system() == "Linux":
+            choices.append(
+                {
+                    "attr": "suppress_sudo_warning",
+                    "object": kernel.root,
+                    "default": False,
+                    "type": bool,
+                    "label": _("Suppress sudo/admin warning"),
+                    "tip": _("Don't show the warning when running MeerK40t as root/admin on Linux"),
+                    "page": "Gui",
+                    # Hint for translation _("General")
+                    "section": "General",
+                }
+            )
+            
         kernel.register_choices("preferences", choices)
 
     elif lifecycle == "mainloop":


### PR DESCRIPTION
## Summary by Sourcery

Add a Linux-only warning dialog when MeerK40t is run with root/administrator privileges and provide guidance for configuring USB access without sudo.

New Features:
- Display an administrator/root warning dialog on Linux when the application is started with elevated privileges.
- Provide a one-click option to copy recommended udev and user-group configuration instructions for USB device access to the clipboard.
- Expose a preference option to suppress the sudo/admin warning on Linux.