### PR TITLE
Make locale inclusion more flexible

### DIFF
--- a/.github/workflows/linux/meerk40t.spec
+++ b/.github/workflows/linux/meerk40t.spec
@@ -1,5 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+# Dynamically generate locale data
+def get_locale_data():
+    locale_base = './locale'
+    datas = []
+    if os.path.exists(locale_base):
+        for lang in os.listdir(locale_base):
+            mo_path = os.path.join(locale_base, lang, 'LC_MESSAGES', 'meerk40t.mo')
+            if os.path.exists(mo_path):
+                datas.append((f'locale/{lang}/LC_MESSAGES/meerk40t.mo', f'locale/{lang}/LC_MESSAGES/meerk40t.mo', 'DATA'))
+    return datas
+
 block_cipher = None
 
 
@@ -15,19 +28,9 @@ a = Analysis(['../../../mk40t.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
-a.datas += [('locale/es/LC_MESSAGES/meerk40t.mo', 'locale/es/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/it/LC_MESSAGES/meerk40t.mo', 'locale/it/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/de/LC_MESSAGES/meerk40t.mo', 'locale/de/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/zh/LC_MESSAGES/meerk40t.mo', 'locale/zh/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/fr/LC_MESSAGES/meerk40t.mo', 'locale/fr/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/hu/LC_MESSAGES/meerk40t.mo', 'locale/hu/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ja/LC_MESSAGES/meerk40t.mo', 'locale/ja/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/nl/LC_MESSAGES/meerk40t.mo', 'locale/nl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ru/LC_MESSAGES/meerk40t.mo', 'locale/ru/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pl/LC_MESSAGES/meerk40t.mo', 'locale/pl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/tr/LC_MESSAGES/meerk40t.mo', 'locale/tr/LC_MESSAGES/meerk40t.mo', 'DATA')]
+
+# Add locale data
+a.datas += get_locale_data()
 
 pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)

--- a/.github/workflows/linux/meerk40t_build.spec
+++ b/.github/workflows/linux/meerk40t_build.spec
@@ -1,5 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+# Dynamically generate locale data
+def get_locale_data():
+    locale_base = './locale'
+    datas = []
+    if os.path.exists(locale_base):
+        for lang in os.listdir(locale_base):
+            mo_path = os.path.join(locale_base, lang, 'LC_MESSAGES', 'meerk40t.mo')
+            if os.path.exists(mo_path):
+                datas.append((f'locale/{lang}/LC_MESSAGES/meerk40t.mo', f'locale/{lang}/LC_MESSAGES/meerk40t.mo', 'DATA'))
+    return datas
+
 block_cipher = None
 
 
@@ -15,19 +28,9 @@ a = Analysis(['../../../meerk40t.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
-a.datas += [('locale/es/LC_MESSAGES/meerk40t.mo', 'locale/es/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/it/LC_MESSAGES/meerk40t.mo', 'locale/it/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/de/LC_MESSAGES/meerk40t.mo', 'locale/de/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/zh/LC_MESSAGES/meerk40t.mo', 'locale/zh/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/fr/LC_MESSAGES/meerk40t.mo', 'locale/fr/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/hu/LC_MESSAGES/meerk40t.mo', 'locale/hu/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ja/LC_MESSAGES/meerk40t.mo', 'locale/ja/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/nl/LC_MESSAGES/meerk40t.mo', 'locale/nl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ru/LC_MESSAGES/meerk40t.mo', 'locale/ru/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pl/LC_MESSAGES/meerk40t.mo', 'locale/pl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/tr/LC_MESSAGES/meerk40t.mo', 'locale/tr/LC_MESSAGES/meerk40t.mo', 'DATA')]
+
+# Add locale data
+a.datas += get_locale_data()
 
 pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)

--- a/.github/workflows/mac11_pyinst.yml
+++ b/.github/workflows/mac11_pyinst.yml
@@ -106,7 +106,14 @@ jobs:
         echo "mkversion=$(echo $MKVERSION)" >> $GITHUB_OUTPUT
         ## python3.8 setup_mac.py py2app --dylib-excludes /usr/local/lib/libssl.1.1.dylib,/usr/local/lib/libcrypto.1.1.dylib,/Users/runner/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/PIL/.dylibs/libfreetype.6.dylib,/Users/runner/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/PIL/.dylibs/liblzma.5.dylib --frameworks libusb-1.0.dylib
         mv meerk40t.py mk40t.py
-        python3.8 -m PyInstaller --hidden-import wx._adv --hidden-import wx._xml --hidden-import meerk40t --windowed --noconfirm -i meerk40t.icns --add-data 'locale/:locale/' --name MeerK40t mk40t.py
+        LOCALE_ARGS=""
+        for lang_dir in locale/*/; do
+            lang=$(basename "$lang_dir")
+            if [ -f "locale/$lang/LC_MESSAGES/meerk40t.mo" ]; then
+                LOCALE_ARGS="$LOCALE_ARGS --add-data locale/$lang/LC_MESSAGES/meerk40t.mo:locale/$lang/LC_MESSAGES/"
+            fi
+        done
+        python3.8 -m PyInstaller --hidden-import wx._adv --hidden-import wx._xml --hidden-import meerk40t --windowed --noconfirm -i meerk40t.icns $LOCALE_ARGS --name MeerK40t mk40t.py
         mv mk40t.py meerk40t.py
         rm -rf dist/MeerK40t
         sed -i "" "s|$MKVERSION|0.0.0|g" setup_mac.py

--- a/.github/workflows/macos-preliminary.yml
+++ b/.github/workflows/macos-preliminary.yml
@@ -47,6 +47,13 @@ jobs:
 
         mv meerk40t.py mk40t.py
         # --target-architecture universal2   - does not work!
+        LOCALE_ARGS=""
+        for lang_dir in locale/*/; do
+            lang=$(basename "$lang_dir")
+            if [ -f "locale/$lang/LC_MESSAGES/meerk40t.mo" ]; then
+                LOCALE_ARGS="$LOCALE_ARGS --add-data locale/$lang/LC_MESSAGES/meerk40t.mo:locale/$lang/LC_MESSAGES/"
+            fi
+        done
         pyinstaller \
           --hidden-import wx._adv \
           --hidden-import wx._xml \
@@ -54,7 +61,7 @@ jobs:
           --windowed \
           --noconfirm \
           -i .github/workflows/mac/meerk40t.icns \
-          --add-data 'locale/:locale/' \
+          $LOCALE_ARGS \
           --name MeerK40t \
           mk40t.py
         mv mk40t.py meerk40t.py

--- a/.github/workflows/weekly-binaries.yml
+++ b/.github/workflows/weekly-binaries.yml
@@ -106,6 +106,13 @@ jobs:
 
         mv meerk40t.py mk40t.py
         # --target-architecture universal2   - does not work!
+        LOCALE_ARGS=""
+        for lang_dir in locale/*/; do
+            lang=$(basename "$lang_dir")
+            if [ -f "locale/$lang/LC_MESSAGES/meerk40t.mo" ]; then
+                LOCALE_ARGS="$LOCALE_ARGS --add-data locale/$lang/LC_MESSAGES/meerk40t.mo:locale/$lang/LC_MESSAGES/"
+            fi
+        done
         pyinstaller \
           --hidden-import wx._adv \
           --hidden-import wx._xml \
@@ -113,7 +120,7 @@ jobs:
           --windowed \
           --noconfirm \
           -i .github/workflows/mac/meerk40t.icns \
-          --add-data 'locale/:locale/' \
+          $LOCALE_ARGS \
           --name MeerK40t \
           mk40t.py
         mv mk40t.py meerk40t.py

--- a/.github/workflows/win/meerk40t-all.spec
+++ b/.github/workflows/win/meerk40t-all.spec
@@ -1,5 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+# Dynamically generate locale data
+def get_locale_data():
+    locale_base = './locale'
+    datas = []
+    if os.path.exists(locale_base):
+        for lang in os.listdir(locale_base):
+            mo_path = os.path.join(locale_base, lang, 'LC_MESSAGES', 'meerk40t.mo')
+            if os.path.exists(mo_path):
+                datas.append((f'locale/{lang}/LC_MESSAGES/meerk40t.mo', f'locale/{lang}/LC_MESSAGES/meerk40t.mo', 'DATA'))
+    return datas
+
 block_cipher = None
 
 
@@ -19,19 +32,9 @@ a = Analysis(['../../../mk40t.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
-a.datas += [('locale/es/LC_MESSAGES/meerk40t.mo', 'locale/es/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/it/LC_MESSAGES/meerk40t.mo', 'locale/it/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/de/LC_MESSAGES/meerk40t.mo', 'locale/de/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/zh/LC_MESSAGES/meerk40t.mo', 'locale/zh/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/fr/LC_MESSAGES/meerk40t.mo', 'locale/fr/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/hu/LC_MESSAGES/meerk40t.mo', 'locale/hu/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ja/LC_MESSAGES/meerk40t.mo', 'locale/ja/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/nl/LC_MESSAGES/meerk40t.mo', 'locale/nl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ru/LC_MESSAGES/meerk40t.mo', 'locale/ru/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pl/LC_MESSAGES/meerk40t.mo', 'locale/pl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/tr/LC_MESSAGES/meerk40t.mo', 'locale/tr/LC_MESSAGES/meerk40t.mo', 'DATA')]
+
+# Add locale data
+a.datas += get_locale_data()
 
 
 pyz = PYZ(a.pure, a.zipped_data,

--- a/.github/workflows/win/meerk40t.spec
+++ b/.github/workflows/win/meerk40t.spec
@@ -1,5 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+# Dynamically generate locale data
+def get_locale_data():
+    locale_base = './locale'
+    datas = []
+    if os.path.exists(locale_base):
+        for lang in os.listdir(locale_base):
+            mo_path = os.path.join(locale_base, lang, 'LC_MESSAGES', 'meerk40t.mo')
+            if os.path.exists(mo_path):
+                datas.append((f'locale/{lang}/LC_MESSAGES/meerk40t.mo', f'locale/{lang}/LC_MESSAGES/meerk40t.mo', 'DATA'))
+    return datas
+
 block_cipher = None
 
 
@@ -17,19 +30,9 @@ a = Analysis(['../../../mk40t.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
-a.datas += [('locale/es/LC_MESSAGES/meerk40t.mo', 'locale/es/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/it/LC_MESSAGES/meerk40t.mo', 'locale/it/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/de/LC_MESSAGES/meerk40t.mo', 'locale/de/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/zh/LC_MESSAGES/meerk40t.mo', 'locale/zh/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/fr/LC_MESSAGES/meerk40t.mo', 'locale/fr/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/hu/LC_MESSAGES/meerk40t.mo', 'locale/hu/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'locale/pt_BR/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'locale/pt_PT/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ja/LC_MESSAGES/meerk40t.mo', 'locale/ja/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/nl/LC_MESSAGES/meerk40t.mo', 'locale/nl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/ru/LC_MESSAGES/meerk40t.mo', 'locale/ru/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/pl/LC_MESSAGES/meerk40t.mo', 'locale/pl/LC_MESSAGES/meerk40t.mo', 'DATA')]
-a.datas += [('locale/tr/LC_MESSAGES/meerk40t.mo', 'locale/tr/LC_MESSAGES/meerk40t.mo', 'DATA')]
+
+# Add locale data
+a.datas += get_locale_data()
 
 
 pyz = PYZ(a.pure, a.zipped_data,


### PR DESCRIPTION
## Summary by Sourcery

Make locale inclusion for packaged builds dynamic based on available translation files instead of hardcoded paths.

Enhancements:
- Generate PyInstaller locale data entries programmatically in Windows and Linux spec files.
- Construct macOS PyInstaller --add-data arguments at build time by scanning existing locale directories.