### PR TITLE
Fallback logic for invalid bitmap creation

### DIFF
--- a/meerk40t/gui/hersheymanager.py
+++ b/meerk40t/gui/hersheymanager.py
@@ -185,13 +185,20 @@ class FontGlyphPicker(wx.Dialog):
                 wincol.green,
                 0,
             )
-            dc = wx.MemoryDC()
-            dc.SelectObject(bmp)
-            # dc.SetBackground(self._background)
-            # dc.SetBackground(wx.RED_BRUSH)
-            # dc.Clear()
-            gc = wx.GraphicsContext.Create(dc)
-            gc.dc = dc
+            if not bmp.IsOk():
+                # Fallback for systems where FromRGBA fails
+                bmp = wx.Bitmap(final_icon_width, final_icon_height)
+                dc = wx.MemoryDC()
+                dc.SelectObject(bmp)
+                dc.SetBackground(wx.Brush(wincol))
+                dc.Clear()
+                gc = wx.GraphicsContext.Create(dc)
+                gc.dc = dc
+            else:
+                dc = wx.MemoryDC()
+                dc.SelectObject(bmp)
+                gc = wx.GraphicsContext.Create(dc)
+                gc.dc = dc
 
             gp = geomstr_to_gcpath(gc, geom)
             m_x, m_y, p_w, p_h = gp.Box

--- a/meerk40t/gui/icons.py
+++ b/meerk40t/gui/icons.py
@@ -574,10 +574,20 @@ class VectorIcon:
             blue,
             0,
         )
-        dc = wx.MemoryDC()
-        dc.SelectObject(bmp)
-        gc = wx.GraphicsContext.Create(dc)
-        gc.dc = dc
+        if not bmp.IsOk():
+            # Fallback for systems where FromRGBA fails
+            bmp = wx.Bitmap(final_icon_width, final_icon_height)
+            dc = wx.MemoryDC()
+            dc.SelectObject(bmp)
+            dc.SetBackground(wx.Brush(wincol))
+            dc.Clear()
+            gc = wx.GraphicsContext.Create(dc)
+            gc.dc = dc
+        else:
+            dc = wx.MemoryDC()
+            dc.SelectObject(bmp)
+            gc = wx.GraphicsContext.Create(dc)
+            gc.dc = dc
         # Fill the complete canvas with a color
         if forced_background:
             gc.SetBrush(


### PR DESCRIPTION
Dealing with an  issue caused by wx.Bitmap.FromRGBA creating an invalid bitmap on some systems (particularly Windows with certain wxPython versions), which cannot be selected into a wx.MemoryDC, leading to an assertion failure.

## Summary by Sourcery

Bug Fixes:
- Guard bitmap creation in Hershey manager and icon bitmap preparation with a fallback path when FromRGBA returns an invalid bitmap, avoiding assertion failures on affected systems.