### PR TITLE
GRBL: Add explicit G1 S0 if required

### DIFF
--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -443,6 +443,17 @@ class GRBLDevice(Service, Status):
                 ),
             },
             {
+                "attr": "use_g1_for_power",
+                "object": self,
+                "default": False,
+                "type": bool,
+                "label": _("Use G1 before Rapid Moves"),
+                "section": "_5_Config",
+                "tip": _(
+                    "Uses G1 S0 to explicitly set the power to 0 instead of a G0 X Y S0 "
+                ),
+            },
+            {
                 "attr": "extended_alarm_clear",
                 "object": self,
                 "default": False,

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -871,6 +871,11 @@ class GRBLDriver(Parameters):
             self.native_y += y
         line = []
         if self.move_mode == 0:
+            if self.power_dirty and self.service.use_g1_for_power:
+                if self.power is not None:
+                    # Turn off laser before rapid move if power is changing
+                    line.append(f"G1 S{self.power * self.on_value:.1f}")
+                self.power_dirty = False
             line.append("G0")
         else:
             line.append("G1")


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a configuration option to use G1 S0 before rapid moves instead of relying on G0 with S0 for power-off behavior.