### PR TITLE
Try to avoid X11 thread related crashes by forcing UI updates into the main UI thread

### DIFF
--- a/meerk40t/gui/alignment.py
+++ b/meerk40t/gui/alignment.py
@@ -28,6 +28,7 @@ from ..gui.wxutils import (
     wxRadioBox,
     wxStaticBitmap,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from ..kernel import signal_listener
 from .icons import STD_ICON_SIZE, get_default_icon_size, icons8_arrange
@@ -1622,10 +1623,8 @@ class Alignment(MWindow):
 
     @signal_listener("reference")
     @signal_listener("emphasized")
-    def on_emphasize_signal(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_emphasize_signal, origin, *args)
-            return
+    @dispatch_to_main_thread
+    def on_emphasize_signal(self, origin, *args, **kwargs):
         has_emph = self.context.elements.has_emphasis()
         self.panel_align.show_stuff(has_emph)
         self.panel_distribution.show_stuff(has_emph)

--- a/meerk40t/gui/autoexec.py
+++ b/meerk40t/gui/autoexec.py
@@ -1,6 +1,7 @@
 """
 This module offers the opportunity to define a couple of commands that will automatically be executed on a (main) file load
 """
+
 from platform import system
 
 import wx
@@ -8,7 +9,7 @@ from wx import aui
 
 from .icons import STD_ICON_SIZE, icons8_circled_play
 from .mwindow import MWindow
-from .wxutils import TextCtrl, dip_size, wxButton, wxCheckBox
+from .wxutils import TextCtrl, dip_size, wxButton, wxCheckBox, dispatch_to_main_thread
 
 _ = wx.GetTranslation
 
@@ -185,10 +186,8 @@ class AutoExecPanel(wx.Panel):
             self.button_execute.Enable(True)
         self.context.elements.signal("autoexec", self)
 
-    def on_autoexec_listen(self, origin, source=None):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_autoexec_listen, origin, source)
-            return
+    @dispatch_to_main_thread
+    def on_autoexec_listen(self, origin, source=None, **kwargs):
         if source is self:
             return
         commands = self.context.elements.last_file_autoexec

--- a/meerk40t/gui/basicops.py
+++ b/meerk40t/gui/basicops.py
@@ -32,6 +32,7 @@ from .wxutils import (
     wxComboBox,
     wxStaticBitmap,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 
 _ = wx.GetTranslation
@@ -438,7 +439,11 @@ class BasicOpPanel(wx.Panel):
         except RuntimeError:
             return
         self.operation_sizer = StaticBoxSizer(
-            self.op_panel, wx.ID_ANY, _("Operations"), wx.VERTICAL, context=self.context,
+            self.op_panel,
+            wx.ID_ANY,
+            _("Operations"),
+            wx.VERTICAL,
+            context=self.context,
         )
         self.op_panel.SetSizer(self.operation_sizer)
         elements = self.context.elements
@@ -459,21 +464,33 @@ class BasicOpPanel(wx.Panel):
         self.context.themes.set_window_colors(header)
         header.SetMinSize(dip_size(self, 20, -1))
         header.SetMaxSize(dip_size(self, 20, -1))
-        header.SetToolTip(_("A: Active = toggle whether the elements assigned to this operation will be burned or not"))
+        header.SetToolTip(
+            _(
+                "A: Active = toggle whether the elements assigned to this operation will be burned or not"
+            )
+        )
         info_sizer.Add(header, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
         header = wxStaticText(self.op_panel, wx.ID_ANY, label="S")
         self.context.themes.set_window_colors(header)
         header.SetMinSize(dip_size(self, 20, -1))
         header.SetMaxSize(dip_size(self, 20, -1))
-        header.SetToolTip(_("S: Show = if inactive then you can suppress the drawing of the assigned elements"))
+        header.SetToolTip(
+            _(
+                "S: Show = if inactive then you can suppress the drawing of the assigned elements"
+            )
+        )
         info_sizer.Add(header, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
         header = wxStaticText(self.op_panel, wx.ID_ANY, label="C")
         self.context.themes.set_window_colors(header)
         header.SetMinSize(dip_size(self, 20, -1))
         header.SetMaxSize(dip_size(self, 20, -1))
-        header.SetToolTip(_("C: Coolant = determines whether coolant remains / will be turned on / turned off at start of this operation"))
+        header.SetToolTip(
+            _(
+                "C: Coolant = determines whether coolant remains / will be turned on / turned off at start of this operation"
+            )
+        )
         info_sizer.Add(header, 1, wx.ALIGN_CENTER_VERTICAL, 0)
 
         unit = " [%]" if self.use_percent else ""
@@ -781,14 +798,14 @@ class BasicOpPanel(wx.Panel):
         self.ask_for_refill()
 
     @signal_listener("emphasized")
+    @dispatch_to_main_thread
     def signal_handler_emphasized(self, origin, *args, **kwargs):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.signal_handler_emphasized, origin, *args, **kwargs)
-            return
         if not self.IsShown():
             # print ("Delay highlight_operations")
             self.pending_ops["highlight_operations"] = True
             return
         self.context.elements.set_start_time("BasicOpPanel")
         self.highlight_operations(source="emphasized")
-        self.context.elements.set_end_time("BasicOpPanel", message=f"vis={self.visible}")
+        self.context.elements.set_end_time(
+            "BasicOpPanel", message=f"vis={self.visible}"
+        )

--- a/meerk40t/gui/consolepanel.py
+++ b/meerk40t/gui/consolepanel.py
@@ -6,7 +6,7 @@ from wx import aui
 
 from meerk40t.gui.icons import STD_ICON_SIZE, icons8_console
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import TextCtrl
+from meerk40t.gui.wxutils import TextCtrl, dispatch_to_main_thread
 from meerk40t.kernel import signal_listener
 
 try:
@@ -360,10 +360,8 @@ class ConsolePanel(wx.ScrolledWindow):
             self.context.signal("console_update")
 
     @signal_listener("console_update")
+    @dispatch_to_main_thread
     def update_console_main(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.update_console_main, origin, *args)
-            return
         with self._buffer_lock:
             buffer = self._buffer
             self._buffer = ""

--- a/meerk40t/gui/devicepanel.py
+++ b/meerk40t/gui/devicepanel.py
@@ -11,6 +11,7 @@ from meerk40t.gui.wxutils import (
     wxListCtrl,
     wxStaticText,
     wxTreeCtrl,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
 
@@ -365,10 +366,8 @@ class DevicePanel(wx.Panel):
     @signal_listener("activate;device")
     @signal_listener("device;renamed")
     @lookup_listener("service/device/available")
+    @dispatch_to_main_thread
     def refresh_device_tree(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.refresh_device_tree, *args)
-            return
         self.devices = []
         names = []
         for obj, name, sname in self.context.find("dev_info"):

--- a/meerk40t/gui/executejob.py
+++ b/meerk40t/gui/executejob.py
@@ -10,6 +10,7 @@ from .wxutils import (
     wxButton,
     wxComboBox,
     wxListBox,
+    dispatch_to_main_thread,
 )
 
 _ = wx.GetTranslation
@@ -199,10 +200,8 @@ class PlannerPanel(wx.Panel):
         self.context(f"plan{self.plan_name} clear\n")
 
     @signal_listener("plan")
+    @dispatch_to_main_thread
     def plan_update(self, origin, *message):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.plan_update, origin, *message)
-            return
         plan_name, stage = message[0], message[1]
         if stage is not None:
             self.stage = stage
@@ -210,10 +209,8 @@ class PlannerPanel(wx.Panel):
         self.update_gui()
 
     @signal_listener("element_property_reload")
+    @dispatch_to_main_thread
     def on_element_property_update(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_element_property_update, origin, *args)
-            return
         self.update_gui()
 
     def update_gui(self):

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -31,6 +31,7 @@ from meerk40t.gui.wxutils import (
     wxComboBox,
     wxListCtrl,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
 
@@ -532,10 +533,8 @@ class LaserPanel(wx.Panel):
             self.context.signal("optimize", newval)
 
     @signal_listener("optimize")
+    @dispatch_to_main_thread
     def optimize_update(self, origin, *message):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.optimize_update, origin, *message)
-            return
         try:
             newvalue = bool(message[0])
         except ValueError:
@@ -547,24 +546,20 @@ class LaserPanel(wx.Panel):
             self.checkbox_optimize.SetValue(newvalue)
 
     @signal_listener("pwm_mode_changed")
+    @dispatch_to_main_thread
     def on_pwm_mode_changed(self, origin, *message):
         """
         This is called when the power scale of the device changes.
         It updates the slider and label accordingly.
         """
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_pwm_mode_changed, origin, *message)
-            return
         self.update_override_controls()
 
     @signal_listener("device;modified")
     @signal_listener("device;renamed")
     @lookup_listener("service/device/active")
     @lookup_listener("service/device/available")
+    @dispatch_to_main_thread
     def on_device_changes(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_device_changes, *args)
-            return
         # Devices Initialize.
         self.available_devices = self.context.kernel.services("device")
         self.selected_device = self.context.device
@@ -588,10 +583,8 @@ class LaserPanel(wx.Panel):
         self.Layout()
 
     @signal_listener("device;connected")
+    @dispatch_to_main_thread
     def on_connectivity(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_connectivity, *args)
-            return
         # There's no signal yet, but there should be one...
         self.update_override_controls()
 
@@ -611,17 +604,13 @@ class LaserPanel(wx.Panel):
         self.button_pause.SetLabelText(new_caption)
 
     @signal_listener("pause")
+    @dispatch_to_main_thread
     def on_device_pause_toggle(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_device_pause_toggle, origin, *args)
-            return
         self.set_pause_color()
 
     @signal_listener("laser_armed")
+    @dispatch_to_main_thread
     def signal_laser_arm(self, origin, *message):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.signal_laser_arm, origin, *message)
-            return
         try:
             newval = bool(message[0])
         except ValueError:
@@ -632,10 +621,8 @@ class LaserPanel(wx.Panel):
             self.check_laser_arm()
 
     @signal_listener("laserpane_arm")
+    @dispatch_to_main_thread
     def check_laser_arm(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.check_laser_arm, *args)
-            return
         ctxt = self.context.kernel.root
         ctxt.setting(bool, "_laser_may_run", False)
         if self.context.root.laserpane_arm:
@@ -928,10 +915,8 @@ class JobPanel(wx.Panel):
                     break
 
     @signal_listener("plan")
+    @dispatch_to_main_thread
     def plan_update(self, origin, *message):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.plan_update, origin, *message)
-            return
         if self.shown:
             self.refresh_plan_list()
 
@@ -1124,10 +1109,8 @@ class OptimizePanel(wx.Panel):
         self.parent.add_module_delegate(self.optimize_panel)
 
     @signal_listener("optimize")
+    @dispatch_to_main_thread
     def optimize_update(self, origin, *message):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.optimize_update, origin, *message)
-            return
         try:
             newvalue = bool(message[0])
         except ValueError:

--- a/meerk40t/gui/mkdebug.py
+++ b/meerk40t/gui/mkdebug.py
@@ -36,6 +36,7 @@ from meerk40t.gui.wxutils import (
     wxStaticBitmap,
     wxStaticText,
     wxToggleButton,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel.kernel import signal_listener
 from meerk40t.svgelements import Color
@@ -347,10 +348,8 @@ class DebugTreePanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
-    def _update_position(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self._update_position, *args)
-            return
+    @dispatch_to_main_thread
+    def _update_position(self, *args, **kwargs):
         self.context.elements.set_start_time("Emphasis mkdebug")
         self.update_position(True)
         self.context.elements.set_end_time("Emphasis mkdebug")
@@ -527,7 +526,8 @@ class DebugViewPanel(ScrolledPanel):
 
     @signal_listener("view;realized")
     @signal_listener("device;modified")
-    def on_view_change(self, origin, *args):
+    @dispatch_to_main_thread
+    def on_view_change(self, origin, *args, **kwargs):
         self.refresh_info()
         self.on_test_position(None)
 
@@ -1156,10 +1156,8 @@ class DebugSettingsPanel(wx.Panel):
         self.Layout()
         # end wxGlade
 
-    def _update_position(self, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self._update_position, *args)
-            return
+    @dispatch_to_main_thread
+    def _update_position(self, *args, **kwargs):
         self.update_position(True)
 
     def update_position(self, reset):

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -60,6 +60,7 @@ from meerk40t.gui.wxutils import (
     wxBitmapButton,
     wxStaticBitmap,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel import signal_listener
 
@@ -480,13 +481,13 @@ class ZMovePanel(wx.Panel):
 
     def z_move_down(self, distance):
         def handler():
-            self.context(f"z_move -{distance*0.1:.2f}mm")
+            self.context(f"z_move -{distance * 0.1:.2f}mm")
 
         return handler
 
     def z_move_up(self, distance):
         def handler():
-            self.context(f"z_move {distance*0.1:.2f}mm")
+            self.context(f"z_move {distance * 0.1:.2f}mm")
 
         return handler
 
@@ -514,10 +515,8 @@ class ZMovePanel(wx.Panel):
         self.navigation_sizer.Layout()
         self.Layout()
 
+    @dispatch_to_main_thread
     def on_update(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_update, origin, *args)
-            return
         has_home = self.context.kernel.has_command("z_home")
         # print (f"Has_home for {self.context.device.name}: {has_home}")
         self.button_z_home.Show(has_home)
@@ -1058,10 +1057,8 @@ class Drag(wx.Panel):
     def on_button_repeat(self, origin, *args):
         self.set_timer_options()
 
+    @dispatch_to_main_thread
     def on_update(self, origin, pos):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_update, origin, pos)
-            return
         # bb = self.get_bbox()
         elements = self.context.elements
         bb = elements._emphasized_bounds
@@ -1461,10 +1458,8 @@ class Jog(wx.Panel):
                 break
         self.button_navigate_home.SetToolTip(tip)
 
+    @dispatch_to_main_thread
     def on_update(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_update, origin, *args)
-            return
         self.set_home_logic()
         self.set_z_support()
         self.set_lockrail()
@@ -1769,10 +1764,8 @@ class MovePanel(wx.Panel):
         except ValueError:
             return
 
+    @dispatch_to_main_thread
     def update_position_info(self, origin, pos):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.update_position_info, origin, pos)
-            return
         # origin, pos
 
         if pos is None:
@@ -1915,10 +1908,8 @@ class PulsePanel(wx.Panel):
     def pane_hide(self, *args):
         self.context.unlisten("activate;device", self.on_update)
 
+    @dispatch_to_main_thread
     def on_update(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_update, origin, *args)
-            return
         self.update_power_controls()
 
     def update_power_controls(self):
@@ -1933,7 +1924,7 @@ class PulsePanel(wx.Panel):
             dval = 50
         self.spin_pulse_duration.SetValue(dval)
         if self.context.device.setting(bool, "use_percent_for_power_display", False):
-            self.text_power.SetValue(f"{pval/10.0:.1f}")
+            self.text_power.SetValue(f"{pval / 10.0:.1f}")
             self.text_power.set_range(0, 100)
             self.text_power.SetToolTip(_("Set the power of the laser pulse in percent"))
             self.label_power.SetLabel("%")

--- a/meerk40t/gui/propertypanels/hatchproperty.py
+++ b/meerk40t/gui/propertypanels/hatchproperty.py
@@ -4,7 +4,13 @@ from meerk40t.gui.wxutils import ScrolledPanel, StaticBoxSizer
 
 from ...core.units import Angle, Length
 from ...svgelements import Matrix
-from ..wxutils import TextCtrl, set_ctrl_value, wxCheckBox, wxComboBox
+from ..wxutils import (
+    TextCtrl,
+    set_ctrl_value,
+    wxCheckBox,
+    wxComboBox,
+    dispatch_to_main_thread,
+)
 from .attributes import ColorPanel, IdPanel
 
 _ = wx.GetTranslation
@@ -458,6 +464,7 @@ class HatchPropertyPanel(ScrolledPanel):
         self.travel_lines = None
         self.refresh_display()
 
+    @dispatch_to_main_thread
     def refresh_display(self):
         # print(
         #     f"Distance={self.node.distance} / {self.node.hatch_distance} / {self.node.settings.get('hatch_distance', '')}"
@@ -465,10 +472,7 @@ class HatchPropertyPanel(ScrolledPanel):
         # print(
         #     f"Angle={self.node.angle} / {self.node.hatch_angle} / {self.node.settings.get('hatch_angle', '')}"
         # )
-        if not wx.IsMainThread():
-            wx.CallAfter(self.refresh_in_ui)
-        else:
-            self.refresh_in_ui()
+        self.refresh_in_ui()
 
     def calculate_hatch_lines(self):
         # from time import perf_counter

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -25,6 +25,7 @@ from meerk40t.gui.wxutils import (
     wxRadioBox,
     wxStaticBitmap,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel import lookup_listener, signal_listener
 
@@ -644,7 +645,7 @@ class SpeedPpiPanel(wx.Panel):
             return
         try:
             value = float(self.text_power.GetValue())
-            self.power_sizer.SetLabel(_("Power (ppi)") + f" ({value/10:.1f}%)")
+            self.power_sizer.SetLabel(_("Power (ppi)") + f" ({value / 10:.1f}%)")
         except ValueError:
             return
 
@@ -1109,14 +1110,12 @@ class PanelStartPreference(wx.Panel):
         self.direction_lines = None
         wx.CallAfter(self.refresh_in_ui)
 
+    @dispatch_to_main_thread
     def refresh_display(self):
         if self._Buffer is None:
             self.set_buffer()
 
-        if not wx.IsMainThread():
-            wx.CallAfter(self.refresh_in_ui)
-        else:
-            self.refresh_in_ui()
+        self.refresh_in_ui()
 
     def calculate_raster_lines(self):
         w, h = self._Buffer.Size

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -60,6 +60,7 @@ from .wxutils import (
     wxListBox,
     wxListCtrl,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from .zmatrix import ZMatrix
 
@@ -1117,7 +1118,7 @@ class SimulationPanel(wx.Panel, Job):
         self.running = False
         self.slided_in = True
         self.start_time = perf_counter()
-        self.debug(f"Init done: {perf_counter()-self.start_time}")
+        self.debug(f"Init done: {perf_counter() - self.start_time}")
 
     def reload_statistics(self):
         try:
@@ -1134,7 +1135,7 @@ class SimulationPanel(wx.Panel, Job):
         return
 
     def _startup(self):
-        self.debug(f"Startup: {perf_counter()-self.start_time}")
+        self.debug(f"Startup: {perf_counter() - self.start_time}")
         self.slided_in = True
         self.fit_scene_to_panel()
 
@@ -1652,7 +1653,7 @@ class SimulationPanel(wx.Panel, Job):
         self.interval = factor * 100.0 / float(value)
 
     def _refresh_simulated_plan(self):
-        self.debug(f"Refresh simulated: {perf_counter()-self.start_time}")
+        self.debug(f"Refresh simulated: {perf_counter() - self.start_time}")
         # Stop animation
         if self.running:
             self._stop()
@@ -1730,19 +1731,17 @@ class SimulationPanel(wx.Panel, Job):
 
     @signal_listener("device;modified")
     @signal_listener("plan")
-    def on_plan_change(self, origin, plan_name=None, status=None):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_plan_change, origin, plan_name, status)
-            return
+    @dispatch_to_main_thread
+    def on_plan_change(self, origin, plan_name=None, status=None, **kwargs):
         def resend_signal():
-            self.debug(f"Resending signal: {perf_counter()-self.start_time}")
+            self.debug(f"Resending signal: {perf_counter() - self.start_time}")
             self.context.signal("plan", plan_name=self.plan_name, status=1)
 
         winsize = self.view_pane.GetSize()
         winsize1 = self.hscene_sizer.GetSize()
         winsize2 = self.GetSize()
         self.debug(
-            f"Plan called : {perf_counter()-self.start_time} (Pane: {winsize}, Sizer: {winsize1}, Window: {winsize2})"
+            f"Plan called : {perf_counter() - self.start_time} (Pane: {winsize}, Sizer: {winsize1}, Window: {winsize2})"
         )
         if plan_name == self.plan_name:
             # This may come too early before all things have been done
@@ -2569,10 +2568,8 @@ class Simulation(MWindow):
         yield self.panel
 
     @signal_listener("background")
-    def on_background_signal(self, origin, background):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_background_signal, origin, background)
-            return
+    @dispatch_to_main_thread
+    def on_background_signal(self, origin, background, **kwargs):
         if background is not None:
             background = wx.Bitmap.FromBuffer(*background)
         self.panel.widget_scene._signal_widget(

--- a/meerk40t/gui/thread_info.py
+++ b/meerk40t/gui/thread_info.py
@@ -9,6 +9,7 @@ from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     wxListCtrl,
     wxStaticText,
+    dispatch_to_main_thread,
 )
 from meerk40t.kernel import Job, signal_listener
 
@@ -147,10 +148,8 @@ class ThreadPanel(wx.Panel):
         self.list_job_threads.Refresh()
 
     @signal_listener("thread_update")
+    @dispatch_to_main_thread
     def on_thread_signal(self, origin, *args):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.on_thread_signal, origin, *args)
-            return
         doit = True
         with self.update_lock:
             # Only update every 2 seconds or so

--- a/meerk40t/gui/usbconnect.py
+++ b/meerk40t/gui/usbconnect.py
@@ -2,7 +2,8 @@ import wx
 
 from meerk40t.gui.icons import icons8_usb_connector
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import TextCtrl
+from meerk40t.gui.wxutils import TextCtrl, dispatch_to_main_thread
+
 _ = wx.GetTranslation
 
 
@@ -37,11 +38,9 @@ class UsbConnectPanel(wx.Panel):
         active = self._active_when_loaded
         self.context.channel(f"{active}/usb").unwatch(self.update_text)
 
-    def update_text(self, text):
-        if not wx.IsMainThread():
-            wx.CallAfter(self.update_text_gui, text + "\n")
-        else:
-            self.update_text_gui(text + "\n")
+    @dispatch_to_main_thread
+    def update_text(self, text, **kwargs):
+        self.update_text_gui(text + "\n")
 
     def update_text_gui(self, text):
         try:


### PR DESCRIPTION
## Summary by Sourcery

Route GUI-related signal handlers through the wx main thread to avoid X11 thread-related crashes and ensure thread-safe UI updates. Should address #3151 

Enhancements:
- Add main-thread checks and wx.CallAfter dispatch to numerous GUI signal handlers so that UI updates are executed on the main UI thread.
- Document thread-safe use of request_refresh in simulation-related handlers.