### PR TITLE
Attempt for K40 regression fix

### DIFF
--- a/meerk40t/lihuiyu/controller.py
+++ b/meerk40t/lihuiyu/controller.py
@@ -202,7 +202,13 @@ class LihuiyuController:
         self.state = "unknown"
         self.is_shutdown = False
         self.serial_confirmed = False  # Initialize as boolean, not None
-        self._finish_seen = False  # Set when FINISH is received during packet confirmation
+        # Tracks whether a FINISH (0xEC) status was received from the device during
+        # the packet confirmation polling loop (_confirm_packet_receipt).  When this
+        # is True, _execute_post_send_command skips the explicit wait_finished() call
+        # because the device has already signalled completion and returned to OK state —
+        # calling wait_finished() at that point would poll forever since OK (0xCE) never
+        # satisfies the PEMP-bit exit condition (status & 0x02 == 0) used by that method.
+        self._finish_seen = False
 
         self._thread = None
         self._buffer = (
@@ -1000,11 +1006,22 @@ class LihuiyuController:
                 self.context.rejected_count += 1
                 return not flawless  # Return True if there were connection errors
             elif status == LihuiyuStatus.FINISH.value:
-                # Device has already finished — note it so wait_finished won't be called.
+                # FINISH (0xEC) means the device has completed its internal buffer and
+                # is signalling end-of-job.  It is NOT a packet acknowledgement — the
+                # device still owes us an OK or ERROR for the packet we just sent, so we
+                # record that FINISH arrived and keep polling.
+                # Recording it here is critical: the post-send command for end-of-job
+                # packets is wait_finished(), which blocks until it observes FINISH.
+                # If FINISH arrives now (during confirmation), by the time wait_finished()
+                # is actually called the device will already be back in OK state and will
+                # never send FINISH again, causing wait_finished() to loop forever.
                 self._finish_seen = True
-                continue  # This is not a packet confirmation; keep polling for OK/ERROR.
+                continue  # Not a packet confirmation; keep polling for OK/ERROR.
             elif status == LihuiyuStatus.SERIAL_CORRECT_M3_FINISH.value:
-                # On M3 devices this also serves as a "finished" signal.
+                # On M3 boards, 0xCC serves a dual role: it both acknowledges the packet
+                # and signals end-of-job (equivalent to FINISH on standard boards).
+                # Record finish_seen for the same reason as FINISH above so that a
+                # subsequent wait_finished() call is skipped if the M3 already finished.
                 self._finish_seen = True
                 self.context.packet_count += 1
                 return True
@@ -1041,15 +1058,42 @@ class LihuiyuController:
         """
         Execute post-send command if one was specified.
 
-        If FINISH was already observed during packet confirmation, skip wait_finished
-        — the device has already completed and returned to OK, so waiting for FINISH
-        again would loop forever.
+        Background
+        ----------
+        End-of-job packets carry a '-' pipe command which sets post_send_command to
+        wait_finished().  wait_finished() polls device status until the PEMP bit clears
+        (status & 0x02 == 0), which only happens when the device reports FINISH (0xEC).
+
+        Race condition fixed here
+        -------------------------
+        If the device executes its buffer quickly, FINISH (0xEC) may arrive while
+        _confirm_packet_receipt() is still polling for the packet acknowledgement.
+        _confirm_packet_receipt() records this via self._finish_seen and keeps polling
+        until it receives OK or ERROR.  By the time we reach this method the device has
+        already transitioned past FINISH back to OK (0xCE).
+
+        Calling wait_finished() at this point would poll forever: OK (0xCE & 0x02 = 2)
+        never satisfies the exit condition, and the device will not send FINISH again
+        until the next job.  The result is a permanently hung controller thread.
+
+        Fix: if _finish_seen is set we skip wait_finished() entirely — the device has
+        already finished, there is nothing left to wait for.
+
+        Note on the identity check
+        --------------------------
+        Python 3 creates a new bound-method object on every attribute access, so
+        ``post_send_command is self.wait_finished`` is always False.  We compare the
+        underlying function objects via __func__ instead, which is stable.
 
         @param post_send_command: The command to execute after sending
         """
         if post_send_command is not None:
-            if post_send_command is self.wait_finished and self._finish_seen:
-                return  # FINISH was seen during confirmation; no need to wait again.
+            wait_finished_func = getattr(
+                self.wait_finished, "__func__", self.wait_finished
+            )
+            callback_func = getattr(post_send_command, "__func__", post_send_command)
+            if callback_func is wait_finished_func and self._finish_seen:
+                return  # FINISH already received during confirmation — skip redundant wait.
             try:
                 post_send_command()
             except ConnectionError:


### PR DESCRIPTION
The Sep 2025 refactor split process_queue into helper methods. The original monolithic method had post_send_command accessible inside the confirmation loop, so when FINISH (0xEC) arrived during polling it could cancel the pending wait_finished call. After the refactor, _confirm_packet_receipt is isolated and has no access to post_send_command.

Failure path:

1. Last packet of an operation carries post_send_command = wait_finished (from -\n)
2. Machine executes fast — FINISH arrives while software is still polling for confirmation
3. Old code: post_send_command = None → wait_finished never called ✓
4. New code: FINISH just continues → wait_finished called after confirmation
5. Machine is already back at OK (0xCE); wait_finished checks status & 0x02 == 0 — OK never satisfies this — infinite loop

The fix uses a single self._finish_seen flag:

- Reset to False at the start of each _confirm_packet_receipt call
- Set to True when FINISH or SERIAL_CORRECT_M3_FINISH (M3 equivalent) is received during polling
- Checked in _execute_post_send_command: if wait_finished is the command and finish was already seen, skip it

## Summary by Sourcery

Bug Fixes:
- Ensure FINISH and M3 FINISH statuses seen during packet confirmation prevent a redundant wait_finished call that could otherwise loop indefinitely.