### PR TITLE
Working fix for GetTextExtent issue that was affecting layout of ribbon

### DIFF
--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -1162,7 +1162,12 @@ class RibbonBarPanel(wx.Control):
                 width = 1
             if height <= 0:
                 height = 1
-            self._ribbon_buffer = wx.Bitmap(width, height)
+            bmp = wx.Bitmap(width, height);
+
+# Tiger note: This will be helpful when making ribbon DPI aware but Meerk40t isn't ready for that quite yet.
+#            bmp.CreateWithDIPSize(width, height, self.GetDPIScaleFactor())
+
+            self._ribbon_buffer = bmp
         return self._ribbon_buffer
 
     def toggle_show_labels(self, v):
@@ -1452,6 +1457,8 @@ class Art:
         self.hover_tab = None
         self.hover_button = None
         self.hover_dropdown = None
+
+        self.text_bmp = wx.Bitmap(1,1)
 
     def get_cached_font(self, ptsize):
         """
@@ -2148,6 +2155,14 @@ class Art:
         if button.dropdown is not None and button.dropdown.position is not None:
             self._paint_dropdown(dc, button.dropdown)
 
+    def get_text_extent(self, text):
+        temp_dc = wx.MemoryDC()
+        temp_dc.SelectObjectAsSource(self.text_bmp)   # bind to bitmap in a readonly way
+        temp_dc.SetFont(self.default_font)
+        result = temp_dc.GetTextExtent(text)
+        temp_dc.SelectObjectAsSource(wx.NullBitmap)
+        return result
+
     def layout(self, dc: wx.DC, ribbon):
         """
         Performs the layout of the page. This is determined to be the size of the ribbon minus any edge buffering.
@@ -2157,7 +2172,7 @@ class Art:
         @return:
         """
         ribbon_width, ribbon_height = dc.Size
-        # print(f"ribbon: {dc.Size}")
+#        print(f"ribbon: {dc.Size}")
         horizontal = self.parent.prefer_horizontal()
         xpos = 0
         ypos = 0
@@ -2170,7 +2185,10 @@ class Art:
             # Compute tabwidth according to be displayed label,
             # if bigger than default then extend width
             if has_page_header:
-                line_width, line_height = dc.GetTextExtent(page.label)
+
+                line_width, line_height = self.get_text_extent(page.label)
+#                line_width, line_height = dc.GetTextExtent(page.label)
+
                 if line_height + 4 > self.tab_height:
                     self.tab_height = line_height + 4
                     for former in range(0, pn):

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -1458,7 +1458,8 @@ class Art:
         self.hover_button = None
         self.hover_dropdown = None
 
-        self.text_bmp = wx.Bitmap(1,1)
+        # This can be static across all ribbon, as it is only used to support GetTextExtent
+        Art.text_bmp = wx.Bitmap(1,1)
 
     def get_cached_font(self, ptsize):
         """
@@ -2157,7 +2158,7 @@ class Art:
 
     def get_text_extent(self, text):
         temp_dc = wx.MemoryDC()
-        temp_dc.SelectObjectAsSource(self.text_bmp)   # bind to bitmap in a readonly way
+        temp_dc.SelectObjectAsSource(Art.text_bmp)   # bind to bitmap in a readonly way
         temp_dc.SetFont(self.default_font)
         result = temp_dc.GetTextExtent(text)
         temp_dc.SelectObjectAsSource(wx.NullBitmap)


### PR DESCRIPTION
I can't really explain why this code works better than what we had previously.
For whatever reason, when we used the dc derived from the Bitmap from _set_buffer() in layout(), it would provide inconsistent results for calls to GetTextExtent().

It's not even necessary for the Bitmap to be anything but wx.Bitmap(1, 1) if we're just calling GetTextExtent on it.

Stored the text_bmp = wx.Bitmap(1, 1) as a class variable so that there is only one copy for all ribbon, and used SelectObjectAsSource to indicate to wxwidgets that this is a readonly binding of the dc to the bitmap (I presume this is more efficient gdi object count/memory-wise)

## Summary by Sourcery

Improve ribbon text measurement to avoid inconsistent GetTextExtent results during layout.

Enhancements:
- Use a shared 1x1 bitmap and dedicated helper method to measure text extents for ribbon labels instead of relying on the layout DC.
- Prepare ribbon buffer creation for future DPI-aware rendering by routing bitmap construction through a local variable.
- Reduce layout noise by commenting out a debug print of the ribbon size.