### PR TITLE
Fix Raster Op handling of bitmaps

### DIFF
--- a/meerk40t/core/color_cache.py
+++ b/meerk40t/core/color_cache.py
@@ -203,6 +203,10 @@ class CachedColor:
         return inst
 
     # Instance delegation -------------------------------------------------
+    def __copy__(self):
+        """Return self — CachedColor instances are shared/immutable wrappers."""
+        return self
+
     def __getattr__(self, name):
         """Delegate attribute access to the underlying Color instance."""
         return getattr(self._color, name)

--- a/meerk40t/core/color_cache.py
+++ b/meerk40t/core/color_cache.py
@@ -204,8 +204,14 @@ class CachedColor:
 
     # Instance delegation -------------------------------------------------
     def __copy__(self):
-        """Return self — CachedColor instances are shared/immutable wrappers."""
-        return self
+        """Return a new CachedColor wrapping an independent copy of the underlying Color."""
+        target_class = _original_color_class or svgelements_module.Color
+        new_color = target_class.__new__(target_class)
+        new_color.__dict__.update(self._color.__dict__)
+        inst = object.__new__(CachedColor)
+        object.__setattr__(inst, "_color", new_color)
+        object.__setattr__(inst, "_key", None)
+        return inst
 
     def __getattr__(self, name):
         """Delegate attribute access to the underlying Color instance."""

--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -506,6 +506,12 @@ class ImageNode(Node, LabelDisplay, Suppressable):
             self._processed_matrix = actualized_matrix * inverted_main_matrix
             self._processed_image = image
             self._process_image_failed = False
+            # The rendered cache reflects the *previous* processed image; once
+            # the processed image is replaced, the cache is stale and must not
+            # be reused. (Reusing it across cutplan copy + matrix-flip
+            # preprocess caused raster ops to render unflipped pixels at flipped
+            # device coords, producing a mirrored simulation.)
+            self._cache = None
             bb = self.bbox()
             self._bounds = bb
             self._paint_bounds = bb

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -80,12 +80,20 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         self.set_dirty_bounds()
 
     def __copy__(self):
-        nd = self.node_dict
-        nd["geometry"] = copy(self.geometry)
-        nd["matrix"] = copy(self.matrix)
-        nd["stroke"] = copy(self.stroke)
-        nd["fill"] = copy(self.fill)
-        return PathNode(**nd)
+        obj = PathNode.__new__(PathNode)
+        obj.__dict__.update(self.__dict__)
+        obj._children = list()
+        obj._references = list()
+        obj._points = list()
+        obj._default_map = dict()
+        obj._parent = None
+        obj._root = None
+        # Deep-copy mutable geometry/style objects
+        obj.geometry = copy(self.geometry)
+        obj.matrix = copy(self.matrix)
+        obj.stroke = copy(self.stroke)
+        obj.fill = copy(self.fill)
+        return obj
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -80,20 +80,12 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         self.set_dirty_bounds()
 
     def __copy__(self):
-        obj = PathNode.__new__(PathNode)
-        obj.__dict__.update(self.__dict__)
-        obj._children = list()
-        obj._references = list()
-        obj._points = list()
-        obj._default_map = dict()
-        obj._parent = None
-        obj._root = None
-        # Deep-copy mutable geometry/style objects
-        obj.geometry = copy(self.geometry)
-        obj.matrix = copy(self.matrix)
-        obj.stroke = copy(self.stroke)
-        obj.fill = copy(self.fill)
-        return obj
+        nd = self.node_dict
+        nd["geometry"] = copy(self.geometry)
+        nd["matrix"] = copy(self.matrix)
+        nd["stroke"] = copy(self.stroke)
+        nd["fill"] = copy(self.fill)
+        return PathNode(**nd)
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -809,7 +809,6 @@ class Node:
         @return:
         """
         for child in copy_node.children:
-            child = child
             if child.type == "reference":
                 child = child.node
             copy_child = copy(child)

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -649,8 +649,14 @@ class RasterOpNode(OperationMixin, Node, Parameters):
 
             # print (f"Raster direction for {image_node.type}: {direction}, horizontal: {horizontal}, bidir: {bidirectional}, start_on_left: {start_on_left}, start_on_top: {start_on_top}")
 
-            step_x = image_node.step_x
-            step_y = image_node.step_y
+            # Use as_image() — reading raw .image/.matrix drops the flip that
+            # _process_image bakes into the processed pixels.
+            pil_image, bounds = image_node.as_image()
+            offset_x = bounds[0]
+            offset_y = bounds[1]
+            image_width, image_height = pil_image.size
+            step_x = (bounds[2] - bounds[0]) / image_width
+            step_y = (bounds[3] - bounds[1]) / image_height
 
             dotwidth = 2 * self._spot_in_device_units / (step_x + step_y)
             # print (f"Laserspot in device units: {self._spot_in_device_units:.2f}, step: {step_x:.2f} + {step_y:.2f} -> {dotwidth:.2f}")
@@ -663,15 +669,6 @@ class RasterOpNode(OperationMixin, Node, Parameters):
                 # Raster step is only along x for vertical raster
                 settings["raster_step_x"] = step_x
                 settings["raster_step_y"] = 0
-
-            # Perform correct actualization
-            image_node.process_image()
-
-            # Set variables
-            matrix = image_node.matrix
-            pil_image = image_node.image
-            offset_x = matrix.value_trans_x()
-            offset_y = matrix.value_trans_y()
 
             # Establish path
             min_x = offset_x

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -649,14 +649,8 @@ class RasterOpNode(OperationMixin, Node, Parameters):
 
             # print (f"Raster direction for {image_node.type}: {direction}, horizontal: {horizontal}, bidir: {bidirectional}, start_on_left: {start_on_left}, start_on_top: {start_on_top}")
 
-            # Use as_image() — reading raw .image/.matrix drops the flip that
-            # _process_image bakes into the processed pixels.
-            pil_image, bounds = image_node.as_image()
-            offset_x = bounds[0]
-            offset_y = bounds[1]
-            image_width, image_height = pil_image.size
-            step_x = (bounds[2] - bounds[0]) / image_width
-            step_y = (bounds[3] - bounds[1]) / image_height
+            step_x = image_node.step_x
+            step_y = image_node.step_y
 
             dotwidth = 2 * self._spot_in_device_units / (step_x + step_y)
             # print (f"Laserspot in device units: {self._spot_in_device_units:.2f}, step: {step_x:.2f} + {step_y:.2f} -> {dotwidth:.2f}")
@@ -669,6 +663,15 @@ class RasterOpNode(OperationMixin, Node, Parameters):
                 # Raster step is only along x for vertical raster
                 settings["raster_step_x"] = step_x
                 settings["raster_step_y"] = 0
+
+            # Perform correct actualization
+            image_node.process_image()
+
+            # Set variables
+            matrix = image_node.matrix
+            pil_image = image_node.image
+            offset_x = matrix.value_trans_x()
+            offset_y = matrix.value_trans_y()
 
             # Establish path
             min_x = offset_x

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -486,10 +486,10 @@ class RasterOpNode(OperationMixin, Node, Parameters):
             img_mx = Matrix.scale(step_x, step_y)
             data = []
             for node in self.flat():
-                if node.type not in self._allowed_elements_dnd:
-                    continue
                 if node.type == "reference":
                     node = node.node
+                if node.type not in self._allowed_elements_dnd:
+                    continue
                 if getattr(node, "hidden", False):
                     continue
                 data.append(node)


### PR DESCRIPTION
At some point, a bug was introduced that caused the Raster op to render bitmaps rotated/flipped in a way that was directly related to the device configs flip x and/or flip y values.

The issue was an ImageNode._cache being passed by reference and not being cleared which caused it to skip ConcatTransform.

This fix is to add a self._cache = None.

## Summary by Sourcery

Bug Fixes:
- Fix raster operations rendering bitmaps with incorrect mirroring or rotation when device flip settings are applied by clearing the cached render after image reprocessing.