### PR TITLE
Fix raster op

### DIFF
--- a/meerk40t/core/color_cache.py
+++ b/meerk40t/core/color_cache.py
@@ -203,6 +203,10 @@ class CachedColor:
         return inst
 
     # Instance delegation -------------------------------------------------
+    def __copy__(self):
+        """Return self — CachedColor instances are shared/immutable wrappers."""
+        return self
+
     def __getattr__(self, name):
         """Delegate attribute access to the underlying Color instance."""
         return getattr(self._color, name)

--- a/meerk40t/core/color_cache.py
+++ b/meerk40t/core/color_cache.py
@@ -204,8 +204,14 @@ class CachedColor:
 
     # Instance delegation -------------------------------------------------
     def __copy__(self):
-        """Return self — CachedColor instances are shared/immutable wrappers."""
-        return self
+        """Return a new CachedColor wrapping an independent copy of the underlying Color."""
+        target_class = _original_color_class or svgelements_module.Color
+        new_color = target_class.__new__(target_class)
+        new_color.__dict__.update(self._color.__dict__)
+        inst = object.__new__(CachedColor)
+        object.__setattr__(inst, "_color", new_color)
+        object.__setattr__(inst, "_key", None)
+        return inst
 
     def __getattr__(self, name):
         """Delegate attribute access to the underlying Color instance."""

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -80,12 +80,20 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         self.set_dirty_bounds()
 
     def __copy__(self):
-        nd = self.node_dict
-        nd["geometry"] = copy(self.geometry)
-        nd["matrix"] = copy(self.matrix)
-        nd["stroke"] = copy(self.stroke)
-        nd["fill"] = copy(self.fill)
-        return PathNode(**nd)
+        obj = PathNode.__new__(PathNode)
+        obj.__dict__.update(self.__dict__)
+        obj._children = list()
+        obj._references = list()
+        obj._points = list()
+        obj._default_map = dict()
+        obj._parent = None
+        obj._root = None
+        # Deep-copy mutable geometry/style objects
+        obj.geometry = copy(self.geometry)
+        obj.matrix = copy(self.matrix)
+        obj.stroke = copy(self.stroke)
+        obj.fill = copy(self.fill)
+        return obj
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"

--- a/meerk40t/core/node/elem_path.py
+++ b/meerk40t/core/node/elem_path.py
@@ -80,20 +80,12 @@ class PathNode(Node, Stroked, FunctionalParameter, LabelDisplay, Suppressable):
         self.set_dirty_bounds()
 
     def __copy__(self):
-        obj = PathNode.__new__(PathNode)
-        obj.__dict__.update(self.__dict__)
-        obj._children = list()
-        obj._references = list()
-        obj._points = list()
-        obj._default_map = dict()
-        obj._parent = None
-        obj._root = None
-        # Deep-copy mutable geometry/style objects
-        obj.geometry = copy(self.geometry)
-        obj.matrix = copy(self.matrix)
-        obj.stroke = copy(self.stroke)
-        obj.fill = copy(self.fill)
-        return obj
+        nd = self.node_dict
+        nd["geometry"] = copy(self.geometry)
+        nd["matrix"] = copy(self.matrix)
+        nd["stroke"] = copy(self.stroke)
+        nd["fill"] = copy(self.fill)
+        return PathNode(**nd)
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{self.type}', {str(self._parent)})"

--- a/meerk40t/core/node/node.py
+++ b/meerk40t/core/node/node.py
@@ -809,7 +809,6 @@ class Node:
         @return:
         """
         for child in copy_node.children:
-            child = child
             if child.type == "reference":
                 child = child.node
             copy_child = copy(child)

--- a/meerk40t/core/node/op_raster.py
+++ b/meerk40t/core/node/op_raster.py
@@ -486,10 +486,10 @@ class RasterOpNode(OperationMixin, Node, Parameters):
             img_mx = Matrix.scale(step_x, step_y)
             data = []
             for node in self.flat():
-                if node.type not in self._allowed_elements_dnd:
-                    continue
                 if node.type == "reference":
                     node = node.node
+                if node.type not in self._allowed_elements_dnd:
+                    continue
                 if getattr(node, "hidden", False):
                     continue
                 data.append(node)


### PR DESCRIPTION
Raster Op was producing blank output for paths.   Issue was when copying from CachedColor the stroke was being set to None.   Fix is adding a proper __copy__  to CachedColor.

## Summary by Sourcery

Fix raster rasterization issues by correcting color copying and node handling in raster operations.

Bug Fixes:
- Ensure CachedColor instances are shallow-copied with an independent underlying Color to preserve stroke and other attributes during copy operations.
- Adjust raster operation node iteration to resolve reference nodes before validating allowed element types, preventing valid referenced elements from being skipped.
- Remove a no-op assignment in node child copying to avoid confusion and potential side effects.

Enhancements:
- Improve CachedColor copy behavior to avoid inadvertent sharing of internal state between instances.