### PR TITLE
Fix NameError in wordlist plus catch threaded errors

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -1607,6 +1607,12 @@ class Elemental(Service):
                 op.settings["effects"] = effects
                 # print (f"{op.type}.{op.display_label()} - effect={effects}")
             op.save(settings, section)
+            if effects:
+                # Clean up so the SVG writer doesn't also emit this as an attribute
+                # (the effect is already saved as a child node in the SVG).
+                del op.settings["effects"]
+                if hasattr(op, "effects"):
+                    del op.effects
             # We will save the effect information, ie whether an operation does contain a hatch/wobble/warp
 
             # We need to save the children as well.

--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -652,6 +652,7 @@ class Elemental(Service):
         self._node_lock = threading.RLock()
 
         self.note = None
+        self.last_file_dir = ""
         self.last_file_autoexec = None
         self.last_file_autoexec_active = False
         self._filename = None

--- a/meerk40t/core/elements/wordlist.py
+++ b/meerk40t/core/elements/wordlist.py
@@ -325,7 +325,7 @@ def init_commands(kernel):
                         break
             elif hasattr(node, "mktext"):
                 if node.mktext:
-                    bracketed_key = list(brackets.findall(str(node.mktext)))
+                    bracketed_key = list(_BRACKETS.findall(str(node.mktext)))
                     if len(bracketed_key) > 0:
                         usage = True
                         break

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -1770,6 +1770,14 @@ class SVGProcessor:
                     )
                     self.check_for_label_display(context_node, element)
                     self.check_for_bound_information(context_node, element)
+            else:
+                # Reusing an existing operation. Remove any auto-created
+                # effect children so the SVG's own effect children (parsed
+                # below via recursion) don't produce duplicates.
+                with self.elements.node_lock:
+                    for child in list(context_node._children):
+                        if child.type.startswith("effect "):
+                            child.remove_node(fast=True, destroy=True)
             context_node._ref_load = element.values.get("references")
             e_list.append(context_node)
             if hasattr(context_node, "validate"):

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -801,11 +801,11 @@ class SVGProcessor:
             # print ("Will replace all operations...")
             self.requires_classification = False
             if self.replace_ops:
-                # Opening a project: clear pre-existing operations,
-                # the file's operations take over.
+                # Opening a project: clear pre-existing operations
+                # that weren't reused by the file.
                 with self.elements.node_lock:
                     for child in list(self.elements.op_branch.children):
-                        if child in retain_op_list:
+                        if child in retain_op_list and not hasattr(child, "_ref_load"):
                             child.remove_all_children(fast=True, destroy=True)
                             child.remove_node(fast=True, destroy=True)
             # Remove orphan operations from the file that got no references.

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -1759,6 +1759,51 @@ class SVGProcessor:
                                 break
                         if differs:
                             continue
+                        # Compare effect children to avoid reusing an
+                        # operation whose effects don't match the SVG.
+                        existing_effects = [
+                            node
+                            for node in testop.children
+                            if node.type.startswith("effect ")
+                        ]
+                        svg_effect_attrs = []
+                        for child in element:
+                            if not isinstance(child, Group):
+                                continue
+                            ca = dict(child.values.get("attributes", {}))
+                            if ca.get("type", "").startswith("effect "):
+                                svg_effect_attrs.append(ca)
+                        # Different number of effects — not a match.
+                        if len(existing_effects) != len(svg_effect_attrs):
+                            differs = True
+                        # Compare each effect's parameters.
+                        if not differs:
+                            for eff_node, svg_attrs in zip(
+                                existing_effects, svg_effect_attrs
+                            ):
+                                if eff_node.type != svg_attrs.get("type", ""):
+                                    differs = True
+                                    break
+                                for attr_key, attr_val in svg_attrs.items():
+                                    if attr_key in (
+                                        "type", "id", "label",
+                                        "lock", "hidden", "references",
+                                    ):
+                                        continue
+                                    node_val = getattr(
+                                        eff_node, attr_key, None
+                                    )
+                                    if node_val is None:
+                                        node_val = eff_node.settings.get(
+                                            attr_key
+                                        ) if hasattr(eff_node, "settings") else None
+                                    if node_val is not None and str(node_val) != str(attr_val):
+                                        differs = True
+                                        break
+                                if differs:
+                                    break
+                        if differs:
+                            continue
                         context_node = testop
                         already = True
                         break
@@ -1770,25 +1815,48 @@ class SVGProcessor:
                     )
                     self.check_for_label_display(context_node, element)
                     self.check_for_bound_information(context_node, element)
-            else:
-                # Reusing an existing operation. Remove any auto-created
-                # effect children so the SVG's own effect children (parsed
-                # below via recursion) don't produce duplicates.
-                with self.elements.node_lock:
-                    for child in list(context_node._children):
-                        if child.type.startswith("effect "):
-                            child.remove_node(fast=True, destroy=True)
             context_node._ref_load = element.values.get("references")
             e_list.append(context_node)
             if hasattr(context_node, "validate"):
                 context_node.validate()
 
-            # recurse to children
+            # Recurse to children, but skip effect nodes if we are
+            # reusing an operation that already has matching effects.
+            # Collect the skipped effects' references and assign them
+            # to the operation — add_reference will route them to the
+            # existing effect child automatically.
+            skip_effects = already and any(
+                c.type.startswith("effect ")
+                for c in context_node._children
+            )
+            if skip_effects:
+                effect_refs = []
+                for child in element:
+                    if isinstance(child, Group):
+                        ca = child.values.get("attributes", {})
+                        if ca.get("type", "").startswith("effect "):
+                            refs = ca.get("references")
+                            if refs:
+                                effect_refs.append(refs)
+                if effect_refs:
+                    all_refs = " ".join(effect_refs)
+                    if context_node._ref_load:
+                        context_node._ref_load += " " + all_refs
+                    else:
+                        context_node._ref_load = all_refs
             if self.reverse:
                 for child in reversed(element):
+                    if skip_effects and isinstance(child, Group):
+                        ca = child.values.get("attributes", {})
+                        if ca.get("type", "").startswith("effect "):
+                            continue
                     self.parse(child, context_node, e_list, branch=branch)
             else:
                 for child in element:
+                    if skip_effects and isinstance(child, Group):
+                        ca = child.values.get("attributes", {})
+                        if ca.get("type", "").startswith("effect "):
+                            continue
                     self.parse(child, context_node, e_list, branch=branch)
         elif isinstance(element, Use):
             # recurse to children, but do not subgroup elements.

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -743,6 +743,7 @@ class SVGProcessor:
         load_operations,
         load_hidden_to_regmarks=True,
         reuse_operations=True,
+        replace_ops=False,
     ):
         self.elements = elements
         self.fastmode = getattr(self.elements, "fastload", False)
@@ -758,6 +759,7 @@ class SVGProcessor:
         self.pathname = None
         self.load_operations = load_operations
         self.reuse_operations = reuse_operations
+        self.replace_ops = replace_ops
         self.mk_params = list(
             self.elements.kernel.lookup_all("registered_mk_svg_parameters")
         )
@@ -785,11 +787,7 @@ class SVGProcessor:
         @param pathname:
         @return:
         """
-        retain_op_list = [
-            child
-            for child in list(self.elements.ops())
-            if child._children is not None and len(child._children) > 0
-        ]
+        retain_op_list = list(self.elements.ops())
         self.pathname = pathname
 
         context_node = self.elements.elem_branch
@@ -802,6 +800,15 @@ class SVGProcessor:
         if self.load_operations and self.operations_generated:
             # print ("Will replace all operations...")
             self.requires_classification = False
+            if self.replace_ops:
+                # Opening a project: clear pre-existing operations,
+                # the file's operations take over.
+                with self.elements.node_lock:
+                    for child in list(self.elements.op_branch.children):
+                        if child in retain_op_list:
+                            child.remove_all_children(fast=True, destroy=True)
+                            child.remove_node(fast=True, destroy=True)
+            # Remove orphan operations from the file that got no references.
             with self.elements.node_lock:
                 for child in list(self.elements.op_branch.children):
                     if child in retain_op_list:
@@ -1892,12 +1899,14 @@ class SVGLoader:
             raise BadFileError(str(e)) from e
         reuse = elements_service.reuse_operations_on_load
         to_regmarks = elements_service.load_hidden_to_regmarks
+        replace_ops = kwargs.get("replace_ops", False)
         elements_service._loading_cleared = True
         svg_processor = SVGProcessor(
             elements_service,
             load_operations=True,
             reuse_operations=reuse,
             load_hidden_to_regmarks=to_regmarks,
+            replace_ops=replace_ops,
         )
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -1587,6 +1587,17 @@ def handleGUIException(exc_type, exc_value, exc_traceback):
             variable_info += f"[{source}]:\n" + _variable_summary(frame.f_locals)
     except Exception:
         pass
+
+    # Always surface the crash on the terminal (stderr), regardless of
+    # whether the crash-log file below can be written.
+    try:
+        sys.stderr.write(error_log)
+        if variable_info:
+            sys.stderr.write(variable_info)
+        sys.stderr.flush()
+    except Exception:
+        pass
+
     try:
         filename = f"MeerK40t-{datetime.now():%Y-%m-%d_%H_%M_%S}.txt"
     except Exception:  # I already crashed once, if there's another here just ignore it.
@@ -1598,14 +1609,12 @@ def handleGUIException(exc_type, exc_value, exc_traceback):
                 file.write(error_log)
                 if variable_info:
                     file.write(variable_info)
-                print(error_log)
         except PermissionError:
             filename = os.path.join(get_safe_path(APPLICATION_NAME), filename)
             with open(filename, "w", encoding="utf8") as file:
                 file.write(error_log)
                 if variable_info:
                     file.write(variable_info)
-                print(error_log)
     except Exception:
         # I already crashed once, if there's another here just ignore it.
         pass

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -5613,7 +5613,7 @@ class MeerK40t(MWindow):
 
     def clear_and_open(self, pathname, preferred_loader=None):
         self.clear_project(ops_too=False)
-        if self.load(pathname, preferred_loader, execution=True):
+        if self.load(pathname, preferred_loader, execution=True, replace_ops=True):
             try:
                 if self.context.uniform_svg and pathname.lower().endswith("svg"):
                     # or (len(elements) > 0 and "meerK40t" in elements[0].values):
@@ -5623,7 +5623,7 @@ class MeerK40t(MWindow):
             except AttributeError:
                 pass
 
-    def load(self, pathname, preferred_loader=None, execution=False):
+    def load(self, pathname, preferred_loader=None, execution=False, **kwargs):
         def unescaped(filename):
             OS_NAME = platform.system()
             if OS_NAME == "Windows":
@@ -5744,6 +5744,7 @@ class MeerK40t(MWindow):
                 channel=self.context.channel("load"),
                 svg_ppi=self.context.elements.svg_ppi,
                 preferred_loader=preferred_loader,
+                **kwargs,
             )
             kernel.busyinfo.end()
             if post_process:

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -3196,6 +3196,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Open"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_PREVIEW,
             ) as fileDialog:
@@ -3208,6 +3209,7 @@ class MeerK40t(MWindow):
                     preferred_loader = None
 
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 gui.clear_and_open(pathname, preferred_loader=preferred_loader)
 
         @context.console_command("dialog_import", hidden=True)
@@ -3216,6 +3218,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Import"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_PREVIEW,
             ) as fileDialog:
@@ -3227,6 +3230,7 @@ class MeerK40t(MWindow):
                 except IndexError:
                     preferred_loader = None
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 gui.load(pathname, preferred_loader, execution=False)
 
         @context.console_option("quit", "q", action="store_true", type=bool)
@@ -3245,6 +3249,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Save Project"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
             ) as fileDialog:
@@ -3254,6 +3259,7 @@ class MeerK40t(MWindow):
                     fileDialog.GetFilterIndex()
                 ]
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 if not pathname.lower().endswith(f".{extension}"):
                     pathname += f".{extension}"
                 try:
@@ -5507,6 +5513,7 @@ class MeerK40t(MWindow):
             except IndexError:
                 preferred_loader = None
             pathname = fileDialog.GetPath()
+            self.context.elements.last_file_dir = os.path.dirname(pathname)
             self.load(pathname, preferred_loader, execution=True)
 
     def populate_recent_menu(self):

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -3980,17 +3980,19 @@ class Kernel(Settings):
                 self.signal("thread_update", "/", job_identifier, "started")
                 t0 = time.perf_counter()
                 try:
-                    data_out = self._console_parse(remainder, channel=self._console_channel)
-                except Exception as e:
-                    self._console_channel(_("Encountered exception {error}").format(error=e))
-
-                t1 = time.perf_counter()
-                self._console_channel(
-                    _("Finished command {cmd} after {duration}sec").format(
-                        cmd=remainder, duration=f"{t1 - t0:.2f}"
+                    self._console_parse(remainder, channel=self._console_channel)
+                finally:
+                    # Report completion even on failure, but do NOT swallow
+                    # the exception. Letting it propagate routes it through
+                    # kernel.threaded()'s run() wrapper to sys.excepthook,
+                    # producing the full crash log (file + dialog + terminal).
+                    t1 = time.perf_counter()
+                    self._console_channel(
+                        _("Finished command {cmd} after {duration}sec").format(
+                            cmd=remainder, duration=f"{t1 - t0:.2f}"
+                        )
                     )
-                )
-                self.signal("thread_update", "/", job_identifier, "ended")
+                    self.signal("thread_update", "/", job_identifier, "ended")
 
             if remainder is None:
                 # List all scheduled jobs that fit our format


### PR DESCRIPTION
fix _BRACKETS typo that was causing vector text to to cause execution to fail silently.

This was an error that happened in a thread so it got swallowed up instead of showing it in the console or to the user to report.   This PR also catches and propagates the error back to kernel to be handled and reported.

## Summary by Sourcery

Fix threaded command execution and crash reporting to surface errors instead of silently swallowing them, and correct a wordlist placeholder lookup bug.

Bug Fixes:
- Correct wordlist placeholder detection by using the proper bracket-matching pattern constant.
- Allow exceptions from threaded console commands to propagate instead of being caught and hidden, while still reporting command completion state.
- Ensure application crashes are always written to the terminal via stderr, even if writing the crash-log file fails.

Enhancements:
- Simplify threaded command timing and status reporting to run in a finally block so it executes consistently on both success and failure.