### PR TITLE
Quality of life improvment for opening vs importing svg

### DIFF
--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -801,11 +801,11 @@ class SVGProcessor:
             # print ("Will replace all operations...")
             self.requires_classification = False
             if self.replace_ops:
-                # Opening a project: clear pre-existing operations,
-                # the file's operations take over.
+                # Opening a project: clear pre-existing operations
+                # that weren't reused by the file.
                 with self.elements.node_lock:
                     for child in list(self.elements.op_branch.children):
-                        if child in retain_op_list:
+                        if child in retain_op_list and not hasattr(child, "_ref_load"):
                             child.remove_all_children(fast=True, destroy=True)
                             child.remove_node(fast=True, destroy=True)
             # Remove orphan operations from the file that got no references.

--- a/meerk40t/core/svg_io.py
+++ b/meerk40t/core/svg_io.py
@@ -743,6 +743,7 @@ class SVGProcessor:
         load_operations,
         load_hidden_to_regmarks=True,
         reuse_operations=True,
+        replace_ops=False,
     ):
         self.elements = elements
         self.fastmode = getattr(self.elements, "fastload", False)
@@ -758,6 +759,7 @@ class SVGProcessor:
         self.pathname = None
         self.load_operations = load_operations
         self.reuse_operations = reuse_operations
+        self.replace_ops = replace_ops
         self.mk_params = list(
             self.elements.kernel.lookup_all("registered_mk_svg_parameters")
         )
@@ -785,11 +787,7 @@ class SVGProcessor:
         @param pathname:
         @return:
         """
-        retain_op_list = [
-            child
-            for child in list(self.elements.ops())
-            if child._children is not None and len(child._children) > 0
-        ]
+        retain_op_list = list(self.elements.ops())
         self.pathname = pathname
 
         context_node = self.elements.elem_branch
@@ -802,6 +800,15 @@ class SVGProcessor:
         if self.load_operations and self.operations_generated:
             # print ("Will replace all operations...")
             self.requires_classification = False
+            if self.replace_ops:
+                # Opening a project: clear pre-existing operations,
+                # the file's operations take over.
+                with self.elements.node_lock:
+                    for child in list(self.elements.op_branch.children):
+                        if child in retain_op_list:
+                            child.remove_all_children(fast=True, destroy=True)
+                            child.remove_node(fast=True, destroy=True)
+            # Remove orphan operations from the file that got no references.
             with self.elements.node_lock:
                 for child in list(self.elements.op_branch.children):
                     if child in retain_op_list:
@@ -1892,12 +1899,14 @@ class SVGLoader:
             raise BadFileError(str(e)) from e
         reuse = elements_service.reuse_operations_on_load
         to_regmarks = elements_service.load_hidden_to_regmarks
+        replace_ops = kwargs.get("replace_ops", False)
         elements_service._loading_cleared = True
         svg_processor = SVGProcessor(
             elements_service,
             load_operations=True,
             reuse_operations=reuse,
             load_hidden_to_regmarks=to_regmarks,
+            replace_ops=replace_ops,
         )
         svg_processor.process(svg, pathname)
         svg_processor.cleanup()

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -5613,7 +5613,7 @@ class MeerK40t(MWindow):
 
     def clear_and_open(self, pathname, preferred_loader=None):
         self.clear_project(ops_too=False)
-        if self.load(pathname, preferred_loader, execution=True):
+        if self.load(pathname, preferred_loader, execution=True, replace_ops=True):
             try:
                 if self.context.uniform_svg and pathname.lower().endswith("svg"):
                     # or (len(elements) > 0 and "meerK40t" in elements[0].values):
@@ -5623,7 +5623,7 @@ class MeerK40t(MWindow):
             except AttributeError:
                 pass
 
-    def load(self, pathname, preferred_loader=None, execution=False):
+    def load(self, pathname, preferred_loader=None, execution=False, **kwargs):
         def unescaped(filename):
             OS_NAME = platform.system()
             if OS_NAME == "Windows":
@@ -5744,6 +5744,7 @@ class MeerK40t(MWindow):
                 channel=self.context.channel("load"),
                 svg_ppi=self.context.elements.svg_ppi,
                 preferred_loader=preferred_loader,
+                **kwargs,
             )
             kernel.busyinfo.end()
             if post_process:


### PR DESCRIPTION
Importing an svg would remove operations that have no elements assigned.  This caused a problematic workflow when using operations loaded from material manager.  You would load your settings, import svg's in and lose your settings, then to reload them from material manager you'd lose any operations loaded in from your svg.

This change does two things:
* importing file on an svg only adds operations (if necessary) and doesn't remove
* opening a project, replaces operations with the file operations unless there are none.

## Summary by Sourcery

Adjust SVG loading to differentiate between importing SVGs and opening projects, preserving existing operations on import while allowing full replacement on open.

New Features:
- Add an option to replace existing operations with those from the loaded SVG when opening a project.

Enhancements:
- Change SVG import behavior to retain existing operations and only remove newly loaded operations that end up unreferenced.
- Propagate loader keyword arguments through the GUI load path to control SVG processing behavior.