### PR TITLE
remember last file dialog location

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -652,6 +652,7 @@ class Elemental(Service):
         self._node_lock = threading.RLock()
 
         self.note = None
+        self.last_file_dir = ""
         self.last_file_autoexec = None
         self.last_file_autoexec_active = False
         self._filename = None

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -3196,6 +3196,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Open"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_PREVIEW,
             ) as fileDialog:
@@ -3208,6 +3209,7 @@ class MeerK40t(MWindow):
                     preferred_loader = None
 
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 gui.clear_and_open(pathname, preferred_loader=preferred_loader)
 
         @context.console_command("dialog_import", hidden=True)
@@ -3216,6 +3218,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Import"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_PREVIEW,
             ) as fileDialog:
@@ -3227,6 +3230,7 @@ class MeerK40t(MWindow):
                 except IndexError:
                     preferred_loader = None
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 gui.load(pathname, preferred_loader, execution=False)
 
         @context.console_option("quit", "q", action="store_true", type=bool)
@@ -3245,6 +3249,7 @@ class MeerK40t(MWindow):
             with wx.FileDialog(
                 gui,
                 _("Save Project"),
+                defaultDir=context.elements.last_file_dir,
                 wildcard=files,
                 style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
             ) as fileDialog:
@@ -3254,6 +3259,7 @@ class MeerK40t(MWindow):
                     fileDialog.GetFilterIndex()
                 ]
                 pathname = fileDialog.GetPath()
+                context.elements.last_file_dir = os.path.dirname(pathname)
                 if not pathname.lower().endswith(f".{extension}"):
                     pathname += f".{extension}"
                 try:
@@ -5507,6 +5513,7 @@ class MeerK40t(MWindow):
             except IndexError:
                 preferred_loader = None
             pathname = fileDialog.GetPath()
+            self.context.elements.last_file_dir = os.path.dirname(pathname)
             self.load(pathname, preferred_loader, execution=True)
 
     def populate_recent_menu(self):


### PR DESCRIPTION
This is a simple quality of life change.  When you open, import, or save a file, the file dialog now opens to the same directory you last used, instead of wherever the OS defaults to.

This pr:
 * creates a last_file_dir variable in the context
 * uses it as the defaultDir on the 4 dialogs in wxmain
 * updates the variable when those 4 dialogs are use
 * instance-only (not persistent across restarts)

## Summary by Sourcery

Remember and reuse the last directory used in file dialogs within a running session.

New Features:
- Track the last used file directory in the elements context for use by file dialogs.

Enhancements:
- Make open, import, save, and try-open dialogs default to the last used directory instead of the OS default, updating the stored directory on each use.