### PR TITLE
fix bounds crash

### DIFF
--- a/meerk40t/core/elements/elements.py
+++ b/meerk40t/core/elements/elements.py
@@ -3250,7 +3250,7 @@ class Elemental(Service):
                     bounds = e.bounds
                     bounds_painted = e.paint_bounds
                 e_list.append(e)
-                if self._emphasized_bounds is not None:
+                if bounds is not None and self._emphasized_bounds is not None:
                     cc = self._emphasized_bounds
                     bounds = (
                         min(bounds[0], cc[0]),
@@ -3258,9 +3258,9 @@ class Elemental(Service):
                         max(bounds[2], cc[2]),
                         max(bounds[3], cc[3]),
                     )
-                if self._emphasized_bounds_painted is not None:
+                if bounds_painted is not None and self._emphasized_bounds_painted is not None:
                     cc = self._emphasized_bounds_painted
-                    bounds = (
+                    bounds_painted = (
                         min(bounds_painted[0], cc[0]),
                         min(bounds_painted[1], cc[1]),
                         max(bounds_painted[2], cc[2]),


### PR DESCRIPTION
Fixes a crash when clicking an element whose bounds come back as None — the union with _emphasized_bounds would blow up with a NoneType subscript error. Also noticed while I was in there that the painted-bounds branch was assigning its result to bounds instead of bounds_painted, so painted bounds were never actually accumulating across selections. Both fixed.

## Summary by Sourcery

Guard union of selection bounds with emphasized bounds to avoid crashes when element bounds are missing and ensure emphasized painted bounds correctly accumulate across selections.

Bug Fixes:
- Prevent a crash when computing emphasized bounds for elements with missing bounds.
- Fix accumulation of emphasized painted bounds so they correctly update across multiple selections.