### PR TITLE
Meerkat local changes for MKS DLC32 K40 workflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Workspace (hardware, EEPROM, workflow):** [meerk40t_Makerbase_DLC32](https://github.com/Andre6553/meerk40t_Makerbase_DLC32)
 
-**Current version:** `0.9.9034` · **Upstream:** [meerk40t/meerk40t](https://github.com/meerk40t/meerk40t)
+**Current version:** `0.9.9040` · **Upstream:** [meerk40t/meerk40t](https://github.com/meerk40t/meerk40t)
 
 Personal fork for a **Makerbase MKS DLC32** GRBL controller on a **30×40 cm, 60 W CO2** laser. Active local development — not the upstream maintenance branch.
 
@@ -14,9 +14,31 @@ Personal fork for a **Makerbase MKS DLC32** GRBL controller on a **30×40 cm, 60
 
 ## Fork changelog (MeerK40t)
 
-**Latest entry:** **v0.9.9034**. Canonical copy also lives in the workspace repo at [`docs/meerk40t/15-meerkat-local-changes.md`](https://github.com/Andre6553/meerk40t_Makerbase_DLC32/blob/main/docs/meerk40t/15-meerkat-local-changes.md) (keep in sync when editing).
+**Latest entry:** **v0.9.9040**. Canonical copy also lives in the workspace repo at [`docs/meerk40t/15-meerkat-local-changes.md`](https://github.com/Andre6553/meerk40t_Makerbase_DLC32/blob/main/docs/meerk40t/15-meerkat-local-changes.md) (keep in sync when editing).
 
 All entries are **fork-style edits** in this repository, not upstream MeerK40t releases.
+
+## 2026-06 — Rotary: Fit uses native units → mm correctly (v0.9.9040)
+
+**Files:** `meerk40t/meerk40t/rotary/rotary.py`
+
+**Problem:** Fit treated scene bounds as mm but MeerK40t stores them in **native units** (~2580 per mm). It also stripped the normal text matrix `scale(UNITS_PER_PIXEL)`, which blew up font size and triggered false “bounds look wrong” errors on **new** text.
+
+**Fix:** Convert selection size with `UNITS_PER_MM`; only remove **extra** matrix scale (old bugs), always keep `UNITS_PER_PIXEL` on text; use standard `selected_area()` for bounds.
+
+## 2026-06 — Rotary: Fit selection fixes text (v0.9.9038)
+
+**Files:** `meerk40t/meerk40t/rotary/rotary.py`
+
+**Problem:** **Fit selection to rotary** scaled text by multiplying its matrix. wxPython draws text with `DrawText` + matrix, so scaled text looked like a shattered round blob.
+
+**Fix:** Text is scaled via **font size** (and position nudge), not matrix scale.
+
+## 2026-06 — Rotary Pro: diameter, steps calibration, GRBL hooks (v0.9.9035)
+
+**Files:** `meerk40t/meerk40t/rotary/rotary.py`, `meerk40t/meerk40t/rotary/rotary_cam.py`, `meerk40t/meerk40t/grbl/driver.py`, `meerk40t/meerk40t/rotary/gui/rotarysettings.py`
+
+**Feature:** Y-motor-swap chuck rotary for GRBL/DLC32 — diameter, usable length, Y steps compensation, homing guards, **Fit selection to rotary**, console `rotary` / `rotaryfit` / `rotarycal` / `rotarysuggest`.
 
 ## 2026-06 — Living Hinges: Apply to scene button visible (v0.9.9034)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,599 @@
+# MeerK40t — Andre van der Westhuizen fork
+
+**GitHub:** https://github.com/Andre6553/meerk40t
+
+**Workspace (hardware, EEPROM, workflow):** [meerk40t_Makerbase_DLC32](https://github.com/Andre6553/meerk40t_Makerbase_DLC32)
+
+**Current version:** `0.9.9034` · **Upstream:** [meerk40t/meerk40t](https://github.com/meerk40t/meerk40t)
+
+Personal fork for a **Makerbase MKS DLC32** GRBL controller on a **30×40 cm, 60 W CO2** laser. Active local development — not the upstream maintenance branch.
+
+**On this page:** [Fork changelog](#fork-changelog-meerk40t) · [Upstream README](#welcome-to-meerk40t)
+
+---
+
+## Fork changelog (MeerK40t)
+
+**Latest entry:** **v0.9.9034**. Canonical copy also lives in the workspace repo at [`docs/meerk40t/15-meerkat-local-changes.md`](https://github.com/Andre6553/meerk40t_Makerbase_DLC32/blob/main/docs/meerk40t/15-meerkat-local-changes.md) (keep in sync when editing).
+
+All entries are **fork-style edits** in this repository, not upstream MeerK40t releases.
+
+## 2026-06 — Living Hinges: Apply to scene button visible (v0.9.9034)
+
+**File:** `meerk40t/meerk40t/tools/livinghinges.py`
+
+**Problem:** **Generate** sat below the left-column sliders and was often off-screen; users saw preview only with no obvious way to commit the pattern.
+
+**Fix:** Renamed **Generate** → **Apply to scene**; moved it (with **Close**) under the **Preview** panel so it stays visible. Default window height 480 px.
+
+## 2026-06 — Kerf-Test Create Pattern crash fix (v0.9.9033)
+
+**File:** `meerk40t/meerk40t/tools/kerftest.py`
+
+**Problem:** **Kerf-Test** → **Create Pattern** crashed with `AttributeError: 'Context' object has no attribute 'signal_refresh'`.
+
+**Fix:** After generating the test pattern, refresh the scene with `refresh_scene` (same as **Parameter-Test**), not the non-existent `context.signal_refresh()`.
+
+## 2026-06 — Line tool: click on existing geometry + precise preview (v0.9.9032)
+
+**Files:** `meerk40t/meerk40t/gui/scenewidgets/selectionwidget.py`, `meerk40t/meerk40t/gui/scenewidgets/rectselectwidget.py`, `meerk40t/meerk40t/gui/toolwidgets/toolpointlistbuilder.py`
+
+**Problem:** With the line tool active, clicks on top of an existing (selected) line were intercepted by selection/rect-select widgets, so a new line could not start on existing geometry unless the cursor moved away. While placing the second point, snap preview pulled the rubber-band endpoint away from the cursor (felt like overshoot when zoomed in).
+
+**Fix:**
+- Selection handles and rectangular selection now defer mouse events whenever `active_tool != "none"`.
+- Point-list tools (line/polyline) follow the raw cursor for preview (`move`/`hover`/`leftdown`); snap is applied only on `leftclick` when placing a point.
+
+## 2026-06 — Start new line directly on existing line (v0.9.9031)
+
+**File:** `meerk40t/meerk40t/gui/scenewidgets/elementswidget.py`
+
+**Problem:** After finishing a line, clicking directly on top of an existing line could be consumed as element selection first, so the first point of the next line did not start unless the cursor moved off the line.
+
+**Fix:** `ElementsWidget` no longer consumes `leftclick` for selection while any non-`none` tool is active. This lets line/polyline and other creation tools start exactly on existing geometry.
+
+## 2026-06 — Middle-mouse pan while drawing point tools (v0.9.9030)
+
+**File:** `meerk40t/meerk40t/gui/toolwidgets/toolpointlistbuilder.py`
+
+**Problem:** While drawing with point-based tools (Line/Polyline and related), pressing and dragging the middle mouse button did not pan the scene because move events were consumed by the active tool.
+
+**Fix:** Point-list tools now pass through `move` events when the middle button is held (`m_middle` modifier), so scene panning can work during active drawing without ending the tool.
+
+## 2026-06 — Camera Calibration Enter-key crash fix (v0.9.9029)
+
+**Files:** `meerk40t/meerk40t/camera/gui/cameracal.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`
+
+**Problem:** Opening **Camera Calibration** crashed: `wxTE_PROCESS_ENTER` required for Enter-key connect on the URI text box.
+
+**Fix:** Camera URI fields created with `wx.TE_PROCESS_ENTER`.
+
+## 2026-06 — Camera paste URL / IP connect (v0.9.9028)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/camera/gui/cameracal.py`
+
+**Feature:** Users can paste a **USB index**, **full `rtsp://` URL**, **`user:pass@IP`**, or **bare IP** — `normalize_camera_uri()` builds the OpenCV address. **Connect** in **Camera URI** manager and **Camera Calibration** applies it to `camera0` (or chosen index) and saves it in the URI list.
+
+**Andre's setup unchanged:** full URL `rtsp://admin:***@192.168.10.133:8554/stream1` still works as-is; shorthand `admin:***@192.168.10.133:8554/stream1` also works.
+
+## 2026-06 — Camera align offset crash fix (v0.9.9027)
+
+**File:** `meerk40t/meerk40t/camera/camera.py`
+
+**Problem:** Crash on scene refresh after Update image: `AttributeError: 'Context' object has no attribute 'align_offset_scene_units'` — `camera_align_offsets_for_context` used `kernel.get_context("camera/N")` which can return a plain Context stub, not the Camera service.
+
+**Fix:** `_camera_service_for_index()` resolves the real Camera service from `kernel.services("camera")` by path; skips non-Camera contexts. Composite path wraps offset lookup in try/except.
+
+## 2026-06 — Camera bed photo MemoryDC composite (v0.9.9026)
+
+**Files:** `meerk40t/meerk40t/gui/scene/scene.py`, `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`
+
+**Problem:** Console still reported success with 1 bed widget but main scene stayed grey — `GraphicsContext.DrawBitmap` inside the scene layer cache does not paint reliably on Windows.
+
+**Fix:** After the background layer is drawn, `composite_bed_photo_on_device_dc()` blits the bed photo with `MemoryDC.DrawBitmap` in device pixels. Bed widget skips the GC bitmap path. Console logs center-pixel RGB to confirm the frame has real image data.
+
+## 2026-06 — Camera bed photo draw fix (v0.9.9025)
+
+**Files:** `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`, `meerk40t/meerk40t/camera/camera.py`
+
+**Problem:** Console reported `Bed background applied` but main scene stayed **grey** — camera bitmap was stored but not painted (Hide Background draw mode and/or `GraphicsContext.DrawBitmap` failing on Windows).
+
+**Fix:** Bed widget **always draws** a stored camera bitmap (not gated by Hide Background). Pre-scales bitmap to screen pixels before draw; falls back to `CreateBitmapFromImage`. Clears Hide Background on root + scene contexts; `wx.CallAfter` refresh. Console shows bed widget count.
+
+## 2026-06 — Camera bed apply crash fix (v0.9.9024)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`
+
+**Problem:** **Update image** crashed with `NameError: name '_' is not defined` in `push_bed_background_bitmap` right after the bed bitmap was built (v0.9.9023).
+
+**Fix:** Module-level messages use `kernel.translation`; `Camera.background()` uses `self._()`.
+
+## 2026-06 — Camera Update Image console messages fix (v0.9.9023)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`
+
+**Problem:** **Update image** appeared to do nothing — messages used `self.channel("the message")` (wrong API) or the **camera** channel only, so nothing showed in the **Console** pane. `CameraInterface` passed the wrong context to `CameraPanel`.
+
+**Fix:** `camera_user_log()` writes to **console** and **camera** channels. **Update image** calls `camera.background()` (same as right-click **Update Background**). Clear errors when the camera is **stopped**. `CameraInterface` uses **root** context like the docked camera pane.
+
+## 2026-06 — Camera bed background direct widget apply (v0.9.9022)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`, `meerk40t/meerk40t/gui/wxmscene.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`
+
+**Problem:** On v0.9.9021 the bed stayed **grey** after **Update image** — background signal did not reliably land on the bed widget; large full-res bitmaps could fail to draw on Windows.
+
+**Fix:** `_apply_bed_background_to_scene()` sets the bitmap on every `BedWidget` directly (simulation-style path). Perspective warp capped at **1280 px** long edge. Bed draw tries `CreateBitmapFromImage` fallback. Console reports `Bed background applied (W x H px)` or a clear error.
+
+## 2026-06 — Camera bed background direct scene push (v0.9.9021)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`
+
+**Problem:** **Update image** still left a **grey** bed — background signal did not always reach the bed widget; bitmap build via `FromBuffer` was unreliable on Windows.
+
+**Fix:** `push_bed_background_bitmap()` builds the bitmap with `wx.Image.SetData`, pushes it **directly** to the main scene bed widget (not only via kernel signal), clears **Hide Background** draw mode, and refreshes. Bed image stored under device label and `__default__` fallback.
+
+## 2026-06 — Camera bed background grey regression fix (v0.9.9020)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`, `meerk40t/meerk40t/gui/wxmscene.py`
+
+**Problem:** After v0.9.9019, **Update image** showed a **solid grey** bed again. v0.9.9019 bed pre-scaling used scene units (mm) as pixel sizes; shallow bitmap copies could be invalidated when the camera thread refreshed the live frame.
+
+**Fix:** Reverted bed pre-scaling — `DrawBitmap` scales the photo to the bed rect. New `make_bed_bitmap_from_frame()` builds an **owned** wx bitmap from RGB bytes. Camera stream size is synced into `width`/`height` each frame so perspective warp stays at full resolution without the broken scale step.
+
+## 2026-06 — Camera bed background full resolution (v0.9.9019)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`
+
+**Problem:** Bed overlay looked **grainy / black-and-white** — perspective warp output was forced to **640×480** then stretched across the full bed.
+
+**Fix:** Perspective correction now keeps the **live camera resolution** (e.g. 1920×1080). Bed draw uses **high-quality scaling** when fitting the photo to the bed.
+
+## 2026-06 — Camera Update Image uses live bitmap (v0.9.9018)
+
+**Files:** `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/gui/wxmscene.py`, `meerk40t/meerk40t/gui/simulation.py`
+
+**Problem:** **Update image** still filled the bed with **solid grey** — frame buffer conversion failed (non-uint8 / wrong buffer type).
+
+**Fix:** **Update image** now copies the **same wx bitmap** already shown in the camera window to the main scene. `camera background` console path forces **uint8 RGB** before `FromBuffer`. Console confirms `Bed background updated (W x H px).`
+
+## 2026-06 — Camera Update Image grey bed fix (v0.9.9017)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/gui/wxmscene.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`
+
+**Problem:** **Update image** on the camera window left the main scene **grey** (no bed photo).
+
+**Fix:** Safer RGB buffer for `wx.Bitmap.FromBuffer`; bed draw handles **negative height** (top-left / Flip Y); background stored even if device label was missing; **Show Background** draw mode turned on when updating; console message if no camera frame yet.
+
+## 2026-06 — Camera Calibration window shows Fine alignment (v0.9.9016)
+
+**Files:** `meerk40t/meerk40t/camera/gui/cameracal.py`
+
+**Fix:** **Fine alignment (mm)** was hidden when the window kept an old saved size. Window now auto-grows to fit; section lives inside **Actions**. Close and reopen **Camera Calibration** after update.
+
+## 2026-06 — Camera fine alignment offset (v0.9.9015)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/cameracal.py`, `meerk40t/meerk40t/gui/scenewidgets/bedwidget.py`
+
+**Feature:** **Fine alignment (mm)** in **Camera Calibration** — `align_offset_x` / `align_offset_y` per camera shift the bed photo on the main scene without changing GRBL steps/mm. **Overlay ←/→/↑/↓** nudges 1 mm; spinners for exact values; **Apply offset** / **Reset offset**.
+
+## 2026-06 — Camera flip crash fix (v0.9.9014)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`
+
+**Problem:** **Flip 180°** / flip toggles crashed with `TypeError: 'NoneType' object is not subscriptable` — `reset_perspective()` cleared corners before the UI redrew.
+
+**Fix:** `ensure_perspective()` re-initializes default TL/TR/BR/BL corners from the live (oriented) frame size immediately after flip or reset.
+
+## 2026-06 — Camera flip horizontal / vertical / 180° (v0.9.9013)
+
+**Files:** `meerk40t/meerk40t/camera/camera.py`, `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/camera/gui/cameracal.py`
+
+**Change:** IP camera feed can be **flipped** so on-screen TL/TR/BR/BL match the physical bed (e.g. upside-down mount where TL appeared at BR). Settings: `flip_x`, `flip_y` on each camera. **Camera right-click** → Flip horizontal / Flip vertical / **Flip 180°**. **Camera Calibration** window → **Flip camera 180°** (resets perspective corners). Toggling flip resets perspective so corners are re-dragged on the corrected image.
+
+## 2026-06 — Camera perspective corner markers easier to see (v0.9.9012)
+
+**Files:** `meerk40t/meerk40t/camera/gui/camerapanel.py`, `meerk40t/meerk40t/camera/gui/cameracal.py`
+
+**Change:** Perspective calibration handles are now **large filled circles** (56 px hit area) with **white outline**, **TL/TR/BR/BL labels**, and a **yellow dashed** bed outline. Markers stay visible even when camera **Aspect** is on (only hidden when **Correct Perspective** is on).
+
+## 2026-06 — Camera Calibration startup recursion fix (v0.9.9011)
+
+**Files:** `meerk40t/meerk40t/camera/gui/cameracal.py`, `meerk40t/meerk40t/camera/gui/gui.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** Startup **RecursionError** — `sub_register` called `kernel.register("window/CameraCalib", …)` which called `sub_register` again in a loop.
+
+**Fix:** Register the window once in `gui.py` (like `BatchRun` in `wxmeerk40t.py`); `sub_register` only registers the ribbon button.
+
+## 2026-06 — Camera Calibration startup crash fix (v0.9.9010)
+
+**Files:** `meerk40t/meerk40t/camera/gui/cameracal.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** MeerK40t crashed on startup with `ImportError: cannot import name 'wxSpinCtrl' from meerk40t.gui.wxutils`.
+
+**Fix:** Use `wx.SpinCtrl` directly (same as CSV Batch Run and other panels).
+
+## 2026-06 — Camera Calibration helper (v0.9.9009)
+
+**Files:** `meerk40t/meerk40t/camera/gui/cameracal.py` (new), `meerk40t/meerk40t/camera/gui/gui.py`, `meerk40t/meerk40t/gui/wxmmain.py`, `meerk40t/meerk40t/main.py`
+
+**Feature:** Guided **camera bed calibration** — perspective corners, background overlay, corner test marks.
+
+**Open:** **Settings → Camera Calibration**, ribbon **Preparation → Camera Calib**, or `window open CameraCalib`.
+
+**Workflow:** Home machine → open camera → drag four corner markers (perspective OFF) → Correct Perspective ON → link DLC32 device (camera right-click) → **Update background** → **Add corner test marks** → low-power cut test.
+
+## 2026-06 — Abort button crash after async estop (v0.9.9008)
+
+**Files:** `meerk40t/meerk40t/gui/wxutils.py`, `meerk40t/meerk40t/gui/spoolerpanel.py`, `meerk40t/meerk40t/gui/laserpanel.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** After **Abort**, crash: `RuntimeError: wrapped C/C++ object of type HoverButton has been deleted` when re-enabling the Stop button via `wx.CallAfter`.
+
+**Fix:** `safe_enable_control()` ignores deleted widgets; `HoverButton.Enable()` catches `RuntimeError`.
+
+## 2026-06 — Spooler Abort freeze fix v2 (v0.9.9007)
+
+**Files:** `meerk40t/meerk40t/grbl/driver.py`, `meerk40t/meerk40t/core/spoolers.py`, `meerk40t/meerk40t/gui/spoolerpanel.py`, `meerk40t/meerk40t/gui/laserpanel.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** Job Spooler still froze on **Abort** — especially during **raster** jobs.
+
+**Root cause (v2):** `plot_start()` raster / PlotCut loops only checked `hold_work()` (pause/buffer), **not** abort. A stopped job could keep queuing millions of G-code points on the spooler thread while the UI ran `estop` synchronously.
+
+**Fix:**
+
+- Abort check on **every raster / PlotCut point**; skip `wait_finish()` when aborted.
+- `clear_queue()` sets **`_user_aborted` immediately**, stops jobs under lock, logs **after** releasing lock.
+- **Abort** on Job Spooler + Laser tab runs **`estop` on a worker thread** (UI stays responsive).
+- Job Spooler list no longer calls **`calc_steps()`** on **Running** jobs (was blocking the UI).
+
+## 2026-06 — Spooler Abort freeze fix (v0.9.9006)
+
+**Files:** `meerk40t/meerk40t/grbl/controller.py`, `meerk40t/meerk40t/grbl/driver.py`, `meerk40t/meerk40t/core/spoolers.py`, `meerk40t/meerk40t/gui/batchrun.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** **Abort** / **Stop** often left MeerK40t “Not responding” — especially on GRBL/Wi‑Fi and during **CSV Batch Run**.
+
+**Causes:**
+
+1. Soft reset (`0x18`) cleared the send queue but **not** the forward buffer waiting for `ok` — spooler thread could spin in `wait_finish()` / `plot_start()`.
+2. **clear_queue** fired **`spooler;completed` once per queued job**, flooding UI updates.
+3. **CSV Batch Run** treated abort as “job finished” and could **spool the next CSV row** immediately.
+
+**Fix:**
+
+- On estop reset: send **`0x18` first**, clear forward buffer, stop jobs, exit plot loops when aborted.
+- New signal **`spooler;aborted`**; one **`spooler;completed`** after clear (not N times).
+- Batch window listens for **`spooler;aborted`** and stops the chain.
+
+## 2026-06 — CSV Batch Run open crash fix (v0.9.9005)
+
+**Files:** `meerk40t/meerk40t/gui/batchrun.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** Opening **CSV Batch Run** crashed with `RuntimeError: wrapped C/C++ object of type BoxSizer has been deleted` in `restore_aspect()`.
+
+**Fix:** Build UI on `self.sizer` from `MWindow` (same as Wordlist Editor) instead of calling `SetSizer()` with a new box sizer.
+
+## 2026-06 — CSV Batch Run (v0.9.9004)
+
+**Files:** `meerk40t/meerk40t/gui/batchrun.py` (new), `meerk40t/meerk40t/gui/wxmeerk40t.py`, `meerk40t/meerk40t/gui/wxmmain.py`, `meerk40t/meerk40t/main.py`
+
+**Feature:** LightBurn-style **batch personalization** from CSV wordlist data — no camera required.
+
+**Open:** **Settings → CSV Batch Run**, ribbon **Preparation → CSV Batch**, or console `window open BatchRun`.
+
+**Workflow:**
+
+1. Design text with `{column}` placeholders (CSV header names, lowercased).
+2. **Import** a CSV (Auto / Data / Headers first row).
+3. **Prev / Next** or spin control to preview each row; scene text updates via wordlist.
+4. **Run current row** — spools one job for the active row.
+5. **Run all rows** — runs row 1, then auto-advances after each **`spooler;completed`** until done or **Stop batch**.
+
+**Notes:** Arm the laser before batch run if your device profile requires it. Uses existing wordlist CSV engine (`wordlist load` compatible). For camera overlay see **Camera Calibration** (v0.9.9009).
+
+## 2026-06 — Plan Export: no UI freeze on large jobs (v0.9.9003)
+
+**Files:** `meerk40t/meerk40t/gui/laserpanel.py`, `meerk40t/meerk40t/grbl/device.py`, `meerk40t/meerk40t/grbl/esp3d_upload.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** **Plan → Export** ran on the UI thread. Huge rasters froze MeerK40t (“Not responding”). SD patch then loaded the **entire file into RAM** (second long freeze).
+
+**Fix:**
+
+- Export runs **`threaded plan… save_job`** — UI stays usable; **Thread Info** window can show the task
+- Console: `Exporting to …`, `Patching for MKS SD card…`, then success/fail, then `Finished command … after N sec`
+- **`prepare_sd_gcode_file`** streams line-by-line (no 300 MB load into memory)
+
+## 2026-06 — Plan → Export SD-ready for MKS DLC32 (v0.9.9002)
+
+**Files:** `meerk40t/meerk40t/grbl/device.py`, `meerk40t/meerk40t/grbl/esp3d_upload.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** **Laser → Plan → Export** wrote **CR-only** G-code with trailing **`G28`**. MKS SD firmware reads lines on **`\\n` only**, so uploaded files often **Execute with no motion** (same as old `tree.gcode` / `sq2.gc` failures).
+
+**Fix:**
+
+- After every successful **Export**, when **Prepare Plan exports for SD card** is on (default): **LF** line endings, **M3** (if **Use M3** is on), **`G28` removed**
+- Default **Line Ending** for new GRBL configs changed from **CR** → **LF**
+- Console confirms: `Export succeeded (SD-ready): …` and homing reminder (**$HY** / **$HX** before Execute)
+
+**Setting:** **Configuration → Device → ESP3D Upload → Prepare Plan exports for SD card** (disable only if you need raw CR exports for another host).
+
+**Note:** Huge raster jobs (e.g. photo engraves **100+ MB**) may still fail **web upload** — use **ESP3D Upload** (right-click = upload only) or stream over **:8080**.
+
+## 2026-06 — ESP3D upload: choose SD filename (v0.9.9001)
+
+**Files:** `meerk40t/meerk40t/grbl/gui/esp3dupload.py`, `meerk40t/meerk40t/grbl/gui/gui.py`, `meerk40t/meerk40t/grbl/esp3d_upload.py`, `meerk40t/meerk40t/grbl/plugin.py`, `meerk40t/meerk40t/main.py`
+
+**Problem:** **ESP3D Upload+Run** auto-named SD files (`file3a7f.gc`, etc.), so **ESP3D Files** was hard to use for reruns.
+
+**Fix:** Toolbar button now opens a **filename dialog** before upload:
+
+- Default from **project name** (window title label, trimmed to **8.3** — e.g. `example edit` → `example.gc`) or **last upload** this session
+- You can edit the name; **same name overwrites** on the SD card (repeat jobs easily)
+- **Left click:** upload + run; **right click:** upload only (unchanged)
+- Console **`esp3d_upload_run`** without **`-f`** still auto-generates a name
+
+**8.3 rule:** max **8** characters before **`.gc`** (MKS SD convention).
+
+## 2026-06 — Scene right-click: Move laser head here
+
+**Files:** `meerk40t/meerk40t/gui/wxmscene.py`, `meerk40t/meerk40t/gui/scenewidgets/elementswidget.py`
+
+**Behavior:** Right-click on the main scene grid (empty area, no tool active) → **Move laser head here** sends `move_absolute` to the click position (same coordinate path as **Tools → Relocate**). Position is clamped to the device bed in scene space.
+
+**Use:** Connect GRBL first; spooler must be idle (not mid-job). Homed machine recommended before relying on coordinates.
+
+## 2026-06 — CO2 jobs: Use M3 (laser fires on touch panel but not in jobs)
+
+**Files:** `MeerK40t.cfg`, `meerk40t/meerk40t/grbl/plugin.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Symptom:** Head moves during a MeerK40t job but the tube does not fire; touch-panel laser test still works.
+
+**Cause:** Touch panel sends **`M3`** (constant PWM). MeerK40t had **`use_m3 = False`** → jobs used **`M4`**, which with **`$32=1`** scales power by speed — often too weak to strike on CO2, especially at low **S** or high **F**.
+
+**Fix:** **`use_m3 = True`** for **GRBL-DLC32-400** (config + DLC32 device profile default). Workflow doc §5 troubleshooting table added.
+
+## 2026-06 — GRBL false “connected” / jog & settings dead (sync mode)
+
+**Files:** `meerk40t/meerk40t/grbl/controller.py`
+
+**Symptom:** GRBL Controller shows green **Connected** (USB or Wi‑Fi) but the log stays empty, **Status** / **Read settings** / jog do nothing.
+
+**Cause:** In **sync** mode, realtime commands (`?`, `!`, `~`, soft reset) were queued in the **forward buffer** and waited forever for `ok` — GRBL answers those with status reports, not `ok`. Boot validation sends `?` at the end; one stuck `?` blocked all later G-code. With **`require_validator = True`** and **`reset_on_connect = False`**, USB attach often never sends a welcome string, so validation never started.
+
+**Fix:** `_expects_ok()` / `_send_realtime()` — status and pause/resume bytes bypass the forward buffer. `_connect_validation_fallback()` starts the `$` boot sequence if no welcome arrives within ~0.5 s.
+
+**Use:** Restart MeerK40t → **Device-Control → GRBL Controller → Connect** → **Status** should show `<--` / `-->` traffic; jog and **Read settings** should work. Console **`grbl_validate`** still forces ready if needed.
+
+## 2026-06 — ESP3D SD jobs: Execute “started” but machine idle
+
+**Files:** `meerk40t/meerk40t/grbl/esp3d_upload.py`, `meerk40t/meerk40t/grbl/gui/esp3dfilemgr.py`, `meerk40t/meerk40t/grbl/plugin.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Symptom:** ESP3D Files **Execute** reports success; head/laser do nothing even after homing.
+
+**Cause:** MKS firmware `readFileLine()` splits on `\n` only. Old MeerK40t exports used **CR** line endings → SD file unreadable (silent no-op). Old files also had **M4** instead of **M3** for CO2.
+
+**Fix:** `prepare_sd_gcode_file()` on upload (LF + M3). `execute_file()` uses `PAGEID=0`, parses Alarm/Busy, polls GRBL `?` after ESP220. ESP3D Files pane uses dropdown + clear failure messages. Re-upload via **`esp3d_upload_run -e`**.
+
+
+**Files:** `docs/meerk40t/19-dlc32-eeprom-settings.md`, `meerk40t/meerk40t/grbl/plugin.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`, `docs/meerk40t/16-mks-dlc32-board.md`
+
+**Saved (Andre, homing verified):** **`$3=0`** (jog + touch screen), **`$23=1`** (homing — Y correct like `$23=0`, X homing inverted), **`$5=0`**, **`$27=5`**, **`$HY`** then **`$HX`**. Full snapshot: **`19-dlc32-eeprom-settings.md`**.
+
+**Bed:** **`$130=405`**, **`$131=285`** — full `$$` snapshot in **`19-dlc32-eeprom-settings.md`** and Cursor rule **`.cursor/rules/dlc32-eeprom-settings.mdc`** (always apply).
+
+## 2026-05 — Scene startup crash (0×0 window / null background bitmap)
+
+**Files:** `meerk40t/meerk40t/gui/scene/scene.py`
+
+**Problem:** MeerK40t could crash on start with `MemoryDC.SelectObject(): argument 1 has unexpected type 'NoneType'` in `_update_buffer_ui_thread` when `ClientSize` was **0×0** before the window laid out.
+
+**Fix:** `LayerCache.ensure_size` allocates at least **1×1** bitmaps when size is zero and does not skip allocation when `_size` is already `(0,0)` but bitmaps were never created. `_update_buffer_ui_thread` returns early for zero client size and before using a missing background bitmap.
+
+## 2026-05 — Queue warning when shapes are unassigned
+
+**Files:** `meerk40t/meerk40t/gui/laserpanel.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md` (§9)
+
+**Problem:** Jobs could run with only the **outer border** cutting because inner geometry was never assigned to a Cut op (common with **fill-only** SVG art).
+
+**Fix:** **`queue_cutplan_to_spooler()`** warns if **`have_unassigned_elements()`** before spooling (cancel or queue anyway). Workflow doc §9 lists classification fixes (stroke vs fill, Re-Classify, Outline vs full job).
+
+## 2026-05 — Parameter-Test → spooler queue + Hold fix
+
+**Files:** `meerk40t/meerk40t/gui/materialtest.py`, `meerk40t/meerk40t/gui/laserpanel.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Problem:** **Parameter-Test** only runs **Create Pattern** (scene ops); **Arm → Start** often left the **Job Spooler** empty — especially with **Hold** on (re-spool old plan without blob), **threaded** planning still running, or no burnable ops after a failed create.
+
+**Fix:** Shared **`queue_cutplan_to_spooler()`** in `laserpanel.py` (checks device connected, burnable ops; **Hold** only re-spools when the held plan already has a **blob** stage). **Parameter-Test** adds **Queue to Spooler** (always rebuilds from scene). Clearer workflow doc steps.
+
+## 2026-06 — Laser-Control job progress bar fix
+
+**Files:** `meerk40t/meerk40t/gui/laserpanel.py`
+
+**Problem:** **Job progress** stayed at **“No job running”** (or froze at 0%) during burns. The panel listened for `spooler;update`, but that signal is only relayed inside the status-bar widget — it is **never** emitted on the kernel signal bus. During a job, only `spooler;queue` (at enqueue) and `spooler;completed` fired, so the gauge rarely refreshed. Progress also used top-level `item_index` / `len(items)`; typical jobs have one `CutCode` item, so the bar stayed at **0%** even when updates did run.
+
+**Fix:** Listen to **`driver;position`** and **`emulator;position`** (same as **Job Spooler**). Compute **%** from **`steps_done` / `steps_total`** when available, with fallback to item index. Throttled ~1 s. Idle: “No job running”.
+
+## 2026-05 — Laser-Control job progress bar
+
+**Files:** `meerk40t/meerk40t/gui/laserpanel.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Behavior:** On the **Laser** tab of **Laser-Control**, a **Job progress** gauge shows **0–100%** while a `LaserJob` is running (spooler steps). A detail line shows step counts, rough time remaining, optional GRBL send-buffer counts (`current/total` from the driver), and queue position when multiple jobs are queued. Updates on `spooler;queue`, `spooler;completed`, and position signals (throttled ~1 s). Idle: “No job running”.
+
+**Note:** Progress reflects **planner/spooler steps**, not “% of drawn geometry on screen.” If Wi‑Fi drops, the bar may freeze and the job stops — use USB for long cuts until the link is stable (see workflow doc §8).
+
+## 2026-06 — Sequential homing ($HY / $HX) for DLC32
+
+**Files:** `meerk40t/meerk40t/grbl/driver.py`, `device.py`, `gui/navigationpanels.py`, `grbl/plugin.py`, `MeerK40t.cfg`
+
+**Problem:** MeerK40t **Home** sent **`$H`** or **`G28`**; homing stopped **~50 mm** before **X− / Y+** switches with **ALARM:1**.
+
+**Fix:** Device setting **Sequential homing** — **`physical_home`** sends **`$HY`** then **`$HX`**. **Home** toolbar button calls **`physical_home`** when **Has endstops** is on. DLC32 profile defaults: endstops on, sequential on; macros **Home Y** / **Home X**.
+
+## 2026-06 — GRBL MPos sync + ALARM:1 hard limit notes
+
+**Files:** `meerk40t/meerk40t/grbl/controller.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**MPos sync:** After connect, `declare_position()` now runs on every status **`MPos:`** update so MeerK40t confined jogs match the board (avoids commanding extra travel when the head was moved on the touch panel).
+
+**ALARM:1:** Documented recovery and safe Y travel (home → jog down in steps toward **−300**, stop before ramming the switch). See workflow doc §5.
+
+## 2026-06 — GRBL ALARM:2 on Y jog (Flip Y must be on)
+
+**Files:** `MeerK40t.cfg`, `meerk40t/meerk40t/grbl/controller.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Symptom:** **ALARM:2 Soft limit** when jogging Y in MeerK40t; X OK.
+
+**Cause:** Board **MPos Y** is **0 at top**, **negative into bed**. With **Flip Y off**, MeerK40t’s down jog sends **G91 Y+** → past soft limit. Saved config had **`flip_y = False`**.
+
+**Fix:** **`flip_y = True`**, **`home_corner = top-left`**. One-time console warning if MPos Y &lt; 0 and Flip Y is off.
+
+## 2026-06 — GRBL Y jog in MeerK40t (confined + home corner)
+
+**Files:** `meerk40t/meerk40t/grbl/driver.py`, `MeerK40t.cfg` (`[grbl1]`), `meerk40t/meerk40t/grbl/plugin.py`
+
+**Problem:** X jog worked; **Y jog did nothing** in Navigation (down arrow) while the touch panel moved Y fine. Board uses **MPos Y 0 at top** and **negative Y into the bed** (e.g. **−300**).
+
+**Cause:** `move_rel(confined=True)` compared **native** `native_y` with **UI** jog deltas (`0…300`). That mixed coordinate systems and often zeroed `dy` (e.g. at home, or when `native_y` was already negative). **`home_corner=auto`** also left the bed origin wrong for top-left homing with **`flip_y=True`**.
+
+**Fix:** Confined clamping now uses **`device.current`** (bed/UI coords), same as the Navigation panel. Saved device: **`home_corner=top-left`**, **`bedwidth=405mm`**. DLC32 profile defaults: **405×300**, **`swap_xy=False`**, **`flip_y=True`**, **`home_corner=top-left`**.
+
+**User:** Restart MeerK40t after pulling this change. In **Configuration → Device**, confirm **Home corner = top-left**, **Flip Y = on**, bed **405×300 mm**. Jog **down** should move into the bed; **up** toward home.
+
+## 2026-06 — DLC32 X steps/mm calibrated (`$100=158`)
+
+**Board EEPROM (Andre):** **`$100=158`** so **`G0 X100`** moves **100 mm** real (was **80** — display reached **400** while X only traveled ~half). **`$101=160`** unchanged (Y full travel to **−300**). Homing: **`$HY`** then **`$HX`**, **`$23=1`**, **`$5=0`**, **`$27=3`**, probe/Z/unused limits **GND–S** jumpers. Doc: `16-mks-dlc32-board.md`, `17-meerkat-dlc32-workflow.md`.
+
+## 2026-06 — DLC32 GRBL TCP port 8080 (not 23)
+
+**Files:** `meerk40t/meerk40t/grbl/tcp_connection.py`, `meerk40t/meerk40t/grbl/plugin.py`, `scripts/wake-mks-dlc32.ps1`, `docs/meerk40t/17-meerkat-dlc32-workflow.md` (§8)
+
+**Cause:** MKS DLC32 V2.2.6 reports **Data port: 8080** in `[ESP420]`; port **23** is refused even when `http://192.168.10.90/` works.
+
+**Behavior:** On connect, after HTTP wake, `resolve_grbl_tcp_port()` tries configured port, then **8080**, then **23**. Device profile and saved config use **8080**. Wake script checks TCP **8080** after HTTP.
+
+## 2026 — DLC32 Wi‑Fi wake (script + TCP connect)
+
+**Files:** `meerk40t/meerk40t/grbl/tcp_connection.py`, `scripts/wake-mks-dlc32.ps1`, `run-meerk40t-dev.bat`, `docs/meerk40t/17-meerkat-dlc32-workflow.md` (§8)
+
+**Behavior:** Before GRBL TCP connect, MeerK40t HTTP-wakes the board (same as opening the phone browser), retries TCP up to 4×. Launcher script retries wake 8×. Doc covers DHCP reservation, Post Connection Delay 500 ms.
+
+**Fix (same file):** Removed 8 s read timeout on the live TCP socket — it had caused connect-then-disconnect ~8 s later during `$$` validation over Wi-Fi. Connect still uses 8 s timeout; reads are blocking again.
+
+## 2026 — Backup-before-edit rule + DLC32 400×300 device profile
+
+**Rules:** `.cursor/rules/meerkat-backup-before-edit.mdc` — agent must rotate `.bak.1`–`.bak.3` before any edit under `meerk40t/`, `docs/meerk40t/`, or `.cursor/rules/`.
+
+**Files:** `meerk40t/meerk40t/grbl/plugin.py`, `meerk40t/meerk40t/grbl/device.py`, `docs/meerk40t/17-meerkat-dlc32-workflow.md`
+
+**Behavior:**
+
+- New device type **K40 CO2 — MKS DLC32 (400×300 mm)** (`dev_info/grbl-dlc32-k40-400`): bed 400×300, Swap XY, TCP `192.168.10.90:8080`, reset on connect, five GRBL macros.
+- `dev_info` choices can set `macro_0` … `macro_title_4`; persisted when the device is created.
+- Workflow doc covers Material Test, Material Manager presets (manual), macros, safety — camera/LBRN deferred.
+
+## 2026 — Bed movement limit on by default + disable warning
+
+**Files:** `meerk40t/meerk40t/gui/navigationpanels.py`, `meerk40t/meerk40t/gui/plugin.py`, `meerk40t/meerk40t/core/spoolers.py`
+
+**Behavior:**
+
+- **Limit laser movement to bed size** (confined) is turned **on** when MeerK40t starts and when the Jog panel opens.
+- Clicking the fence button to **turn it off** shows a **warning** (Yes/No, default No) about GRBL max travel, alarms, and driver stress before allowing unconfined jogs.
+- Console/spooler `move_relative` uses confined **True** by default if the setting is missing.
+
+## 2026 — GRBL confined jog crash (bed size strings)
+
+**Files:** `meerk40t/meerk40t/grbl/driver.py`
+
+**Problem:** Jogging to the bed edge (e.g. **Y to max** with **Confined** on) could crash MeerK40t with `TypeError: unsupported operand type(s) for -: 'str' and 'float'` because `view.width` / `view.height` are stored as length strings (e.g. `"400mm"`) but `move_rel(confined=True)` compared and subtracted them as raw values.
+
+**Fix:** Convert `dx`, `dy`, and bed limits with `float(Length(...))` before confined clamping.
+
+**Backups:** `driver.py.bak.1` … `.bak.3` beside the file.
+
+## 2026 — Simulation preview cache
+
+**Files:** `meerk40t/meerk40t/gui/simulation.py`
+
+**Behavior:** While the simulation panel rebuilds raster/plot preview caches, the **Send to Laser** button label becomes **Calculating**. A **Stop calculating** button appears below it so you can abort that phase without closing the app.
+
+**Mechanism:** Cooperative cancel (`wx.YieldIfNeeded()` between cuts, cancel flag). UI cleanup runs in a `finally` block so the spool button is restored.
+
+**Limit:** Cancellation applies **between** cuts. A single very large raster can still block inside one `list(plot…)` until that call finishes.
+
+**Backups:** Rotating snapshots `simulation.py.bak.1` … `.bak.3` beside the file (see workspace Cursor rule §4).
+
+## 2026 — Tips at startup preference
+
+**Files:** `meerk40t/meerk40t/gui/tips.py`
+
+**Behavior:** Toggling **Show tips at startup** now calls `context.write_persistent("show_tips", state)` so the choice is saved immediately instead of only on shutdown.
+
+## 2026 — Ribbon toolbar: delayed description tooltip
+
+**Files:** `meerk40t/meerk40t/gui/ribbon.py`, `meerk40t/meerk40t/gui/plugin.py`
+
+**Behavior:** The ribbon bar uses its own hover timer (default **2000 ms**). After you pause on a toolbar button that long, the tooltip shows the **short tip** and, when defined, the **extended help** text in one popup (two paragraphs separated by a blank line).
+
+**Preference:** **Gui → Tooltips → Ribbon: hover before description** (`ribbon_tooltip_delay_ms`). **Gui → Tooltips → Long ribbon hover descriptions** (`ribbon_verbose_hover_help`) and **Panes → Help → Long hover descriptions on ribbon toolbars** (same setting). The global **ToolTip delay** still applies to other controls only (via `wx.ToolTip.SetDelay`).
+
+**Scope:** Only the **custom ribbon strips** at the top (`wxmribbon.py`: primary, tools, edit/modify). Other panes (scene, tree, etc.) use normal wx tooltips, not this delayed ribbon job.
+
+**Tree / scene context menus:** The same **`ribbon_verbose_hover_help`** flag controls **`create_menu_for_node`** in `wxutils.py`: when it is on, each menu item’s status-bar help uses formatted `help=` text from `element_treeops.py`, and if that is empty, the first paragraph of the operation’s docstring (when present). **Look at the status bar** while moving through a right-click menu (not a floating tooltip). When the flag is off, only explicit `help=` strings are used (no docstring fallback).
+
+## 2026-06 — Laser-Control override: 5% steps, typed Set, power direction fix
+
+**Files:** `meerk40t/meerk40t/gui/laserpanel.py`, `meerk40t/meerk40t/grbl/driver.py`
+
+**Problem:** Override sliders moved in **10%** steps only. No way to type a value. **Power slider felt reversed** on GRBL/DLC32: moving right (+70%) reduced burn because `0x9A`/`0x9B` spindle commands were swapped vs GRBL 1.1 (increase/decrease).
+
+**Fix:** Sliders use **5%** steps (center = 0%, range about −100% to +100%). Small **text + Set** beside Power and Speed for typed percent (e.g. `70`, `-30`). GRBL driver resets to 100% then steps in **5%** with correct **0x9A** increase / **0x9B** decrease.
+
+**Use:** Enable **Override**, adjust while engraving; **right = more power**, **left = less**.
+
+## 2026-06 — Material Manager delete-by-category crash fix
+
+**Files:** `meerk40t/meerk40t/gui/materialmanager.py`
+
+**Problem:** Right-click **Delete category** (e.g. under **&lt;All Lasertypes&gt; → New material**) crashed with `AttributeError: 'int' object has no attribute 'replace'` because `laser` is stored as an integer index, not a string.
+
+**Fix:** `_entry_category_label()` maps laser indices to the same labels as the library tree; delete matching uses that helper. Also fixed secondary-key comparison in the delete loop (`sec_key == secondary`).
+
+## 2026-06 — Tree panel material preset dropdown
+
+**Files:** `meerk40t/meerk40t/gui/wxmtree.py`
+
+**Behavior:** On the **Tree → Details** tab, a **Material:** dropdown lists all **Material Manager** library entries (e.g. `Acrylic — 3mm — …`). Choosing one runs `material load` — the **Operations** branch is replaced with that preset’s cut/engrave/raster speeds and powers (same as right-click **Operations → Load → …**). Optionally updates the status-bar operation buttons when **Update Statusbar on load** is checked (right-click **Operations** menu).
+
+**Use:** Create presets in **Edit → Material Manager**, restart MeerK40t if the list was open during edits, then pick from the dropdown.
+
+## 2026-06 — Keyboard Delete matches ribbon Delete
+
+**Files:** `meerk40t/meerk40t/gui/scene/scenepanel.py`, `meerk40t/meerk40t/gui/wxmtree.py`, `meerk40t/meerk40t/gui/wxutils.py`, `meerk40t/meerk40t/core/bindalias.py`
+
+**Problem:** Ribbon **Delete** worked (`tree selected delete`) but **Delete** / numpad **Del** on the canvas often did nothing (key-up vs key-down on Windows; numpad not in the default keymap).
+
+**Fix:** Default keymap adds **`numpad_delete` → `tree selected delete`**. Scene panel runs the same command on **key-up** when the keymap did not already fire on key-down (mirrors the tree widget). Tree **key-up** handles numpad Delete too.
+
+**Use:** Select shape(s) on the scene, press **Delete** or numpad **Del** — same as the ribbon button. While a draw/edit tool is active (`tool_active`), tools keep priority. Console **Window → Keymap** can still remap `delete` / `numpad_delete`.
+
+## 2026-06 — Tree double-click on operations opens Parameter-Test
+
+**Files:** `meerk40t/meerk40t/gui/wxmmain.py`, `meerk40t/meerk40t/gui/materialtest.py`
+
+**Problem:** Double-clicking a **Cut / Engrave / Raster / Image / Dots** operation in the **Tree** opened the standalone **Properties** window (or element PathNode for mis-clicks) instead of **Parameter-Test** with the operation’s speed/power tabs.
+
+**Fix:** `open_property_window_for_node()` routes laser operation types to **`window/Templatetool`** (title **Parameter-Test**), syncs the **Generator** operation combo via `select_operation_for_node()`, and embeds the real operation node in the notebook **Properties** tab (`focus_properties=True`). **Elements** (paths, text, images) still open **Properties** as before.
+
+**Use:** Restart MeerK40t after pulling. Double-click **Cut** or **Engrave** under **Operations** in the tree — expect **Parameter-Test**, **Properties** tab selected. Double-click geometry under **Elements** — still the normal **Properties** editor.
+
+## Workspace rules (Cursor)
+
+**File:** `.cursor/rules/meerk40t-knowledge-base.mdc`
+
+- **§4:** Rotate three `.bak.N` backups before substantive edits under `meerk40t/`.
+- **§5:** When code behavior changes, update `docs/meerk40t/README.md` and the relevant topic note (such as this file) in the same batch; update the workspace root `README.md` if one exists and should mention the change.
+
+---
+
 # Welcome to MeerK40t!
 MeerK40t (pronounced MeerKat) is a built-from-the-ground-up MIT licensed open-source laser cutting software.
 

--- a/meerk40t/camera/camera.py
+++ b/meerk40t/camera/camera.py
@@ -54,6 +54,10 @@ class Camera(Service):
         self.setting(bool, "autonormal", False)
         self.setting(bool, "aspect", False)
         self.setting(str, "preserve_aspect", "xMinYMin meet")
+        self.setting(bool, "flip_x", False)
+        self.setting(bool, "flip_y", False)
+        self.setting(float, "align_offset_x", 0.0)
+        self.setting(float, "align_offset_y", 0.0)
         self.fisheye_k = None
         self.fisheye_d = None
         if self.fisheye is not None and len(self.fisheye) != 0:
@@ -84,6 +88,12 @@ class Camera(Service):
             return False
 
     def get_frame(self):
+        return self._last_frame
+
+    def get_display_frame(self):
+        """Latest RGB frame for UI; prefers the current frame over last."""
+        if self._current_frame is not None:
+            return self._current_frame
         return self._last_frame
 
     def get_raw(self):
@@ -249,7 +259,7 @@ class Camera(Service):
 
     def logger(self, msg):
         # print (msg)
-        self.channel(msg)
+        camera_user_log(self.kernel, msg)
 
     def guess_supported_resolutions(self):
         # List of supported resolutions
@@ -311,8 +321,65 @@ class Camera(Service):
             pass
         return supported_resolutions
 
+    def nudge_align(self, dx_mm=0.0, dy_mm=0.0):
+        self.align_offset_x = float(self.align_offset_x or 0.0) + float(dx_mm)
+        self.align_offset_y = float(self.align_offset_y or 0.0) + float(dy_mm)
+
+    def align_offset_scene_units(self):
+        from meerk40t.core.units import Length
+
+        return (
+            float(Length(f"{float(self.align_offset_x or 0.0)}mm")),
+            float(Length(f"{float(self.align_offset_y or 0.0)}mm")),
+        )
+
+    def _orient_frame(self, frame):
+        if frame is None:
+            return frame
+        if self.flip_x and self.flip_y:
+            return cv2.flip(frame, -1)
+        if self.flip_x:
+            return cv2.flip(frame, 1)
+        if self.flip_y:
+            return cv2.flip(frame, 0)
+        return frame
+
+    def _perspective_frame_size(self):
+        frame = self._orient_frame(self._current_raw)
+        if frame is None:
+            frame = self._orient_frame(self._last_raw)
+        if frame is not None:
+            height, width = frame.shape[:2]
+            return width, height
+        if self.image_width > 0 and self.image_height > 0:
+            return self.image_width, self.image_height
+        return self.width, self.height
+
+    def ensure_perspective(self):
+        if self.perspective is not None:
+            return
+        width, height = self._perspective_frame_size()
+        self.perspective = [
+            [0, 0],
+            [width, 0],
+            [width, height],
+            [0, height],
+        ]
+
+    def set_image_flip(self, flip_x=None, flip_y=None, reset_corners=True):
+        changed = False
+        if flip_x is not None and bool(flip_x) != bool(self.flip_x):
+            self.flip_x = bool(flip_x)
+            changed = True
+        if flip_y is not None and bool(flip_y) != bool(self.flip_y):
+            self.flip_y = bool(flip_y)
+            changed = True
+        if changed and reset_corners:
+            self.reset_perspective()
+        return changed
+
     def process_frame(self):
-        frame = self._current_raw
+        frame = self._orient_frame(self._current_raw)
         if (
             self.fisheye_k is not None
             and self.fisheye_d is not None
@@ -333,6 +400,9 @@ class Camera(Service):
                 borderMode=cv2.BORDER_CONSTANT,
             )
         width, height = frame.shape[:2][::-1]
+        if width > 0 and height > 0:
+            self.width = width
+            self.height = height
         if self.perspective is None:
             self.perspective = [
                 [0, 0],
@@ -341,9 +411,14 @@ class Camera(Service):
                 [0, height],
             ]
         if self.correction_perspective:
-            # Perspective the drawing.
-            dest_width = self.width
-            dest_height = self.height
+            dest_width = int(self.width)
+            dest_height = int(self.height)
+            max_edge = 1280
+            edge = max(dest_width, dest_height)
+            if edge > max_edge and edge > 0:
+                scale = max_edge / float(edge)
+                dest_width = max(1, int(dest_width * scale))
+                dest_height = max(1, int(dest_height * scale))
             rect = np.array(
                 self.perspective,
                 dtype="float32",
@@ -471,6 +546,7 @@ class Camera(Service):
         @return:
         """
         self.perspective = None
+        self.ensure_perspective()
 
     def backtrack_fisheye(self):
         if self._object_points:
@@ -501,12 +577,42 @@ class Camera(Service):
         Sets image background to main scene.
         @return:
         """
-        frame = self._last_frame
-        if frame is not None:
-            self.image_height, self.image_width = frame.shape[:2]
-            self.signal("background", (self.image_width, self.image_height, frame))
-            return self.image_width, self.image_height, frame
-        return None
+        frame = self.get_display_frame()
+        if frame is None:
+            if self.capture is None:
+                camera_user_log(
+                    self.kernel,
+                    self._(
+                        "No camera frame — camera is stopped. Click Reconnect or run: camera{index} start"
+                    ).format(index=self.index),
+                )
+            else:
+                camera_user_log(
+                    self.kernel,
+                    self._("No camera frame yet — wait for live video, then try again."),
+                )
+            return None
+        frame = frame_for_wx_bitmap(frame)
+        if frame is None:
+            camera_user_log(
+                self.kernel,
+                self._("Camera frame could not be converted for the bed overlay."),
+            )
+            return None
+        self.image_height, self.image_width = frame.shape[:2]
+        bed_bitmap = make_bed_bitmap_from_frame(frame)
+        if bed_bitmap is None:
+            camera_user_log(
+                self.kernel,
+                self._("Camera frame could not be converted for the bed overlay."),
+            )
+            return None
+        if not push_bed_background_bitmap(self.kernel, bed_bitmap):
+            camera_user_log(
+                self.kernel, self._("Bed overlay could not be sent to the main scene.")
+            )
+            return None
+        return self.image_width, self.image_height, frame
 
     def export(self):
         """
@@ -518,3 +624,332 @@ class Camera(Service):
             self.signal("export-image", (self.image_width, self.image_height, frame))
             return self.image_width, self.image_height, frame
         return None
+
+
+def camera_user_log(kernel, message):
+    """Write camera/bed messages to the main Console (and camera log)."""
+    for channel_name in ("console", "camera"):
+        channel = kernel.channel(channel_name)
+        if channel:
+            channel(message)
+
+
+def frame_for_wx_bitmap(frame):
+    """Return uint8 contiguous RGB numpy array for wx.Bitmap.FromBuffer, or None."""
+    if frame is None:
+        return None
+    arr = np.ascontiguousarray(frame)
+    if arr.ndim == 2:
+        arr = np.stack([arr, arr, arr], axis=-1)
+    if arr.ndim != 3 or arr.shape[2] < 3:
+        return None
+    if arr.shape[2] > 3:
+        arr = arr[:, :, :3]
+    if arr.dtype != np.uint8:
+        arr = np.clip(arr, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(arr)
+
+
+def frame_to_wx_buffer(frame):
+    """Return RGB byte buffer for wx.Bitmap.FromBuffer, or None."""
+    arr = frame_for_wx_bitmap(frame)
+    if arr is None:
+        return None
+    return arr.tobytes()
+
+
+def make_bed_bitmap_from_frame(frame):
+    """Owned wx.Bitmap for bed overlay (not tied to the camera refresh buffer)."""
+    import wx
+
+    arr = frame_for_wx_bitmap(frame)
+    if arr is None:
+        return None
+    h, w = arr.shape[:2]
+    data = arr.tobytes()
+    try:
+        img = wx.Image(w, h)
+        img.SetData(data)
+        if img.IsOk():
+            bmp = wx.Bitmap(img)
+            if bmp.IsOk():
+                return bmp
+    except (TypeError, ValueError, wx.wxAssertionError):
+        pass
+    try:
+        bmp = wx.Bitmap(img, wx.BITMAP_SCREEN_DEPTH)
+        if bmp.IsOk():
+            return bmp
+    except (TypeError, ValueError, wx.wxAssertionError):
+        pass
+    try:
+        bmp = wx.Bitmap.FromBuffer(w, h, data)
+        if bmp.IsOk():
+            return bmp
+    except (TypeError, ValueError, wx.wxAssertionError):
+        pass
+    return None
+
+
+def _camera_service_for_index(kernel, idx):
+    """Return the Camera service for camera/{idx}, or None if not instantiated."""
+    path = f"camera/{idx}"
+    try:
+        services = kernel.services("camera") or []
+    except (AttributeError, TypeError):
+        services = []
+    for service in services:
+        if getattr(service, "path", None) == path:
+            return service
+    try:
+        obj = kernel.get_context(path)
+        if obj is not None and hasattr(obj, "align_offset_scene_units"):
+            return obj
+    except (AttributeError, KeyError):
+        pass
+    return None
+
+
+def composite_bed_photo_on_device_dc(scene, dc):
+    """
+    Paint the bed camera photo with MemoryDC.DrawBitmap in device pixels.
+
+    wx.GraphicsContext.DrawBitmap inside the scene layer cache is unreliable on
+    Windows; this path runs after the background layer widgets are drawn.
+    """
+    import wx
+
+    try:
+        if not scene.has_background:
+            return False
+        bg = scene.active_background
+        if bg is None or isinstance(bg, int):
+            return False
+        if not isinstance(bg, wx.Bitmap) or not bg.IsOk():
+            return False
+        root = scene.widget_root
+        if root is None:
+            return False
+        matrix = root.scene_widget.matrix
+        if matrix is None:
+            from meerk40t.svgelements import Matrix
+
+            matrix = Matrix()
+    except AttributeError:
+        return False
+
+    context = scene.context
+    try:
+        vw = context.device.view
+        unit_width = vw.unit_width
+        unit_height = vw.unit_height
+    except AttributeError:
+        return False
+
+    from meerk40t.gui.scenewidgets.bedwidget import _bed_rect
+
+    try:
+        offset_x, offset_y = camera_align_offsets_for_context(context)
+    except (AttributeError, TypeError, ValueError):
+        offset_x, offset_y = 0.0, 0.0
+    x, y, w, h = _bed_rect(offset_x, offset_y, unit_width, unit_height)
+
+    def to_device(px, py):
+        return (
+            matrix.a * px + matrix.c * py + matrix.e,
+            matrix.b * px + matrix.d * py + matrix.f,
+        )
+
+    corners = (
+        to_device(x, y),
+        to_device(x + w, y),
+        to_device(x + w, y + h),
+        to_device(x, y + h),
+    )
+    xs = [c[0] for c in corners]
+    ys = [c[1] for c in corners]
+    dev_x = min(xs)
+    dev_y = min(ys)
+    dev_w = max(xs) - dev_x
+    dev_h = max(ys) - dev_y
+    if dev_w < 1 or dev_h < 1:
+        return False
+
+    pw = max(1, int(round(dev_w)))
+    ph = max(1, int(round(dev_h)))
+    try:
+        img = bg.ConvertToImage()
+        if not img.IsOk():
+            return False
+        if img.GetWidth() != pw or img.GetHeight() != ph:
+            scaled = img.Scale(pw, ph, wx.IMAGE_QUALITY_HIGH)
+            if scaled.IsOk():
+                img = scaled
+        bmp = wx.Bitmap(img, wx.BITMAP_SCREEN_DEPTH)
+        if not bmp.IsOk():
+            bmp = wx.Bitmap(img)
+        if not bmp.IsOk():
+            return False
+        dc.DrawBitmap(bmp, int(round(dev_x)), int(round(dev_y)), True)
+        return True
+    except (AttributeError, TypeError, ValueError, wx.wxAssertionError):
+        return False
+
+
+def _bed_bitmap_sample_rgb(bed_bitmap):
+    """Return center-pixel RGB tuple for console diagnostics, or None."""
+    import wx
+
+    try:
+        img = bed_bitmap.ConvertToImage()
+        if not img.IsOk():
+            return None
+        cx = max(0, img.GetWidth() // 2)
+        cy = max(0, img.GetHeight() // 2)
+        return img.GetRed(cx, cy), img.GetGreen(cx, cy), img.GetBlue(cx, cy)
+    except (AttributeError, TypeError, ValueError, wx.wxAssertionError):
+        return None
+
+
+def get_main_scene_panel(kernel):
+    """Return the docked main MeerK40tScenePanel, if the GUI is up."""
+    gui = getattr(kernel.root, "gui", None)
+    if gui is None:
+        return None
+    try:
+        pane_info = gui._mgr.GetPane("scene")
+        window = getattr(pane_info, "window", None)
+        if window is not None and hasattr(window, "widget_scene"):
+            return window
+    except (AttributeError, RuntimeError):
+        pass
+    try:
+        for pane_info in gui._mgr.GetAllPanes():
+            window = getattr(pane_info, "window", None)
+            if window is not None and hasattr(window, "widget_scene"):
+                return window
+    except (AttributeError, RuntimeError):
+        pass
+    return None
+
+
+def iter_bed_widgets(widget):
+    """Yield every BedWidget under a scene widget root."""
+    from meerk40t.gui.scenewidgets.bedwidget import BedWidget
+
+    if isinstance(widget, BedWidget):
+        yield widget
+    try:
+        children = list(widget)
+    except TypeError:
+        return
+    for child in children:
+        if child is not None:
+            yield from iter_bed_widgets(child)
+
+
+def _ensure_show_bed_background(context):
+    from meerk40t.gui.laserrender import DRAW_MODE_BACKGROUND
+
+    if context.draw_mode & DRAW_MODE_BACKGROUND:
+        context.draw_mode &= ~DRAW_MODE_BACKGROUND
+        context.signal("draw_mode", context.draw_mode)
+
+
+def _apply_bed_background_to_scene(scene, bed_bitmap):
+    """Set bed bitmap on scene bed widget(s) and scene background flags."""
+    scene._signal_widget(scene.widget_root, "background", bed_bitmap)
+    for bed in iter_bed_widgets(scene.widget_root):
+        bed.background = bed_bitmap
+    if bed_bitmap is None:
+        scene.has_background = False
+    elif isinstance(bed_bitmap, int):
+        scene.has_background = False
+    else:
+        scene.has_background = True
+        scene.active_background = bed_bitmap
+    scene.invalidate_background()
+
+
+def push_bed_background_bitmap(kernel, bed_bitmap):
+    """
+    Push an owned bed bitmap to the main scene bed widget.
+    Also clears Hide Background draw mode and refreshes the scene.
+    """
+    from meerk40t.gui.laserrender import DRAW_MODE_BACKGROUND
+
+    if bed_bitmap is None or not bed_bitmap.IsOk():
+        return False
+
+    ctx = kernel.root
+    panel = get_main_scene_panel(kernel)
+    if panel is None:
+        _ = kernel.translation
+        camera_user_log(kernel, _("Bed background: main scene panel not found."))
+        return False
+
+    scene = panel.widget_scene
+    for show_ctx in (ctx, scene.context, panel.context):
+        try:
+            _ensure_show_bed_background(show_ctx)
+        except AttributeError:
+            pass
+
+    _apply_bed_background_to_scene(scene, bed_bitmap)
+    ctx.signal("background", bed_bitmap)
+
+    def _refresh():
+        try:
+            scene.invalidate_background()
+            panel.request_refresh()
+            panel.scene_panel.Refresh()
+            ctx.signal("refresh_scene", "Scene")
+        except (AttributeError, RuntimeError):
+            pass
+
+    import wx
+
+    wx.CallAfter(_refresh)
+    _ = kernel.translation
+    bed_count = sum(1 for _ in iter_bed_widgets(scene.widget_root))
+    sample = _bed_bitmap_sample_rgb(bed_bitmap)
+    if sample is not None:
+        camera_user_log(
+            kernel,
+            _("Bed photo center pixel RGB: {r}, {g}, {b}.").format(
+                r=sample[0], g=sample[1], b=sample[2]
+            ),
+        )
+    camera_user_log(
+        kernel,
+        _("Bed background applied ({w} x {h} px, {n} bed widget(s)).").format(
+            w=bed_bitmap.GetWidth(),
+            h=bed_bitmap.GetHeight(),
+            n=bed_count,
+        ),
+    )
+    return True
+
+
+def camera_align_offsets_for_context(context):
+    """Return (offset_x, offset_y) in scene units from the active camera service."""
+    try:
+        kernel = context.kernel
+    except AttributeError:
+        return 0.0, 0.0
+    fallback = (0.0, 0.0)
+    for idx in range(8):
+        cam = _camera_service_for_index(kernel, idx)
+        if cam is None:
+            continue
+        try:
+            units = cam.align_offset_scene_units()
+        except AttributeError:
+            continue
+        if idx == 0:
+            fallback = units
+        ox = float(getattr(cam, "align_offset_x", 0.0) or 0.0)
+        oy = float(getattr(cam, "align_offset_y", 0.0) or 0.0)
+        if ox != 0.0 or oy != 0.0:
+            return units
+    return fallback

--- a/meerk40t/camera/camera.py
+++ b/meerk40t/camera/camera.py
@@ -566,10 +566,11 @@ class Camera(Service):
         self.fisheye = None
 
     def set_uri(self, uri):
+        uri = normalize_camera_uri(uri)
         self.uri = uri
         try:
             self.uri = int(self.uri)  # URI is an index.
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
     def background(self):
@@ -624,6 +625,115 @@ class Camera(Service):
             self.signal("export-image", (self.image_width, self.image_height, frame))
             return self.image_width, self.image_height, frame
         return None
+
+
+def normalize_camera_uri(text):
+    """
+    Turn a pasted camera address into an OpenCV VideoCapture URI.
+
+    Accepts:
+    - USB index: ``0``, ``1``, …
+    - Full stream URL: ``rtsp://…``, ``http://…`` (unchanged)
+    - ``user:pass@host``, ``user:pass@host:8554/stream1``
+    - Bare IP/hostname: ``192.168.10.133`` → ``rtsp://192.168.10.133:8554/profile0``
+
+    Andre's IP camera (unchanged when pasted in full):
+    ``rtsp://admin:***@192.168.10.133:8554/stream1``
+    or shorthand ``admin:***@192.168.10.133:8554/stream1``.
+    """
+    import re
+
+    if text is None:
+        return None
+    text = str(text).strip()
+    if not text:
+        return None
+
+    lower = text.lower()
+    if lower.startswith(("rtsp://", "http://", "https://", "rtmp://", "file://")):
+        return text
+
+    if re.fullmatch(r"\d+", text):
+        return int(text)
+
+    if "@" in text and "://" not in text:
+        text = f"rtsp://{text}"
+        lower = text.lower()
+
+    if lower.startswith("rtsp://"):
+        body = text[7:]
+        path_part = body.split("?", 1)[0]
+        if "/" not in path_part:
+            host_part = path_part.rsplit("@", 1)[-1]
+            if ":" in host_part:
+                text = f"{text}/profile0"
+            else:
+                text = f"{text}:8554/profile0"
+        return text
+
+    if re.match(r"^[\w.:-]+/", text) or re.match(r"^\d+\.\d+\.\d+\.\d+", text):
+        if "/" in text:
+            return f"rtsp://{text}"
+        if ":" in text:
+            return f"rtsp://{text}/profile0"
+        return f"rtsp://{text}:8554/profile0"
+
+    return text
+
+
+def _ensure_camera_service(kernel, camera_index):
+    """Return Camera service for camera/N, creating it if needed."""
+    cam = _camera_service_for_index(kernel, camera_index)
+    if cam is not None:
+        return cam
+    path = f"camera/{camera_index}"
+    try:
+        if path not in kernel.contexts:
+            kernel.add_service("camera", Camera(kernel, path))
+        kernel.activate_service_path("camera", path)
+    except (AttributeError, ValueError, KeyError):
+        return None
+    return _camera_service_for_index(kernel, camera_index)
+
+
+def connect_camera_from_paste(kernel, camera_index, raw_text, start=True):
+    """
+    Normalize a pasted address, save it in the URI list, and connect camera/N.
+    """
+    uri = normalize_camera_uri(raw_text)
+    if uri is None:
+        return None
+
+    cam = _ensure_camera_service(kernel, camera_index)
+    if cam is None:
+        _ = kernel.translation
+        camera_user_log(
+            kernel,
+            _("Camera {n} could not be opened.").format(n=camera_index),
+        )
+        return None
+
+    try:
+        camera_root = kernel.get_context("camera")
+        camera_root.setting(list, "uris", [])
+        store = uri if isinstance(uri, int) else str(uri)
+        known = [str(u) for u in camera_root.uris]
+        if str(store) not in known:
+            camera_root.uris.append(store)
+    except (AttributeError, TypeError):
+        pass
+
+    cam.set_uri(uri)
+    if start:
+        cam.close_camera()
+        cam.open_camera()
+
+    _ = kernel.translation
+    camera_user_log(
+        kernel,
+        _("Camera {n} set to: {uri}").format(n=camera_index, uri=uri),
+    )
+    return uri
 
 
 def camera_user_log(kernel, message):

--- a/meerk40t/camera/gui/cameracal.py
+++ b/meerk40t/camera/gui/cameracal.py
@@ -1,0 +1,384 @@
+"""
+Camera Calibration — guided bed overlay setup for Meerkat.
+
+Walks through perspective corners on the live camera feed, pushes the
+flattened image to the main scene bed, and can place corner test marks.
+"""
+
+import wx
+
+from meerk40t.core.units import Length
+from meerk40t.gui.icons import icons8_image_in_frame
+from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import StaticBoxSizer, wxButton, wxStaticText
+from meerk40t.svgelements import Color
+
+_ = wx.GetTranslation
+
+
+def _bed_bbox(device):
+    """Return bed bounds in scene units (x0, y0, x1, y1)."""
+    try:
+        return device.view.source_bbox()
+    except AttributeError:
+        return 0.0, 0.0, 405.0, -285.0
+
+
+def _corner_positions(x0, y0, x1, y1, margin, size):
+    """Place test squares inset from each bed corner."""
+    x_left = min(x0, x1)
+    x_right = max(x0, x1)
+    y_top = max(y0, y1)
+    y_bot = min(y0, y1)
+    return (
+        (_("Calib TL"), x_left + margin, y_top - margin - size),
+        (_("Calib TR"), x_right - margin - size, y_top - margin - size),
+        (_("Calib BR"), x_right - margin - size, y_bot + margin),
+        (_("Calib BL"), x_left + margin, y_bot + margin),
+    )
+
+
+class CameraCalibWindow(MWindow):
+    """Step-by-step helper for camera perspective and bed background."""
+
+    def __init__(self, *args, **kwds):
+        super().__init__(480, 640, *args, **kwds)
+
+        steps = StaticBoxSizer(self, wx.ID_ANY, _("Steps"), wx.VERTICAL)
+        self.lbl_steps = wxStaticText(
+            self,
+            wx.ID_ANY,
+            _(
+                "1. Home the machine ($HY then $HX).\n"
+                "2. Open the camera window — live feed on the bed.\n"
+                "   If TL is on the wrong corner, click Flip camera 180°.\n"
+                "3. Click Reset perspective, then drag the large\n"
+                "   coloured TL/TR/BR/BL circles to each bed corner\n"
+                "   (Correct Perspective OFF).\n"
+                "4. Turn Correct Perspective ON in the camera window.\n"
+                "5. Right-click camera → link your DLC32 device.\n"
+                "6. Update Background — bed photo appears on the main scene.\n"
+                "7. Add corner test marks, run a low-power cut.\n"
+                "8. Use Fine alignment (mm) to nudge the overlay — no GRBL change."
+            ),
+        )
+        steps.Add(self.lbl_steps, 0, wx.EXPAND, 0)
+
+        cam_box = StaticBoxSizer(self, wx.ID_ANY, _("Camera"), wx.HORIZONTAL)
+        cam_box.Add(wxStaticText(self, wx.ID_ANY, _("Index")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.spin_camera = wx.SpinCtrl(self, wx.ID_ANY, min=0, max=8, initial=0)
+        cam_box.Add(self.spin_camera, 0, wx.LEFT, 4)
+        self.btn_open = wxButton(self, wx.ID_ANY, _("Open camera window"))
+        cam_box.Add(self.btn_open, 0, wx.LEFT, 8)
+
+        actions = StaticBoxSizer(self, wx.ID_ANY, _("Actions"), wx.VERTICAL)
+        row1 = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_reset = wxButton(self, wx.ID_ANY, _("Reset perspective"))
+        self.btn_flip180 = wxButton(self, wx.ID_ANY, _("Flip camera 180°"))
+        row1.Add(self.btn_reset, 1, wx.EXPAND, 0)
+        row1.Add(self.btn_flip180, 1, wx.LEFT | wx.EXPAND, 4)
+        actions.Add(row1, 0, wx.EXPAND, 0)
+
+        row1b = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_background = wxButton(self, wx.ID_ANY, _("Update background"))
+        row1b.Add(self.btn_background, 1, wx.EXPAND, 0)
+        actions.Add(row1b, 0, wx.EXPAND | wx.TOP, 4)
+
+        row2 = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_corners = wxButton(self, wx.ID_ANY, _("Add corner test marks"))
+        self.btn_fit = wxButton(self, wx.ID_ANY, _("Zoom scene to bed"))
+        row2.Add(self.btn_corners, 1, wx.EXPAND, 0)
+        row2.Add(self.btn_fit, 1, wx.LEFT | wx.EXPAND, 4)
+        actions.Add(row2, 0, wx.EXPAND | wx.TOP, 4)
+
+        align_box = StaticBoxSizer(self, wx.ID_ANY, _("Fine alignment (mm)"), wx.VERTICAL)
+        align_hint = wxStaticText(
+            self,
+            wx.ID_ANY,
+            _(
+                "Shift the bed photo vs the laser grid (steps/mm unchanged).\n"
+                "If the burn is right of the mark → Overlay →. Left of mark → Overlay ←.\n"
+                "Below the mark → Overlay ↓. Above the mark → Overlay ↑."
+            ),
+        )
+        align_box.Add(align_hint, 0, wx.EXPAND | wx.BOTTOM, 4)
+
+        row_ax = wx.BoxSizer(wx.HORIZONTAL)
+        row_ax.Add(wxStaticText(self, wx.ID_ANY, _("Offset X")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.spin_align_x = wx.SpinCtrl(self, wx.ID_ANY, min=-100, max=100, initial=0)
+        row_ax.Add(self.spin_align_x, 1, wx.LEFT | wx.EXPAND, 4)
+        align_box.Add(row_ax, 0, wx.EXPAND, 0)
+
+        row_ay = wx.BoxSizer(wx.HORIZONTAL)
+        row_ay.Add(wxStaticText(self, wx.ID_ANY, _("Offset Y")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.spin_align_y = wx.SpinCtrl(self, wx.ID_ANY, min=-100, max=100, initial=0)
+        row_ay.Add(self.spin_align_y, 1, wx.LEFT | wx.EXPAND, 4)
+        align_box.Add(row_ay, 0, wx.EXPAND | wx.TOP, 4)
+
+        row_nudge = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_align_left = wxButton(self, wx.ID_ANY, _("Overlay ←"))
+        self.btn_align_right = wxButton(self, wx.ID_ANY, _("Overlay →"))
+        self.btn_align_up = wxButton(self, wx.ID_ANY, _("Overlay ↑"))
+        self.btn_align_down = wxButton(self, wx.ID_ANY, _("Overlay ↓"))
+        for btn in (
+            self.btn_align_left,
+            self.btn_align_right,
+            self.btn_align_up,
+            self.btn_align_down,
+        ):
+            row_nudge.Add(btn, 1, wx.EXPAND, 0)
+        align_box.Add(row_nudge, 0, wx.EXPAND | wx.TOP, 4)
+
+        row_nudge2 = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_align_apply = wxButton(self, wx.ID_ANY, _("Apply offset"))
+        self.btn_align_reset = wxButton(self, wx.ID_ANY, _("Reset offset"))
+        row_nudge2.Add(self.btn_align_apply, 1, wx.EXPAND, 0)
+        row_nudge2.Add(self.btn_align_reset, 1, wx.LEFT | wx.EXPAND, 4)
+        align_box.Add(row_nudge2, 0, wx.EXPAND | wx.TOP, 4)
+        actions.Add(align_box, 0, wx.EXPAND | wx.TOP, 8)
+
+        bed_box = StaticBoxSizer(self, wx.ID_ANY, _("Bed"), wx.VERTICAL)
+        self.lbl_bed = wxStaticText(self, wx.ID_ANY, "")
+        bed_box.Add(self.lbl_bed, 0, wx.EXPAND, 0)
+
+        self.sizer.Add(steps, 0, wx.EXPAND | wx.ALL, 8)
+        self.sizer.Add(cam_box, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 8)
+        self.sizer.Add(actions, 0, wx.EXPAND | wx.ALL, 8)
+        self.sizer.Add(bed_box, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+
+        self.btn_open.Bind(wx.EVT_BUTTON, self.on_open_camera)
+        self.btn_reset.Bind(wx.EVT_BUTTON, self.on_reset_perspective)
+        self.btn_flip180.Bind(wx.EVT_BUTTON, self.on_flip180)
+        self.btn_background.Bind(wx.EVT_BUTTON, self.on_update_background)
+        self.btn_corners.Bind(wx.EVT_BUTTON, self.on_add_corners)
+        self.btn_fit.Bind(wx.EVT_BUTTON, self.on_fit_scene)
+        self.btn_align_left.Bind(wx.EVT_BUTTON, lambda e: self.on_nudge_align(-1, 0))
+        self.btn_align_right.Bind(wx.EVT_BUTTON, lambda e: self.on_nudge_align(1, 0))
+        self.btn_align_up.Bind(wx.EVT_BUTTON, lambda e: self.on_nudge_align(0, 1))
+        self.btn_align_down.Bind(wx.EVT_BUTTON, lambda e: self.on_nudge_align(0, -1))
+        self.btn_align_apply.Bind(wx.EVT_BUTTON, self.on_apply_align)
+        self.btn_align_reset.Bind(wx.EVT_BUTTON, self.on_reset_align)
+
+        self.Layout()
+        self.refresh_bed_info()
+        self.refresh_align_spins()
+        self._ensure_window_fits_content()
+
+    def _ensure_window_fits_content(self):
+        self.Layout()
+        self.sizer.Fit(self)
+        need_w, need_h = self.GetSize()
+        try:
+            dip = self.FromDIP(wx.Size(480, 680))
+            need_w = max(need_w, dip[0])
+            need_h = max(need_h, dip[1])
+        except AttributeError:
+            need_w = max(need_w, 480)
+            need_h = max(need_h, 680)
+        self.SetMinSize((need_w, need_h))
+        cur_w, cur_h = self.GetSize()
+        if cur_h < need_h or cur_w < need_w:
+            self.SetSize((max(cur_w, need_w), max(cur_h, need_h)))
+
+    def _camera_index(self):
+        return self.spin_camera.GetValue()
+
+    def refresh_bed_info(self):
+        device = self.context.device
+        x0, y0, x1, y1 = _bed_bbox(device)
+        try:
+            label = device.label
+            w = device.view.width
+            h = device.view.height
+        except AttributeError:
+            label = _("(no device)")
+            w = "405mm"
+            h = "285mm"
+        self.lbl_bed.SetLabel(
+            _("Device: {label}\nBed: {w} × {h}\nScene bounds: X {x0:.1f}…{x1:.1f}, Y {y0:.1f}…{y1:.1f}").format(
+                label=label,
+                w=w,
+                h=h,
+                x0=x0,
+                x1=x1,
+                y0=y0,
+                y1=y1,
+            )
+        )
+
+    def refresh_align_spins(self):
+        try:
+            cam = self._camera_service()
+        except AttributeError:
+            return
+        self.spin_align_x.SetValue(int(round(float(cam.align_offset_x or 0.0))))
+        self.spin_align_y.SetValue(int(round(float(cam.align_offset_y or 0.0))))
+
+    def _save_align_from_spins(self):
+        cam = self._camera_service()
+        cam.align_offset_x = float(self.spin_align_x.GetValue())
+        cam.align_offset_y = float(self.spin_align_y.GetValue())
+
+    def _refresh_overlay(self):
+        self.context.signal("refresh_scene")
+
+    def on_nudge_align(self, dx_mm, dy_mm, event=None):
+        try:
+            cam = self._camera_service()
+        except AttributeError:
+            wx.MessageBox(
+                _("Open the camera window first."),
+                _("Fine alignment"),
+                wx.OK | wx.ICON_WARNING,
+                parent=self,
+            )
+            return
+        cam.nudge_align(dx_mm, dy_mm)
+        self.refresh_align_spins()
+        self._refresh_overlay()
+
+    def on_apply_align(self, event=None):
+        try:
+            self._save_align_from_spins()
+        except AttributeError:
+            wx.MessageBox(
+                _("Open the camera window first."),
+                _("Fine alignment"),
+                wx.OK | wx.ICON_WARNING,
+                parent=self,
+            )
+            return
+        self._refresh_overlay()
+
+    def on_reset_align(self, event=None):
+        try:
+            cam = self._camera_service()
+        except AttributeError:
+            return
+        cam.align_offset_x = 0.0
+        cam.align_offset_y = 0.0
+        self.refresh_align_spins()
+        self._refresh_overlay()
+
+    def on_open_camera(self, event=None):
+        idx = self._camera_index()
+        self.context(f"camwin {idx}\n")
+
+    def _camera_service(self):
+        idx = self._camera_index()
+        return self.context.get_context(f"camera/{idx}")
+
+    def on_flip180(self, event=None):
+        try:
+            cam = self._camera_service()
+        except AttributeError:
+            wx.MessageBox(
+                _("Camera not available yet. Open the camera window first."),
+                _("Flip camera"),
+                wx.OK | wx.ICON_WARNING,
+                parent=self,
+            )
+            return
+        cam.set_image_flip(flip_x=True, flip_y=True)
+        wx.MessageBox(
+            _(
+                "Camera image flipped 180° (horizontal + vertical).\n\n"
+                "Perspective corners were reset — drag TL/TR/BR/BL\n"
+                "to the matching bed corners again."
+            ),
+            _("Flip camera 180°"),
+            wx.OK | wx.ICON_INFORMATION,
+            parent=self,
+        )
+
+    def on_reset_perspective(self, event=None):
+        idx = self._camera_index()
+        self.context(f"camera{idx} perspective reset\n")
+        wx.MessageBox(
+            _(
+                "Perspective corners reset.\n\n"
+                "In the camera window: leave Correct Perspective OFF,\n"
+                "drag each large labelled circle (TL, TR, BR, BL)\n"
+                "onto a bed corner, then turn Correct Perspective ON."
+            ),
+            _("Perspective reset"),
+            wx.OK | wx.ICON_INFORMATION,
+            parent=self,
+        )
+
+    def on_update_background(self, event=None):
+        idx = self._camera_index()
+        self.context(f"camera{idx} background\n")
+        wx.MessageBox(
+            _(
+                "Background sent to the main scene.\n\n"
+                "If nothing appears: link your laser device in the camera\n"
+                "right-click menu (...refresh → device), then try again."
+            ),
+            _("Background updated"),
+            wx.OK | wx.ICON_INFORMATION,
+            parent=self,
+        )
+
+    def on_add_corners(self, event=None):
+        elements = self.context.elements
+        device = self.context.device
+        x0, y0, x1, y1 = _bed_bbox(device)
+        margin = float(Length("15mm"))
+        size = float(Length("12mm"))
+        stroke = Color("red")
+        corners = _corner_positions(x0, y0, x1, y1, margin, size)
+        branch = elements.op_branch
+        for label, cx, cy in corners:
+            node = branch.add(
+                x=cx,
+                y=cy,
+                width=size,
+                height=size,
+                stroke=stroke,
+                fill=None,
+                type="elem rect",
+            )
+            node.label = label
+        elements.signal("refresh_scene")
+        wx.MessageBox(
+            _(
+                "Four small red squares were added near the bed corners.\n"
+                "Assign them to a low-power Cut operation and run a test.\n"
+                "If marks are off, nudge camera corners and Update background again."
+            ),
+            _("Corner marks added"),
+            wx.OK | wx.ICON_INFORMATION,
+            parent=self,
+        )
+
+    def on_fit_scene(self, event=None):
+        self.context("scene focus -5% -5% 105% 105%\n")
+
+    def window_open(self):
+        self.refresh_bed_info()
+        self.refresh_align_spins()
+        self._ensure_window_fits_content()
+        self.Raise()
+
+    @staticmethod
+    def sub_register(kernel):
+        kernel.register(
+            "button/preparation/CameraCalib",
+            {
+                "label": _("Camera Calib"),
+                "icon": icons8_image_in_frame,
+                "tip": _("Guided camera bed calibration"),
+                "help": "cameracal",
+                "action": lambda v: kernel.console("window toggle CameraCalib\n"),
+                "priority": 4,
+            },
+        )
+
+    @staticmethod
+    def submenu():
+        return "Editing", "Camera", True
+
+    @staticmethod
+    def helptext():
+        return _("Guide perspective calibration and bed background overlay from the camera")

--- a/meerk40t/camera/gui/cameracal.py
+++ b/meerk40t/camera/gui/cameracal.py
@@ -10,7 +10,7 @@ import wx
 from meerk40t.core.units import Length
 from meerk40t.gui.icons import icons8_image_in_frame
 from meerk40t.gui.mwindow import MWindow
-from meerk40t.gui.wxutils import StaticBoxSizer, wxButton, wxStaticText
+from meerk40t.gui.wxutils import StaticBoxSizer, wxButton, wxStaticText, TextCtrl
 from meerk40t.svgelements import Color
 
 _ = wx.GetTranslation
@@ -64,12 +64,29 @@ class CameraCalibWindow(MWindow):
         )
         steps.Add(self.lbl_steps, 0, wx.EXPAND, 0)
 
-        cam_box = StaticBoxSizer(self, wx.ID_ANY, _("Camera"), wx.HORIZONTAL)
-        cam_box.Add(wxStaticText(self, wx.ID_ANY, _("Index")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        cam_box = StaticBoxSizer(self, wx.ID_ANY, _("Camera"), wx.VERTICAL)
+        row_cam = wx.BoxSizer(wx.HORIZONTAL)
+        row_cam.Add(wxStaticText(self, wx.ID_ANY, _("Index")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.spin_camera = wx.SpinCtrl(self, wx.ID_ANY, min=0, max=8, initial=0)
-        cam_box.Add(self.spin_camera, 0, wx.LEFT, 4)
+        row_cam.Add(self.spin_camera, 0, wx.LEFT, 4)
         self.btn_open = wxButton(self, wx.ID_ANY, _("Open camera window"))
-        cam_box.Add(self.btn_open, 0, wx.LEFT, 8)
+        row_cam.Add(self.btn_open, 0, wx.LEFT, 8)
+        cam_box.Add(row_cam, 0, wx.EXPAND, 0)
+
+        row_uri = wx.BoxSizer(wx.HORIZONTAL)
+        self.text_camera_uri = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER
+        )
+        self.text_camera_uri.SetToolTip(
+            _(
+                "Paste: 0 (USB), rtsp://user:pass@IP:8554/stream1,\n"
+                "user:pass@IP, or bare IP (defaults to rtsp://IP:8554/profile0)."
+            )
+        )
+        self.btn_connect = wxButton(self, wx.ID_ANY, _("Connect"))
+        row_uri.Add(self.text_camera_uri, 1, wx.EXPAND, 0)
+        row_uri.Add(self.btn_connect, 0, wx.LEFT, 4)
+        cam_box.Add(row_uri, 0, wx.EXPAND | wx.TOP, 4)
 
         actions = StaticBoxSizer(self, wx.ID_ANY, _("Actions"), wx.VERTICAL)
         row1 = wx.BoxSizer(wx.HORIZONTAL)
@@ -147,6 +164,8 @@ class CameraCalibWindow(MWindow):
         self.sizer.Add(bed_box, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
 
         self.btn_open.Bind(wx.EVT_BUTTON, self.on_open_camera)
+        self.btn_connect.Bind(wx.EVT_BUTTON, self.on_connect_camera)
+        self.text_camera_uri.Bind(wx.EVT_TEXT_ENTER, self.on_connect_camera)
         self.btn_reset.Bind(wx.EVT_BUTTON, self.on_reset_perspective)
         self.btn_flip180.Bind(wx.EVT_BUTTON, self.on_flip180)
         self.btn_background.Bind(wx.EVT_BUTTON, self.on_update_background)
@@ -162,7 +181,15 @@ class CameraCalibWindow(MWindow):
         self.Layout()
         self.refresh_bed_info()
         self.refresh_align_spins()
+        self._load_saved_camera_uri()
         self._ensure_window_fits_content()
+
+    def _load_saved_camera_uri(self):
+        from meerk40t.camera.camera import _camera_service_for_index
+
+        cam = _camera_service_for_index(self.context.kernel, self._camera_index())
+        if cam is not None and getattr(cam, "uri", None) is not None:
+            self.text_camera_uri.SetValue(str(cam.uri))
 
     def _ensure_window_fits_content(self):
         self.Layout()
@@ -264,9 +291,29 @@ class CameraCalibWindow(MWindow):
         idx = self._camera_index()
         self.context(f"camwin {idx}\n")
 
-    def _camera_service(self):
+    def on_connect_camera(self, event=None):
+        from meerk40t.camera.camera import connect_camera_from_paste
+
+        raw = self.text_camera_uri.GetValue()
+        if not str(raw).strip():
+            wx.MessageBox(
+                _("Paste a camera address (USB 0, rtsp://…, user:pass@IP, or IP)."),
+                _("Connect camera"),
+                wx.OK | wx.ICON_INFORMATION,
+                parent=self,
+            )
+            return
         idx = self._camera_index()
-        return self.context.get_context(f"camera/{idx}")
+        uri = connect_camera_from_paste(self.context.kernel, idx, raw, start=True)
+        if uri is None:
+            return
+        self.text_camera_uri.SetValue(str(uri) if not isinstance(uri, int) else str(uri))
+        self.context(f"camwin {idx}\n")
+
+    def _camera_service(self):
+        from meerk40t.camera.camera import _camera_service_for_index
+
+        return _camera_service_for_index(self.context.kernel, self._camera_index())
 
     def on_flip180(self, event=None):
         try:
@@ -358,6 +405,7 @@ class CameraCalibWindow(MWindow):
     def window_open(self):
         self.refresh_bed_info()
         self.refresh_align_spins()
+        self._load_saved_camera_uri()
         self._ensure_window_fits_content()
         self.Raise()
 

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -31,7 +31,13 @@ from meerk40t.svgelements import Color
 
 _ = wx.GetTranslation
 
-CORNER_SIZE = 25
+CORNER_HIT_SIZE = 56
+CORNER_LABELS = ("TL", "TR", "BR", "BL")
+
+
+def _perspective_markers_visible(camera):
+    """Corner handles are shown whenever perspective correction is off."""
+    return not camera.correction_perspective
 
 
 def _get_camera_attribute(kernel, camera, attribute, default=None):
@@ -349,16 +355,18 @@ class CameraPanel(wx.Panel, Job):
     def on_refresh_scene(self, origin, *args):
         self.widget_scene.request_refresh(*args)
 
-    def update_camera_frame(self, event=None):
+    def update_camera_frame(self, event=None, force=False):
         if self.camera is None:
             return
 
-        if self.camera.frame_index == self.last_frame_index:
+        if not force and self.camera.frame_index == self.last_frame_index:
             return
         else:
             self.last_frame_index = self.camera.frame_index
 
-        frame = self.camera.get_frame()
+        from meerk40t.camera.camera import make_bed_bitmap_from_frame
+
+        frame = self.camera.get_display_frame()
         if frame is None:
             return
 
@@ -368,16 +376,10 @@ class CameraPanel(wx.Panel, Job):
             self.widget_scene.widget_root.set_view(
                 0, 0, self.image_width, self.image_height, self.camera.preserve_aspect
             )
-        self.frame_bitmap = wx.Bitmap.FromBuffer(
-            self.image_width, self.image_height, frame
-        )
-        if self.camera.correction_perspective:
-            if (
-                self.camera.width != self.image_width
-                or self.camera.height != self.image_height
-            ):
-                self.image_width = self.camera.width
-                self.image_height = self.camera.height
+        bmp = make_bed_bitmap_from_frame(frame)
+        if bmp is None:
+            return
+        self.frame_bitmap = bmp
 
         self.widget_scene.request_refresh()
 
@@ -389,15 +391,6 @@ class CameraPanel(wx.Panel, Job):
         @return:
         """
         self.camera(f"camera{self.index} perspective reset\n")
-        if self.camera.perspective is None:
-            width = self.camera.width
-            height = self.camera.height
-            self.camera.perspective = [
-                [0, 0],
-                [width, 0],
-                [width, height],
-                [0, height],
-            ]
         for v in self.widget_scene.widget_root.scene_widget:
             if hasattr(v, "update"):
                 v.update()
@@ -438,7 +431,13 @@ class CameraPanel(wx.Panel, Job):
         @param event:
         @return:
         """
-        self.camera(f"camera{self.index} background\n")
+        from meerk40t.camera.camera import camera_user_log
+
+        camera_user_log(
+            self.context.kernel, _("Update image: sending frame to main scene...")
+        )
+        self.update_camera_frame(force=True)
+        self.camera.background()
 
     def on_button_export(self, event=None):  # wxGlade: CameraInterface.<event_handler>
         """
@@ -744,6 +743,37 @@ class CamInterfaceWidget(Widget):
             )
             menu.AppendSeparator()
 
+            flip_h = menu.Append(wx.ID_ANY, _("Flip horizontal"), "", wx.ITEM_CHECK)
+            flip_v = menu.Append(wx.ID_ANY, _("Flip vertical"), "", wx.ITEM_CHECK)
+            flip_h.Check(self.cam.camera.flip_x)
+            flip_v.Check(self.cam.camera.flip_y)
+
+            def toggle_flip_h(event=None):
+                self.cam.camera.set_image_flip(flip_x=flip_h.IsChecked())
+                for v in self.scene.widget_root.scene_widget:
+                    if hasattr(v, "update"):
+                        v.update()
+
+            def toggle_flip_v(event=None):
+                self.cam.camera.set_image_flip(flip_y=flip_v.IsChecked())
+                for v in self.scene.widget_root.scene_widget:
+                    if hasattr(v, "update"):
+                        v.update()
+
+            def flip_180(event=None):
+                self.cam.camera.set_image_flip(flip_x=True, flip_y=True)
+                flip_h.Check(True)
+                flip_v.Check(True)
+                for v in self.scene.widget_root.scene_widget:
+                    if hasattr(v, "update"):
+                        v.update()
+
+            self.cam.Bind(wx.EVT_MENU, toggle_flip_h, flip_h)
+            self.cam.Bind(wx.EVT_MENU, toggle_flip_v, flip_v)
+            item = menu.Append(wx.ID_ANY, _("Flip 180° (upside down)"), "")
+            self.cam.Bind(wx.EVT_MENU, flip_180, id=item.GetId())
+            menu.AppendSeparator()
+
             fisheye = menu.Append(wx.ID_ANY, _("Correct Fisheye"), "", wx.ITEM_CHECK)
             fisheye.Check(self.cam.camera.correction_fisheye)
             self.cam.camera.correction_fisheye = fisheye.IsChecked()
@@ -764,15 +794,6 @@ class CamInterfaceWidget(Widget):
 
             def reset_perspect(event=None):
                 self.cam.camera(f"camera{self.cam.index} perspective reset\n")
-                if self.cam.camera.perspective is None:
-                    width = self.cam.camera.width
-                    height = self.cam.camera.height
-                    self.cam.camera.perspective = [
-                        [0, 0],
-                        [width, 0],
-                        [width, height],
-                        [0, height],
-                    ]
                 for v in self.scene.widget_root.scene_widget:
                     if hasattr(v, "update"):
                         v.update()
@@ -858,14 +879,15 @@ class CamPerspectiveWidget(Widget):
         self.cam = camera
         self.mid = mid
         self.index = index
-        half = CORNER_SIZE / 2.0
+        half = CORNER_HIT_SIZE / 2.0
         Widget.__init__(self, scene, -half, -half, half, half, **kwargs)
         self.update()
         c = Color.distinct(self.index + 2)
-        self.pen = wx.Pen(wx.Colour(c.red, c.green, c.blue))
+        self.fill_colour = wx.Colour(c.red, c.green, c.blue, 210)
 
     def update(self):
-        half = CORNER_SIZE / 2.0
+        half = CORNER_HIT_SIZE / 2.0
+        self.cam.camera.ensure_perspective()
         pos_x, pos_y = self.cam.camera.perspective[self.index]
         self.set_position(pos_x - half, pos_y - half)
 
@@ -873,27 +895,44 @@ class CamPerspectiveWidget(Widget):
         return HITCHAIN_HIT
 
     def process_draw(self, gc):
-        if not self.cam.camera.correction_perspective and not self.cam.camera.aspect:
-            gc.SetPen(self.pen)
-            gc.SetBrush(wx.TRANSPARENT_BRUSH)
-            gc.StrokeLine(
-                self.left,
-                self.top + self.height / 2.0,
-                self.right,
-                self.bottom - self.height / 2.0,
+        if not _perspective_markers_visible(self.cam.camera):
+            return
+        cx = self.left + self.width / 2.0
+        cy = self.top + self.height / 2.0
+        pad = 6
+        gc.SetPen(wx.Pen(wx.WHITE, 4))
+        gc.SetBrush(wx.Brush(wx.Colour(255, 255, 255, 90)))
+        gc.DrawEllipse(
+            self.left - pad,
+            self.top - pad,
+            self.width + pad * 2,
+            self.height + pad * 2,
+        )
+        gc.SetPen(wx.Pen(wx.BLACK, 2))
+        gc.SetBrush(wx.Brush(self.fill_colour))
+        gc.DrawEllipse(self.left, self.top, self.width, self.height)
+        gc.SetPen(wx.Pen(wx.WHITE, 2))
+        gc.StrokeLine(self.left, cy, self.right, cy)
+        gc.StrokeLine(cx, self.top, cx, self.bottom)
+        try:
+            font = wx.Font(
+                12,
+                wx.FONTFAMILY_SWISS,
+                wx.FONTSTYLE_NORMAL,
+                wx.FONTWEIGHT_BOLD,
             )
-            gc.StrokeLine(
-                self.left + self.width / 2.0,
-                self.top,
-                self.right - self.width / 2.0,
-                self.bottom,
-            )
-            gc.DrawEllipse(self.left, self.top, self.width, self.height)
+            gc.SetFont(font, wx.WHITE)
+            label = CORNER_LABELS[self.index]
+            tw, th = gc.GetTextExtent(label)
+            gc.DrawText(label, cx - tw / 2.0, cy - th / 2.0)
+        except Exception:
+            pass
 
     def event(self, window_pos=None, space_pos=None, event_type=None, **kwargs):
         if event_type == "leftdown":
             return RESPONSE_CONSUME
         if event_type == "move":
+            self.cam.camera.ensure_perspective()
             self.cam.camera.perspective[self.index][0] += space_pos[4]
             self.cam.camera.perspective[self.index][1] += space_pos[5]
             if self.parent is not None:
@@ -910,20 +949,20 @@ class CamSceneWidget(Widget):
         self.cam = camera
 
     def process_draw(self, gc):
-        if not self.cam.camera.correction_perspective and not self.cam.camera.aspect:
-            if self.cam.camera.perspective is not None:
-                if not len(self):
-                    for i in range(len(self.cam.camera.perspective)):
-                        self.add_widget(
-                            -1, CamPerspectiveWidget(self.scene, self.cam, i, False)
-                        )
-                gc.SetPen(wx.BLACK_DASHED_PEN)
-                lines = list(self.cam.camera.perspective)
-                lines.append(lines[0])
-                gc.StrokeLines(lines)
-        else:
+        if not _perspective_markers_visible(self.cam.camera):
             if len(self):
                 self.remove_all_widgets()
+            return
+        if self.cam.camera.perspective is not None:
+            if not len(self):
+                for i in range(len(self.cam.camera.perspective)):
+                    self.add_widget(
+                        -1, CamPerspectiveWidget(self.scene, self.cam, i, False)
+                    )
+            gc.SetPen(wx.Pen(wx.Colour(255, 220, 0), 3, wx.PENSTYLE_SHORT_DASH))
+            lines = list(self.cam.camera.perspective)
+            lines.append(lines[0])
+            gc.StrokeLines(lines)
 
     def update(self):
         for v in self:
@@ -956,7 +995,13 @@ class CameraInterface(MWindow):
         self.index = index
         super().__init__(640, 480, context, path, parent, **kwds)
         self.camera = self.context.get_context(f"camera/{self.index}")
-        self.panel = CameraPanel(self, wx.ID_ANY, context=self.camera, index=self.index)
+        self.panel = CameraPanel(
+            self,
+            wx.ID_ANY,
+            context=self.root_context,
+            gui=self.root_context.gui,
+            index=self.index,
+        )
         self.sizer.Add(self.panel, 1, wx.EXPAND, 0)
         self.add_module_delegate(self.panel)
 

--- a/meerk40t/camera/gui/camerapanel.py
+++ b/meerk40t/camera/gui/camerapanel.py
@@ -1325,7 +1325,8 @@ class CameraURIPanel(wx.Panel):
             list_name="list_camerauri",
         )
         self.button_add = wxButton(self, wx.ID_ANY, _("Add URI"))
-        self.text_uri = TextCtrl(self, wx.ID_ANY, "")
+        self.button_connect = wxButton(self, wx.ID_ANY, _("Connect"))
+        self.text_uri = TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PROCESS_ENTER)
 
         self.__set_properties()
         self.__do_layout()
@@ -1335,6 +1336,8 @@ class CameraURIPanel(wx.Panel):
             wx.EVT_LIST_ITEM_RIGHT_CLICK, self.on_list_right_clicked, self.list_uri
         )
         self.Bind(wx.EVT_BUTTON, self.on_button_add_uri, self.button_add)
+        self.Bind(wx.EVT_BUTTON, self.on_button_connect, self.button_connect)
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_button_connect, self.text_uri)
         self.Bind(wx.EVT_TEXT, self.on_text_uri, self.text_uri)
         # end wxGlade
         self.changed = False
@@ -1345,7 +1348,19 @@ class CameraURIPanel(wx.Panel):
         self.list_uri.AppendColumn(_("URI"), format=wx.LIST_FORMAT_LEFT, width=348)
         self.list_uri.resize_columns()
         self.button_add.SetToolTip(_("Add a new URL"))
-        # end wxGlade
+        self.button_connect.SetToolTip(
+            _(
+                "Connect camera {index} using the pasted address.\n"
+                "Examples: 0 (USB webcam), rtsp://user:pass@192.168.1.50:8554/stream1,\n"
+                "user:pass@192.168.1.50, or bare IP 192.168.1.50"
+            ).format(index=self.index)
+        )
+        self.text_uri.SetToolTip(
+            _(
+                "Paste camera address: USB index (0), full rtsp:// URL,\n"
+                "user:pass@IP[:port][/path], or bare IP/hostname."
+            )
+        )
 
     def __do_layout(self):
         # begin wxGlade: CameraURI.__do_layout
@@ -1353,7 +1368,8 @@ class CameraURIPanel(wx.Panel):
         sizer_2 = wx.BoxSizer(wx.HORIZONTAL)
         sizer_1.Add(self.list_uri, 1, wx.EXPAND, 0)
         sizer_2.Add(self.button_add, 0, 0, 0)
-        sizer_2.Add(self.text_uri, 2, 0, 0)
+        sizer_2.Add(self.button_connect, 0, wx.LEFT, 4)
+        sizer_2.Add(self.text_uri, 2, wx.LEFT, 4)
         sizer_1.Add(sizer_2, 0, wx.EXPAND, 0)
         self.SetSizer(sizer_1)
         self.Layout()
@@ -1440,7 +1456,9 @@ class CameraURIPanel(wx.Panel):
             except IndexError:
                 return
             if dlg.ShowModal() == wx.ID_OK:
-                self.context.uris[index] = dlg.GetValue()
+                from meerk40t.camera.camera import normalize_camera_uri
+
+                self.context.uris[index] = normalize_camera_uri(dlg.GetValue())
                 self.changed = True
                 self.on_list_refresh()
 
@@ -1458,13 +1476,39 @@ class CameraURIPanel(wx.Panel):
         return delete
 
     def on_button_add_uri(self, event=None):  # wxGlade: CameraURI.<event_handler>
-        uri = self.text_uri.GetValue()
-        if uri is None or uri == "":
+        from meerk40t.camera.camera import normalize_camera_uri
+
+        raw = self.text_uri.GetValue()
+        if raw is None or str(raw).strip() == "":
             return
-        self.context.uris.append(uri)
+        uri = normalize_camera_uri(raw)
+        if uri is None:
+            return
+        store = uri if isinstance(uri, int) else str(uri)
+        known = [str(u) for u in self.context.uris]
+        if str(store) not in known:
+            self.context.uris.append(store)
         self.text_uri.SetValue("")
         self.changed = True
         self.on_list_refresh()
+
+    def on_button_connect(self, event=None):
+        from meerk40t.camera.camera import connect_camera_from_paste
+
+        raw = self.text_uri.GetValue()
+        if raw is None or str(raw).strip() == "":
+            return
+        uri = connect_camera_from_paste(
+            self.context.kernel, self.index, raw, start=True
+        )
+        if uri is not None:
+            store = uri if isinstance(uri, int) else str(uri)
+            known = [str(u) for u in self.context.uris]
+            if str(store) not in known:
+                self.context.uris.append(store)
+                self.changed = True
+                self.on_list_refresh()
+            self.text_uri.SetValue(str(uri) if not isinstance(uri, int) else "")
 
     def on_text_uri(self, event):  # wxGlade: CameraURI.<event_handler>
         pass

--- a/meerk40t/camera/gui/gui.py
+++ b/meerk40t/camera/gui/gui.py
@@ -12,7 +12,10 @@ def plugin(kernel, lifecycle):
             register_panel_camera,
         )
 
+        from meerk40t.camera.gui.cameracal import CameraCalibWindow
+
         kernel.register("window/CameraInterface", CameraInterface)
+        kernel.register("window/CameraCalib", CameraCalibWindow)
         kernel.register("wxpane/CameraPane", register_panel_camera)
 
         @kernel.console_argument("x", type=str, help="x position")

--- a/meerk40t/core/bindalias.py
+++ b/meerk40t/core/bindalias.py
@@ -109,6 +109,9 @@ DEFAULT_KEYMAP = {
         "tree emphasized delete",
         "element delete",
     ),
+    "numpad_delete": (
+        "tree selected delete",
+    ),
     "escape": (
         "",
         "pause",

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -211,7 +211,7 @@ def plugin(kernel, lifecycle):
                 idy = spooler._dy
             except AttributeError:
                 return
-            confined = getattr(kernel.root, 'confined', False)
+            confined = getattr(kernel.root, "confined", True)
 
             if force:
                 spooler.command("move_rel", idx, idy, False)
@@ -264,7 +264,7 @@ def plugin(kernel, lifecycle):
         def move_relative(channel, _, dx, dy, data=None, force=False, **kwgs):
             if data is None:
                 data = kernel.device.spooler
-            confined = getattr(kernel.root, 'confined', False)
+            confined = getattr(kernel.root, "confined", True)
             spooler = data
             if dy is None:
                 raise CommandSyntaxError

--- a/meerk40t/core/spoolers.py
+++ b/meerk40t/core/spoolers.py
@@ -449,6 +449,8 @@ class Spooler:
 
         self._shutdown = False
         self._thread = None
+        self._abort_clear = False
+        self._user_aborted = False
         # If True, jobs that are stopped and have priority will be reinserted into the queue.
         # This can affect job ordering and execution, as stopped priority jobs may be retried or reordered.
         # Use with caution: enabling this may lead to repeated execution of certain jobs
@@ -619,6 +621,7 @@ class Spooler:
         )
         ljob.helper = helper
         ljob.uid = self.context.logging.uid("job")
+        self._user_aborted = False
         with self._lock:
             stopped_jobs = self._stop_lower_priority_running_jobs(priority)
             self._queue.append(ljob)
@@ -635,6 +638,7 @@ class Spooler:
         )
         ljob.helper = helper
         ljob.uid = self.context.logging.uid("job")
+        self._user_aborted = False
         with self._lock:
             stopped_jobs = self._stop_lower_priority_running_jobs(priority)
             self._queue.append(ljob)
@@ -654,6 +658,7 @@ class Spooler:
         @return:
         """
         job.uid = self.context.logging.uid("job")
+        self._user_aborted = False
         with self._lock:
             if prevent_duplicate:
                 for q in self._queue:
@@ -682,39 +687,54 @@ class Spooler:
         return stopped_jobs
 
     def clear_queue(self):
-        with self._lock:
-            for element in self._queue:
-                loop = getattr(element, "loops_executed", 0)
-                total = getattr(element, "loops", 0)
-                if isinf(total):
-                    status = "stopped"
-                elif loop < total:
-                    status = "stopped"
-                else:
-                    status = "completed"
-                self.context.logging.event(
-                    {
-                        "uid": getattr(element, "uid"),
-                        "status": status,
-                        "loop": getattr(element, "loops_executed", None),
-                        "total": getattr(element, "loops", None),
-                        "label": getattr(element, "label", None),
-                        "start_time": getattr(element, "time_started", None),
-                        "duration": getattr(element, "runtime", None),
-                        "device": self.context.label,
-                        "important": not getattr(element, "helper", False),
-                        "estimate": element.estimate_time()
-                        if hasattr(element, "estimate_time")
-                        else None,
-                        "steps_done": getattr(element, "steps_done", None),
-                        "steps_total": getattr(element, "steps_total", None),
-                    }
-                )
-                self.context.signal("spooler;completed")
-                element.stop()
-            self._queue.clear()
-            self._lock.notify()
+        """Stop all queued jobs. Must return quickly so the UI stays responsive."""
+        aborted = False
+        log_events = []
+        self._user_aborted = True
+        self._abort_clear = True
+        try:
+            with self._lock:
+                for element in list(self._queue):
+                    if hasattr(element, "is_running") and element.is_running():
+                        aborted = True
+                    element.stop()
+                    loop = getattr(element, "loops_executed", 0)
+                    total = getattr(element, "loops", 0)
+                    if isinf(total):
+                        status = "stopped"
+                    elif loop < total:
+                        status = "stopped"
+                    else:
+                        status = "completed"
+                    log_events.append(
+                        {
+                            "uid": getattr(element, "uid", None),
+                            "status": status,
+                            "loop": getattr(element, "loops_executed", None),
+                            "total": getattr(element, "loops", None),
+                            "label": getattr(element, "label", None),
+                            "start_time": getattr(element, "time_started", None),
+                            "duration": getattr(element, "runtime", None),
+                            "device": self.context.label,
+                            "important": not getattr(element, "helper", False),
+                            "estimate": element.estimate_time()
+                            if hasattr(element, "estimate_time")
+                            else None,
+                            "steps_done": getattr(element, "steps_done", None),
+                            "steps_total": getattr(element, "steps_total", None),
+                        }
+                    )
+                self._queue.clear()
+                self._current = None
+                self._lock.notify()
+        finally:
+            self._abort_clear = False
+        for entry in log_events:
+            self.context.logging.event(entry)
+        if aborted:
+            self.context.signal("spooler;aborted")
         self.context.signal("spooler;queue", len(self._queue))
+        self.context.signal("spooler;completed")
 
     def remove(self, element):
         with self._lock:

--- a/meerk40t/grbl/controller.py
+++ b/meerk40t/grbl/controller.py
@@ -658,6 +658,9 @@ class GrblController:
         if "\x18" in data:
             with self._sending_lock:
                 self._sending_queue.clear()
+            with self._forward_lock:
+                self._forward_buffer.clear()
+            self._assembled_response = []
         self.service.signal(
             "grbl;buffer", len(self._sending_queue) + len(self._realtime_queue)
         )

--- a/meerk40t/grbl/controller.py
+++ b/meerk40t/grbl/controller.py
@@ -468,6 +468,7 @@ class GrblController:
         self._log = None
 
         self._paused = False
+        self._warned_flip_y = False
         self._watchers = []
         self.is_shutdown = False
         self._last_state = None
@@ -1023,10 +1024,23 @@ class GrblController:
                 try:
                     nx = float(coords[0])
                     ny = float(coords[1])
+                    if (
+                        ny < -0.5
+                        and not self.service.flip_y
+                        and not self._warned_flip_y
+                    ):
+                        self._warned_flip_y = True
+                        self.log(
+                            "GRBL machine Y is negative (into bed) but Device "
+                            "'Flip Y' is off — Y jogs may trigger ALARM:2 soft "
+                            "limit. Enable Flip Y and Home corner top-left, then "
+                            "restart MeerK40t.",
+                            type="warning",
+                        )
 
-                    if not self.fully_validated():
-                        # During validation, we declare positions.
-                        self.driver.declare_position(nx, ny)
+                    # Keep driver native position aligned with MPos for confined
+                    # jogs (GRBL only reported position during connect before).
+                    self.driver.declare_position(nx, ny)
                     ox = self.driver.mpos_x
                     oy = self.driver.mpos_y
 

--- a/meerk40t/grbl/controller.py
+++ b/meerk40t/grbl/controller.py
@@ -590,12 +590,19 @@ class GrblController:
         if self.service.reset_on_connect:
             self.driver.reset()
         if not self.service.require_validator:
-            # We are required to wait for the validation.
             if self.service.boot_connect_sequence:
                 self._validation_stage = 1
                 self.validate_start("$")
             else:
                 self._validation_stage = 5
+        elif self.service.boot_connect_sequence:
+            # Serial/TCP may not re-send the welcome without a soft reset; start
+            # validation if the recv thread never sees one.
+            self.service.threaded(
+                self._connect_validation_fallback,
+                thread_name="grbl-connect-validate",
+                daemon=True,
+            )
         if self.service.startup_commands:
             self.log("Queue startup commands", type="event")
             lines = self.service.startup_commands.split("\n")
@@ -722,6 +729,18 @@ class GrblController:
                 with self._forward_lock:
                     self._forward_buffer.clear()
 
+    def _connect_validation_fallback(self):
+        """Start boot validation when GRBL does not send a welcome on attach."""
+        delay = max(0.5, self.service.connect_delay / 1000)
+        time.sleep(delay)
+        if not self.connection.connected or self.fully_validated():
+            return
+        if self._validation_stage != 0:
+            return
+        self.log("Starting validation (no welcome received).", type="event")
+        self._validation_stage = 1
+        self.validate_start("$")
+
     def _rstop(self, *args):
         self._recving_thread = None
 
@@ -744,6 +763,25 @@ class GrblController:
     ####################
     # GRBL SEND ROUTINES
     ####################
+
+    def _expects_ok(self, line):
+        """GRBL line commands get ok; status/pause/resume/reset bytes do not."""
+        if not line:
+            return False
+        core = line.strip("\r\n \t")
+        if not core:
+            return False
+        if core in ("?", "!", "~") or "\x18" in line:
+            return False
+        return "\r" in line or "\n" in line
+
+    def _send_realtime(self, data):
+        """Send GRBL realtime bytes without forward-buffer tracking (no ok)."""
+        if not data:
+            return
+        writer = getattr(self.connection, "realtime_write", self.connection.write)
+        writer(data)
+        self.log(data, type="send")
 
     def _send(self, line):
         """
@@ -772,7 +810,10 @@ class GrblController:
         if "~" in line:
             self._paused = False
         if line is not None:
-            self._send(line)
+            if self._expects_ok(line):
+                self._send(line)
+            else:
+                self._send_realtime(line)
         if "\x18" in line:
             self._paused = False
             with self._forward_lock:

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -705,13 +705,14 @@ class GRBLDevice(Service, Status):
             {
                 "attr": "line_end",
                 "object": self,
-                "default": "CR",
+                "default": "LF",
                 "type": str,
                 "style": "combosmall",
                 "choices": ["CR", "LF", "CRLF"],
                 "label": _("Line Ending"),
                 "tip": _(
-                    "CR for carriage return (\\r), LF for line feed(\\n), CRLF for both"
+                    "LF (\\n) is required for MKS DLC32 SD card files. "
+                    "CR (\\r) is legacy; CRLF for some serial hosts."
                 ),
                 # Hint for translation _("Protocol")
                 "section": "_20_Protocol",
@@ -825,6 +826,21 @@ class GRBLDevice(Service, Status):
                 "type": bool,
                 "label": _("Cleanup Local Files"),
                 "tip": _("Automatically delete local G-code files after successful upload"),
+                # Hint for translation _("ESP3D Upload")
+                "section": "_45_ESP3D Upload",
+                "subsection": "_10_Settings",
+            },
+            {
+                "attr": "sd_export_prepare",
+                "object": self,
+                "default": True,
+                "type": bool,
+                "label": _("Prepare Plan exports for SD card"),
+                "tip": _(
+                    "After Laser → Plan → Export, patch the file for MKS DLC32 SD: "
+                    "LF line endings, M3 laser mode, remove G28. "
+                    "Home on the panel ($HY / $HX) before Execute."
+                ),
                 # Hint for translation _("ESP3D Upload")
                 "section": "_45_ESP3D Upload",
                 "subsection": "_10_Settings",
@@ -1172,6 +1188,7 @@ class GRBLDevice(Service, Status):
         def gcode_save(channel, _, filename, data=None, **kwgs):
             if filename is None:
                 raise CommandSyntaxError
+            channel(_("Exporting to {filename}...").format(filename=filename))
             # Save the existing driver output routines so they can always be restored.
             old_routine_1 = self.driver.out_pipe
             old_routine_2 = self.driver.out_real
@@ -1198,7 +1215,31 @@ class GRBLDevice(Service, Status):
                 self.driver.out_pipe = old_routine_1
                 self.driver.out_real = old_routine_2
             if success:
-                channel(_("Export succeeded: {filename}").format(filename=filename))
+                if getattr(self, "sd_export_prepare", True):
+                    from .esp3d_upload import prepare_sd_gcode_file
+
+                    channel(_("Patching for MKS SD card..."))
+                    use_m3 = getattr(self, "use_m3", True)
+                    prepare_sd_gcode_file(
+                        filename,
+                        use_m3=use_m3,
+                        force_lf=True,
+                        strip_g28=True,
+                    )
+                    channel(
+                        _("Export succeeded (SD-ready): {filename}").format(
+                            filename=filename
+                        )
+                    )
+                    channel(
+                        _(
+                            "Patched for MKS SD: LF lines"
+                            + (", M3 mode" if use_m3 else "")
+                            + ", G28 removed — home ($HY / $HX) before Execute."
+                        )
+                    )
+                else:
+                    channel(_("Export succeeded: {filename}").format(filename=filename))
 
         @self.console_command(
             "grblinterpreter", help=_("activate the grbl interpreter.")

--- a/meerk40t/grbl/device.py
+++ b/meerk40t/grbl/device.py
@@ -40,6 +40,10 @@ class GRBLDevice(Service, Status):
                 default = c.get("default")
                 if attr is not None and default is not None:
                     setattr(self, attr, default)
+            for idx in range(5):
+                for key in (f"macro_{idx}", f"macro_title_{idx}"):
+                    if hasattr(self, key):
+                        self.setting(str, key, getattr(self, key))
 
         # self.redlight_preferred = False
 
@@ -158,7 +162,9 @@ class GRBLDevice(Service, Status):
                 "type": bool,
                 "label": _("Flip Y"),
                 "tip": _(
-                    "-Y is standard for grbl but sometimes settings can flip that."
+                    "On this machine Y goes negative into the bed (0 at top). "
+                    "Leave Flip Y on with Home corner top-left, or Y jogs can "
+                    "trigger GRBL ALARM:2 (soft limit)."
                 ),
                 # Hint for translation _("Flip Axis")
                 "subsection": "_40_Flip Axis",
@@ -480,6 +486,18 @@ class GRBLDevice(Service, Status):
                 "section": "_5_Config",
                 "tip": _(
                     "If the device has endstops, then the laser can home itself to this position = physical home ($H)"
+                ),
+            },
+            {
+                "attr": "sequential_homing",
+                "object": self,
+                "default": False,
+                "type": bool,
+                "label": _("Sequential homing ($HY then $HX)"),
+                "section": "_5_Config",
+                "tip": _(
+                    "For MKS DLC32 / top-left limits: home Y then X separately "
+                    "instead of $H. Avoids ALARM:1 stopping ~50 mm before switches."
                 ),
             },
             {

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -461,6 +461,11 @@ class GRBLDriver(Parameters):
         self._g90_absolute()
         self._g94_feedrate()
         self._clean()
+        self._rotary_firmware_active = False
+        rotary = getattr(self.service, "rotary", None)
+        if rotary is not None and rotary.active:
+            if rotary.apply_firmware_steps(self):
+                self._rotary_firmware_active = True
         if self.service.use_m3:
             self(f"M3{self.line_end}")
         else:
@@ -470,6 +475,7 @@ class GRBLDriver(Parameters):
         current = 0
         for q in self.queue:
             if self._job_aborted():
+                self._rotary_restore_firmware_steps()
                 self.queue.clear()
                 return
             # Are there any custom commands to be executed?
@@ -633,11 +639,13 @@ class GRBLDriver(Parameters):
                         self.move_mode = 1
                     self._move(x, y)
         if self._job_aborted():
+            self._rotary_restore_firmware_steps()
             self.queue.clear()
             self._set_queue_status(0, 0)
             return
         self.queue.clear()
         self._set_queue_status(0, 0)
+        self._rotary_restore_firmware_steps()
 
         self(f"G1 S0{self.line_end}")
         self(f"M5{self.line_end}")
@@ -667,6 +675,35 @@ class GRBLDriver(Parameters):
 
         @return:
         """
+        rotary = getattr(self.service, "rotary", None)
+        if rotary is not None and rotary.active:
+            channel = self.service.channel("grbl")
+            _ = self.service._
+            old_current = self.service.current
+            self.native_x = 0
+            self.native_y = 0
+            if self.service.has_endstops and rotary.home_x_only:
+                channel(
+                    _(
+                        "Rotary mode: homing X axis only ($HX). Y is the chuck — do not $HY."
+                    )
+                )
+                self(f"$HX{self.line_end}")
+            else:
+                channel(
+                    _(
+                        "Rotary mode: physical homing blocked. Console: $HX for X only, "
+                        "or disable rotary mode for flat-bed."
+                    )
+                )
+                return
+            new_current = self.service.current
+            if self._signal_updates:
+                self.service.signal(
+                    "driver;position",
+                    (old_current[0], old_current[1], new_current[0], new_current[1]),
+                )
+            return
         old_current = self.service.current
         self.native_x = 0
         self.native_y = 0
@@ -925,8 +962,45 @@ class GRBLDriver(Parameters):
     # PROTECTED DRIVER CODE
     ####################
 
+    def _rotary_y_grbl_factor(self):
+        rotary = getattr(self.service, "rotary", None)
+        if rotary is None:
+            return 1.0
+        return rotary.y_grbl_factor()
+
+    def _rotary_restore_firmware_steps(self):
+        if not getattr(self, "_rotary_firmware_active", False):
+            return
+        rotary = getattr(self.service, "rotary", None)
+        if rotary is not None:
+            rotary.restore_firmware_steps(self)
+        self._rotary_firmware_active = False
+
+    def _rotary_transform_move(self, x, y):
+        """Mirror output at G-code time (does not distort scene preview)."""
+        rotary = getattr(self.service, "rotary", None)
+        if rotary is None or not rotary.active:
+            return x, y
+        if self._absolute:
+            try:
+                bw = float(Length(self.service.view.width))
+                bh = float(Length(self.service.view.height))
+            except (ValueError, TypeError):
+                return x, y
+            if rotary.flip_x:
+                x = bw - x
+            if rotary.flip_y:
+                y = bh - y
+        else:
+            if rotary.flip_x:
+                x = -x
+            if rotary.flip_y:
+                y = -y
+        return x, y
+
     def _move(self, x, y, absolute=False):
         old_current = self.service.current
+        x, y = self._rotary_transform_move(x, y)
         if self._absolute:
             self.native_x = x
             self.native_y = y
@@ -944,7 +1018,7 @@ class GRBLDriver(Parameters):
         else:
             line.append("G1")
         x /= self.unit_scale
-        y /= self.unit_scale
+        y = (y * self._rotary_y_grbl_factor()) / self.unit_scale
         line.append(f"X{x:.3f}")
         line.append(f"Y{y:.3f}")
         if self.zaxis_dirty:

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -203,22 +203,28 @@ class GRBLDriver(Parameters):
         # x, y = self.service.view.position(x, y)
         # self._move(x, y)
         if confined:
-            new_x = self.native_x * self.service.view.native_scale_x + dx
-            new_y = self.native_y * self.service.view.native_scale_y + dy
+            if not isinstance(dx, (int, float)):
+                dx = float(Length(dx))
+            if not isinstance(dy, (int, float)):
+                dy = float(Length(dy))
+            bed_w = float(Length(self.service.view.width))
+            bed_h = float(Length(self.service.view.height))
+            # Clamp in bed/UI coordinates (same as Navigation get_movement).
+            # Do not mix native machine coords with UI jog deltas — breaks Y when
+            # GRBL MPos Y is negative (0 at top, -bedheight into the bed).
+            cur_x, cur_y = self.service.current
+            cur_x = float(cur_x)
+            cur_y = float(cur_y)
+            new_x = cur_x + dx
+            new_y = cur_y + dy
             if new_x < 0:
-                dx = -self.native_x * self.service.view.native_scale_x
-            elif new_x > self.service.view.width:
-                dx = (
-                    self.service.view.width
-                    - self.native_x * self.service.view.native_scale_x
-                )
+                dx = -cur_x
+            elif new_x > bed_w:
+                dx = bed_w - cur_x
             if new_y < 0:
-                dy = -self.native_y * self.service.view.native_scale_y
-            elif new_y > self.service.view.height:
-                dy = (
-                    self.service.view.height
-                    - self.native_y * self.service.view.native_scale_y
-                )
+                dy = -cur_y
+            elif new_y > bed_h:
+                dy = bed_h - cur_y
         self._g91_relative()
         self._clean()
         old_current = self.service.current
@@ -622,7 +628,13 @@ class GRBLDriver(Parameters):
         self.native_x = 0
         self.native_y = 0
         if self.service.has_endstops:
-            self(f"$H{self.line_end}")
+            # DLC32 / top-left (X−, Y+): $H homes both axes and often alarms
+            # ~50 mm before switches; $HY then $HX matches touch-panel homing.
+            if self.service.sequential_homing:
+                self(f"$HY{self.line_end}")
+                self(f"$HX{self.line_end}")
+            else:
+                self(f"$H{self.line_end}")
         else:
             self(f"G28{self.line_end}")
         new_current = self.service.current
@@ -993,44 +1005,44 @@ class GRBLDriver(Parameters):
         self.unit_scale = UNITS_PER_MM / self.stepper_step_size  # g21 is mm mode.
         self.units_dirty = True
 
+    def _apply_grbl_override_scale(
+        self, factor, reset_cmd, increase_cmd, decrease_cmd, step=0.05
+    ):
+        """Apply GRBL realtime override from 100% in ``step`` increments (default 5%)."""
+        if factor <= 0 or factor > 2.0:
+            factor = 1.0
+        self(reset_cmd, real=True)
+        current = 1.0
+        if factor > 1.0:
+            while current + step <= factor + 1e-6:
+                self(increase_cmd, real=True)
+                current += step
+        elif factor < 1.0:
+            while current - step >= factor - 1e-6:
+                self(decrease_cmd, real=True)
+                current -= step
+
     def set_power_scale(self, factor):
-        # Grbl can only deal with factors between 10% and 200%
+        # Grbl spindle override: 10%..200% (0x99 reset, 0x9A +10%, 0x9B -10%)
         if factor <= 0 or factor > 2.0:
             factor = 1.0
         if self.power_scale == factor:
             return
         self.power_scale = factor
-
-        # Grbl can only deal with factors between 10% and 200%
-        self("\x99\r", real=True)
-        # Upward loop
-        start = 1.0
-        while start < 2.0 and start < factor:
-            self("\x9B\r", real=True)
-            start += 0.1
-        # Downward loop
-        start = 1.0
-        while start > 0.0 and start > factor:
-            self("\x9A\r", real=True)
-            start -= 0.1
+        self._apply_grbl_override_scale(
+            factor, "\x99\r", "\x9A\r", "\x9B\r", step=0.05
+        )
 
     def set_speed_scale(self, factor):
-        # Grbl can only deal with factors between 10% and 200%
+        # Grbl feed override: 10%..200% (0x90 reset, 0x91 +10%, 0x92 -10%)
         if factor <= 0 or factor > 2.0:
             factor = 1.0
         if self.speed_scale == factor:
             return
         self.speed_scale = factor
-        self("\x90\r", real=True)
-        start = 1.0
-        while start < 2.0 and start < factor:
-            self("\x91\r", real=True)
-            start += 0.1
-        # Downward loop
-        start = 1.0
-        while start > 0.0 and start > factor:
-            self("\x92\r", real=True)
-            start -= 0.1
+        self._apply_grbl_override_scale(
+            factor, "\x90\r", "\x91\r", "\x92\r", step=0.05
+        )
 
     @staticmethod
     def has_adjustable_power():

--- a/meerk40t/grbl/driver.py
+++ b/meerk40t/grbl/driver.py
@@ -157,6 +157,24 @@ class GRBLDriver(Parameters):
             self.speed_dirty = True
         self.settings[key] = value
 
+    def _job_aborted(self):
+        """True while estop/clear_queue is stopping the active job."""
+        try:
+            spooler = self.service.spooler
+        except AttributeError:
+            return False
+        return getattr(spooler, "_user_aborted", False) or getattr(
+            spooler, "_abort_clear", False
+        )
+
+    def _abort_plot_if_needed(self):
+        """Exit plot_start quickly when the user aborted the spooler job."""
+        if self._job_aborted():
+            self.queue.clear()
+            self._set_queue_status(0, 0)
+            return True
+        return False
+
     def status(self):
         """
         Wants a status report of what the driver is doing.
@@ -322,7 +340,7 @@ class GRBLDriver(Parameters):
         g = Geomstr()
         for segment_type, start, c1, c2, end, sets in geom.as_lines():
             while self.hold_work(0):
-                if self.service.kernel.is_shutdown:
+                if self.service.kernel.is_shutdown or self._job_aborted():
                     return
                 time.sleep(0.05)
             x = self.native_x
@@ -365,7 +383,9 @@ class GRBLDriver(Parameters):
                 g.clear()
                 g.quad(complex(start), complex(c1), complex(end))
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.paused:
+                    while self.paused or self._job_aborted():
+                        if self._job_aborted():
+                            return
                         time.sleep(0.05)
                     self._move(p.real, p.imag)
             elif segment_type == "cubic":
@@ -379,7 +399,9 @@ class GRBLDriver(Parameters):
                     complex(end),
                 )
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.paused:
+                    while self.paused or self._job_aborted():
+                        if self._job_aborted():
+                            return
                         time.sleep(0.05)
                     self._move(p.real, p.imag)
             elif segment_type == "arc":
@@ -393,7 +415,9 @@ class GRBLDriver(Parameters):
                     complex(end),
                 )
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.paused:
+                    while self.paused or self._job_aborted():
+                        if self._job_aborted():
+                            return
                         time.sleep(0.05)
                     self._move(p.real, p.imag)
             elif segment_type == "point":
@@ -445,6 +469,9 @@ class GRBLDriver(Parameters):
         total = len(self.queue)
         current = 0
         for q in self.queue:
+            if self._job_aborted():
+                self.queue.clear()
+                return
             # Are there any custom commands to be executed?
             # Usecase (as described in issue https://github.com/meerk40t/meerk40t/issues/2764 ):
             # Switch between M3 and M4 mode for cut / raster
@@ -460,7 +487,7 @@ class GRBLDriver(Parameters):
             current += 1
             self._set_queue_status(current, total)
             while self.hold_work(0):
-                if self.service.kernel.is_shutdown:
+                if self.service.kernel.is_shutdown or self._job_aborted():
                     return
                 time.sleep(0.05)
             x = self.native_x
@@ -506,7 +533,9 @@ class GRBLDriver(Parameters):
                 g = Geomstr()
                 g.quad(complex(*q.start), complex(*q.c()), complex(*q.end))
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.paused:
+                    while self.paused or self._job_aborted():
+                        if self._job_aborted():
+                            return
                         time.sleep(0.05)
                     self._move(p.real, p.imag)
             elif isinstance(q, CubicCut):
@@ -520,7 +549,9 @@ class GRBLDriver(Parameters):
                     complex(*q.end),
                 )
                 for p in list(g.as_equal_interpolated_points(distance=interp))[1:]:
-                    while self.paused:
+                    while self.paused or self._job_aborted():
+                        if self._job_aborted():
+                            return
                         time.sleep(0.05)
                     self._move(p.real, p.imag)
             elif isinstance(q, WaitCut):
@@ -539,7 +570,11 @@ class GRBLDriver(Parameters):
                 self.move_mode = 1
                 self.set("power", 1000)
                 for ox, oy, on, x, y in q.plot:
+                    if self._abort_plot_if_needed():
+                        return
                     while self.hold_work(0):
+                        if self._abort_plot_if_needed():
+                            return
                         time.sleep(0.05)
                     # q.plot can have different on values, these are parsed
                     if self.on_value != on:
@@ -555,7 +590,11 @@ class GRBLDriver(Parameters):
                 self.plot_planner.push(q)
                 self.move_mode = 1
                 for x, y, on in self.plot_planner.gen():
+                    if self._abort_plot_if_needed():
+                        return
                     while self.hold_work(0):
+                        if self._abort_plot_if_needed():
+                            return
                         time.sleep(0.05)
                     if on > 1:
                         # Special Command.
@@ -593,6 +632,10 @@ class GRBLDriver(Parameters):
                     else:
                         self.move_mode = 1
                     self._move(x, y)
+        if self._job_aborted():
+            self.queue.clear()
+            self._set_queue_status(0, 0)
+            return
         self.queue.clear()
         self._set_queue_status(0, 0)
 
@@ -715,6 +758,8 @@ class GRBLDriver(Parameters):
         @return:
         """
         while True:
+            if self._job_aborted():
+                return
             if self.queue or len(self.service.controller):
                 time.sleep(0.05)
                 continue
@@ -823,10 +868,10 @@ class GRBLDriver(Parameters):
         @param args:
         @return:
         """
+        self(f"\x18{self.line_end}", real=True)
         self.service.spooler.clear_queue()
         self.queue.clear()
         self.plot_planner.clear()
-        self(f"\x18{self.line_end}", real=True)
         self._g94_feedrate()
         self._g21_units_mm()
         self._g90_absolute()

--- a/meerk40t/grbl/esp3d_upload.py
+++ b/meerk40t/grbl/esp3d_upload.py
@@ -7,6 +7,7 @@ on network-connected GRBL lasers with ESP3D firmware.
 
 import os
 import re
+import tempfile
 import time
 import random
 from urllib.parse import urlencode, quote
@@ -522,23 +523,98 @@ def normalize_sd_file_entry(entry):
     return {"name": name, "size": size, "time": timestamp, "is_dir": is_dir}
 
 
-def prepare_sd_gcode_file(path, use_m3=True, force_lf=True):
+def prepare_sd_gcode_file(path, use_m3=True, force_lf=True, strip_g28=True):
     """
     Patch exported G-code for MKS DLC32 SD execution.
 
     - LF line endings (board readFileLine splits on \\n only)
     - M3 instead of M4 when use_m3 (CO2 + $32=1 often needs constant PWM)
+    - Optional removal of G28 (DLC32: home with $HY / $HX before Execute, not G28)
+
+    Streams line-by-line so large raster exports (100+ MB) do not freeze the UI.
     """
-    with open(path, "rb") as f:
-        raw = f.read()
-    text = raw.decode("latin-1", errors="replace")
-    if force_lf:
-        text = text.replace("\r\n", "\n").replace("\r", "\n")
-    if use_m3:
-        text = re.sub(r"^M4\b", "M3", text, flags=re.MULTILINE | re.IGNORECASE)
-    with open(path, "wb") as f:
-        f.write(text.encode("latin-1"))
+    g28_pat = re.compile(
+        rb"^G28(\.\d+)?(\s+[XYZ]-?\d*\.?\d*)*\s*$", re.IGNORECASE
+    )
+    m4_pat = re.compile(rb"^M4\b", re.IGNORECASE)
+    dirname = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp_path = tempfile.mkstemp(suffix=".sdtmp", dir=dirname)
+    os.close(fd)
+    try:
+        with open(path, "rb") as src, open(tmp_path, "wb") as dst:
+            buf = b""
+            chunk_size = 8 * 1024 * 1024
+            while True:
+                chunk = src.read(chunk_size)
+                if not chunk:
+                    break
+                buf += chunk
+                parts = re.split(br"[\r\n]+", buf)
+                buf = parts.pop()
+                for line in parts:
+                    if not line.strip():
+                        continue
+                    if strip_g28 and g28_pat.match(line):
+                        continue
+                    if use_m3:
+                        line = m4_pat.sub(b"M3", line, count=1)
+                    dst.write(line + b"\n")
+            if buf.strip():
+                line = buf
+                if not (strip_g28 and g28_pat.match(line)):
+                    if use_m3:
+                        line = m4_pat.sub(b"M3", line, count=1)
+                    dst.write(line + b"\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
     return path
+
+
+def normalize_8_3_filename(name, default_ext="gc"):
+    """
+    Normalize user input to a valid 8.3 SD filename.
+
+    Adds .gc when no extension is given, strips invalid characters, and truncates.
+    Returns None when the result would be empty.
+    """
+    if not name:
+        return None
+    name = name.strip()
+    if not name:
+        return None
+    if "." not in name:
+        name = f"{name}.{default_ext}"
+    base, ext = name.rsplit(".", 1)
+    base = re.sub(r"[^A-Za-z0-9_]", "", base)[:8]
+    ext = re.sub(r"[^A-Za-z0-9]", "", ext)[:3] or default_ext[:3]
+    if not base:
+        return None
+    return f"{base}.{ext}"
+
+
+def suggest_esp3d_filename(project_label=None, last=None, extension="gc"):
+    """
+    Suggest an 8.3 filename for ESP3D SD upload.
+
+    Prefers the last successful upload name, then the project/window label,
+    then a short job#### style name.
+    """
+    extension = extension[:3]
+    if last:
+        normalized = normalize_8_3_filename(last, default_ext=extension)
+        if normalized and validate_filename_8_3(normalized):
+            return normalized
+    if project_label:
+        label = project_label
+        if os.sep in label or (len(label) > 1 and label[1] == ":"):
+            label = os.path.splitext(os.path.basename(label))[0]
+        clean = re.sub(r"[^A-Za-z0-9]", "", label)[:8]
+        if clean:
+            return f"{clean.lower()}.{extension}"
+    return generate_8_3_filename("job", extension)
 
 
 def generate_8_3_filename(base="file", extension="gc", counter=None):

--- a/meerk40t/grbl/esp3d_upload.py
+++ b/meerk40t/grbl/esp3d_upload.py
@@ -6,6 +6,7 @@ on network-connected GRBL lasers with ESP3D firmware.
 """
 
 import os
+import re
 import time
 import random
 from urllib.parse import urlencode, quote
@@ -266,34 +267,110 @@ class ESP3DConnection:
             }
         except requests.RequestException as e:
             raise ESP3DUploadError(f"Delete failed: {e}")
-    def execute_file(self, filename, path="/"):
+    def _command_request(self, command_text):
+        """Send one command via MKS / ESP3D ``/command?commandText=`` API."""
+        url = f"{self.base_url}/command"
+        params = {"commandText": command_text, "PAGEID": "0"}
+        session = self.session if self.session else requests
+        response = session.get(url, params=params, timeout=self.timeout)
+        return response
+
+    def query_grbl_status(self):
+        """
+        Query GRBL status report (``?``) over HTTP.
+
+        Returns:
+            dict: Parsed status with raw response text
+        """
+        try:
+            response = self._command_request("?")
+            body = (response.text or "").strip()
+            state = None
+            if body.startswith("<") and "|" in body:
+                state = body.split("|", 1)[0].lstrip("<").strip()
+            return {
+                "success": response.status_code < 400,
+                "state": state,
+                "response": body,
+                "status_code": response.status_code,
+            }
+        except requests.RequestException as e:
+            raise ESP3DUploadError(f"Status query failed: {e}")
+
+    def execute_file(self, filename, path="/", verify_started=True):
         """
         Execute a G-code file on the device.
 
         Args:
             filename: Name of file to execute
             path: Path prefix (ignored for OEM firmwares like MKS DLC32)
+            verify_started: After ESP220, poll ``?`` to catch silent SD read failures
 
         Returns:
-            dict: Execution result
+            dict: Execution result with success flag and human-readable message
         """
         try:
-            # Use the correct prefix and parameter for MKS DLC32 V2.1 firmware
             if filename.startswith("/"):
                 filename = filename[1:]
             command_text = f"[ESP220]/{filename}"
-            
-            url = f"{self.base_url}/command"
-            params = {"commandText": command_text}
-            
-            session = self.session if self.session else requests
-            response = session.get(url, params=params, timeout=self.timeout)
-            response.raise_for_status()
-            
+
+            response = self._command_request(command_text)
+            body = (response.text or "").strip()
+            parsed = interpret_esp3d_command_response(body, response.status_code)
+
+            if parsed["success"] is False:
+                return {
+                    "success": False,
+                    "message": parsed["message"],
+                    "response": body,
+                    "status_code": response.status_code,
+                }
+
+            if verify_started:
+                time.sleep(0.4)
+                status = self.query_grbl_status()
+                grbl_state = (status.get("state") or "").lower()
+                if grbl_state == "run":
+                    return {
+                        "success": True,
+                        "message": f"File running: {filename}",
+                        "response": body or status.get("response", ""),
+                        "grbl_state": grbl_state,
+                    }
+                if grbl_state == "alarm":
+                    return {
+                        "success": False,
+                        "message": (
+                            "GRBL is in Alarm. Send $X, then $HY and $HX, and try again."
+                        ),
+                        "response": status.get("response", body),
+                        "grbl_state": grbl_state,
+                    }
+                if grbl_state == "hold":
+                    return {
+                        "success": True,
+                        "message": f"File started (Hold): {filename}",
+                        "response": body or status.get("response", ""),
+                        "grbl_state": grbl_state,
+                    }
+                if parsed["success"] is None or grbl_state in ("", "idle"):
+                    return {
+                        "success": False,
+                        "message": (
+                            f"File did not start ({filename}). "
+                            "Old SD files often use CR-only lines — the board needs LF. "
+                            "Delete the file, run esp3d_upload_run -e in the console, "
+                            "then Execute the new file."
+                        ),
+                        "response": body or status.get("response", ""),
+                        "grbl_state": grbl_state or "idle",
+                    }
+
             return {
                 "success": True,
-                "message": f"File execution started: {filename}",
-                "response": response.text
+                "message": parsed["message"] or f"File execution started: {filename}",
+                "response": body,
+                "status_code": response.status_code,
             }
         except requests.RequestException as e:
             raise ESP3DUploadError(f"Execute failed: {e}")
@@ -309,17 +386,15 @@ class ESP3DConnection:
             dict: Command result
         """
         try:
-            url = f"{self.base_url}/command"
-            params = {"cmd": command}
-            
-            session = self.session if self.session else requests
-            response = session.get(url, params=params, timeout=self.timeout)
-            response.raise_for_status()
-            
+            response = self._command_request(command)
+            body = (response.text or "").strip()
+            parsed = interpret_esp3d_command_response(body, response.status_code)
+            success = parsed["success"] is not False
             return {
-                "success": True,
-                "message": f"Command sent: {command}",
-                "response": response.text
+                "success": success,
+                "message": parsed["message"] or f"Command sent: {command}",
+                "response": body,
+                "status_code": response.status_code,
             }
         except requests.RequestException as e:
             raise ESP3DUploadError(f"Command failed: {e}")
@@ -362,6 +437,108 @@ class ESP3DConnection:
             return self.send_command("\x18")
         except ESP3DUploadError as e:
             raise ESP3DUploadError(f"Stop failed: {e}")
+
+
+def interpret_esp3d_command_response(body, status_code):
+    """
+    Parse MKS / ESP3D ``/command`` HTTP response for ESP220 and other commands.
+
+    Returns dict with ``success`` True / False / None (ambiguous empty body).
+    """
+    text = (body or "").strip()
+    lower = text.lower()
+
+    if status_code >= 500:
+        return {
+            "success": False,
+            "message": text or f"HTTP {status_code} server error",
+        }
+
+    if status_code >= 400:
+        return {
+            "success": False,
+            "message": text or f"HTTP {status_code}",
+        }
+
+    if lower == "alarm":
+        return {
+            "success": False,
+            "message": "GRBL is in Alarm. Send $X, then $HY and $HX.",
+        }
+
+    if lower == "busy":
+        return {
+            "success": False,
+            "message": "GRBL is busy (not Idle). Wait or stop the current job first.",
+        }
+
+    if lower.startswith("error"):
+        return {"success": False, "message": text}
+
+    for phrase in (
+        "cannot stat file",
+        "cannot delete",
+        "no sd card",
+        "sd card busy",
+        "missing file name",
+    ):
+        if phrase in lower:
+            return {"success": False, "message": text}
+
+    if lower == "ok":
+        return {"success": True, "message": "ok"}
+
+    if text.startswith("<") and "|" in text:
+        state = text.split("|", 1)[0].lstrip("<").strip().lower()
+        if state == "run":
+            return {"success": True, "message": "Job running"}
+        if state == "hold":
+            return {"success": True, "message": "Job on hold"}
+        if state == "alarm":
+            return {
+                "success": False,
+                "message": "GRBL is in Alarm. Send $X, then $HY and $HX.",
+            }
+
+    if not text:
+        return {"success": None, "message": "Empty response (check GRBL state)"}
+
+    return {"success": True, "message": text}
+
+
+def normalize_sd_file_entry(entry):
+    """
+    Normalize one file record from MKS / ESP3D ``/upload`` JSON.
+
+    MKS DLC32 uses ``datetime`` (not ``time``) and may include ``shortname``.
+    """
+    name = entry.get("name") or entry.get("shortname") or ""
+    size = entry.get("size", "-1")
+    if size is None:
+        size = "-1"
+    size = str(size)
+    timestamp = entry.get("time") or entry.get("datetime") or ""
+    is_dir = size == "-1"
+    return {"name": name, "size": size, "time": timestamp, "is_dir": is_dir}
+
+
+def prepare_sd_gcode_file(path, use_m3=True, force_lf=True):
+    """
+    Patch exported G-code for MKS DLC32 SD execution.
+
+    - LF line endings (board readFileLine splits on \\n only)
+    - M3 instead of M4 when use_m3 (CO2 + $32=1 often needs constant PWM)
+    """
+    with open(path, "rb") as f:
+        raw = f.read()
+    text = raw.decode("latin-1", errors="replace")
+    if force_lf:
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+    if use_m3:
+        text = re.sub(r"^M4\b", "M3", text, flags=re.MULTILINE | re.IGNORECASE)
+    with open(path, "wb") as f:
+        f.write(text.encode("latin-1"))
+    return path
 
 
 def generate_8_3_filename(base="file", extension="gc", counter=None):

--- a/meerk40t/grbl/gui/esp3dfilemgr.py
+++ b/meerk40t/grbl/gui/esp3dfilemgr.py
@@ -1,9 +1,7 @@
 import wx
 from wx import aui
-from datetime import datetime
 
-from meerk40t.gui.icons import icons8_delete, icons8_save
-from meerk40t.gui.wxutils import ScrolledPanel, wxButton
+from meerk40t.gui.wxutils import wxButton
 
 _ = wx.GetTranslation
 
@@ -34,9 +32,8 @@ def register_panel_esp3d_files(window, context):
 class ESP3DFileManagerPanel(wx.Panel):
     """
     File manager panel for ESP3D SD card files.
-    
-    Provides GUI controls for listing, executing, and deleting files
-    on the ESP3D SD card.
+
+    Uses a dropdown to pick which SD file to run (Execute asks for confirmation).
     """
 
     def __init__(self, *args, context=None, **kwds):
@@ -44,25 +41,23 @@ class ESP3DFileManagerPanel(wx.Panel):
         wx.Panel.__init__(self, *args, **kwds)
         self.context = context
         self.pane_aui = None
+        self._file_names = []
         if self.context is not None:
             self.context.themes.set_window_colors(self)
         self.SetHelpText("esp3dfilemgr")
 
         sizer_main = wx.BoxSizer(wx.VERTICAL)
 
-        # File list
-        list_label = wx.StaticText(self, wx.ID_ANY, _("Files on ESP3D SD Card:"))
+        list_label = wx.StaticText(self, wx.ID_ANY, _("Select file to run:"))
         sizer_main.Add(list_label, 0, wx.ALL, 5)
 
-        self.list_files = wx.ListCtrl(
-            self, wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL
-        )
-        self.list_files.InsertColumn(0, _("Filename"), width=200)
-        self.list_files.InsertColumn(1, _("Size"), width=100)
-        self.list_files.InsertColumn(2, _("Date/Time"), width=150)
-        sizer_main.Add(self.list_files, 1, wx.EXPAND | wx.ALL, 5)
+        self.choice_files = wx.Choice(self, wx.ID_ANY, choices=[])
+        self.choice_files.SetMinSize((-1, 28))
+        sizer_main.Add(self.choice_files, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
 
-        # Buttons
+        self.label_selected = wx.StaticText(self, wx.ID_ANY, _("Selected: (none)"))
+        sizer_main.Add(self.label_selected, 0, wx.ALL, 5)
+
         sizer_buttons = wx.BoxSizer(wx.HORIZONTAL)
 
         self.btn_refresh = wxButton(self, wx.ID_ANY, _("Refresh"))
@@ -85,40 +80,75 @@ class ESP3DFileManagerPanel(wx.Panel):
 
         sizer_main.Add(sizer_buttons, 0, wx.EXPAND, 0)
 
-        # Status text
         self.text_status = wx.TextCtrl(
             self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
         )
         self.text_status.SetMinSize((-1, 150))
         sizer_main.Add(self.text_status, 0, wx.EXPAND | wx.ALL, 5)
 
-        # SD card info
         self.label_sd_info = wx.StaticText(self, wx.ID_ANY, "")
         sizer_main.Add(self.label_sd_info, 0, wx.ALL, 5)
 
         self.SetSizer(sizer_main)
         self.Layout()
 
-        # List selection handler
-        self.list_files.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_file_selected)
-        self.list_files.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.on_file_deselected)
+        self.choice_files.Bind(wx.EVT_CHOICE, self.on_file_selected)
+
+    def _device(self):
+        device = self.context
+        if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
+            device = self.context.kernel.device
+        return device
 
     def on_file_selected(self, event):
-        """Enable buttons when file is selected."""
-        self.btn_execute.Enable(True)
-        self.btn_delete.Enable(True)
-
-    def on_file_deselected(self, event):
-        """Disable buttons when no file is selected."""
-        self.btn_execute.Enable(False)
-        self.btn_delete.Enable(False)
+        filename = self.get_selected_filename()
+        has_sel = filename is not None
+        self.btn_execute.Enable(has_sel)
+        self.btn_delete.Enable(has_sel)
+        if filename:
+            self.label_selected.SetLabel(_("Selected: {name}").format(name=filename))
+        else:
+            self.label_selected.SetLabel(_("Selected: (none)"))
 
     def get_selected_filename(self):
-        """Get the currently selected filename."""
-        index = self.list_files.GetFirstSelected()
-        if index != -1:
-            return self.list_files.GetItemText(index, 0)
+        index = self.choice_files.GetSelection()
+        if index == wx.NOT_FOUND:
+            return None
+        if 0 <= index < len(self._file_names):
+            return self._file_names[index]
         return None
+
+    def _populate_file_list(self, files):
+        """Fill dropdown and status log from SD card JSON."""
+        from ..esp3d_upload import normalize_sd_file_entry
+
+        self._file_names = []
+        labels = []
+        self.choice_files.Clear()
+        self.text_status.AppendText(_("Files on SD card:\n"))
+
+        for raw in files:
+            f = normalize_sd_file_entry(raw)
+            if f["is_dir"]:
+                continue
+            name = f["name"]
+            size = f["size"]
+            self._file_names.append(name)
+            label = f"{name}  ({size})"
+            labels.append(label)
+            self.text_status.AppendText(f"  {label}\n")
+
+        if labels:
+            self.choice_files.AppendItems(labels)
+            self.choice_files.SetSelection(0)
+            self.on_file_selected(None)
+        else:
+            self.btn_execute.Enable(False)
+            self.btn_delete.Enable(False)
+            self.label_selected.SetLabel(_("Selected: (none)"))
+
+        self.text_status.AppendText("\n")
+        return len(self._file_names)
 
     def on_refresh(self, event):
         """Refresh file list."""
@@ -126,7 +156,11 @@ class ESP3DFileManagerPanel(wx.Panel):
         wx.Yield()
 
         try:
-            from ..esp3d_upload import ESP3DConnection, ESP3DUploadError, REQUESTS_AVAILABLE
+            from ..esp3d_upload import (
+                ESP3DConnection,
+                ESP3DUploadError,
+                REQUESTS_AVAILABLE,
+            )
 
             if not REQUESTS_AVAILABLE:
                 self.text_status.AppendText(
@@ -134,14 +168,14 @@ class ESP3DFileManagerPanel(wx.Panel):
                 )
                 return
 
-            # Get device - context might be device itself or have kernel.device
-            device = self.context
-            if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
-                device = self.context.kernel.device
+            device = self._device()
 
             if not hasattr(device, "esp3d_enabled") or not device.esp3d_enabled:
                 self.text_status.AppendText(
-                    _("Error: ESP3D upload is not enabled.\n")
+                    _(
+                        "Error: ESP3D upload is not enabled.\n"
+                        "Configuration → Device → ESP3D Upload → Enable.\n"
+                    )
                 )
                 return
 
@@ -159,59 +193,39 @@ class ESP3DFileManagerPanel(wx.Panel):
                 device.esp3d_port,
                 username,
                 password,
-                timeout=5
+                timeout=5,
             ) as esp3d:
                 sd_info = esp3d.get_sd_info()
                 files = sd_info.get("files", [])
 
-                # Clear list
-                self.list_files.DeleteAllItems()
+                file_count = self._populate_file_list(files)
 
-                # Add files
-                for f in files:
-                    name = f.get("name", "")
-                    size = f.get("size", "-1")
-                    time = f.get("time", "")
-
-                    # Skip directories
-                    if size == "-1":
-                        continue
-
-                    # Format time according to locale
-                    formatted_time = time
-                    if time:
-                        try:
-                            # ESP3D returns time in format like "2024-12-30 15:30:45"
-                            # Parse and reformat according to locale
-                            dt = datetime.strptime(time, "%Y-%m-%d %H:%M:%S")
-                            formatted_time = dt.strftime("%x %X")  # Locale's date and time representation
-                        except (ValueError, AttributeError):
-                            # If parsing fails, keep original format
-                            formatted_time = time
-
-                    index = self.list_files.InsertItem(self.list_files.GetItemCount(), name)
-                    self.list_files.SetItem(index, 1, size)
-                    self.list_files.SetItem(index, 2, formatted_time)
-
-                # Update SD info
                 total_mb = sd_info["total"] / (1024 * 1024)
                 used_mb = sd_info["used"] / (1024 * 1024)
                 free_mb = sd_info["free"] / (1024 * 1024)
                 occupation = sd_info["occupation"]
 
                 self.label_sd_info.SetLabel(
-                    _("SD Card: {used:.2f} MB / {total:.2f} MB used ({occupation}%) - Free: {free:.2f} MB").format(
+                    _(
+                        "SD Card: {used:.2f} MB / {total:.2f} MB used ({occupation}%) - Free: {free:.2f} MB"
+                    ).format(
                         used=used_mb,
                         total=total_mb,
                         occupation=occupation,
-                        free=free_mb
+                        free=free_mb,
                     )
                 )
 
-                file_count = self.list_files.GetItemCount()
                 self.text_status.AppendText(
                     _("✓ Found {count} file(s)\n").format(count=file_count)
                 )
+                if file_count:
+                    self.text_status.AppendText(
+                        _(
+                            "Pick a file from the dropdown, then click Execute.\n"
+                            "Old SD files may need re-upload (esp3d_upload_run) for M3 + LF.\n"
+                        )
+                    )
 
         except ESP3DUploadError as e:
             self.text_status.AppendText(_("✗ Error: {error}\n").format(error=e))
@@ -222,13 +236,38 @@ class ESP3DFileManagerPanel(wx.Panel):
         """Execute selected file."""
         filename = self.get_selected_filename()
         if not filename:
+            wx.MessageBox(
+                _("Choose a file from the dropdown first."),
+                _("ESP3D Files"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
             return
+
+        dlg = wx.MessageDialog(
+            self,
+            _(
+                "Run this file on the laser?\n\n{filename}\n\n"
+                "Home first ($HY then $HX).\n\n"
+                "If this file was uploaded before today, delete it and use "
+                "Console → esp3d_upload_run -e instead (LF lines + M3 laser)."
+            ).format(filename=filename),
+            _("Confirm Execute"),
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
+        )
+        if dlg.ShowModal() != wx.ID_YES:
+            dlg.Destroy()
+            return
+        dlg.Destroy()
 
         self.text_status.SetValue(_("Executing {filename}...\n").format(filename=filename))
         wx.Yield()
 
         try:
-            from ..esp3d_upload import ESP3DConnection, ESP3DUploadError, REQUESTS_AVAILABLE
+            from ..esp3d_upload import (
+                ESP3DConnection,
+                ESP3DUploadError,
+                REQUESTS_AVAILABLE,
+            )
 
             if not REQUESTS_AVAILABLE:
                 self.text_status.AppendText(
@@ -236,10 +275,7 @@ class ESP3DFileManagerPanel(wx.Panel):
                 )
                 return
 
-            # Get device - context might be device itself or have kernel.device
-            device = self.context
-            if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
-                device = self.context.kernel.device
+            device = self._device()
 
             if not hasattr(device, "esp3d_enabled") or not device.esp3d_enabled:
                 self.text_status.AppendText(
@@ -261,14 +297,29 @@ class ESP3DFileManagerPanel(wx.Panel):
                 device.esp3d_port,
                 username,
                 password,
-                timeout=5
+                timeout=10,
             ) as esp3d:
                 result = esp3d.execute_file(filename)
                 if result["success"]:
-                    self.text_status.AppendText(_("✓ File execution started\n"))
+                    self.text_status.AppendText(_("✓ {message}\n").format(
+                        message=result.get("message", _("File execution started"))
+                    ))
                 else:
                     self.text_status.AppendText(
-                        _("✗ Execution failed: {message}\n").format(message=result.get('message', 'Unknown error'))
+                        _("✗ {message}\n").format(
+                            message=result.get("message", _("Execution failed"))
+                        )
+                    )
+                    self.text_status.AppendText(
+                        _(
+                            "Fix: Console → esp3d_upload_run -e (fresh LF + M3 file), "
+                            "or Clear All old files first.\n"
+                        )
+                    )
+                resp = result.get("response")
+                if resp:
+                    self.text_status.AppendText(
+                        _("Board: {resp}\n").format(resp=resp[:200])
                     )
 
         except ESP3DUploadError as e:
@@ -282,12 +333,11 @@ class ESP3DFileManagerPanel(wx.Panel):
         if not filename:
             return
 
-        # Confirm deletion
         dlg = wx.MessageDialog(
             self,
             _("Delete file '{filename}'?").format(filename=filename),
             _("Confirm Delete"),
-            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
         )
         result = dlg.ShowModal()
         dlg.Destroy()
@@ -299,7 +349,11 @@ class ESP3DFileManagerPanel(wx.Panel):
         wx.Yield()
 
         try:
-            from ..esp3d_upload import ESP3DConnection, ESP3DUploadError, REQUESTS_AVAILABLE
+            from ..esp3d_upload import (
+                ESP3DConnection,
+                ESP3DUploadError,
+                REQUESTS_AVAILABLE,
+            )
 
             if not REQUESTS_AVAILABLE:
                 self.text_status.AppendText(
@@ -307,10 +361,7 @@ class ESP3DFileManagerPanel(wx.Panel):
                 )
                 return
 
-            # Get device - context might be device itself or have kernel.device
-            device = self.context
-            if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
-                device = self.context.kernel.device
+            device = self._device()
 
             if not hasattr(device, "esp3d_enabled") or not device.esp3d_enabled:
                 self.text_status.AppendText(
@@ -332,16 +383,19 @@ class ESP3DFileManagerPanel(wx.Panel):
                 device.esp3d_port,
                 username,
                 password,
-                timeout=5
+                timeout=5,
             ) as esp3d:
                 result = esp3d.delete_file(filename, device.esp3d_path)
                 if result["success"]:
-                    self.text_status.AppendText(_("✓ File deleted: {filename}\n").format(filename=filename))
-                    # Refresh list
+                    self.text_status.AppendText(
+                        _("✓ File deleted: {filename}\n").format(filename=filename)
+                    )
                     self.on_refresh(None)
                 else:
                     self.text_status.AppendText(
-                        _("✗ Delete failed: {message}\n").format(message=result.get('message', 'Unknown error'))
+                        _("✗ Delete failed: {message}\n").format(
+                            message=result.get("message", "Unknown error")
+                        )
                     )
 
         except ESP3DUploadError as e:
@@ -351,22 +405,23 @@ class ESP3DFileManagerPanel(wx.Panel):
 
     def on_clear_all(self, event):
         """Delete all files on SD card."""
-        file_count = self.list_files.GetItemCount()
-        
+        file_count = len(self._file_names)
+
         if file_count == 0:
             wx.MessageBox(
                 _("No files to delete"),
                 _("Clear All"),
-                wx.OK | wx.ICON_INFORMATION
+                wx.OK | wx.ICON_INFORMATION,
             )
             return
 
-        # Confirm deletion
         dlg = wx.MessageDialog(
             self,
-            _("Delete ALL {count} file(s) from SD card?\n\nThis cannot be undone!").format(count=file_count),
+            _(
+                "Delete ALL {count} file(s) from SD card?\n\nThis cannot be undone!"
+            ).format(count=file_count),
             _("Confirm Clear All"),
-            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
         )
         result = dlg.ShowModal()
         dlg.Destroy()
@@ -378,7 +433,12 @@ class ESP3DFileManagerPanel(wx.Panel):
         wx.Yield()
 
         try:
-            from ..esp3d_upload import ESP3DConnection, ESP3DUploadError, REQUESTS_AVAILABLE
+            from ..esp3d_upload import (
+                ESP3DConnection,
+                ESP3DUploadError,
+                REQUESTS_AVAILABLE,
+                normalize_sd_file_entry,
+            )
 
             if not REQUESTS_AVAILABLE:
                 self.text_status.AppendText(
@@ -386,10 +446,7 @@ class ESP3DFileManagerPanel(wx.Panel):
                 )
                 return
 
-            # Get device - context might be device itself or have kernel.device
-            device = self.context
-            if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
-                device = self.context.kernel.device
+            device = self._device()
 
             if not hasattr(device, "esp3d_enabled") or not device.esp3d_enabled:
                 self.text_status.AppendText(
@@ -405,32 +462,24 @@ class ESP3DFileManagerPanel(wx.Panel):
 
             username = device.esp3d_username if device.esp3d_username else None
             password = device.esp3d_password if device.esp3d_password else None
-            if hasattr(self.context, "kernel") and hasattr(self.context.kernel, "device"):
-                device = self.context.kernel.device
-
-            username = device.esp3d_username if device.esp3d_username else None
-            password = device.esp3d_password if device.esp3d_password else None
 
             with ESP3DConnection(
                 device.esp3d_host,
                 device.esp3d_port,
                 username,
                 password,
-                timeout=5
+                timeout=5,
             ) as esp3d:
-                # Get list of files
                 sd_info = esp3d.get_sd_info()
                 files = sd_info.get("files", [])
 
                 deleted = 0
                 failed = 0
 
-                for f in files:
-                    name = f.get("name", "")
-                    size = f.get("size", "-1")
-
-                    # Skip directories
-                    if size == "-1":
+                for raw in files:
+                    f = normalize_sd_file_entry(raw)
+                    name = f["name"]
+                    if f["is_dir"]:
                         continue
 
                     try:
@@ -441,18 +490,26 @@ class ESP3DFileManagerPanel(wx.Panel):
                         else:
                             failed += 1
                             self.text_status.AppendText(
-                                _("  ✗ {name}: {message}\n").format(name=name, message=result.get('message', 'Unknown error'))
+                                _("  ✗ {name}: {message}\n").format(
+                                    name=name,
+                                    message=result.get("message", "Unknown error"),
+                                )
                             )
                     except ESP3DUploadError as e:
                         failed += 1
-                        self.text_status.AppendText(_("  ✗ {name}: {error}\n").format(name=name, error=e))
+                        self.text_status.AppendText(
+                            _("  ✗ {name}: {error}\n").format(name=name, error=e)
+                        )
 
                     wx.Yield()
 
                 self.text_status.AppendText("\n")
-                self.text_status.AppendText(_("Deleted: {deleted}, Failed: {failed}\n").format(deleted=deleted, failed=failed))
+                self.text_status.AppendText(
+                    _("Deleted: {deleted}, Failed: {failed}\n").format(
+                        deleted=deleted, failed=failed
+                    )
+                )
 
-                # Refresh list
                 self.on_refresh(None)
 
         except ESP3DUploadError as e:
@@ -461,9 +518,10 @@ class ESP3DFileManagerPanel(wx.Panel):
             self.text_status.AppendText(_("✗ Unexpected error: {error}\n").format(error=e))
 
     def pane_show(self):
-        """Called when panel is shown."""
-        pass
+        """Refresh when the pane is opened."""
+        if not self._file_names:
+            self.on_refresh(None)
 
     def pane_hide(self):
         """Called when panel is hidden."""
-        pass
+        return

--- a/meerk40t/grbl/gui/esp3dupload.py
+++ b/meerk40t/grbl/gui/esp3dupload.py
@@ -1,0 +1,71 @@
+"""
+ESP3D upload filename dialog for GRBL GUI toolbar.
+"""
+import wx
+
+from ..esp3d_upload import (
+    normalize_8_3_filename,
+    suggest_esp3d_filename,
+    validate_filename_8_3,
+)
+
+_ = wx.GetTranslation
+
+
+def default_esp3d_filename_for_device(service):
+    """Build default SD filename from project label and last upload."""
+    project_label = None
+    root = service.kernel.root
+    gui = getattr(root, "gui", None)
+    if gui and getattr(gui, "working_files", None):
+        if len(gui.working_files) == 1:
+            project_label = gui.working_files[0]
+    last = getattr(service, "esp3d_last_filename", None)
+    return suggest_esp3d_filename(project_label, last=last)
+
+
+def prompt_esp3d_upload_filename(default_name):
+    """
+    Ask the user for an 8.3 SD filename.
+
+    Returns the normalized filename, or None if cancelled / invalid.
+    """
+    message = _(
+        "SD card filename (8.3 format).\n"
+        "Use up to 8 characters before .gc — e.g. logo01.gc, cut001.gc.\n"
+        "Same name overwrites the previous file on the card (easy rerun)."
+    )
+    with wx.TextEntryDialog(
+        None,
+        message,
+        _("ESP3D upload filename"),
+        default_name,
+    ) as dlg:
+        if dlg.ShowModal() != wx.ID_OK:
+            return None
+        raw = dlg.GetValue()
+    normalized = normalize_8_3_filename(raw)
+    if not normalized or not validate_filename_8_3(normalized):
+        wx.MessageBox(
+            _(
+                "Invalid filename.\n\n"
+                "Use up to 8 letters/numbers, then .gc\n"
+                "(example: mycut01.gc)."
+            ),
+            _("ESP3D upload"),
+            wx.OK | wx.ICON_WARNING,
+        )
+        return None
+    return normalized
+
+
+def run_esp3d_upload_with_prompt(service, execute=False):
+    """Show filename dialog, then run esp3d_upload_run with -f."""
+    default_name = default_esp3d_filename_for_device(service)
+    filename = prompt_esp3d_upload_filename(default_name)
+    if not filename:
+        return
+    cmd = f'esp3d_upload_run -f {filename}'
+    if execute:
+        cmd += " -e"
+    service(f"{cmd}\n")

--- a/meerk40t/grbl/gui/gui.py
+++ b/meerk40t/grbl/gui/gui.py
@@ -152,17 +152,19 @@ def plugin(service, lifecycle):
             """Check if ESP3D upload is enabled."""
             return hasattr(service, "esp3d_enabled") and service.esp3d_enabled
 
+        from meerk40t.grbl.gui.esp3dupload import run_esp3d_upload_with_prompt
+
         service.register(
             "button/control/ESP3DUpload",
             {
                 "label": _("ESP3D Upload+Run"),
                 "icon": icons8_save,
                 "tip": _("Upload current job to ESP3D and execute") + "\n"
-                + _("(right click: upload only)"),
+                + _("(right click: upload only; you choose the SD filename)"),
                 "help": "devicegrbl",
                 "rule_visible": lambda v: esp3d_is_enabled(),
-                "action": lambda v: service("esp3d_upload_run -e\n"),
-                "action_right": lambda v: service("esp3d_upload_run\n"),    
+                "action": lambda v: run_esp3d_upload_with_prompt(service, execute=True),
+                "action_right": lambda v: run_esp3d_upload_with_prompt(service, execute=False),
             },
         )
 

--- a/meerk40t/grbl/plugin.py
+++ b/meerk40t/grbl/plugin.py
@@ -100,6 +100,7 @@ def plugin(kernel, lifecycle=None):
                     {"attr": "flip_y", "default": True},
                     {"attr": "home_corner", "default": "top-left"},
                     {"attr": "source", "default": "co2"},
+                    {"attr": "use_m3", "default": True},
                     {"attr": "require_validator", "default": True},
                     {"attr": "reset_on_connect", "default": True},
                     {"attr": "interface", "default": "tcp"},
@@ -115,6 +116,9 @@ def plugin(kernel, lifecycle=None):
                     {"attr": "macro_3", "default": "$HY"},
                     {"attr": "macro_title_4", "default": "Home X"},
                     {"attr": "macro_4", "default": "$HX"},
+                    {"attr": "esp3d_enabled", "default": True},
+                    {"attr": "esp3d_host", "default": "192.168.10.90"},
+                    {"attr": "esp3d_port", "default": 80},
                 ],
             },
         )
@@ -549,6 +553,7 @@ def plugin(kernel, lifecycle=None):
                     ESP3DUploadError, 
                     generate_8_3_filename,
                     validate_filename_8_3,
+                    prepare_sd_gcode_file,
                     REQUESTS_AVAILABLE
                 )
                 
@@ -607,6 +612,14 @@ def plugin(kernel, lifecycle=None):
                         return
                     
                     channel(_("Generated {size} bytes of G-code").format(size=file_size))
+
+                    use_m3 = getattr(device, "use_m3", True)
+                    prepare_sd_gcode_file(temp_path, use_m3=use_m3, force_lf=True)
+                    channel(
+                        _("Prepared for SD card (LF lines{mode}).").format(
+                            mode=_(", M3 laser mode") if use_m3 else ""
+                        )
+                    )
                     
                     # Upload to ESP3D
                     busy.change(msg=_("Uploading G-code to ESP3D..."))

--- a/meerk40t/grbl/plugin.py
+++ b/meerk40t/grbl/plugin.py
@@ -79,6 +79,46 @@ def plugin(kernel, lifecycle=None):
             },
         )
         kernel.register(
+            "dev_info/grbl-dlc32-k40-400",
+            {
+                "provider": "provider/device/grbl",
+                "friendly_name": _("K40 CO2 — MKS DLC32 (405×285 mm)"),
+                "extended_info": _(
+                    "K40-style CO2 with Makerbase MKS DLC32 (Grbl 1.1h). "
+                    "Bed 405×285 mm, Swap XY, Wi-Fi TCP defaults for Meerkat. "
+                    "Tune power/speed after Material Test."
+                ),
+                "priority": 20,
+                "family": _("K-Series CO2-Laser"),
+                "choices": [
+                    {"attr": "label", "default": "GRBL-DLC32-400"},
+                    {"attr": "has_endstops", "default": True},
+                    {"attr": "sequential_homing", "default": True},
+                    {"attr": "bedwidth", "default": "405mm"},
+                    {"attr": "bedheight", "default": "285mm"},
+                    {"attr": "swap_xy", "default": False},
+                    {"attr": "flip_y", "default": True},
+                    {"attr": "home_corner", "default": "top-left"},
+                    {"attr": "source", "default": "co2"},
+                    {"attr": "require_validator", "default": True},
+                    {"attr": "reset_on_connect", "default": True},
+                    {"attr": "interface", "default": "tcp"},
+                    {"attr": "address", "default": "192.168.10.90"},
+                    {"attr": "port", "default": 8080},
+                    {"attr": "macro_title_0", "default": "Clear alarm"},
+                    {"attr": "macro_0", "default": "$X"},
+                    {"attr": "macro_title_1", "default": "Work zero"},
+                    {"attr": "macro_1", "default": "G92 X0 Y0"},
+                    {"attr": "macro_title_2", "default": "Status"},
+                    {"attr": "macro_2", "default": "?"},
+                    {"attr": "macro_title_3", "default": "Home Y"},
+                    {"attr": "macro_3", "default": "$HY"},
+                    {"attr": "macro_title_4", "default": "Home X"},
+                    {"attr": "macro_4", "default": "$HX"},
+                ],
+            },
+        )
+        kernel.register(
             "dev_info/grbl-k40",
             {
                 "provider": "provider/device/grbl",

--- a/meerk40t/grbl/plugin.py
+++ b/meerk40t/grbl/plugin.py
@@ -642,6 +642,7 @@ def plugin(kernel, lifecycle=None):
                         
                         if result["success"]:
                             channel(_("✓ Upload successful: {filename}").format(filename=remote_filename))
+                            device.esp3d_last_filename = remote_filename
                             
                             # Execute if requested
                             if execute:

--- a/meerk40t/grbl/tcp_connection.py
+++ b/meerk40t/grbl/tcp_connection.py
@@ -5,6 +5,76 @@ Communicate with a TCP network destination with the GRBL driver.
 """
 
 import socket
+import time
+
+
+def probe_grbl_port(address, ports, timeout=2.5):
+    """
+    Return the first TCP port that answers like GRBL (MKS DLC32 often uses 8080, not 23).
+    """
+    seen = set()
+    for port in ports:
+        if port in seen or port < 1 or port > 65535:
+            continue
+        seen.add(port)
+        sock = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((address, port))
+            sock.sendall(b"\r\n")
+            chunk = sock.recv(128)
+            if chunk:
+                return port
+        except OSError:
+            pass
+        finally:
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+    return None
+
+
+def resolve_grbl_tcp_port(address, preferred_port):
+    """Prefer configured port, then MKS DLC32 defaults (8080), then classic telnet (23)."""
+    candidates = []
+    for port in (preferred_port, 8080, 23):
+        if port not in candidates:
+            candidates.append(port)
+    return probe_grbl_port(address, candidates)
+
+
+def wake_lan_host(address, http_port=80, attempts=6, delay=0.5):
+    """
+    MKS DLC32 / Grbl_Esp32 may not answer TCP until something hits the web UI first.
+    Mimics opening http://<address>/ on a phone before MeerK40t connects on port 23.
+    """
+    for attempt in range(attempts):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(2.0)
+            sock.connect((address, http_port))
+            sock.sendall(
+                f"GET / HTTP/1.0\r\nHost: {address}\r\nConnection: close\r\n\r\n".encode(
+                    "ascii"
+                )
+            )
+            try:
+                sock.recv(512)
+            except OSError:
+                pass
+            sock.close()
+            return True
+        except OSError:
+            try:
+                sock.close()
+            except Exception:
+                pass
+            if attempt + 1 < attempts:
+                time.sleep(delay)
+    return False
 
 
 class TCPOutput:
@@ -23,24 +93,59 @@ class TCPOutput:
     def connect(self):
         try:
             self.controller.log("Attempting to Connect...", type="connection")
-            self._stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            # Enable TCP keep-alive to prevent connection timeouts
-            self._stream.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            # Set keep-alive parameters (platform-dependent)
-            try:
-                # TCP_KEEPIDLE: Time before sending keep-alive probes
-                self._stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-                # TCP_KEEPINTVL: Interval between keep-alive probes
-                self._stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30)
-                # TCP_KEEPCNT: Number of failed probes before connection is closed
-                self._stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
-            except (AttributeError, OSError):
-                # TCP keep-alive parameters may not be available on all platforms
-                # Basic SO_KEEPALIVE should still work
-                pass
-            # Make sure port is in a valid range...
-            port = min(65535, max(0, self.service.port))
-            self._stream.connect((self.service.address, port))
+            address = self.service.address
+            configured_port = min(65535, max(0, self.service.port))
+            if not wake_lan_host(address):
+                self.controller.log(
+                    "Wake HTTP failed; trying GRBL port anyway...",
+                    type="connection",
+                )
+            port = resolve_grbl_tcp_port(address, configured_port)
+            if port is None:
+                port = configured_port
+            elif port != configured_port:
+                self.controller.log(
+                    f"GRBL on port {port} (device was set to {configured_port}); "
+                    f"update Configuration → Interface → port to {port}.",
+                    type="connection",
+                )
+            last_error = None
+            for attempt in range(4):
+                try:
+                    if self._stream is not None:
+                        self._stream.close()
+                    self._stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    self._stream.settimeout(8.0)
+                    # Enable TCP keep-alive to prevent connection timeouts
+                    self._stream.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                    try:
+                        self._stream.setsockopt(
+                            socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60
+                        )
+                        self._stream.setsockopt(
+                            socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30
+                        )
+                        self._stream.setsockopt(
+                            socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3
+                        )
+                    except (AttributeError, OSError):
+                        pass
+                    if attempt > 0:
+                        found = resolve_grbl_tcp_port(address, port)
+                        if found is not None:
+                            port = found
+                    self._stream.connect((address, port))
+                    # Blocking reads: $$ validation over Wi-Fi can take >8s between chunks
+                    self._stream.settimeout(None)
+                    last_error = None
+                    break
+                except OSError as e:
+                    last_error = e
+                    if attempt + 1 < 4:
+                        wake_lan_host(address, attempts=2, delay=0.3)
+                        time.sleep(0.8)
+            if last_error is not None:
+                raise last_error
             self.service.signal("grbl;status", "connected")
         except TimeoutError:
             self.disconnect()
@@ -89,7 +194,18 @@ class TCPOutput:
         f = self.read_buffer.find(b"\n")
         if f == -1:
             try:
-                self.read_buffer += self._stream.recv(self._read_buffer_size)
+                chunk = self._stream.recv(self._read_buffer_size)
+                if not chunk:
+                    self.disconnect()
+                    self.service.signal("grbl;status", "connection closed by device")
+                    return
+                self.read_buffer += chunk
+            except (TimeoutError, socket.timeout):
+                return
+            except OSError as e:
+                self.disconnect()
+                self.service.signal("grbl;status", f"unknown error on read: {str(e)}")
+                return
             except Exception as e:
                 self.disconnect()
                 self.service.signal("grbl;status", f"unknown error on read: {str(e)}")

--- a/meerk40t/gui/batchrun.py
+++ b/meerk40t/gui/batchrun.py
@@ -1,0 +1,413 @@
+"""
+CSV Batch Run — batch personalization using wordlist CSV columns.
+
+Import a CSV, preview each row against text elements using {variable} placeholders,
+run jobs row-by-row, optionally auto-advance after each completed spooler job.
+"""
+
+import os
+
+import wx
+
+from meerk40t.core.wordlist import IDX_DATA_START, IDX_POSITION, IDX_TYPE, TYPE_CSV
+from meerk40t.gui.icons import icons8_curly_brackets, icons8_gas_industry
+from meerk40t.gui.mwindow import MWindow
+from meerk40t.gui.wxutils import StaticBoxSizer, TextCtrl, dip_size, wxButton, wxCheckBox, wxStaticText
+from meerk40t.kernel import signal_listener
+
+_ = wx.GetTranslation
+
+
+def csv_column_keys(wordlist):
+    """Return normalized keys for CSV-backed wordlist columns."""
+    return [
+        skey
+        for skey, entry in wordlist.content.items()
+        if entry[IDX_TYPE] == TYPE_CSV and skey not in wordlist.prohibited
+    ]
+
+
+def csv_row_count(wordlist):
+    """Number of data rows across CSV columns (uses the longest column)."""
+    count = 0
+    for skey in csv_column_keys(wordlist):
+        entry = wordlist.content[skey]
+        rows = len(entry) - IDX_DATA_START
+        if rows > count:
+            count = rows
+    return count
+
+
+def current_csv_row(wordlist):
+    """Zero-based row index from the first CSV column, or 0 if none loaded."""
+    keys = csv_column_keys(wordlist)
+    if not keys:
+        return 0
+    return max(0, wordlist.content[keys[0]][IDX_POSITION] - IDX_DATA_START)
+
+
+def set_csv_row(elements, row_index):
+    """Set all CSV columns to the same row and refresh the scene."""
+    wlist = elements.mywordlist
+    for skey in csv_column_keys(wlist):
+        wlist.set_index(skey, row_index)
+    elements.refresh_signal()
+    elements.signal("wordlist")
+
+
+def collect_text_previews(elements):
+    """Return lines describing text elements with variables translated for the current row."""
+    lines = []
+    for node in elements.elems():
+        if node.type != "elem text":
+            continue
+        raw = getattr(node, "text", None) or ""
+        if not raw:
+            continue
+        if "{" not in raw:
+            continue
+        translated = elements.wordlist_translate(raw, elemnode=node, increment=False)
+        lines.append(f"{node.display_label()}: {translated}")
+    return lines
+
+
+class BatchRunWindow(MWindow):
+    """Run repeated jobs from CSV wordlist rows with preview and optional auto-advance."""
+
+    def __init__(self, *args, **kwds):
+        super().__init__(520, 560, *args, **kwds)
+        self._batch_chain = False
+
+        self.wlist = self.context.elements.mywordlist
+
+        csv_box = StaticBoxSizer(self, wx.ID_ANY, _("CSV data"), wx.VERTICAL)
+        row_file = wx.BoxSizer(wx.HORIZONTAL)
+        row_file.Add(wxStaticText(self, wx.ID_ANY, _("File")), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.txt_csv = TextCtrl(self, wx.ID_ANY, "")
+        row_file.Add(self.txt_csv, 1, wx.EXPAND | wx.LEFT, 4)
+        self.btn_browse = wxButton(self, wx.ID_ANY, "...")
+        self.btn_browse.SetMinSize(dip_size(self, 28, 28))
+        row_file.Add(self.btn_browse, 0, wx.LEFT, 4)
+        self.btn_import = wxButton(self, wx.ID_ANY, _("Import"))
+        row_file.Add(self.btn_import, 0, wx.LEFT, 4)
+        csv_box.Add(row_file, 0, wx.EXPAND, 0)
+
+        header_row = wx.BoxSizer(wx.HORIZONTAL)
+        self.rbox_header = wx.RadioBox(
+            self,
+            wx.ID_ANY,
+            _("First row"),
+            choices=(_("Auto"), _("Data"), _("Headers")),
+            majorDimension=3,
+            style=wx.RA_SPECIFY_COLS,
+        )
+        header_row.Add(self.rbox_header, 1, wx.EXPAND, 0)
+        csv_box.Add(header_row, 0, wx.EXPAND | wx.TOP, 6)
+        self.sizer.Add(csv_box, 0, wx.EXPAND | wx.ALL, 6)
+
+        row_box = StaticBoxSizer(self, wx.ID_ANY, _("Row"), wx.VERTICAL)
+        nav = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_prev = wxButton(self, wx.ID_ANY, _("Prev"))
+        self.btn_next = wxButton(self, wx.ID_ANY, _("Next"))
+        self.spin_row = wx.SpinCtrl(self, wx.ID_ANY, min=1, max=1, initial=1)
+        self.lbl_row_status = wxStaticText(self, wx.ID_ANY, _("Row 0 / 0"))
+        nav.Add(self.btn_prev, 0, wx.RIGHT, 4)
+        nav.Add(self.btn_next, 0, wx.RIGHT, 8)
+        nav.Add(wxStaticText(self, wx.ID_ANY, _("Go to")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
+        nav.Add(self.spin_row, 0, wx.RIGHT, 8)
+        nav.Add(self.lbl_row_status, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        row_box.Add(nav, 0, wx.EXPAND, 0)
+
+        self.check_auto = wxCheckBox(
+            self,
+            wx.ID_ANY,
+            _("After each job completes, run the next row automatically"),
+        )
+        row_box.Add(self.check_auto, 0, wx.TOP, 6)
+        self.sizer.Add(row_box, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
+
+        preview_box = StaticBoxSizer(self, wx.ID_ANY, _("Preview (text with {variables})"), wx.VERTICAL)
+        self.txt_preview = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
+        )
+        self.txt_preview.SetMinSize(dip_size(self, -1, 160))
+        preview_box.Add(self.txt_preview, 1, wx.EXPAND, 0)
+        self.sizer.Add(preview_box, 1, wx.EXPAND | wx.ALL, 6)
+
+        cols_box = StaticBoxSizer(self, wx.ID_ANY, _("Current row values"), wx.VERTICAL)
+        self.txt_columns = TextCtrl(
+            self, wx.ID_ANY, "", style=wx.TE_MULTILINE | wx.TE_READONLY
+        )
+        self.txt_columns.SetMinSize(dip_size(self, -1, 80))
+        cols_box.Add(self.txt_columns, 1, wx.EXPAND, 0)
+        self.sizer.Add(cols_box, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+        actions = wx.BoxSizer(wx.HORIZONTAL)
+        self.btn_apply = wxButton(self, wx.ID_ANY, _("Apply row to design"))
+        self.btn_run = wxButton(self, wx.ID_ANY, _("Run current row"))
+        self.btn_run_all = wxButton(self, wx.ID_ANY, _("Run all rows"))
+        self.btn_stop = wxButton(self, wx.ID_ANY, _("Stop batch"))
+        self.btn_stop.Enable(False)
+        actions.Add(self.btn_apply, 0, wx.RIGHT, 4)
+        actions.Add(self.btn_run, 0, wx.RIGHT, 4)
+        actions.Add(self.btn_run_all, 0, wx.RIGHT, 4)
+        actions.Add(self.btn_stop, 0, wx.RIGHT, 4)
+        self.sizer.Add(actions, 0, wx.EXPAND | wx.ALL, 6)
+
+        self.lbl_status = wxStaticText(self, wx.ID_ANY, "")
+        self.sizer.Add(self.lbl_status, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+        self.Layout()
+
+        self.btn_browse.Bind(wx.EVT_BUTTON, self.on_browse)
+        self.btn_import.Bind(wx.EVT_BUTTON, self.on_import)
+        self.btn_prev.Bind(wx.EVT_BUTTON, self.on_prev)
+        self.btn_next.Bind(wx.EVT_BUTTON, self.on_next)
+        self.spin_row.Bind(wx.EVT_SPINCTRL, self.on_spin_row)
+        self.btn_apply.Bind(wx.EVT_BUTTON, self.on_apply)
+        self.btn_run.Bind(wx.EVT_BUTTON, self.on_run_current)
+        self.btn_run_all.Bind(wx.EVT_BUTTON, self.on_run_all)
+        self.btn_stop.Bind(wx.EVT_BUTTON, self.on_stop_batch)
+
+        icon = wx.NullIcon
+        icon.CopyFromBitmap(icons8_curly_brackets.GetBitmap())
+        self.SetIcon(icon)
+        self.SetTitle(_("CSV Batch Run"))
+        self.restore_aspect()
+        self.refresh_ui()
+
+    def _header_mode(self):
+        sel = self.rbox_header.GetSelection()
+        if sel == 1:
+            return False
+        if sel == 2:
+            return True
+        return None
+
+    def set_status(self, msg):
+        self.lbl_status.SetLabel(msg)
+
+    def refresh_ui(self):
+        total = csv_row_count(self.wlist)
+        row = current_csv_row(self.wlist)
+        if total <= 0:
+            row = 0
+            self.spin_row.SetRange(1, 1)
+            self.spin_row.SetValue(1)
+            self.lbl_row_status.SetLabel(_("No CSV loaded"))
+            self.btn_prev.Enable(False)
+            self.btn_next.Enable(False)
+            self.btn_run.Enable(False)
+            self.btn_run_all.Enable(False)
+            self.btn_apply.Enable(False)
+        else:
+            self.spin_row.SetRange(1, total)
+            self.spin_row.SetValue(row + 1)
+            self.lbl_row_status.SetLabel(
+                _("Row {current} of {total}").format(current=row + 1, total=total)
+            )
+            self.btn_prev.Enable(row > 0)
+            self.btn_next.Enable(row < total - 1)
+            self.btn_run.Enable(True)
+            self.btn_run_all.Enable(True)
+            self.btn_apply.Enable(True)
+        self._refresh_previews(row, total)
+
+    def _refresh_previews(self, row, total):
+        if total <= 0:
+            self.txt_preview.SetValue(_("Import a CSV with column headers matching your {variables}."))
+            self.txt_columns.SetValue("")
+            return
+
+        previews = collect_text_previews(self.context.elements)
+        if previews:
+            self.txt_preview.SetValue("\n".join(previews))
+        else:
+            self.txt_preview.SetValue(
+                _(
+                    "No text elements with {variables} found.\n"
+                    "Add text like Hello {name} and ensure CSV columns match."
+                )
+            )
+
+        col_lines = []
+        for skey in sorted(csv_column_keys(self.wlist)):
+            entry = self.wlist.content[skey]
+            idx = entry[IDX_POSITION]
+            if idx < len(entry):
+                col_lines.append(f"{skey} = {entry[idx]}")
+        self.txt_columns.SetValue("\n".join(col_lines))
+
+    def go_to_row(self, row_index):
+        total = csv_row_count(self.wlist)
+        if total <= 0:
+            return
+        row_index = max(0, min(row_index, total - 1))
+        set_csv_row(self.context.elements, row_index)
+        self.refresh_ui()
+
+    def on_browse(self, event=None):
+        with wx.FileDialog(
+            self,
+            message=_("Choose a CSV file"),
+            wildcard="CSV (*.csv)|*.csv|Text (*.txt)|*.txt|All (*.*)|*.*",
+            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+        ) as dlg:
+            if dlg.ShowModal() == wx.ID_OK:
+                self.txt_csv.SetValue(dlg.GetPath())
+
+    def on_import(self, event=None):
+        path = self.txt_csv.GetValue().strip()
+        if not path or not os.path.exists(path):
+            self.set_status(_("Choose a valid CSV file first."))
+            return
+        rows, cols, headers = self.wlist.load_csv_file(path, force_header=self._header_mode())
+        if self.wlist.has_load_warnings():
+            channel = self.context.kernel.root.channel("console")
+            channel(_("CSV import warnings:"))
+            for warning in self.wlist.get_load_warnings():
+                channel("  " + warning)
+        self.context.elements.signal("wordlist_modified")
+        self._batch_chain = False
+        self.go_to_row(0)
+        self.set_status(
+            _("Imported {cols} columns, {rows} rows.").format(cols=cols, rows=rows)
+        )
+
+    def on_prev(self, event=None):
+        self.go_to_row(current_csv_row(self.wlist) - 1)
+
+    def on_next(self, event=None):
+        self.go_to_row(current_csv_row(self.wlist) + 1)
+
+    def on_spin_row(self, event=None):
+        self.go_to_row(self.spin_row.GetValue() - 1)
+
+    def on_apply(self, event=None):
+        row = current_csv_row(self.wlist)
+        set_csv_row(self.context.elements, row)
+        self.set_status(_("Applied row {row} to the design.").format(row=row + 1))
+
+    def _spool_job(self):
+        context = self.context.kernel.root
+        kernel = self.context.kernel
+        hold = context.setting(bool, "laserpane_hold", False)
+        prefer_threaded = context.setting(bool, "prefer_threaded_mode", True)
+        prefix = "threaded " if prefer_threaded else ""
+        opt = kernel.planner.do_optimization
+        last_plan = kernel.planner.get_last_plan()
+        if last_plan is not None and hold:
+            context(f"plan{last_plan} spool\n")
+        else:
+            new_plan = kernel.planner.get_free_plan()
+            if opt:
+                context(
+                    f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
+                )
+            else:
+                context(
+                    f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n"
+                )
+        if context.auto_spooler:
+            context("window open JobSpooler\n")
+
+    def on_run_current(self, event=None):
+        total = csv_row_count(self.wlist)
+        if total <= 0:
+            self.set_status(_("Import a CSV first."))
+            return
+        row = current_csv_row(self.wlist)
+        set_csv_row(self.context.elements, row)
+        self._batch_chain = False
+        self._spool_job()
+        self.set_status(_("Running row {row} of {total}.").format(row=row + 1, total=total))
+
+    def on_run_all(self, event=None):
+        total = csv_row_count(self.wlist)
+        if total <= 0:
+            self.set_status(_("Import a CSV first."))
+            return
+        self._batch_chain = True
+        self.check_auto.SetValue(True)
+        self.btn_stop.Enable(True)
+        self.go_to_row(0)
+        self._spool_job()
+        self.set_status(_("Batch started at row 1 of {total}.").format(total=total))
+
+    def on_stop_batch(self, event=None):
+        self._batch_chain = False
+        self.btn_stop.Enable(False)
+        self.set_status(_("Batch stopped."))
+
+    def _continue_batch_if_needed(self):
+        if not self._batch_chain or not self.check_auto.GetValue():
+            self.btn_stop.Enable(False)
+            return
+        total = csv_row_count(self.wlist)
+        next_row = current_csv_row(self.wlist) + 1
+        if next_row >= total:
+            self._batch_chain = False
+            self.btn_stop.Enable(False)
+            self.set_status(_("Batch complete — {total} rows processed.").format(total=total))
+            return
+        self.go_to_row(next_row)
+        self._spool_job()
+        self.set_status(
+            _("Batch continuing — row {row} of {total}.").format(row=next_row + 1, total=total)
+        )
+
+    @signal_listener("spooler;aborted")
+    def on_spooler_aborted(self, origin, *args):
+        self._batch_chain = False
+        self.btn_stop.Enable(False)
+        self.set_status(_("Batch stopped — job was aborted."))
+
+    @signal_listener("spooler;completed")
+    def on_spooler_completed(self, origin, *args):
+        if not self._batch_chain:
+            return
+        if getattr(self.context.device.spooler, "_user_aborted", False):
+            return
+        self._continue_batch_if_needed()
+
+    @signal_listener("wordlist")
+    @signal_listener("wordlist_modified")
+    def on_wordlist_changed(self, origin, *args):
+        self.refresh_ui()
+
+    @staticmethod
+    def sub_register(kernel):
+        kernel.register(
+            "button/preparation/BatchRun",
+            {
+                "label": _("CSV Batch"),
+                "icon": icons8_gas_industry,
+                "tip": _("Run jobs from CSV wordlist rows"),
+                "help": "batchrun",
+                "action": lambda v: kernel.console("window toggle BatchRun\n"),
+            },
+        )
+        kernel.register(
+            "button/config/BatchRun",
+            {
+                "label": _("CSV Batch Run"),
+                "icon": icons8_curly_brackets,
+                "tip": _("Batch personalization from CSV"),
+                "help": "batchrun",
+                "action": lambda v: kernel.console("window toggle BatchRun\n"),
+            },
+        )
+
+    def window_open(self):
+        self.refresh_ui()
+
+    def window_close(self):
+        self._batch_chain = False
+
+    @staticmethod
+    def submenu():
+        return "Editing", "Variables + Wordlists", True
+
+    @staticmethod
+    def helptext():
+        return _("Import CSV data and run repeated jobs with {variable} text substitution")

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -1,4 +1,6 @@
 import platform
+import time
+from math import isinf
 
 import wx
 from wx import aui
@@ -19,6 +21,7 @@ from meerk40t.gui.icons import (
     icons8_save,
 )
 from meerk40t.gui.navigationpanels import Drag, Jog, JogDistancePanel, MovePanel
+from meerk40t.core.laserjob import LaserJob
 from meerk40t.gui.wxutils import (
     HoverButton,
     ScrolledPanel,
@@ -33,9 +36,95 @@ from meerk40t.gui.wxutils import (
     wxStaticText,
     dispatch_to_main_thread,
 )
+from meerk40t.core.planner import STAGE_PLAN_BLOB
 from meerk40t.kernel import lookup_listener, signal_listener
 
 _ = wx.GetTranslation
+
+# Laser-Control override slider: center = 0%, each step = 5% (GRBL allows ~10%..200%)
+OVERRIDE_STEP_PERCENT = 5
+OVERRIDE_SLIDER_MIN = 1
+OVERRIDE_SLIDER_MAX = 41
+OVERRIDE_SLIDER_CENTER = 21
+
+
+def queue_cutplan_to_spooler(context, optimize=True, hold_policy="laserpane"):
+    """
+    Build a cut plan from the current scene and spool it to the active device.
+
+    hold_policy "laserpane": honour Laser tab Hold (re-spool last plan only if it has blob).
+    hold_policy "never": always rebuild from the scene (used after Parameter-Test).
+    """
+    if not context.elements.have_burnable_elements():
+        wx.MessageBox(
+            _(
+                "Nothing to burn. Operations need assigned shapes "
+                "(check the Operations tree after Create Pattern)."
+            ),
+            _("Queue Job"),
+            wx.OK | wx.ICON_INFORMATION,
+        )
+        return False
+    device = context.device
+    if device is None or getattr(device, "spooler", None) is None:
+        wx.MessageBox(
+            _("Connect your laser device first (Laser tab → Connect)."),
+            _("Queue Job"),
+            wx.OK | wx.ICON_WARNING,
+        )
+        return False
+
+    if context.elements.have_unassigned_elements():
+        answer = wx.MessageBox(
+            _(
+                "Some shapes are not assigned to any operation (Operations tree → "
+                "yellow Unassigned bar, or Elements still outside Cut/Engrave).\n\n"
+                "Only assigned shapes are sent to the laser — e.g. the outer frame "
+                "may cut while inner detail is skipped.\n\n"
+                "Fix: expand your Cut op → Re-Classify, enable Fill on Cut if inner "
+                "art has fill but no stroke, or drag shapes onto the Cut op.\n\n"
+                "Queue anyway?"
+            ),
+            _("Unassigned shapes"),
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+        )
+        if answer != wx.YES:
+            return False
+
+    prefer_threaded = context.setting(bool, "prefer_threaded_mode", True)
+    prefix = "threaded " if prefer_threaded else ""
+
+    last_plan = context.laserpane_plan or context.planner.get_last_plan()
+    states, _info = (
+        context.planner.get_plan_stage(last_plan) if last_plan else (None, "")
+    )
+    has_blob = states is not None and STAGE_PLAN_BLOB in states
+
+    use_hold = (
+        hold_policy == "laserpane"
+        and context.laserpane_hold
+        and last_plan
+        and context.planner.has_content(last_plan)
+        and has_blob
+    )
+    if use_hold:
+        context(f"plan{last_plan} spool\n")
+    else:
+        new_plan = context.planner.get_free_plan()
+        if optimize:
+            context(
+                f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
+            )
+        else:
+            context(
+                f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n"
+            )
+        if prefer_threaded and context.setting(bool, "autoshow_task_window", True):
+            context("window open ThreadInfo\n")
+
+    if context.auto_spooler:
+        context("window open JobSpooler\n")
+    return True
 
 
 def register_panel_laser(window, context):
@@ -336,34 +425,88 @@ class LaserPanel(wx.Panel):
         lb_power = wxStaticText(self, wx.ID_ANY, _("Power"))
         self.label_power = wxStaticText(self, wx.ID_ANY, "0%")
         self.slider_power = wx.Slider(
-            self, wx.ID_ANY, value=10, minValue=1, maxValue=20
+            self,
+            wx.ID_ANY,
+            value=OVERRIDE_SLIDER_CENTER,
+            minValue=OVERRIDE_SLIDER_MIN,
+            maxValue=OVERRIDE_SLIDER_MAX,
         )
-        self.sizer_power.Add(lb_power, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.text_power_override = TextCtrl(
+            self, wx.ID_ANY, "0", limited=True, check="float"
+        )
+        self.text_power_override.SetMinSize(dip_size(self, 40, -1))
+        self.btn_set_power = wxButton(self, wx.ID_ANY, _("Set"))
+        self.sizer_power.Add(lb_power, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.sizer_power.Add(self.slider_power, 3, wx.ALIGN_CENTER_VERTICAL, 0)
-        self.sizer_power.Add(self.label_power, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_power.Add(self.text_power_override, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_power.Add(self.btn_set_power, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_power.Add(self.label_power, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.slider_power.SetToolTip(
-            _("Increases/decreases the regular laser power by this amount.")
+            _("Adjust laser power override in {step}% steps (center = 0%).").format(
+                step=OVERRIDE_STEP_PERCENT
+            )
             + "\n"
-            + _("This affects running jobs, so use with care!")
+            + _("Right = more power, left = less. Affects running jobs.")
+        )
+        self.text_power_override.SetToolTip(
+            _("Percent change from normal, e.g. 70 or -30. Press Set to apply.")
         )
 
         self.sizer_speed = wx.BoxSizer(wx.HORIZONTAL)
         sizer_manipulate.Add(self.sizer_speed, 0, wx.EXPAND, 0)
         lb_speed = wxStaticText(self, wx.ID_ANY, _("Speed"))
         self.label_speed = wxStaticText(self, wx.ID_ANY, "0%")
-        self.slider_size = 20
         self.power_mode = "relative"
         self.slider_speed = wx.Slider(
-            self, wx.ID_ANY, value=10, minValue=1, maxValue=20
+            self,
+            wx.ID_ANY,
+            value=OVERRIDE_SLIDER_CENTER,
+            minValue=OVERRIDE_SLIDER_MIN,
+            maxValue=OVERRIDE_SLIDER_MAX,
         )
-        self.sizer_speed.Add(lb_speed, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.text_speed_override = TextCtrl(
+            self, wx.ID_ANY, "0", limited=True, check="float"
+        )
+        self.text_speed_override.SetMinSize(dip_size(self, 40, -1))
+        self.btn_set_speed = wxButton(self, wx.ID_ANY, _("Set"))
+        self.sizer_speed.Add(lb_speed, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.sizer_speed.Add(self.slider_speed, 3, wx.ALIGN_CENTER_VERTICAL, 0)
-        self.sizer_speed.Add(self.label_speed, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_speed.Add(self.text_speed_override, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_speed.Add(self.btn_set_speed, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self.sizer_speed.Add(self.label_speed, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.slider_speed.SetToolTip(
-            _("Increases/decreases the regular speed by this amount.")
+            _("Adjust feed override in {step}% steps (center = 0%).").format(
+                step=OVERRIDE_STEP_PERCENT
+            )
             + "\n"
-            + _("This affects running jobs, so use with care!")
+            + _("Right = faster, left = slower. Affects running jobs.")
         )
+        self.text_speed_override.SetToolTip(
+            _("Percent change from normal, e.g. 50 or -20. Press Set to apply.")
+        )
+
+        sizer_progress = wx.BoxSizer(wx.VERTICAL)
+        sizer_progress_header = wx.BoxSizer(wx.HORIZONTAL)
+        self.label_job_progress = wxStaticText(self, wx.ID_ANY, _("Job progress"))
+        self.label_progress_percent = wxStaticText(
+            self, wx.ID_ANY, "", style=wx.ALIGN_RIGHT
+        )
+        sizer_progress_header.Add(self.label_job_progress, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        sizer_progress_header.Add(
+            self.label_progress_percent, 0, wx.ALIGN_CENTER_VERTICAL, 0
+        )
+        sizer_progress.Add(sizer_progress_header, 0, wx.EXPAND, 0)
+        self.gauge_job_progress = wx.Gauge(
+            self, range=100, style=wx.GA_HORIZONTAL | wx.GA_SMOOTH
+        )
+        self.gauge_job_progress.SetValue(0)
+        sizer_progress.Add(self.gauge_job_progress, 0, wx.EXPAND, 0)
+        self.label_progress_detail = wxStaticText(self, wx.ID_ANY, _("No job running"))
+        sizer_progress.Add(self.label_progress_detail, 0, wx.EXPAND, 0)
+        sizer_main.Add(sizer_progress, 1, wx.EXPAND | wx.ALL, 4)
+
+        self._progress_last_update = 0.0
+        self._progress_update_delta = 1.0
 
         self.SetSizer(sizer_main)
         self.Layout()
@@ -385,6 +528,8 @@ class LaserPanel(wx.Panel):
         self.Bind(wx.EVT_CHECKBOX, self.on_check_adjust, self.checkbox_adjust)
         self.Bind(wx.EVT_SLIDER, self.on_slider_speed, self.slider_speed)
         self.Bind(wx.EVT_SLIDER, self.on_slider_power, self.slider_power)
+        self.Bind(wx.EVT_BUTTON, self.on_set_power_override, self.btn_set_power)
+        self.Bind(wx.EVT_BUTTON, self.on_set_speed_override, self.btn_set_speed)
         self.Bind(wx.EVT_CHECKBOX, self.on_optimize, self.checkbox_optimize)
         # self.btn_config_laser.Bind(wx.EVT_LEFT_DOWN, self.on_config_button)
         self.btn_config_laser.Bind(wx.EVT_BUTTON, self.on_config_button)
@@ -400,6 +545,145 @@ class LaserPanel(wx.Panel):
             disable_window(self)
         # Check for a real click of the execute button
         self.button_start_was_clicked = False
+        self.update_job_progress(force=True)
+
+    @staticmethod
+    def _format_elapsed(seconds):
+        if isinf(seconds) or seconds < 0:
+            return "∞"
+        hours, remainder = divmod(seconds, 3600)
+        minutes, secs = divmod(remainder, 60)
+        return f"{int(hours)}:{int(minutes):02d}:{int(secs):02d}"
+
+    def update_job_progress(self, force=False):
+        now = time.time()
+        if not force and now - self._progress_last_update < self._progress_update_delta:
+            return
+        self._progress_last_update = now
+
+        percentage = -1
+        detail = _("No job running")
+        job_label = ""
+
+        try:
+            spooler = self.context.device.spooler
+        except AttributeError:
+            spooler = None
+
+        if spooler is not None and spooler.queue:
+            job_pos = 0
+            job_len = 0
+            job_remaining = 0.0
+            job_elapsed = 0.0
+            queue_pos = 0
+            queue_len = len(spooler.queue)
+            job_active = False
+
+            for idx, spool_obj in enumerate(spooler.queue):
+                if spool_obj.is_running() and isinstance(spool_obj, LaserJob):
+                    job_active = True
+                    queue_pos = idx + 1
+                    job_label = spool_obj.label or ""
+                    if spool_obj.steps_total == 0:
+                        spool_obj.calc_steps()
+                    if spool_obj.steps_total > 0:
+                        job_len = spool_obj.steps_total
+                        job_pos = spool_obj.steps_done
+                    else:
+                        job_len = len(spool_obj.items)
+                        job_pos = spool_obj.item_index
+                    if spool_obj.time_started:
+                        job_elapsed = now - spool_obj.time_started
+                    job_estimate = spool_obj.estimate_time()
+                    if job_estimate > job_elapsed:
+                        job_remaining = job_estimate - job_elapsed
+                    elif job_pos > 0 and job_len > 0:
+                        job_remaining = job_elapsed * (job_len - job_pos) / job_pos
+                    if job_len > 0:
+                        percentage = min(100, int(100 * job_pos / job_len))
+                    break
+
+            if job_active:
+                buffer_note = ""
+                driver = getattr(spooler, "driver", None)
+                if driver is not None and hasattr(driver, "get_internal_queue_status"):
+                    internal_current, internal_total = driver.get_internal_queue_status()
+                    if internal_total:
+                        buffer_note = f" · {internal_current}/{internal_total}"
+                if job_label:
+                    detail = _("{label}: {steps}/{total} · {remaining} left{buffer}").format(
+                        label=job_label,
+                        steps=job_pos,
+                        total=job_len,
+                        remaining=self._format_elapsed(job_remaining),
+                        buffer=buffer_note,
+                    )
+                else:
+                    detail = _("Steps {steps}/{total} · {remaining} left{buffer}").format(
+                        steps=job_pos,
+                        total=job_len,
+                        remaining=self._format_elapsed(job_remaining),
+                        buffer=buffer_note,
+                    )
+                if queue_len > 1:
+                    detail += _(" · Queue {pos}/{len}").format(
+                        pos=queue_pos, len=queue_len
+                    )
+            elif queue_len > 0:
+                detail = _("Queued ({count} jobs)").format(count=queue_len)
+                percentage = 0
+
+        if percentage < 0:
+            self.gauge_job_progress.SetValue(0)
+            self.label_progress_percent.SetLabel("")
+            self.label_progress_detail.SetLabel(detail)
+        else:
+            self.gauge_job_progress.SetValue(percentage)
+            self.label_progress_percent.SetLabel(f"{percentage}%")
+            self.label_progress_detail.SetLabel(detail)
+
+        self.gauge_job_progress.Refresh()
+        self.Layout()
+
+    @signal_listener("spooler;queue")
+    @signal_listener("spooler;update")
+    @signal_listener("spooler;completed")
+    @signal_listener("driver;position")
+    @signal_listener("emulator;position")
+    @dispatch_to_main_thread
+    def on_spooler_progress(self, origin, *args):
+        if origin in ("spooler;completed", "spooler;queue"):
+            self._progress_last_update = 0.0
+        self.update_job_progress(force=origin == "spooler;completed")
+
+    @staticmethod
+    def _slider_to_factor(sliderval):
+        offset = sliderval - OVERRIDE_SLIDER_CENTER
+        return max(
+            0.1,
+            min(2.0, 1.0 + offset * (OVERRIDE_STEP_PERCENT / 100.0)),
+        )
+
+    @staticmethod
+    def _factor_to_slider(factor):
+        offset = int(round((factor - 1.0) * 100 / OVERRIDE_STEP_PERCENT))
+        return max(
+            OVERRIDE_SLIDER_MIN,
+            min(OVERRIDE_SLIDER_MAX, OVERRIDE_SLIDER_CENTER + offset),
+        )
+
+    @staticmethod
+    def _format_override_percent(factor):
+        return f"{'+' if factor > 1 else ''}{100 * (factor - 1.0):.0f}%"
+
+    @staticmethod
+    def _parse_override_percent(text):
+        s = text.strip().replace("%", "").replace(" ", "")
+        if not s:
+            return 1.0
+        if s.startswith("+"):
+            s = s[1:]
+        return max(0.1, min(2.0, 1.0 + float(s) / 100.0))
 
     def update_override_controls(self):
         def set_boundaries(slider, current_value, min_value, max_value):
@@ -418,14 +702,19 @@ class LaserPanel(wx.Panel):
             value = self.context.device.driver.power_scale
             if value != 1:
                 override = True
-            half = self.slider_size / 2
-            sliderval = int(value * half)
-            sliderval = max(1, min(self.slider_size, sliderval))
-            set_boundaries(self.slider_power, sliderval, 1, self.slider_size)
+            sliderval = self._factor_to_slider(value)
+            set_boundaries(
+                self.slider_power,
+                sliderval,
+                OVERRIDE_SLIDER_MIN,
+                OVERRIDE_SLIDER_MAX,
+            )
             self.slider_power.SetToolTip(
-                _("Increases/decreases the regular laser power by this amount.")
+                _("Adjust laser power override in {step}% steps (center = 0%).").format(
+                    step=OVERRIDE_STEP_PERCENT
+                )
                 + "\n"
-                + _("This affects running jobs, so use with care!")
+                + _("Right = more power, left = less. Affects running jobs.")
             )
             self.power_mode = "relative"
             self.on_slider_power(None)
@@ -458,10 +747,13 @@ class LaserPanel(wx.Panel):
             value = self.context.device.driver.speed_scale
             if value != 1:
                 override = True
-            half = self.slider_size / 2
-            sliderval = int(value * half)
-            sliderval = max(1, min(self.slider_size, sliderval))
-            set_boundaries(self.slider_speed, sliderval, 1, self.slider_size)
+            sliderval = self._factor_to_slider(value)
+            set_boundaries(
+                self.slider_speed,
+                sliderval,
+                OVERRIDE_SLIDER_MIN,
+                OVERRIDE_SLIDER_MAX,
+            )
             self.on_slider_speed(None)
 
         self.sizer_power.Show(flag_power)
@@ -474,22 +766,35 @@ class LaserPanel(wx.Panel):
         self.checkbox_adjust.SetValue(override)
         self.slider_power.Enable(override)
         self.slider_speed.Enable(override)
+        self.text_power_override.Enable(override and self.power_mode == "relative")
+        self.btn_set_power.Enable(override and self.power_mode == "relative")
+        self.text_speed_override.Enable(override)
+        self.btn_set_speed.Enable(override)
         self.Layout()
 
     def on_check_adjust(self, event):
         if self.checkbox_adjust.GetValue():
             self.slider_power.Enable(True)
             self.slider_speed.Enable(True)
+            self.text_speed_override.Enable(True)
+            self.btn_set_speed.Enable(True)
+            if self.power_mode == "relative":
+                self.text_power_override.Enable(True)
+                self.btn_set_power.Enable(True)
         else:
             self.slider_power.Enable(False)
             self.slider_speed.Enable(False)
+            self.text_power_override.Enable(False)
+            self.btn_set_power.Enable(False)
+            self.text_speed_override.Enable(False)
+            self.btn_set_speed.Enable(False)
             if (
                 hasattr(self.context.device.driver, "has_adjustable_power")
                 and self.context.device.driver.has_adjustable_power
             ):
                 if event is not None:
                     self.context.device.driver.set_power_scale(1.0)
-                self.slider_power.SetValue(10)
+                self.slider_power.SetValue(OVERRIDE_SLIDER_CENTER)
                 self.on_slider_power(None)
             if (
                 hasattr(self.context.device.driver, "has_adjustable_speed")
@@ -497,18 +802,17 @@ class LaserPanel(wx.Panel):
             ):
                 if event is not None:
                     self.context.device.driver.set_speed_scale(1.0)
-                self.slider_speed.SetValue(10)
+                self.slider_speed.SetValue(OVERRIDE_SLIDER_CENTER)
                 self.on_slider_speed(None)
 
     def on_slider_speed(self, event):
         sliderval = self.slider_speed.GetValue()
-        half = self.slider_size / 2
-        newvalue = sliderval - half  # -> -9 to +10
-        factor = 1 + newvalue / half
+        factor = self._slider_to_factor(sliderval)
         if event is not None:
             self.context.device.driver.set_speed_scale(factor)
-        msg = f"{'+' if factor > 1 else ''}{100 * (factor - 1.0):.0f}%"
+        msg = self._format_override_percent(factor)
         self.label_speed.SetLabel(msg)
+        self.text_speed_override.SetValue(f"{100 * (factor - 1.0):.0f}")
 
     def on_slider_power(self, event):
         sliderval = self.slider_power.GetValue()
@@ -518,13 +822,32 @@ class LaserPanel(wx.Panel):
                 self.context.device.driver.max_power_scale = sliderval
             msg = f"{sliderval}%"
         else:
-            half = self.slider_size / 2
-            newvalue = sliderval - half  # -> -9 to +10
-            factor = 1 + newvalue / half
+            factor = self._slider_to_factor(sliderval)
             if event is not None:
                 self.context.device.driver.set_power_scale(factor)
-            msg = f"{'+' if factor > 1 else ''}{100 * (factor - 1.0):.0f}%"
+            msg = self._format_override_percent(factor)
+            self.text_power_override.SetValue(f"{100 * (factor - 1.0):.0f}")
         self.label_power.SetLabel(msg)
+
+    def on_set_power_override(self, event):
+        if self.power_mode == "maximum":
+            return
+        try:
+            factor = self._parse_override_percent(self.text_power_override.GetValue())
+        except ValueError:
+            return
+        self.context.device.driver.set_power_scale(factor)
+        self.slider_power.SetValue(self._factor_to_slider(factor))
+        self.on_slider_power(None)
+
+    def on_set_speed_override(self, event):
+        try:
+            factor = self._parse_override_percent(self.text_speed_override.GetValue())
+        except ValueError:
+            return
+        self.context.device.driver.set_speed_scale(factor)
+        self.slider_speed.SetValue(self._factor_to_slider(factor))
+        self.on_slider_speed(None)
 
     def on_optimize(self, event):
         newval = bool(self.checkbox_optimize.GetValue())
@@ -729,30 +1052,13 @@ class LaserPanel(wx.Panel):
                 )
             )
             return
-        prefer_threaded = self.context.setting(bool, "prefer_threaded_mode", True)
-        prefix = "threaded " if prefer_threaded else ""
-
         busy = self.context.kernel.busyinfo
         busy.start(msg=_("Preparing Laserjob..."))
-        last_plan = self.context.laserpane_plan or self.context.planner.get_last_plan()
-        if self.context.laserpane_hold and self.context.planner.has_content(last_plan):
-            self.context(f"plan{last_plan} spool\n")
-        elif self.checkbox_optimize.GetValue():
-            new_plan = self.context.planner.get_free_plan()
-            self.context(
-                f"{prefix}plan{new_plan} clear copy preprocess validate blob preopt optimize spool\n"
-            )
-            if self.context.setting(bool, "autoshow_task_window", True):
-                self.context("window open ThreadInfo\n")
-        else:
-            new_plan = self.context.planner.get_free_plan()
-            self.context(
-                f"{prefix}plan{new_plan} clear copy preprocess validate blob spool\n"
-            )
+        queue_cutplan_to_spooler(
+            self.context, optimize=self.checkbox_optimize.GetValue()
+        )
         self.armed = False
         self.check_laser_arm()
-        if self.context.auto_spooler:
-            self.context("window open JobSpooler\n")
         busy.end()
         self.button_start_was_clicked = False
 

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -1337,7 +1337,12 @@ class JobPanel(wx.Panel):
 
             if not pathname.lower().endswith(f".{extension}"):
                 pathname += f".{extension}"
-            self.context(f'plan{plan_name} save_job "{pathname}"\n')
+            cmd = f'plan{plan_name} save_job "{pathname}"'
+            self.context(f"threaded {cmd}\n")
+            ch = self.context.kernel.channel("console")
+            ch(_("Export started in background — watch Console for progress."))
+            if self.context.setting(bool, "autoshow_task_window", True):
+                self.context("window open ThreadInfo\n")
 
     def on_hold(self, event):
         self.context.laserpane_hold = self.checkbox_hold.GetValue()

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -35,6 +35,7 @@ from meerk40t.gui.wxutils import (
     wxListCtrl,
     wxStaticText,
     dispatch_to_main_thread,
+    safe_enable_control,
 )
 from meerk40t.core.planner import STAGE_PLAN_BLOB
 from meerk40t.kernel import lookup_listener, signal_listener
@@ -1066,7 +1067,17 @@ class LaserPanel(wx.Panel):
         self.context("pause\n")
 
     def on_button_stop(self, event):  # wxGlade: LaserPanel.<event_handler>
-        self.context("estop\n")
+        if not self.button_stop.IsEnabled():
+            return
+        self.button_stop.Enable(False)
+
+        def do_estop():
+            try:
+                self.context("estop\n")
+            finally:
+                wx.CallAfter(safe_enable_control, self.button_stop, True)
+
+        self.context.threaded(do_estop, thread_name="LaserPanel-estop")
 
     def on_button_outline(self, event):  # wxGlade: LaserPanel.<event_handler>
         try:

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -1232,6 +1232,20 @@ class MaterialPanel(ScrolledPanel):
 
         return handler
 
+    def _entry_category_label(self, entry, sort_key):
+        """Display label for tree/delete matching (laser is stored as int index)."""
+        if sort_key == "laser":
+            ltype = entry.get("laser")
+            if ltype is None:
+                ltype = 0
+            if 0 <= ltype < len(self.laser_choices):
+                return self.laser_choices[ltype]
+            return "???"
+        val = entry.get(sort_key, "")
+        if val is None or val == "":
+            return _("No " + sort_key)
+        return str(val).replace("_", " ")
+
     def _delete_according_to_key(self, keytype: int, primary: str, secondary: str):
         if self.categorisation == 1:
             # lasertype
@@ -1251,12 +1265,14 @@ class MaterialPanel(ScrolledPanel):
             to_delete = False
             if keytype == 0:
                 to_delete = True
-            elif keytype == 1 and entry[sort_key_primary].replace("_", " ") == primary:
+            elif keytype == 1 and self._entry_category_label(
+                entry, sort_key_primary
+            ) == primary:
                 to_delete = True
             elif (
                 keytype == 2
-                and entry[sort_key_primary].replace("_", " ") == primary
-                and entry[sort_key_secondary].replace("_", " ") == secondary
+                and self._entry_category_label(entry, sort_key_primary) == primary
+                and self._entry_category_label(entry, sort_key_secondary) == secondary
             ):
                 to_delete = True
             if to_delete:
@@ -1280,16 +1296,13 @@ class MaterialPanel(ScrolledPanel):
                 busy.change(msg=f"{idx + 1}/{len(self.display_list)}", keep=1)
 
                 to_delete = False
-                prim_key = (
-                    entry[sort_key_primary].replace("_", " ")
-                    if entry[sort_key_primary]
-                    else _("No " + sort_key_primary)
-                )
+                prim_key = self._entry_category_label(entry, sort_key_primary)
+                sec_key = self._entry_category_label(entry, sort_key_secondary)
                 if keytype == 0:
                     to_delete = True
                 elif keytype == 1 and prim_key == primary:
                     to_delete = True
-                elif keytype == 2 and prim_key == primary and prim_key == secondary:
+                elif keytype == 2 and prim_key == primary and sec_key == secondary:
                     to_delete = True
 
                 # print (f"Keytype={keytype}, primary: {prim_key} vs {primary}, secondary: {entry[sort_key_secondary].replace('_', ' ')} vs {secondary} -> {to_delete}")

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -13,6 +13,7 @@ from meerk40t.core.node.op_image import ImageOpNode
 from meerk40t.core.node.op_raster import RasterOpNode
 from meerk40t.core.units import UNITS_PER_PIXEL, Angle, Length
 from meerk40t.gui.icons import get_default_icon_size, icons8_detective
+from meerk40t.gui.laserpanel import queue_cutplan_to_spooler
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.wxutils import (
     StaticBoxSizer,
@@ -385,6 +386,8 @@ class TemplatePanel(wx.Panel):
         self.button_create.SetBitmap(
             icons8_detective.GetBitmap(resize=0.5 * get_default_icon_size(self.context))
         )
+        self.button_queue = wxButton(self, wx.ID_ANY, _("Queue to Spooler"))
+        self.button_queue.Enable(False)
 
         sizer_main = wx.BoxSizer(wx.VERTICAL)
         sizer_param_optype = wx.BoxSizer(wx.HORIZONTAL)
@@ -565,6 +568,7 @@ class TemplatePanel(wx.Panel):
         sizer_main.Add(sizer_param_optype, 0, wx.EXPAND, 0)
         sizer_main.Add(sizer_param_xy, 0, wx.EXPAND, 0)
         sizer_main.Add(self.button_create, 0, wx.EXPAND, 0)
+        sizer_main.Add(self.button_queue, 0, wx.EXPAND, 0)
 
         sizer_info = StaticBoxSizer(self, wx.ID_ANY, _("How to use it"), wx.VERTICAL)
         infomsg = _("To provide the best burning results, the parameters of operations")
@@ -599,6 +603,12 @@ class TemplatePanel(wx.Panel):
         sizer_main.Add(sizer_info, 1, wx.EXPAND, 0)
 
         self.button_create.SetToolTip(_("Create a grid with your values"))
+        self.button_queue.SetToolTip(
+            _(
+                "Plan the test pattern and add it to the Job Spooler. "
+                "Connect the laser first. Does not run the job — use Start in Job Spooler."
+            )
+        )
         s = _("Operation type for which the testpattern will be generated")
         s += "\n" + _(
             "You can define the common parameters for this operation in the other tabs on top of this window"
@@ -669,6 +679,7 @@ class TemplatePanel(wx.Panel):
         )
 
         self.button_create.Bind(wx.EVT_BUTTON, self.on_button_create_pattern)
+        self.button_queue.Bind(wx.EVT_BUTTON, self.on_button_queue_to_spooler)
         self.combo_ops.Bind(wx.EVT_COMBOBOX, self.set_param_according_to_op)
         self.text_min_1.Bind(wx.EVT_TEXT, self.validate_input)
         self.text_max_1.Bind(wx.EVT_TEXT, self.validate_input)
@@ -782,9 +793,35 @@ class TemplatePanel(wx.Panel):
         self.context.device.setting(bool, "use_percent_for_power_display", False)
         return self.context.device.use_percent_for_power_display
 
+    def cap_power_for_display(self, value):
+        """Laser power: 0–100% display (= 0–1000 internal). GRBL cannot exceed 100%."""
+        if not self.use_percent():
+            return value
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return value
+        return max(0.0, min(100.0, v))
+
     def use_mm_min(self):
         self.context.device.setting(bool, "use_mm_min_for_speed_display", False)
         return self.context.device.use_mm_min_for_speed_display
+
+    def select_operation_for_node(self, node):
+        """Match the Generator operation combo to a tree operation type."""
+        if node is None:
+            return
+        type_to_index = {
+            "op cut": 0,
+            "op engrave": 1,
+            "op raster": 2,
+            "op image": 3,
+            "op dots": 1,
+        }
+        idx = type_to_index.get(getattr(node, "type", None), -1)
+        if 0 <= idx < self.combo_ops.GetCount() and self.combo_ops.GetSelection() != idx:
+            self.combo_ops.SetSelection(idx)
+            self.set_param_according_to_op(None)
 
     def set_param_according_to_op(self, event):
         def preset_image_dpi(node=None):
@@ -1257,6 +1294,23 @@ class TemplatePanel(wx.Panel):
         # self.on_combo_1(None)
         # self.on_combo_2(None)
 
+    def on_button_queue_to_spooler(self, event):
+        optimize = getattr(self.context.planner, "do_optimization", True)
+        if queue_cutplan_to_spooler(
+            self.context, optimize=optimize, hold_policy="never"
+        ):
+            prefer_threaded = self.context.setting(bool, "prefer_threaded_mode", True)
+            if prefer_threaded:
+                wx.MessageBox(
+                    _(
+                        "The job is being prepared in the background.\n\n"
+                        "Wait a few seconds, then open Job Spooler and press Start there "
+                        "(or Laser tab → Arm → Start)."
+                    ),
+                    _("Queue to Spooler"),
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+
     def on_button_create_pattern(self, event):
         def make_color(idx1, max1, idx2, max2, aspect1, growing1, aspect2, growing2):
             if self._freecolor:
@@ -1566,7 +1620,10 @@ class TemplatePanel(wx.Panel):
                             prepper(op)
                         v = f"{value}{unit}" if keep_unit else value
                         if ptype == "power" and self.use_percent():
-                            v = v if keep_unit else float(v) * 10.0
+                            if keep_unit:
+                                pass
+                            else:
+                                v = float(self.cap_power_for_display(v)) * 10.0
                         if ptype == "speed" and self.use_mm_min():
                             v = v if keep_unit else float(v) / 60.0
                         if hasattr(op, ptype):
@@ -1744,9 +1801,15 @@ class TemplatePanel(wx.Panel):
                 if param_unit == "deg":
                     min_value = float(text_min)
                     max_value = float(text_max)
-                elif param_unit == "ppi":
+                elif param_unit in ("ppi", "%"):
                     min_value = max(min_value, 0)
-                    max_value = min(max_value, 1000)
+                    if (
+                        self.parameters[idx][0] == "power"
+                        and self.use_percent()
+                    ):
+                        max_value = min(max_value, 100)
+                    else:
+                        max_value = min(max_value, 1000)
                 elif param_unit == "%":
                     min_value = max(min_value, 0)
                     max_value = min(max_value, 100)
@@ -1795,6 +1858,7 @@ class TemplatePanel(wx.Panel):
         self.context.signal("rebuild_tree")
         self.context.signal("refresh_scene", "Scene")
         self.save_settings()
+        self.button_queue.Enable(self.context.elements.have_burnable_elements())
 
     def setup_settings(self):
         self.context.setting(int, "template_optype", 0)
@@ -2075,7 +2139,7 @@ class TemplateTool(MWindow):
 
         return None
 
-    def set_node(self, primary_node, secondary_node=None):
+    def set_node(self, primary_node, secondary_node=None, focus_properties=False):
         def sort_priority(prop):
             prop_sheet, node = prop
             return (
@@ -2168,8 +2232,10 @@ class TemplateTool(MWindow):
 
         self.Layout()
         self.Thaw()
-        self.notebook_main.SetSelection(1)
-        self.notebook_main.SetSelection(0)
+        if focus_properties and self.notebook_main.GetPageCount() > 1:
+            self.notebook_main.SetSelection(1)
+        else:
+            self.notebook_main.SetSelection(0)
         del busy
 
     def window_open(self):

--- a/meerk40t/gui/navigationpanels.py
+++ b/meerk40t/gui/navigationpanels.py
@@ -232,6 +232,28 @@ def register_panel_navigation(window, context):
     context.register("pane/jogdist", pane)
 
 
+def _confined_disable_warning(parent):
+    """Ask before allowing jogs outside the configured bed size."""
+    dlg = wx.MessageDialog(
+        parent,
+        _(
+            "Turning this off allows the laser to be jogged outside the bed size "
+            "set under Device settings.\n\n"
+            "On GRBL controllers this can send moves past $130/$131 max travel, "
+            "trigger alarms, or stress stepper drivers — for example when jogging "
+            "to a mechanical limit.\n\n"
+            "Only disable if you are sure about the safe travel area. Keep bed "
+            "size and $130/$131 correct on the board."
+        ),
+        _("Disable bed movement limit?"),
+        wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+    )
+    try:
+        return dlg.ShowModal() == wx.ID_YES
+    finally:
+        dlg.Destroy()
+
+
 def get_movement(context, dx, dy):
     device = context.device
     _confined = context.confined
@@ -1166,6 +1188,8 @@ class Jog(wx.Panel):
         )
         self.Bind(wx.EVT_BUTTON, self.on_button_confinement, self.button_confine)
         # end wxGlade
+        self.context.confined = True
+        self.is_confined = True
 
     def __set_properties(self):
         # begin wxGlade: Jog.__set_properties
@@ -1368,8 +1392,8 @@ class Jog(wx.Panel):
         except AttributeError:
             value = False
 
-        self.context.confined = value
-        if value == 0:
+        self.context.confined = bool(value)
+        if not value:
             self.button_confine.SetBitmap(
                 icon_fence_open.GetBitmap(
                     resize=self.resize_factor, resolution=self.resolution
@@ -1389,13 +1413,18 @@ class Jog(wx.Panel):
             # self.context("confine 1")
 
     def on_button_confinement(self, event=None):  # wxGlade: Navigation.<event_handler>
-        self.is_confined = not self.is_confined
+        if self.context.confined:
+            if not _confined_disable_warning(self):
+                return
+            self.is_confined = False
+        else:
+            self.is_confined = True
         try:
             current_x, current_y = self.context.device.current
         except AttributeError:
             self.is_confined = False
             return
-        if not self.is_confined:
+        if not self.context.confined:
             return
         min_x = 0
         max_x = float(Length(self.context.device.view.width))
@@ -1423,7 +1452,11 @@ class Jog(wx.Panel):
     def on_button_navigate_home(
         self, event=None
     ):  # wxGlade: Navigation.<event_handler>
-        self.context(".home\n")
+        device = self.context.device
+        if getattr(device, "has_endstops", False):
+            self.context("physical_home\n")
+        else:
+            self.context(".home\n")
 
     def on_button_navigate_physical_home(self, event=None):
         physical = False

--- a/meerk40t/gui/plugin.py
+++ b/meerk40t/gui/plugin.py
@@ -103,6 +103,8 @@ and a wxpython version <= 4.1.1."""
         ]
         kernel.register_choices("units", choices)
     elif lifecycle == "postboot":
+        kernel.root.setting(bool, "confined", True)
+        kernel.root.confined = True
         choices = [
             {
                 "attr": "supress_non_visible",
@@ -257,6 +259,40 @@ and a wxpython version <= 4.1.1."""
                 # Hint for translation _("Tooltips")
                 "section": "Tooltips",
                 "signals": "restart",
+            },
+            {
+                "attr": "ribbon_tooltip_delay_ms",
+                "object": kernel.root,
+                "default": 2000,
+                "type": int,
+                "style": "flat",
+                "label": _("Ribbon: hover before description"),
+                "trailer": "ms",
+                "tip": _(
+                    "How long to hover over a ribbon toolbar button before its "
+                    "tooltip appears. The tooltip combines the short hint and any "
+                    "extended help text for that button. Other windows still use "
+                    "'ToolTip delay' below."
+                ),
+                "page": "Gui",
+                "section": "Tooltips",
+            },
+            {
+                "attr": "ribbon_verbose_hover_help",
+                "object": kernel.root,
+                "default": True,
+                "type": bool,
+                "label": _("Long UI descriptions (ribbon + menus)"),
+                "tip": _(
+                    "When enabled, ribbon toolbar buttons use the ribbon hover delay and "
+                    "may show extended help in the tooltip. Tree and scene context menus "
+                    "use the same flag: menu entries show full help text in the status bar "
+                    "while you highlight them, and may use the function docstring if no "
+                    "help was defined. Also toggled from Panes → Help. When disabled, "
+                    "ribbon tooltips match the normal ToolTip delay and show only the short hint."
+                ),
+                "page": "Gui",
+                "section": "Tooltips",
             },
             {
                 "attr": "tooltip_autopop",

--- a/meerk40t/gui/propertypanels/operationpropertymain.py
+++ b/meerk40t/gui/propertypanels/operationpropertymain.py
@@ -603,7 +603,19 @@ class SpeedPpiPanel(wx.Panel):
                 set_ctrl_value(self.text_speed, str(self.operation.speed))
         if self.operation.power is not None:
             if self.use_percent:
-                set_ctrl_value(self.text_power, f"{self.operation.power / 10.0:.0f}")
+                display_pct = self.operation.power / 10.0
+                if display_pct > 100:
+                    set_ctrl_value(self.text_power, "100")
+                    self.text_power.SetToolTip(
+                        _(
+                            "This operation is stored above 100% ({stored:.0f}%). "
+                            "The laser maximum is 100% — the field is capped here. "
+                            "Lower it and press Enter, or regenerate the Parameter-Test "
+                            "grid with power max ≤ 100."
+                        ).format(stored=display_pct)
+                    )
+                else:
+                    set_ctrl_value(self.text_power, f"{display_pct:.0f}")
             else:
                 set_ctrl_value(self.text_power, f"{self.operation.power:.0f}")
             self.update_power_label()

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -892,6 +892,42 @@ class RibbonPage:
         self.parent.modified()
 
 
+def _ribbon_button_description(button):
+    """Text for the ribbon hover tooltip: short tip plus extended help when present."""
+    if button is None:
+        return ""
+    tip = button.tip
+    if callable(tip):
+        try:
+            tip = tip()
+        except Exception:
+            tip = ""
+    if tip is None:
+        tip = ""
+    help_text = button.help
+    if help_text is None:
+        help_text = ""
+    elif callable(help_text):
+        try:
+            help_text = help_text()
+        except Exception:
+            help_text = ""
+    help_text = str(help_text).strip()
+    tip = str(tip).strip()
+    if help_text:
+        if tip:
+            return f"{tip}\n\n{help_text}"
+        return help_text
+    return tip
+
+
+def _ribbon_hover_delay_ms(context):
+    """Delay before ribbon tooltip; long + rich when verbose help is on."""
+    if context.setting(bool, "ribbon_verbose_hover_help", True):
+        return context.setting(int, "ribbon_tooltip_delay_ms", 2000)
+    return context.setting(int, "tooltip_delay", 100)
+
+
 class RibbonBarPanel(wx.Control):
     """RibbonBarPanel - User interface panel for laser cutting operations
     **Technical Purpose:**
@@ -942,8 +978,9 @@ class RibbonBarPanel(wx.Control):
         self._tooltip = ""
         jobname = f"tooltip_ribbon_bar_{self.GetId()}"
         #  print (f"Requesting job with name: '{jobname}'")
-        tooltip_delay = self.context.setting(int, "tooltip_delay", 100)
-        interval = tooltip_delay / 1000.0
+        # Ribbon uses its own delay so global wx.ToolTip.SetDelay stays fast for other controls.
+        ribbon_delay_ms = _ribbon_hover_delay_ms(self.context)
+        interval = max(0.05, ribbon_delay_ms / 1000.0)
         self._tooltip_job = Job(
             process=self._exec_tooltip_job,
             job_name=jobname,
@@ -1006,6 +1043,8 @@ class RibbonBarPanel(wx.Control):
 
     def start_tooltip_job(self):
         # print (f"Schedule a job with {self._tooltip_job.interval:.2f}sec")
+        ribbon_delay_ms = _ribbon_hover_delay_ms(self.context)
+        self._tooltip_job.interval = max(0.05, ribbon_delay_ms / 1000.0)
         self.context.schedule(self._tooltip_job)
 
     def _exec_tooltip_job(self):
@@ -1051,7 +1090,18 @@ class RibbonBarPanel(wx.Control):
         if hover is None:
             hover = self._button_at_position(pos, use_all=True)
         if hover is not None:
-            self.SetToolTip(hover.tip)
+            if self.context.setting(bool, "ribbon_verbose_hover_help", True):
+                self.SetToolTip(_ribbon_button_description(hover))
+            else:
+                tip = hover.tip
+                if callable(tip):
+                    try:
+                        tip = tip()
+                    except Exception:
+                        tip = ""
+                if tip is None:
+                    tip = ""
+                self.SetToolTip(str(tip))
             hhelp = hover.help
             if hhelp is None:
                 hhelp = ""

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -810,6 +810,9 @@ class Scene(Module, Job):
             gc.SetFont(font, wx.BLACK)
             self._draw_scene_layers(gc, 0, LAYER_GENERIC_NODES)
             gc.Destroy()
+            from meerk40t.camera.camera import composite_bed_photo_on_device_dc
+
+            composite_bed_photo_on_device_dc(self, dc)
             dc.SelectObject(wx.NullBitmap)
             self._cache.mark_background_valid()
             render_time = time.perf_counter() - start_time

--- a/meerk40t/gui/scene/scene.py
+++ b/meerk40t/gui/scene/scene.py
@@ -288,7 +288,17 @@ class LayerCache:
     def ensure_size(self, width, height):
         """Allocate (or reallocate) cache bitmaps when the window size changes.
         A size change invalidates all four caches."""
-        if self._size == (width, height):
+        # wx.Bitmap(0, 0) is invalid on Windows; startup ClientSize can be 0×0 while
+        # _size is already (0, 0) — do not skip allocation and leave bitmaps None.
+        if width <= 0:
+            width = 1
+        if height <= 0:
+            height = 1
+        if (
+            self._size == (width, height)
+            and self._bg_bitmap is not None
+            and self._bg_bitmap.IsOk()
+        ):
             return
         self._size = (width, height)
         self._bg_bitmap = wx.Bitmap(width, height)
@@ -738,6 +748,8 @@ class Scene(Module, Job):
             buf = self.gui.scene_buffer
 
         w, h = self.gui.ClientSize
+        if w <= 0 or h <= 0:
+            return
 
         # Reset clip rect (no partial invalidation with multi-level cache)
         self.clip.SetX(0)
@@ -776,6 +788,11 @@ class Scene(Module, Job):
 
         # --- Cache A: background (bg color + LAYER_BACKGROUND) ---
         if not self._cache.background_valid:
+            if (
+                self._cache.background_bitmap is None
+                or not self._cache.background_bitmap.IsOk()
+            ):
+                return
             start_time = time.perf_counter()
             dc = wx.MemoryDC()
             dc.SelectObject(self._cache.background_bitmap)

--- a/meerk40t/gui/scene/scenepanel.py
+++ b/meerk40t/gui/scene/scenepanel.py
@@ -1,7 +1,11 @@
 import wx
 
 from meerk40t.gui.scene.scene import RESPONSE_ABORT, RESPONSE_CONSUME, RESPONSE_DROP
-from meerk40t.gui.wxutils import get_key_name
+from meerk40t.gui.wxutils import (
+    emit_tree_selected_delete,
+    get_key_name,
+    key_triggers_tree_selected_delete,
+)
 
 
 class ScenePanel(wx.Panel):
@@ -218,6 +222,17 @@ class ScenePanel(wx.Panel):
             if not ignore and self.context.bind.untrigger(literal):
                 if self._keybind_channel:
                     self._keybind_channel(f"Scene key_up: {literal} executed.")
+            elif (
+                not ignore
+                and literal not in self.context.bind.triggered
+                and key_triggers_tree_selected_delete(literal)
+                and emit_tree_selected_delete(self.context)
+            ):
+                consumed = True
+                if self._keybind_channel:
+                    self._keybind_channel(
+                        f"Scene key_up: {literal} tree selected delete."
+                    )
             else:
                 if self._keybind_channel:
                     if ignore:

--- a/meerk40t/gui/scenewidgets/bedwidget.py
+++ b/meerk40t/gui/scenewidgets/bedwidget.py
@@ -16,6 +16,27 @@ from meerk40t.gui.scene.sceneconst import (
 from meerk40t.gui.scene.widget import Widget
 
 
+def _device_label(context):
+    try:
+        return context.device.label
+    except AttributeError:
+        try:
+            return context.root.device.label
+        except AttributeError:
+            return "__default__"
+
+
+def _bed_rect(x, y, width, height):
+    """Normalize signed bed width/height (e.g. flip_y) for wx draw calls."""
+    if height < 0:
+        y = y + height
+        height = -height
+    if width < 0:
+        x = x + width
+        width = -width
+    return x, y, width, height
+
+
 class BedWidget(Widget):
     """
     Bed Widget Interface Widget
@@ -31,25 +52,27 @@ class BedWidget(Widget):
 
     @property
     def background(self):
+        devlabel = _device_label(self.scene.context)
+        if devlabel in self._background:
+            return self._background[devlabel]
+        if "__default__" in self._background:
+            return self._background["__default__"]
         try:
-            devlabel = self.scene.context.device.label
-            if devlabel in self._background:
-                return self._background[devlabel]
+            if self.scene.has_background and self.scene.active_background is not None:
+                return self.scene.active_background
         except AttributeError:
             pass
         return None
 
     @background.setter
     def background(self, value):
-        try:
-            devlabel = self.scene.context.device.label
-        except AttributeError:
-            return
-
+        devlabel = _device_label(self.scene.context)
         if value is None:
             self._background.pop(devlabel, None)
+            self._background.pop("__default__", None)
         else:
             self._background[devlabel] = value
+            self._background["__default__"] = value
 
     def hit(self):
         if self.background is None:
@@ -83,26 +106,32 @@ class BedWidget(Widget):
         """
         Draws the background on the scene.
         """
-        # print ("Bedwidget draw %s" % self.name)
-        if self.scene.context.draw_mode & DRAW_MODE_BACKGROUND == 0:
-            context = self.scene.context
-            try:
-                unit_width = context.device.view.unit_width
-                unit_height = context.device.view.unit_height
-            except AttributeError:
-                return
-            background = self.background
-            if background is None:
-                brush = wx.Brush(
-                    colour=self.scene.colors.color_bed, style=wx.BRUSHSTYLE_SOLID
-                )
-                gc.SetBrush(brush)
-                gc.DrawRectangle(0, 0, unit_width, unit_height)
-            elif isinstance(background, int):
-                gc.SetBrush(wx.Brush(wx.Colour(swizzlecolor(background))))
-                gc.DrawRectangle(0, 0, unit_width, unit_height)
-            else:
-                gc.DrawBitmap(background, 0, 0, unit_width, unit_height)
+        context = self.scene.context
+        try:
+            unit_width = context.device.view.unit_width
+            unit_height = context.device.view.unit_height
+        except AttributeError:
+            return
+
+        background = self.background
+        if background is not None and not isinstance(background, int):
+            # Photo is composited in scene.Scene._update_buffer_ui_thread via
+            # composite_bed_photo_on_device_dc (MemoryDC); skip GC bitmap here.
+            return
+
+        if context.draw_mode & DRAW_MODE_BACKGROUND != 0:
+            return
+
+        bed_x, bed_y, bed_w, bed_h = _bed_rect(0, 0, unit_width, unit_height)
+        if background is None:
+            brush = wx.Brush(
+                colour=self.scene.colors.color_bed, style=wx.BRUSHSTYLE_SOLID
+            )
+            gc.SetBrush(brush)
+            gc.DrawRectangle(bed_x, bed_y, bed_w, bed_h)
+        elif isinstance(background, int):
+            gc.SetBrush(wx.Brush(wx.Colour(swizzlecolor(background))))
+            gc.DrawRectangle(bed_x, bed_y, bed_w, bed_h)
 
     def signal(self, signal, *args, **kwargs):
         """

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -152,7 +152,9 @@ class ElementsWidget(Widget):
                     self.scene.context("tool none\n")
                     return RESPONSE_CONSUME
                 else:
-                    self.scene.context.signal("scene_right_click")
+                    self.scene.context.signal(
+                        "scene_right_click", space_pos[0], space_pos[1]
+                    )
                     return RESPONSE_CONSUME
         elif event_type == "rightdown":  # any modifier
             # if self.scene.context.use_toolmenu:

--- a/meerk40t/gui/scenewidgets/elementswidget.py
+++ b/meerk40t/gui/scenewidgets/elementswidget.py
@@ -162,6 +162,9 @@ class ElementsWidget(Widget):
             #     return RESPONSE_CONSUME
             return RESPONSE_CHAIN
         elif event_type == "leftclick":
+            # If a creation/modification tool is active, do not steal the click for selection.
+            if self.scene.pane.active_tool != "none":
+                return RESPONSE_CHAIN
             if self.scene.pane.modif_active:
                 return RESPONSE_CHAIN
             keep_old = "shift" in modifiers

--- a/meerk40t/gui/scenewidgets/rectselectwidget.py
+++ b/meerk40t/gui/scenewidgets/rectselectwidget.py
@@ -498,6 +498,9 @@ class RectSelectWidget(Widget):
             self.modifiers = []
 
         elements = self.scene.context.elements
+        if getattr(self.scene.pane, "active_tool", "none") != "none":
+            if event_type in ("leftdown", "leftup", "leftclick", "move", "hover"):
+                return RESPONSE_CHAIN
         if event_type == "leftdown":
             check_leftdown(space_pos)
             # print ("RectSelect consumed leftdown")

--- a/meerk40t/gui/scenewidgets/selectionwidget.py
+++ b/meerk40t/gui/scenewidgets/selectionwidget.py
@@ -144,6 +144,8 @@ def process_event(
         if widget.scene.pane.tool_active:
             # print ("ignore")
             return RESPONSE_CHAIN
+        if getattr(widget.scene.pane, "active_tool", "none") != "none":
+            return RESPONSE_CHAIN
 
         single_modifier = (
             modifiers
@@ -3659,8 +3661,8 @@ class SelectionWidget(Widget):
                         self.scene.context.signal("statusmsg", "")
 
         elif event_type in ("leftdown", "leftup", "leftclick", "move"):
-            # self.scene.pane.tool_active = False
-            pass
+            if getattr(self.scene.pane, "active_tool", "none") != "none":
+                return RESPONSE_CHAIN
         elif event_type == "rightdown":
             self.scene.pane.tool_active = False
             self.scene.pane.modif_active = False

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -2616,7 +2616,7 @@ class Simulation(MWindow):
     @signal_listener("background")
     @dispatch_to_main_thread
     def on_background_signal(self, origin, background, **kwargs):
-        if background is not None:
+        if background is not None and not isinstance(background, wx.Bitmap):
             background = wx.Bitmap.FromBuffer(*background)
         self.panel.widget_scene._signal_widget(
             self.panel.widget_scene.widget_root, "background", background

--- a/meerk40t/gui/simulation.py
+++ b/meerk40t/gui/simulation.py
@@ -815,6 +815,7 @@ class SimulationPanel(wx.Panel, Job):
 
         # Initialize core attributes
         self.retries = 0
+        self._cancel_cache_calculate = False
         self.plan_name = plan_name
         self.auto_clear = auto_clear
 
@@ -1035,6 +1036,15 @@ class SimulationPanel(wx.Panel, Job):
         )
         self.wait_info.Hide()
 
+        self.button_cancel_calculate = wxButton(self, wx.ID_ANY, _("Stop calculating"))
+        self.button_cancel_calculate.SetToolTip(
+            _(
+                "Stop building simulation preview paths. The plan stays loaded; "
+                "Recalculate rebuilds caches. Cancellation applies between cuts."
+            )
+        )
+        self.button_cancel_calculate.Hide()
+
     def _setup_layout(self):
         """Setup the layout of all UI components."""
         self.__set_properties()
@@ -1046,6 +1056,11 @@ class SimulationPanel(wx.Panel, Job):
         self.Bind(wx.EVT_BUTTON, self.on_button_play, self.button_play)
         self.Bind(wx.EVT_SLIDER, self.on_slider_playback, self.slider_playbackspeed)
         self.Bind(wx.EVT_BUTTON, self.on_button_spool, self.button_spool)
+        self.Bind(
+            wx.EVT_BUTTON,
+            self.on_button_cancel_calculate,
+            self.button_cancel_calculate,
+        )
         self.Bind(wx.EVT_RIGHT_DOWN, self.on_mouse_right_down)
         self.Bind(wx.EVT_RADIOBUTTON, self.on_radio_playback_mode, self.radio_cut)
         self.Bind(
@@ -1306,6 +1321,7 @@ class SimulationPanel(wx.Panel, Job):
         h_sizer_buttons.Add(sizer_speed_options, 1, wx.EXPAND, 0)
         # sizer_execute.Add(self.combo_device, 0, wx.EXPAND, 0)
         sizer_execute.Add(self.button_spool, 1, wx.EXPAND, 0)
+        sizer_execute.Add(self.button_cancel_calculate, 0, wx.EXPAND, 0)
         h_sizer_buttons.Add(sizer_execute, 1, wx.EXPAND, 0)
         v_sizer_main.Add(self.wait_info, 0, wx.EXPAND, 0)
         v_sizer_main.Add(self.hscene_sizer, 1, wx.EXPAND, 0)
@@ -1802,6 +1818,25 @@ class SimulationPanel(wx.Panel, Job):
         else:
             self.options_optimize.Enable(False)
 
+    def on_button_cancel_calculate(self, event=None):
+        self._cancel_cache_calculate = True
+        if event is not None:
+            event.Skip()
+
+    def _finish_cache_calculate_ui(self, spool_label):
+        try:
+            self.button_cancel_calculate.Hide()
+            self.button_cancel_calculate.Enable(False)
+            self.button_spool.SetLabel(spool_label)
+            self.button_spool.Enable(True)
+        except RuntimeError:
+            pass
+        try:
+            self.Layout()
+            wx.YieldIfNeeded()
+        except RuntimeError:
+            pass
+
     def cache_updater(self):
         try:
             self.button_spool.Enable(False)
@@ -1809,29 +1844,40 @@ class SimulationPanel(wx.Panel, Job):
             # Control no longer existant
             return
         msg = self.button_spool.GetLabel()
-        self.button_spool.SetLabel(_("Calculating"))
-        for cut in self.cutcode:
-            if isinstance(cut, (RasterCut, PlotCut)):
-                if hasattr(cut, "_plotcache") and cut._plotcache is not None:
-                    continue
-                if isinstance(cut, RasterCut):
-                    try:
-                        cut._plotcache = list(cut.plot.plot())
-                    except MemoryError:
-                        cut._plotcache = None
-                elif isinstance(cut, PlotCut):
-                    try:
-                        cut._plotcache = list(cut.plot)
-                    except MemoryError:
-                        cut._plotcache = None
-                self.context.signal("refresh_scene", self.widget_scene.name)
-        self.reload_statistics()
+        self._cancel_cache_calculate = False
         try:
-            self.button_spool.SetLabel(msg)
-            self.button_spool.Enable(True)
+            self.button_spool.SetLabel(_("Calculating"))
+            self.button_cancel_calculate.Show()
+            self.button_cancel_calculate.Enable(True)
+            self.Layout()
+            wx.YieldIfNeeded()
         except RuntimeError:
-            # No longer existing
-            pass
+            self._finish_cache_calculate_ui(msg)
+            return
+
+        try:
+            for cut in self.cutcode:
+                wx.YieldIfNeeded()
+                if self._cancel_cache_calculate:
+                    break
+                if isinstance(cut, (RasterCut, PlotCut)):
+                    if hasattr(cut, "_plotcache") and cut._plotcache is not None:
+                        continue
+                    if isinstance(cut, RasterCut):
+                        try:
+                            cut._plotcache = list(cut.plot.plot())
+                        except MemoryError:
+                            cut._plotcache = None
+                    elif isinstance(cut, PlotCut):
+                        try:
+                            cut._plotcache = list(cut.plot)
+                        except MemoryError:
+                            cut._plotcache = None
+                    self.context.signal("refresh_scene", self.widget_scene.name)
+                    wx.YieldIfNeeded()
+            self.reload_statistics()
+        finally:
+            self._finish_cache_calculate_ui(msg)
 
     def update_fields(self):
         def len_str(value):

--- a/meerk40t/gui/spoolerpanel.py
+++ b/meerk40t/gui/spoolerpanel.py
@@ -23,6 +23,7 @@ from meerk40t.gui.wxutils import (
     wxListCtrl,
     wxStaticText,
     dispatch_to_main_thread,
+    safe_enable_control,
 )
 from meerk40t.kernel import Job, signal_listener
 
@@ -516,7 +517,17 @@ class SpoolerPanel(wx.Panel):
         self.context("pause\n")
 
     def on_button_stop(self, event):  # wxGlade: LaserPanel.<event_handler>
-        self.context("estop\n")
+        if not self.button_stop.IsEnabled():
+            return
+        self.button_stop.Enable(False)
+
+        def do_estop():
+            try:
+                self.context("estop\n")
+            finally:
+                wx.CallAfter(safe_enable_control, self.button_stop, True)
+
+        self.context.threaded(do_estop, thread_name="JobSpooler-estop")
 
     def on_combo_device(self, event=None):  # wxGlade: Spooler.<event_handler>
         index = self.combo_device.GetSelection()
@@ -776,7 +787,7 @@ class SpoolerPanel(wx.Panel):
 
                     # STEPS
                     try:
-                        if spool_obj.steps_total == 0:
+                        if spool_obj.steps_total == 0 and spool_obj.status != "Running":
                             spool_obj.calc_steps()
                         info_s = f"{spool_obj.steps_done}/{spool_obj.steps_total}"
                         if hasattr(spooler, "driver"):

--- a/meerk40t/gui/tips.py
+++ b/meerk40t/gui/tips.py
@@ -335,6 +335,9 @@ class TipPanel(wx.Panel):
     def on_check_startup(self, event):
         state = self.check_startup.GetValue()
         self.context.show_tips = state
+        # Persist into the kernel config dict immediately so shutdown save includes it
+        # (assigning the attribute alone can miss a flush snapshot for this context).
+        self.context.write_persistent("show_tips", state)
 
     def on_tip_prev(self, event):
         self.current_tip -= 1

--- a/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
+++ b/meerk40t/gui/toolwidgets/toolpointlistbuilder.py
@@ -146,18 +146,20 @@ class PointListTool(ToolWidget):
             response = RESPONSE_CONSUME
         elif event_type == "leftdown":
             self.scene.pane.tool_active = True
-            if nearest_snap is None:
-                self.mouse_position = space_pos[0], space_pos[1]
-            else:
-                self.mouse_position = nearest_snap[0], nearest_snap[1]
+            # Preview tracks the raw cursor; snap is applied only on leftclick.
+            self.mouse_position = space_pos[0], space_pos[1]
             if self.point_series:
                 self.scene.request_refresh()
             response = RESPONSE_CONSUME
         elif event_type in ("leftup", "move", "hover"):
-            if nearest_snap is None:
-                self.mouse_position = space_pos[0], space_pos[1]
-            else:
-                self.mouse_position = nearest_snap[0], nearest_snap[1]
+            # Let middle-button drag pan the scene while a point tool is active.
+            if (
+                event_type == "move"
+                and modifiers is not None
+                and "m_middle" in modifiers
+            ):
+                return RESPONSE_CHAIN
+            self.mouse_position = space_pos[0], space_pos[1]
             if self.point_series:
                 self.scene.request_refresh()
                 response = RESPONSE_CONSUME

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -88,6 +88,7 @@ from .propertypanels.wobbleproperty import WobblePropertyPanel
 from .simpleui import SimpleUI
 from .simulation import Simulation
 from .tips import Tips
+from .batchrun import BatchRunWindow
 from .wordlisteditor import WordlistEditor
 from .wxmmain import MeerK40t
 
@@ -1124,6 +1125,7 @@ class wxMeerK40t(wx.App, Module):
         kernel.register("window/About", About)
         kernel.register("window/Keymap", Keymap)
         kernel.register("window/Wordlist", WordlistEditor)
+        kernel.register("window/BatchRun", BatchRunWindow)
         kernel.register("window/MatManager", MaterialManager)
         kernel.register("window/Navigation", Navigation)
         kernel.register("window/Notes", Notes)

--- a/meerk40t/gui/wxmeerk40t.py
+++ b/meerk40t/gui/wxmeerk40t.py
@@ -504,6 +504,7 @@ class wxMeerK40t(wx.App, Module):
         wx.ToolTip.SetAutoPop(autopop_ms)
         wx.ToolTip.SetDelay(delay_ms)
         wx.ToolTip.SetReshow(0)
+        self.context.setting(bool, "ribbon_verbose_hover_help", True)
 
     def _get_usb_config_instructions(self):
         """Get the technical USB configuration instructions.

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -860,6 +860,12 @@ class MeerK40t(MWindow):
         def on_click_pref_wordlist():
             self.context("window open Wordlist\n")
 
+        def on_click_pref_batchrun():
+            self.context("window open BatchRun\n")
+
+        def on_click_pref_cameracal():
+            self.context("window open CameraCalib\n")
+
         def on_click_pref_fonts():
             self.context("window open HersheyFontManager\n")
 
@@ -1057,6 +1063,20 @@ class MeerK40t(MWindow):
                     "action": on_click_pref_wordlist,
                     "level": 2,
                     # Hint for translation _("Settings")
+                    "segment": "Settings",
+                },
+                {
+                    "label": _("CSV Batch Run"),
+                    "help": _("Run repeated jobs from CSV wordlist rows"),
+                    "action": on_click_pref_batchrun,
+                    "level": 2,
+                    "segment": "Settings",
+                },
+                {
+                    "label": _("Camera Calibration"),
+                    "help": _("Guide camera perspective and bed overlay"),
+                    "action": on_click_pref_cameracal,
+                    "level": 2,
                     "segment": "Settings",
                 },
                 {

--- a/meerk40t/gui/wxmmain.py
+++ b/meerk40t/gui/wxmmain.py
@@ -1738,11 +1738,44 @@ class MeerK40t(MWindow):
         """
         Activate the node in question.
 
+        Laser operations open Parameter-Test (embedded property pages).
+        Elements and other nodes open the standalone Properties window.
+
         @param node:
         @return:
         """
-        # print(f"Calling property for {node.type}")
         self.context.elements.set_emphasis([node])
+        target = node
+        if getattr(node, "type", None) == "reference" and hasattr(node, "parent"):
+            target = node.parent
+
+        laser_op_types = ("op cut", "op engrave", "op raster", "op image", "op dots")
+        if getattr(target, "type", None) in laser_op_types:
+
+            def open_parameter_test():
+                window_uri = "window/Templatetool"
+                try:
+                    parent = self.context.gui
+                except AttributeError:
+                    parent = None
+                try:
+                    tool = self.context.opened[window_uri]
+                except KeyError:
+                    self.context.open_as(window_uri, window_uri, parent)
+                    tool = self.context.opened[window_uri]
+                if tool is None:
+                    self.context("window open Properties\n")
+                    return
+                if hasattr(tool, "panel_template"):
+                    tool.panel_template.select_operation_for_node(target)
+                tool.set_node(target, focus_properties=True)
+
+            if wx.IsMainThread():
+                open_parameter_test()
+            else:
+                wx.CallAfter(open_parameter_test)
+            return
+
         self.context("window open Properties\n")
 
     @staticmethod
@@ -3630,6 +3663,11 @@ class MeerK40t(MWindow):
                     pane.window.lock()
         self._mgr.Update()
 
+    def on_toggle_ribbon_verbose_hover_help(self, event):
+        checked = event.IsChecked()
+        self.context.ribbon_verbose_hover_help = checked
+        self.context.write_persistent("ribbon_verbose_hover_help", checked)
+
     def on_pane_create(self, paneinfo: aui.AuiPaneInfo):
         control = paneinfo.control
         if isinstance(control, wx.aui.AuiNotebook):
@@ -3825,6 +3863,26 @@ class MeerK40t(MWindow):
                 pane.window.check = menu_item.Check
             except AttributeError:
                 pass
+
+        help_menu = submenus.get(_("Help"))
+        if help_menu is not None:
+            help_menu.AppendSeparator()
+            self.context.setting(bool, "ribbon_verbose_hover_help", True)
+            item_verbose = help_menu.AppendCheckItem(
+                wx.ID_ANY,
+                _("Long UI descriptions (ribbon + context menus)"),
+                _(
+                    "When checked: ribbon buttons use the long hover delay and extra text; "
+                    "tree and scene right-click menus put full descriptions in the "
+                    "status bar as you move through the menu (bottom of the window)."
+                ),
+            )
+            item_verbose.Check(self.context.ribbon_verbose_hover_help)
+            self.Bind(
+                wx.EVT_MENU,
+                self.on_toggle_ribbon_verbose_hover_help,
+                id=item_verbose.GetId(),
+            )
 
         self.panes_menu.AppendSeparator()
         item = self.main_menubar.lockpane = self.panes_menu.Append(
@@ -5457,6 +5515,8 @@ class MeerK40t(MWindow):
         )
         if self.needs_saving:
             title += "(*)"
+        # Example GUI tweak: remove the next line anytime (demo only).
+        title += " — example edit"
         self.SetTitle(title)
 
     def __set_properties(self):

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -14,6 +14,7 @@ from meerk40t.gui.laserrender import DRAW_MODE_BACKGROUND, DRAW_MODE_GUIDES, Las
 from meerk40t.gui.mwindow import MWindow
 from meerk40t.gui.propertypanels.imageproperty import ContourPanel
 from meerk40t.gui.scene.scenepanel import ScenePanel
+from meerk40t.gui.wxutils import dispatch_to_main_thread
 
 from meerk40t.gui.scene.sceneconst import (
     LAYER_BACKGROUND,
@@ -1739,10 +1740,31 @@ class MeerK40tScenePanel(wx.Panel):
         self.widget_scene.request_refresh_for_animation()
 
     @signal_listener("background")
+    @dispatch_to_main_thread
     def on_background_signal(self, origin, background):
-        background = wx.Bitmap.FromBuffer(*background)
-        self.scene.signal("background", background)
-        self.widget_scene.invalidate_background()
+        from meerk40t.camera.camera import frame_for_wx_bitmap, make_bed_bitmap_from_frame
+
+        if background is None:
+            bitmap = None
+        elif isinstance(background, wx.Bitmap):
+            bitmap = background if background.IsOk() else None
+        else:
+            try:
+                width, height, data = background
+                data = frame_for_wx_bitmap(data)
+                if data is None:
+                    raise ValueError("invalid frame buffer")
+                bitmap = make_bed_bitmap_from_frame(data)
+                if bitmap is None or not bitmap.IsOk():
+                    bitmap = None
+            except (TypeError, ValueError, wx.wxAssertionError) as e:
+                self.context.kernel.channel("camera")(
+                    _("Background image failed: {error}").format(error=e)
+                )
+                bitmap = None
+        from meerk40t.camera.camera import _apply_bed_background_to_scene
+
+        _apply_bed_background_to_scene(self.widget_scene, bitmap)
         self.request_refresh()
 
     @signal_listener("units")

--- a/meerk40t/gui/wxmscene.py
+++ b/meerk40t/gui/wxmscene.py
@@ -8,7 +8,7 @@ from wx import aui
 
 from meerk40t.core.elements.element_types import elem_nodes
 from meerk40t.core.node.elem_image import ImageNode
-from meerk40t.core.units import UNITS_PER_PIXEL, Angle, Length
+from meerk40t.core.units import UNITS_PER_MM, UNITS_PER_PIXEL, Angle, Length
 from meerk40t.gui.icons import STD_ICON_SIZE, icon_meerk40t, icons8_r_white, icons8_text
 from meerk40t.gui.laserrender import DRAW_MODE_BACKGROUND, DRAW_MODE_GUIDES, LaserRender
 from meerk40t.gui.mwindow import MWindow
@@ -1340,7 +1340,30 @@ class MeerK40tScenePanel(wx.Panel):
             self._tool_widget.set_position(orgx, orgy)
 
     @signal_listener("scene_right_click")
-    def on_scene_right(self, origin, *args):
+    def on_scene_right(self, origin, space_x=None, space_y=None, *args):
+        click_pos = None
+        if space_x is not None and space_y is not None:
+            click_pos = (space_x, space_y)
+
+        def move_laser_here(event=None):
+            if click_pos is None:
+                return
+            view = self.context.device.view
+            x, y = click_pos[0], click_pos[1]
+            bed_width = view.unit_width
+            bed_height = view.unit_height
+            if x > bed_width:
+                x = bed_width
+            if y > bed_height:
+                y = bed_height
+            if x < 0:
+                x = 0
+            if y < 0:
+                y = 0
+            xmm = x / UNITS_PER_MM
+            ymm = y / UNITS_PER_MM
+            self.context(f"move_absolute {xmm}mm {ymm}mm\n")
+
         def zoom_in(event=None):
             self.context(f"scene zoom {1.5 / 1.0}\n")
 
@@ -1566,6 +1589,14 @@ class MeerK40tScenePanel(wx.Panel):
                     _("Stop automatic refresh of background image"),
                 ),
             )
+        if click_pos is not None:
+            menu.AppendSeparator()
+            id_move_here = menu.Append(
+                wx.ID_ANY,
+                _("Move laser head here"),
+                _("Move the laser head to the right-click position on the bed"),
+            )
+            self.Bind(wx.EVT_MENU, move_laser_here, id=id_move_here.GetId())
         menu.AppendSeparator()
         self.Bind(
             wx.EVT_MENU,

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -51,6 +51,8 @@ from meerk40t.gui.wxutils import (
     get_key_name,
     is_navigation_key,
     wxButton,
+    wxComboBox,
+    wxStaticText,
     wxTreeCtrl,
 )
 
@@ -153,7 +155,28 @@ class TreePanel(wx.Panel):
 
         self.setup_warn_panel()
 
+        self._material_combo_loading = False
+        self._material_sections = [""]
+        mat_row = wx.BoxSizer(wx.HORIZONTAL)
+        mat_label = wxStaticText(self, wx.ID_ANY, _("Material:"))
+        self.material_combo = wxComboBox(
+            self,
+            wx.ID_ANY,
+            choices=[_("— Load preset —")],
+            style=wx.CB_READONLY,
+        )
+        self.material_combo.SetToolTip(
+            _(
+                "Load a Material Manager preset into Operations "
+                "(replaces current operation list)"
+            )
+        )
+        mat_row.Add(mat_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
+        mat_row.Add(self.material_combo, 1, wx.EXPAND | wx.RIGHT, 4)
+        self.material_combo.Bind(wx.EVT_COMBOBOX, self.on_material_combo_select)
+
         main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.Add(mat_row, 0, wx.EXPAND | wx.TOP, 4)
         main_sizer.Add(self.wxtree, 1, wx.EXPAND, 0)
         main_sizer.Add(self.warn_panel, 0, wx.EXPAND, 0)
         self.SetSizer(main_sizer)
@@ -163,6 +186,72 @@ class TreePanel(wx.Panel):
         self._keybind_channel = self.context.channel("keybinds")
 
         self.context.signal("rebuild_tree", "all")
+        self.refresh_material_combo_list()
+
+    def _material_preset_label(self, section, opinfo):
+        material_name = opinfo.get("material", "")
+        material_title = opinfo.get("title", "")
+        material_thickness = opinfo.get("thickness", "")
+        if material_title == "":
+            if material_name:
+                material_title = material_name
+            elif section == "_default":
+                material_title = _("Generic Defaults")
+            elif section.startswith("_default_"):
+                material_title = _("Default for {dev}").format(dev=section[9:])
+            else:
+                material_title = section.replace("_", " ")
+        parts = []
+        if material_name:
+            parts.append(material_name)
+        if material_thickness:
+            parts.append(material_thickness)
+        if material_title and material_title not in parts:
+            parts.append(material_title)
+        return " — ".join(parts) if parts else section.replace("_", " ")
+
+    def refresh_material_combo_list(self):
+        if not hasattr(self, "material_combo"):
+            return
+        self._material_combo_loading = True
+        choices = [_("— Load preset —")]
+        sections = [""]
+        entries = []
+        elems = self.context.elements
+        elems.op_data.read_configuration()
+        for section in elems.op_data.section_set():
+            if section.startswith("previous"):
+                continue
+            opinfo = elems.load_persistent_op_info(section)
+            entries.append((section, self._material_preset_label(section, opinfo)))
+        entries.sort(key=lambda e: e[1].lower())
+        for section, label in entries:
+            sections.append(section)
+            choices.append(label)
+        self._material_sections = sections
+        self.material_combo.Set(choices)
+        self.material_combo.SetSelection(0)
+        self._material_combo_loading = False
+
+    def on_material_combo_select(self, event):
+        if self._material_combo_loading:
+            return
+        idx = self.material_combo.GetSelection()
+        if idx <= 0 or idx >= len(self._material_sections):
+            return
+        opname = self._material_sections[idx]
+        self.context(f"material load {opname}\n")
+        elems = self.context.elements
+        if elems.update_statusbar_on_material_load:
+            op_list, op_info = elems.load_persistent_op_list(opname)
+            if len(op_list) > 0:
+                elems.default_operations = list(op_list)
+                elems.default_operations_title = elems._get_default_list_title(op_info)
+                elems.default_operation_info = dict(op_info)
+                elems.signal("default_operations")
+        self._material_combo_loading = True
+        self.material_combo.SetSelection(0)
+        self._material_combo_loading = False
 
     def setup_warn_panel(self):
         def fix_unassigned_create(event):
@@ -342,7 +431,7 @@ class TreePanel(wx.Panel):
         # probably there is an issue there, but we use the opportunity not
         # only to catch these but to establish a forced delete via ctrl-delete as well
 
-        if keyvalue == "delete":
+        if keyvalue in ("delete", "numpad_delete"):
             self.context("tree selected delete\n")
             return
         if keyvalue == "ctrl+delete":
@@ -363,7 +452,7 @@ class TreePanel(wx.Panel):
                 self._keybind_channel(f"Tree key_up: {keyvalue} was unbound.")
 
     def pane_show(self):
-        pass
+        self.refresh_material_combo_list()
 
     def pane_hide(self):
         pass
@@ -472,6 +561,7 @@ class TreePanel(wx.Panel):
         if target is None:
             target = "all"
         self.shadow_tree.rebuild_tree(source="signal", target=target)
+        self.refresh_material_combo_list()
 
     @signal_listener("refresh_tree")
     def on_refresh_tree_signal(self, origin, nodes=None, *args):

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -32,6 +32,16 @@ def dispatch_to_main_thread(func):
     return wrapper
 
 
+def safe_enable_control(control, enabled=True):
+    """Re-enable a wx control after async work; ignore if the widget was destroyed."""
+    if control is None:
+        return
+    try:
+        control.Enable(enabled)
+    except RuntimeError:
+        pass
+
+
 ##############
 # DYNAMIC CHOICE
 # NODE MENU
@@ -1521,21 +1531,24 @@ class HoverButton(wxButton):
         return self._focus_color
 
     def Enable(self, value):
-        if value:
-            super().SetBackgroundColour(self._background_color)
-        else:
-            if self._disable_color is None:
-                r, g, b, a = self._background_color.Get()
-                color = wx.Colour(
-                    min(255, int(1.5 * r)),
-                    min(255, int(1.5 * g)),
-                    min(255, int(1.5 * b)),
-                )
+        try:
+            if value:
+                super().SetBackgroundColour(self._background_color)
             else:
-                color = self._disable_color
-            super().SetBackgroundColour(color)
-        super().Enable(value)
-        self.Refresh()
+                if self._disable_color is None:
+                    r, g, b, a = self._background_color.Get()
+                    color = wx.Colour(
+                        min(255, int(1.5 * r)),
+                        min(255, int(1.5 * g)),
+                        min(255, int(1.5 * b)),
+                    )
+                else:
+                    color = self._disable_color
+                super().SetBackgroundColour(color)
+            super().Enable(value)
+            self.Refresh()
+        except RuntimeError:
+            pass
 
     def on_enter(self, event):
         if self._focus_color is not None:

--- a/meerk40t/gui/wxutils.py
+++ b/meerk40t/gui/wxutils.py
@@ -251,6 +251,36 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
 
     tree_operations_for_node = get_tree_operation_for_node(elements)
 
+    def op_status_help(func):
+        """
+        Status-bar help while the user highlights a tree/scene context menu entry.
+        When ``ribbon_verbose_hover_help`` is on, empty explicit help falls back to
+        the operation function's docstring (first paragraph).
+        """
+        verbose = gui.context.setting(bool, "ribbon_verbose_hover_help", True)
+        h = func.help
+        if h is None:
+            h = ""
+        elif callable(h):
+            try:
+                h = h()
+            except Exception:
+                h = ""
+        hs_base = str(h)
+        try:
+            hs = hs_base.format_map(func.func_dict)
+        except (KeyError, ValueError, TypeError, IndexError):
+            hs = hs_base
+        hs = str(hs).strip()
+        if verbose and not hs:
+            wrapped = getattr(func, "__wrapped__", None)
+            if wrapped is not None:
+                doc = getattr(wrapped, "__doc__", None) or ""
+                doc = str(doc).strip()
+                if doc:
+                    return doc.split("\n\n")[0].replace("\n", " ")[:800]
+        return hs if hs else ""
+
     def menu_functions(f, node):
         func_dict = dict(f.func_dict)
 
@@ -342,7 +372,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
                                 parent_menu.AppendSeparator()
                                 func.separate_before = False
 
-                            parent_menu.AppendSubMenu(submenu, sname, func.help)
+                            parent_menu.AppendSubMenu(submenu, sname, op_status_help(func))
                             submenus[common] = submenu
                             parent_menu = submenu
 
@@ -363,7 +393,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
             if func.radio_state is not None:
                 last_was_separator = False
                 item = menu_context.Append(
-                    wx.ID_ANY, func.real_name, func.help, wx.ITEM_RADIO
+                    wx.ID_ANY, func.real_name, op_status_help(func), wx.ITEM_RADIO
                 )
                 check = func.radio_state
                 item.Check(check)
@@ -385,7 +415,9 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
                 else:
                     kind = wx.ITEM_NORMAL
                     check = None
-                item = menu_context.Append(wx.ID_ANY, func.real_name, func.help, kind)
+                item = menu_context.Append(
+                    wx.ID_ANY, func.real_name, op_status_help(func), kind
+                )
                 if check is not None:
                     item.Check(check)
                 if func.enabled:
@@ -429,7 +461,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
                         if func.separate_before:
                             parent_menu.AppendSeparator()
                             func.separate_before = False
-                        parent_menu.AppendSubMenu(submenu, sname, func.help)
+                        parent_menu.AppendSubMenu(submenu, sname, op_status_help(func))
                         submenus[common] = submenu
                         parent_menu = submenu
 
@@ -445,7 +477,7 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
             continue
         if func.radio_state is not None:
             item = menu_context.Append(
-                wx.ID_ANY, func.real_name, func.help, wx.ITEM_RADIO
+                wx.ID_ANY, func.real_name, op_status_help(func), wx.ITEM_RADIO
             )
             check = func.radio_state
             item.Check(check)
@@ -466,7 +498,9 @@ def create_menu_for_node(gui, node, elements, optional_2nd_node=None) -> wx.Menu
             else:
                 kind = wx.ITEM_NORMAL
                 check = None
-            item = menu_context.Append(wx.ID_ANY, func.real_name, func.help, kind)
+            item = menu_context.Append(
+                wx.ID_ANY, func.real_name, op_status_help(func), kind
+            )
             if check is not None:
                 item.Check(check)
             if func.enabled:
@@ -2025,6 +2059,22 @@ WX_SPECIALKEYS = {
     wx.WXK_CLEAR: "clear",
     wx.WXK_WINDOWS_MENU: "menu",
 }
+
+
+TREE_SELECTED_DELETE_KEYS = frozenset(("delete", "numpad_delete"))
+
+
+def key_triggers_tree_selected_delete(keyvalue):
+    """True when the key should run the same command as the ribbon Delete button."""
+    return keyvalue in TREE_SELECTED_DELETE_KEYS
+
+
+def emit_tree_selected_delete(context):
+    """Delete emphasized elements (same as ribbon Delete). Returns True if executed."""
+    if context.elements.has_emphasis():
+        context("tree selected delete\n")
+        return True
+    return False
 
 
 def is_navigation_key(keyvalue):

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -15,7 +15,7 @@ import sys
 faulthandler.enable()
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.9032"
+APPLICATION_VERSION = "0.9.9034"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -15,7 +15,7 @@ import sys
 faulthandler.enable()
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.9027"
+APPLICATION_VERSION = "0.9.9032"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -15,7 +15,7 @@ import sys
 faulthandler.enable()
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.9003"
+APPLICATION_VERSION = "0.9.9027"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -15,7 +15,7 @@ import sys
 faulthandler.enable()
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.9000"
+APPLICATION_VERSION = "0.9.9003"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -15,7 +15,7 @@ import sys
 faulthandler.enable()
 
 APPLICATION_NAME = "MeerK40t"
-APPLICATION_VERSION = "0.9.9034"
+APPLICATION_VERSION = "0.9.9040"
 
 if not getattr(sys, "frozen", False):
     # If .git directory does not exist we are running from a package like pypi

--- a/meerk40t/rotary/README.md
+++ b/meerk40t/rotary/README.md
@@ -1,3 +1,32 @@
-# Rotary
+# Rotary (Meerkat fork)
 
-The Rotary Module is intended to implement rotary. Currently, the supported rotary type is a y-axis replacement rotary. This rotary allows a toggle to turn on extra transformations to the .device view. This will occur regardless what device is being used. If the rotary service is being used, the currently selected .device will permit this extra perspective toggle.
+Y-motor-swap chuck rotary support for GRBL and other device drivers.
+
+## Features
+
+- **Object size:** outside diameter (mm), usable length (mm)
+- **Auto wrap scale:** scene bed height → one full rotation (π × diameter)
+- **Y steps calibration:** flat-bed `$101` vs rotary motor steps/mm
+- **Software compensation (default):** scales Y in the GRBL driver so EEPROM can stay at gantry `$101`
+- **Optional firmware mode:** write `$101` at job start, restore after job
+- **Homing:** ignore G28; physical home → X only (`$HX`) when enabled
+
+## Console
+
+| Command | Purpose |
+|---------|---------|
+| `rotary` | Status (circumference, scales, Y factor) |
+| `rotaryfit` | Scale selection to fit length × circumference (or use **Fit selection to rotary** in Rotary-Settings) |
+| `rotarycal <measured_mm>` | Calibrate rotary Y steps after test line |
+| `rotarysuggest <d_mm> <steps> <microsteps> <ratio>` | Estimate rotary steps/mm |
+| `rotaryview` | Toggle stretched scene preview |
+
+## Workflow (Y motor swap)
+
+1. Wire rotary to Y driver; leave rotary mode **off** until ready.
+2. Device → **Rotary:** set diameter, length, flat `$101` (159.6), calibrate rotary steps.
+3. Enable **Rotary-Mode**; check **Ignore Home** and **Software Y steps compensate**.
+4. Import art → `rotaryfit` → classify → simulate → burn.
+5. Physical home: **$HX** only. Flat bed: disable rotary, restore Y motor and `$101`.
+
+See `docs/meerk40t/20-rotary-pro.md` in the Meerkat workspace.

--- a/meerk40t/rotary/gui/rotarysettings.py
+++ b/meerk40t/rotary/gui/rotarysettings.py
@@ -8,216 +8,45 @@ import wx
 from meerk40t.gui.choicepropertypanel import ChoicePropertyPanel
 from meerk40t.gui.icons import icon_rotary
 from meerk40t.gui.mwindow import MWindow
-
-# from meerk40t.gui.wxutils import TextCtrl, wxButton, wxCheckBox, wxStaticText
+from meerk40t.gui.wxutils import wxButton, wxStaticText
+from meerk40t.rotary.rotary_cam import circumference_mm
 
 _ = wx.GetTranslation
 
 
-# class RotarySettingsPanel(ScrolledPanel):
-#     def __init__(self, *args, context=None, **kwds):
-#         kwds["style"] = kwds.get("style", 0) | wx.TAB_TRAVERSAL
-#         wx.Panel.__init__(self, *args, **kwds)
-#         self.rotary = context
-#         self.scene = getattr(context.root, "mainscene", None)
-#
-#         self.checkbox_rotary = wxCheckBox(self, wx.ID_ANY, _("Enable Rotary"))
-#         self.Children[0].SetFocus()
-#         self.text_rotary_scalex = TextCtrl(
-#             self,
-#             wx.ID_ANY,
-#             "1.0",
-#             check="float",
-#             style=wx.TE_PROCESS_ENTER,
-#             nonzero=True,
-#         )
-#         self.text_rotary_scaley = TextCtrl(
-#             self,
-#             wx.ID_ANY,
-#             "1.0",
-#             check="float",
-#             style=wx.TE_PROCESS_ENTER,
-#             nonzero=True,
-#         )
-#         # self.checkbox_rotary_loop = wxCheckBox(self, wx.ID_ANY, _("Field Loop"))
-#         # self.text_rotary_rotation = TextCtrl(self, wx.ID_ANY, "360.0")
-#         # self.checkbox_rotary_roller = wxCheckBox(self, wx.ID_ANY, _("Uses Roller"))
-#         # self.text_rotary_roller_circumference = TextCtrl(self, wx.ID_ANY, "50.0")
-#         # self.text_rotary_object_circumference = TextCtrl(self, wx.ID_ANY, "50.0")
-#
-#         self.__set_properties()
-#         self.__do_layout()
-#
-#         self.Bind(wx.EVT_CHECKBOX, self.on_check_rotary, self.checkbox_rotary)
-#         self.text_rotary_scalex.SetActionRoutine(self.on_text_rotary_scale_x)
-#         self.text_rotary_scaley.SetActionRoutine(self.on_text_rotary_scale_y)
-#         # self.Bind(wx.EVT_CHECKBOX, self.on_check_rotary_loop, self.checkbox_rotary_loop)
-#         # self.text_rotary_rotation.Bind(wx.EVT_TEXT, self.on_text_rotation)
-#         # self.Bind(
-#         #     wx.EVT_CHECKBOX, self.on_check_rotary_roller, self.checkbox_rotary_roller
-#         # )
-#         # self.Bind(
-#         #     wx.EVT_TEXT,
-#         #     self.on_text_rotary_roller_circumference,
-#         #     self.text_rotary_roller_circumference,
-#         # )
-#         # self.Bind(
-#         #     wx.EVT_TEXT,
-#         #     self.on_text_rotary_object_circumference,
-#         #     self.text_rotary_object_circumference,
-#         # )
-#         self.SetupScrolling()
-#
-#     def pane_show(self):
-#         self.text_rotary_scalex.SetValue(str(self.rotary.scale_x))
-#         self.text_rotary_scaley.SetValue(str(self.rotary.scale_y))
-#         self.checkbox_rotary.SetValue(self.rotary.rotary_enabled)
-#         self.on_check_rotary(None)
-#
-#     def pane_hide(self):
-#         pass
-#
-#     def __set_properties(self):
-#         self.checkbox_rotary.SetFont(
-#             wx.Font(
-#                 12,
-#                 wx.FONTFAMILY_DEFAULT,
-#                 wx.FONTSTYLE_NORMAL,
-#                 wx.FONTWEIGHT_NORMAL,
-#                 0,
-#                 "Segoe UI",
-#             )
-#         )
-#         self.checkbox_rotary.SetToolTip(_("Use Rotary Settings"))
-#         self.text_rotary_scaley.SetMinSize(dip_size(self, 80, -1))
-#         self.text_rotary_scaley.SetToolTip(_("Rotary Scale Factor X"))
-#         self.text_rotary_scaley.Enable(False)
-#         self.text_rotary_scalex.SetMinSize(dip_size(self, 80, -1))
-#         self.text_rotary_scalex.SetToolTip(_("Rotary Scale Factor Y"))
-#         self.text_rotary_scalex.Enable(False)
-#         # self.checkbox_rotary_loop.SetFont(
-#         #     wx.Font(
-#         #         12,
-#         #         wx.FONTFAMILY_DEFAULT,
-#         #         wx.FONTSTYLE_NORMAL,
-#         #         wx.FONTWEIGHT_NORMAL,
-#         #         0,
-#         #         "Segoe UI",
-#         #     )
-#         # )
-#         # self.checkbox_rotary_loop.SetToolTip(_("Use Rotary Settings"))
-#         # self.text_rotary_rotation.SetMinSize(dip_size(self, 80, -1))
-#         # self.text_rotary_rotation.SetToolTip(_("Steps required for a full rotation"))
-#         # self.text_rotary_rotation.Enable(False)
-#         # self.text_rotary_roller_circumference.SetMinSize(dip_size(self, 80, -1))
-#         # self.text_rotary_roller_circumference.SetToolTip(_("Circumference of roller"))
-#         # self.text_rotary_roller_circumference.Enable(False)
-#         # self.text_rotary_object_circumference.SetMinSize(dip_size(self, 80, -1))
-#         # self.text_rotary_object_circumference.SetToolTip(
-#         #     _("Circumference of object in rotary")
-#         # )
-#         # self.text_rotary_object_circumference.Enable(False)
-#         # end wxGlade
-#
-#     def __do_layout(self):
-#         sizer_main = wx.BoxSizer(wx.VERTICAL)
-#         sizer_scale = wx.BoxSizer(wx.HORIZONTAL)
-#         # sizer_circumference = StaticBoxSizer(self, wx.ID_ANY, _("Object Circumference:"), wx.HORIZONTAL)
-#         # sizer_20 = StaticBoxSizer(self, wx.ID_ANY, _("Roller Circumference:"), wx.HORIZONTAL)
-#         # sizer_steps = StaticBoxSizer(self, wx.ID_ANY, _("Rotation Steps:"), wx.HORIZONTAL)
-#         sizer_x = StaticBoxSizer(self, wx.ID_ANY, _("Scale X:"), wx.HORIZONTAL)
-#         sizer_y = StaticBoxSizer(self, wx.ID_ANY, _("Scale Y:"), wx.HORIZONTAL)
-#         sizer_main.Add(self.checkbox_rotary, 0, 0, 0)
-#         sizer_x.Add(self.text_rotary_scalex, 0, 0, 0)
-#         sizer_y.Add(self.text_rotary_scaley, 0, 0, 0)
-#         sizer_scale.Add(sizer_x, 1, wx.EXPAND, 0)
-#         sizer_scale.Add(sizer_y, 1, wx.EXPAND, 0)
-#         sizer_main.Add(sizer_scale, 0, wx.EXPAND, 0)
-#         # sizer_main.Add((20, 20), 0, 0, 0)
-#         # sizer_main.Add(self.checkbox_rotary_loop, 0, 0, 0)
-#         # sizer_steps.Add(self.text_rotary_rotation, 0, 0, 0)
-#         # label_steps = wxStaticText(self, wx.ID_ANY, _("steps"))
-#         # sizer_steps.Add(label_steps, 0, 0, 0)
-#         # sizer_main.Add(sizer_steps, 0, wx.EXPAND, 0)
-#         # sizer_20.Add(self.checkbox_rotary_roller, 0, 0, 0)
-#         # sizer_20.Add(self.text_rotary_roller_circumference, 0, 0, 0)
-#         # label_mm = wxStaticText(self, wx.ID_ANY, _("mm"))
-#         # sizer_20.Add(label_mm, 0, 0, 0)
-#         # sizer_main.Add(sizer_20, 0, wx.EXPAND, 0)
-#         # sizer_circumference.Add(self.text_rotary_object_circumference, 0, 0, 0)
-#         # label_mm2 = wxStaticText(self, wx.ID_ANY, _("mm"))
-#         # sizer_circumference.Add(label_mm2, 0, 0, 0)
-#         # sizer_main.Add(sizer_circumference, 0, wx.EXPAND, 0)
-#         self.SetSizer(sizer_main)
-#         self.Layout()
-#         # end wxGlade
-#
-#     def on_check_rotary(self, event=None):
-#         self.rotary.rotary_enabled = self.checkbox_rotary.GetValue()
-#         self.text_rotary_scalex.Enable(self.checkbox_rotary.GetValue())
-#         self.text_rotary_scaley.Enable(self.checkbox_rotary.GetValue())
-#         self.scene.pane.grid_secondary_scale_x = 1
-#         self.scene.pane.grid_secondary_scale_y = 1
-#         if self.rotary.rotary_enabled:
-#             try:
-#                 self.scene.pane.grid_secondary_scale_x = self.rotary.scale_x
-#                 self.scene.pane.grid_secondary_scale_y = self.rotary.scale_y
-#             except ValueError:
-#                 pass
-#         # Forces guide and grid refresh
-#         self.rotary.signal("units")
-#         self.rotary.signal("refresh_scene", "Scene")
-#
-#     def on_text_rotary_scale_y(self):
-#         if self.rotary is None:
-#             return
-#         try:
-#             self.rotary.scale_y = float(self.text_rotary_scaley.GetValue())
-#         except ValueError:
-#             pass
-#         self.scene.pane.grid_secondary_scale_y = self.rotary.scale_y
-#         self.rotary.signal("units")
-#         self.rotary.signal("refresh_scene", "Scene")
-#
-#     def on_text_rotary_scale_x(self):
-#         if self.rotary is None:
-#             return
-#         try:
-#             self.rotary.scale_x = float(self.text_rotary_scalex.GetValue())
-#         except ValueError:
-#             return
-#         self.scene.pane.grid_secondary_scale_x = self.rotary.scale_x
-#         self.rotary.signal("units")
-#         self.rotary.signal("refresh_scene")
-#
-#     # def on_check_rotary_loop(self, event):
-#     #     print("Event handler 'on_check_rotary_loop' not implemented!")
-#     #     event.Skip()
-#     #
-#     # def on_text_rotation(self, event):
-#     #     print("Event handler 'on_text_rotation' not implemented!")
-#     #     event.Skip()
-#     #
-#     # def on_check_rotary_roller(self, event):
-#     #     print("Event handler 'on_check_rotary_roller' not implemented!")
-#     #     event.Skip()
-#     #
-#     # def on_text_rotary_roller_circumference(self, event):
-#     #     print("Event handler 'on_text_rotary_roller_circumference' not implemented!")
-#     #     event.Skip()
-#     #
-#     # def on_text_rotary_object_circumference(self, event):
-#     #     print("Event handler 'on_text_rotary_object_circumference' not implemented!")
-#     #     event.Skip()
-
-
 class RotarySettings(MWindow):
     def __init__(self, *args, **kwds):
-        super().__init__(350, 250, *args, **kwds)
+        super().__init__(420, 560, *args, **kwds)
         self.panel = ChoicePropertyPanel(
             self, wx.ID_ANY, context=self.context.device, choices="rotary"
         )
         self.sizer.Add(self.panel, 1, wx.EXPAND, 0)
+
+        self.label_fit_hint = wxStaticText(
+            self,
+            wx.ID_ANY,
+            _(
+                "Select artwork on the scene, then fit it to the object "
+                "length × wrap (circumference)."
+            ),
+        )
+        self.button_fit = wxButton(self, wx.ID_ANY, _("Fit selection to rotary"))
+        self.button_fit.SetToolTip(
+            _(
+                "Uniformly scale the current selection to fit inside "
+                "usable length (X) and π × diameter (Y wrap)."
+            )
+        )
+        self.label_fit_status = wxStaticText(self, wx.ID_ANY, "")
+
+        sizer_actions = wx.BoxSizer(wx.VERTICAL)
+        sizer_actions.Add(self.label_fit_hint, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 8)
+        sizer_actions.Add(self.button_fit, 0, wx.EXPAND | wx.ALL, 8)
+        sizer_actions.Add(self.label_fit_status, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+        self.sizer.Add(sizer_actions, 0, wx.EXPAND, 0)
+
+        self.Bind(wx.EVT_BUTTON, self.on_fit_selection, self.button_fit)
+
         self.add_module_delegate(self.panel)
         _icon = wx.NullIcon
         _icon.CopyFromBitmap(icon_rotary.GetBitmap())
@@ -225,17 +54,43 @@ class RotarySettings(MWindow):
         self.SetTitle(_("Rotary-Settings"))
         self.restore_aspect(honor_initial_values=True)
 
+    def on_fit_selection(self, event=None):
+        device = self.context.device
+        rotary = getattr(device, "rotary", None)
+        if rotary is None:
+            self.label_fit_status.SetLabel(_("No rotary service on this device."))
+            return
+        channel = self.context.channel("console")
+        ok, msg = rotary.fit_selection(channel)
+        self.label_fit_status.SetLabel(msg)
+        if ok:
+            self.context.signal("emphasized")
+
     def window_open(self):
         self.panel.pane_show()
+        self._refresh_fit_hint()
 
     def window_close(self):
         self.panel.pane_hide()
 
+    def _refresh_fit_hint(self):
+        try:
+            d = float(self.context.device.rotary_diameter_mm)
+            length = float(self.context.device.rotary_length_mm)
+            circ = circumference_mm(d)
+            self.label_fit_hint.SetLabel(
+                _(
+                    "Target zone: {length:.0f} mm (along object) × {circ:.0f} mm "
+                    "(one full wrap). Select art, then Fit."
+                ).format(length=length, circ=circ)
+            )
+        except (AttributeError, TypeError, ValueError):
+            pass
+
     @staticmethod
     def submenu():
-        # Hint for translation: _("Device-Settings"), _("Rotary-Settings")
         return "Device-Settings", "Rotary-Settings"
 
     @staticmethod
     def helptext():
-        return _("Activate and configure rotary")
+        return _("Activate and configure rotary; fit selection to object size")

--- a/meerk40t/rotary/rotary.py
+++ b/meerk40t/rotary/rotary.py
@@ -1,5 +1,140 @@
+import math
+
+from meerk40t.core.units import UNITS_PER_MM, UNITS_PER_PIXEL
 from meerk40t.kernel import lookup_listener, signal_listener
+from meerk40t.rotary.rotary_cam import (
+    bed_height_mm,
+    bed_length_mm,
+    calibrate_rotary_steps,
+    circumference_mm,
+    length_scale_x,
+    suggest_rotary_steps_per_mm,
+    wrap_scale_y,
+    y_steps_factor,
+)
 from meerk40t.svgelements import Matrix
+
+_FIT_MIN_MM = 0.5
+_FIT_MIN_SCALE = 0.01
+_FIT_MAX_SCALE = 100.0
+_FIT_MAX_DIM_MM = 2000.0
+
+
+def _laser_renderer(kernel):
+    try:
+        import wx
+
+        if not wx.GetApp():
+            return None
+        from meerk40t.gui.laserrender import LaserRender
+
+        return LaserRender(kernel.root)
+    except (ImportError, RuntimeError, AttributeError):
+        return None
+
+
+def _measure_text_nodes(elems, kernel):
+    renderer = _laser_renderer(kernel)
+    if renderer is None:
+        return None
+    text_nodes = [n for n in elems if getattr(n, "type", None) == "elem text"]
+    if text_nodes:
+        renderer.validate_text_nodes(text_nodes, translate_variables=False)
+    return renderer
+
+
+def _native_extent_to_mm(native_extent):
+    return native_extent / UNITS_PER_MM
+
+
+def _repair_text_matrix(node, renderer=None):
+    """
+    MeerK40t text uses translate(x,y) + scale(UNITS_PER_PIXEL) on the matrix.
+    Only *extra* scale (from old matrix-fit bugs) is folded into font_size.
+    """
+    m = node.matrix
+    if m is None:
+        node.matrix = Matrix(f"scale({UNITS_PER_PIXEL})")
+        return False
+    sx = math.hypot(float(m.a), float(m.b))
+    sy = math.hypot(float(m.c), float(m.d))
+    expected = UNITS_PER_PIXEL
+    if expected <= 0:
+        return False
+    extra = ((sx / expected) + (sy / expected)) / 2.0
+    if 0.98 <= extra <= 1.02:
+        return False
+    if extra <= 0 or not math.isfinite(extra):
+        extra = 1.0
+    try:
+        node.font_size = float(node.font_size) * extra
+    except (TypeError, ValueError):
+        node.font_size = 12.0 * extra
+    try:
+        node.line_height = float(node.line_height) * extra
+    except (TypeError, ValueError):
+        pass
+    tx, ty = float(m.e), float(m.f)
+    node.matrix = Matrix(f"translate({tx},{ty}) scale({UNITS_PER_PIXEL})")
+    node.set_dirty_bounds()
+    if renderer is not None:
+        renderer.measure_text(node)
+        node.set_dirty_bounds()
+    return True
+
+
+def _prepare_fit_selection(elems, elements, kernel):
+    renderer = _measure_text_nodes(elems, kernel)
+    for node in elems:
+        if getattr(node, "type", None) == "elem text":
+            _repair_text_matrix(node, renderer)
+    elements.validate_selected_area()
+    return renderer
+
+
+def _scale_text_uniform(node, scale, pivot_x, pivot_y, renderer):
+    _repair_text_matrix(node, renderer)
+    bb = node.bounds
+    if bb is None:
+        return
+    ocx = (bb[0] + bb[2]) / 2
+    ocy = (bb[1] + bb[3]) / 2
+    target_cx = (ocx - pivot_x) * scale + pivot_x
+    target_cy = (ocy - pivot_y) * scale + pivot_y
+    try:
+        node.font_size = float(node.font_size) * scale
+    except (TypeError, ValueError):
+        node.font_size = 12.0 * scale
+    try:
+        node.line_height = float(node.line_height) * scale
+    except (TypeError, ValueError):
+        pass
+    node.set_dirty_bounds()
+    if renderer is not None:
+        renderer.measure_text(node)
+    node.set_dirty_bounds()
+    nbb = node.bounds
+    if nbb is None:
+        return
+    ncx = (nbb[0] + nbb[2]) / 2
+    ncy = (nbb[1] + nbb[3]) / 2
+    if node.matrix is None:
+        node.matrix = Matrix(f"scale({UNITS_PER_PIXEL})")
+    node.matrix.post_translate(target_cx - ncx, target_cy - ncy)
+
+
+def _apply_uniform_scale(node, scale, pivot_x, pivot_y, renderer=None):
+    if getattr(node, "type", None) == "elem text":
+        _scale_text_uniform(node, scale, pivot_x, pivot_y, renderer)
+        return
+    matrix = Matrix(f"scale({scale}, {scale}, {pivot_x}, {pivot_y})")
+    try:
+        if node.matrix is None:
+            node.matrix = matrix
+        else:
+            node.matrix *= matrix
+    except AttributeError:
+        pass
 
 
 def plugin(service, lifecycle=None):
@@ -8,8 +143,6 @@ def plugin(service, lifecycle=None):
 
         return [gui.plugin]
     if lifecycle == "service":
-        # Responding to "service" makes this a service plugin for the specific services created via the provider
-        # We are only a provider of lhystudios devices for now.
         return (
             "provider/device/lhystudios",
             "provider/device/grbl",
@@ -23,7 +156,10 @@ def plugin(service, lifecycle=None):
 
 class Rotary:
     """
-    Rotary Service provides rotary information about the selected rotary you intend to use.
+    Rotary service for Y-motor-swap chuck rotaries on GRBL and other devices.
+
+    Combines wrap scaling (diameter / length), optional Y steps compensation
+    (software or firmware $101), and homing guards.
     """
 
     def __init__(self, service, index=0, *args, **kwargs):
@@ -39,45 +175,163 @@ class Rotary:
                 "default": False,
                 "type": bool,
                 "label": _("Rotary-Mode active"),
-                "tip": _("Is the rotary mode active for this device"),
+                "tip": _(
+                    "Enable when the Y motor drives a rotary chuck (flat-bed Y unplugged). "
+                    "Leave off for normal 400×285 mm cutting."
+                ),
                 "signals": "device;modified",
             },
-            # {
-            #     "attr": "axis",
-            #     "object": rotary,
-            #     "default": 1,
-            #     "type": int,
-            #     "label": _("Rotary Axis:"),
-            #     "tip": _("Which axis does the rotary use?"),
-            # },
+            {
+                "attr": "rotary_diameter_mm",
+                "object": service,
+                "default": 80.0,
+                "type": float,
+                "label": _("Outside diameter (mm)"),
+                "tip": _("Cylinder OD for wrap math. Circumference = π × diameter."),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Object"),
+            },
+            {
+                "attr": "rotary_length_mm",
+                "object": service,
+                "default": 200.0,
+                "type": float,
+                "label": _("Usable length (mm)"),
+                "tip": _("Engravable length along the cylinder axis (X on the machine)."),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Object"),
+            },
+            {
+                "attr": "rotary_auto_wrap_scale",
+                "object": service,
+                "default": True,
+                "type": bool,
+                "label": _("Auto Y wrap from diameter"),
+                "tip": _(
+                    "When on, Fit selection and the hint use π × diameter as the "
+                    "wrap height. The scene stays normal mm — no preview distortion."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Object"),
+            },
+            {
+                "attr": "rotary_auto_length_scale",
+                "object": service,
+                "default": False,
+                "type": bool,
+                "label": _("Auto X scale from length"),
+                "tip": _(
+                    "When on, X-Scale = usable length ÷ bed width. Usually leave off and "
+                    "size artwork manually."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Object"),
+            },
+            {
+                "attr": "rotary_flat_y_steps",
+                "object": service,
+                "default": 159.6,
+                "type": float,
+                "label": _("Flat-bed Y $101"),
+                "tip": _(
+                    "GRBL Y steps/mm for the gantry motor (Andre DLC32: 159.600). "
+                    "Used to restore $101 or for software compensation."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Y steps"),
+            },
+            {
+                "attr": "rotary_y_steps",
+                "object": service,
+                "default": 80.0,
+                "type": float,
+                "label": _("Rotary Y steps/mm"),
+                "tip": _(
+                    "Steps/mm for the rotary motor on the Y driver. Calibrate with "
+                    "rotarycal after a test line, or use rotarysuggest."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Y steps"),
+            },
+            {
+                "attr": "rotary_steps_compensate",
+                "object": service,
+                "default": True,
+                "type": bool,
+                "label": _("Software Y steps compensate"),
+                "tip": _(
+                    "Recommended: scale Y in the driver so GRBL can keep flat-bed $101. "
+                    "Disable if you write rotary $101 to the board instead."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Y steps"),
+            },
+            {
+                "attr": "rotary_firmware_steps",
+                "object": service,
+                "default": False,
+                "type": bool,
+                "label": _("Write $101 at job start"),
+                "tip": _(
+                    "Optional: send $101=rotary value before the job and restore flat-bed "
+                    "$101 after. Turns off software compensation automatically."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Y steps"),
+            },
+            {
+                "attr": "rotary_cal_test_mm",
+                "object": service,
+                "default": 100.0,
+                "type": float,
+                "label": _("Calibration test length (mm)"),
+                "tip": _("Length of the test line you burned before rotarycal."),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Y steps"),
+            },
             {
                 "attr": "rotary_scale_x",
                 "object": service,
                 "default": 1.0,
                 "type": float,
-                "label": _("X-Scale"),
-                "tip": _("Scale that needs to be applied to the X-Axis"),
+                "label": _("X-Scale (manual)"),
+                "tip": _("Manual X scale when Auto X scale is off."),
                 "conditional": (service, "rotary_active"),
-                "subsection": _("Scale"),
+                "subsection": _("Scale (manual)"),
             },
             {
                 "attr": "rotary_scale_y",
                 "object": service,
                 "default": 1.0,
                 "type": float,
-                "label": _("Y-Scale"),
-                "tip": _("Scale that needs to be applied to the Y-Axis"),
+                "label": _("Y-Scale (manual)"),
+                "tip": _("Manual Y scale when Auto Y wrap is off."),
                 "conditional": (service, "rotary_active"),
-                "subsection": _("Scale"),
+                "subsection": _("Scale (manual)"),
             },
             {
                 "attr": "suppress_home",
                 "object": service,
-                "default": False,
+                "default": True,
                 "type": bool,
-                "label": _("Ignore Home"),
-                "tip": _("Ignore Home-Command"),
+                "label": _("Ignore Home (G28)"),
+                "tip": _(
+                    "Skip soft home while rotary is active. Use with Y motor on chuck."
+                ),
                 "conditional": (service, "rotary_active"),
+                "subsection": _("Homing"),
+            },
+            {
+                "attr": "rotary_home_x_only",
+                "object": service,
+                "default": True,
+                "type": bool,
+                "label": _("Physical home: X only ($HX)"),
+                "tip": _(
+                    "If you use physical homing while rotary is on, run $HX only — never $HY."
+                ),
+                "conditional": (service, "rotary_active"),
+                "subsection": _("Homing"),
             },
             {
                 "attr": "rotary_flip_x",
@@ -95,7 +349,7 @@ class Rotary:
                 "default": False,
                 "type": bool,
                 "label": _("Mirror Y"),
-                "tip": _("Mirror the elements on the Y-Axis"),
+                "tip": _("Mirror spin direction on the Y-Axis"),
                 "conditional": (service, "rotary_active"),
                 "subsection": _("Mirror Output"),
             },
@@ -104,26 +358,21 @@ class Rotary:
 
         @service.console_command(
             "rotary",
-            help=_("Rotary base command"),
+            help=_("Show rotary status"),
             output_type="rotary",
         )
         def rotary(command, channel, _, data=None, **kwargs):
-            channel(
-                f"Rotary {self.index} set to scale: {service.rotary_scale_x}, scale:{service.rotary_scale_y}"
-            )
+            self._print_status(channel)
             return "rotary", None
 
-        @service.console_command(
-            "rotaryscale", help=_("Rotary Scale selected elements")
-        )
+        @service.console_command("rotaryscale", help=_("Rotary Scale selected elements"))
         def apply_rotary_scale(*args, **kwargs):
-            sx = service.rotary_scale_x
-            sy = service.rotary_scale_y
+            sx = self.effective_scale_x()
+            sy = self.effective_scale_y()
             x, y = service.device.current
             matrix = Matrix(f"scale({sx}, {sy}, {x}, {y})")
             for node in service.elements.elems():
                 if hasattr(node, "rotary_scale"):
-                    # This element is already scaled
                     return
                 try:
                     node.rotary_scale = sx, sy
@@ -132,13 +381,212 @@ class Rotary:
                 except AttributeError:
                     pass
 
+        @service.console_argument(
+            "measured",
+            type=float,
+            help=_("Measured length of calibration line (mm)"),
+        )
+        @service.console_command(
+            "rotarycal",
+            help=_("Calibrate rotary Y steps/mm from a test burn"),
+        )
+        def rotary_calibrate(channel, _, measured=None, **kwargs):
+            if measured is None:
+                channel(_("Usage: rotarycal <measured_mm>"))
+                return
+            cmd = float(service.rotary_cal_test_mm)
+            new_val = calibrate_rotary_steps(
+                float(service.rotary_y_steps), cmd, float(measured)
+            )
+            service.rotary_y_steps = new_val
+            channel(
+                _("Rotary Y steps/mm updated to {value:.3f} (test {cmd:.1f} mm, measured {meas:.3f} mm)").format(
+                    value=new_val, cmd=cmd, meas=measured
+                )
+            )
+
+        @service.console_argument("diameter", type=float, help=_("Object diameter mm"))
+        @service.console_argument(
+            "motor_steps", type=int, help=_("Full steps per rev (usually 200)")
+        )
+        @service.console_argument("microsteps", type=int, help=_("Driver microsteps"))
+        @service.console_argument(
+            "ratio", type=float, help=_("Gear ratio motor:chuck (e.g. 1.0)")
+        )
+        @service.console_command(
+            "rotarysuggest",
+            help=_("Suggest rotary Y steps/mm from motor and diameter"),
+        )
+        def rotary_suggest(channel, _, diameter=None, motor_steps=200, microsteps=16, ratio=1.0, **kwargs):
+            if diameter is None:
+                diameter = float(service.rotary_diameter_mm)
+            val = suggest_rotary_steps_per_mm(
+                int(motor_steps), int(microsteps), float(ratio), float(diameter)
+            )
+            channel(
+                _("Suggested rotary Y steps/mm: {value:.3f} (D={d:.1f} mm)").format(
+                    value=val, d=diameter
+                )
+            )
+
+        @service.console_command(
+            "rotaryfit",
+            help=_("Scale emphasized elements to fit length × circumference"),
+        )
+        def rotary_fit(channel, _, **kwargs):
+            self.fit_selection(channel)
+
+    def fit_selection(self, channel=None):
+        """
+        Scale emphasized elements to fit rotary length × circumference.
+
+        @param channel: optional console channel for messages
+        @return: (success, message)
+        """
+        _ = self.service._
+        if not self.active:
+            msg = _("Enable rotary mode first.")
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        elems = list(self.service.elements.elems(emphasized=True))
+        if not elems:
+            msg = _("Select artwork on the scene, then click Fit selection.")
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        length = float(self.service.rotary_length_mm)
+        circ = circumference_mm(float(self.service.rotary_diameter_mm))
+        if length <= 0 or circ <= 0:
+            msg = _("Set outside diameter and usable length first.")
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        renderer = _prepare_fit_selection(
+            elems, self.service.elements, self.service.kernel
+        )
+        bb = self.service.elements.selected_area()
+        if bb is None:
+            msg = _("Could not get selection bounds.")
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        w_mm = _native_extent_to_mm(bb[2] - bb[0])
+        h_mm = _native_extent_to_mm(bb[3] - bb[1])
+        if w_mm <= 0 or h_mm <= 0:
+            msg = _("Selection has no size.")
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        if w_mm > _FIT_MAX_DIM_MM or h_mm > _FIT_MAX_DIM_MM:
+            msg = _(
+                "Selection bounds look wrong ({w:.1f} × {h:.1f} mm). "
+                "Delete the text and add it again, or use Undo."
+            ).format(w=w_mm, h=h_mm)
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        if w_mm < _FIT_MIN_MM or h_mm < _FIT_MIN_MM:
+            msg = _(
+                "Selection is too small ({w:.2f} × {h:.2f} mm). "
+                "Use Undo, delete the broken text, and add it again before Fit."
+            ).format(w=w_mm, h=h_mm)
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        sx = length / w_mm
+        sy = circ / h_mm
+        scale = min(sx, sy)
+        if scale < _FIT_MIN_SCALE or scale > _FIT_MAX_SCALE:
+            msg = _(
+                "Fit scale {s:.4f} is out of range — check selection size "
+                "({w:.1f} × {h:.1f} mm)."
+            ).format(s=scale, w=w_mm, h=h_mm)
+            if channel is not None:
+                channel(msg)
+            return False, msg
+        cx = (bb[0] + bb[2]) / 2
+        cy = (bb[1] + bb[3]) / 2
+        with self.service.elements.undoscope("Rotary fit"):
+            for node in elems:
+                _apply_uniform_scale(node, scale, cx, cy, renderer)
+                try:
+                    node.modified()
+                except AttributeError:
+                    pass
+        self.service.signal("refresh_scene", "Scene")
+        msg = _("Fitted selection to {len:.1f} × {circ:.1f} mm (scale {s:.3f})").format(
+            len=length, circ=circ, s=scale
+        )
+        if channel is not None:
+            channel(msg)
+        return True, msg
+
+    def _print_status(self, channel):
+        _ = self.service._
+        d = float(self.service.rotary_diameter_mm)
+        circ = circumference_mm(d)
+        channel(_("Rotary active: {flag}").format(flag=self.active))
+        channel(_("Diameter: {d:.2f} mm  →  circumference: {c:.2f} mm").format(d=d, c=circ))
+        channel(
+            _("Length: {l:.2f} mm  |  Y steps: {ry:.3f}  |  flat $101: {fy:.3f}").format(
+                l=float(self.service.rotary_length_mm),
+                ry=float(self.service.rotary_y_steps),
+                fy=float(self.service.rotary_flat_y_steps),
+            )
+        )
+        channel(
+            _("Effective scale X={sx:.4f} Y={sy:.4f}  |  Y GRBL factor={yf:.4f}").format(
+                sx=self.effective_scale_x(),
+                sy=self.effective_scale_y(),
+                yf=self.y_grbl_factor(),
+            )
+        )
+
+    def effective_scale_x(self):
+        if self.service.rotary_auto_length_scale:
+            bw = bed_length_mm(self.service)
+            return length_scale_x(float(self.service.rotary_length_mm), bw)
+        return float(self.service.rotary_scale_x)
+
+    def effective_scale_y(self):
+        if self.service.rotary_auto_wrap_scale:
+            bh = bed_height_mm(self.service)
+            return wrap_scale_y(float(self.service.rotary_diameter_mm), bh)
+        return float(self.service.rotary_scale_y)
+
+    def y_grbl_factor(self):
+        if not self.active:
+            return 1.0
+        if self.service.rotary_firmware_steps:
+            return 1.0
+        if not self.service.rotary_steps_compensate:
+            return 1.0
+        return y_steps_factor(
+            float(self.service.rotary_flat_y_steps),
+            float(self.service.rotary_y_steps),
+        )
+
+    def apply_firmware_steps(self, driver):
+        if not self.active or not self.service.rotary_firmware_steps:
+            return False
+        driver(f"$101={float(self.service.rotary_y_steps):.3f}{driver.line_end}")
+        driver.wait_finish()
+        return True
+
+    def restore_firmware_steps(self, driver):
+        if not self.service.rotary_firmware_steps:
+            return
+        driver(f"$101={float(self.service.rotary_flat_y_steps):.3f}{driver.line_end}")
+        driver.wait_finish()
+
     @property
     def scale_x(self):
-        return self.service.rotary_scale_x
+        return self.effective_scale_x()
 
     @property
     def scale_y(self):
-        return self.service.rotary_scale_y
+        return self.effective_scale_y()
 
     @property
     def active(self):
@@ -156,41 +604,38 @@ class Rotary:
     def suppress_home(self):
         return self.service.suppress_home
 
+    @property
+    def home_x_only(self):
+        return self.service.rotary_home_x_only
+
     @lookup_listener("service/device/active")
     @signal_listener("rotary_scale_x")
     @signal_listener("rotary_scale_y")
     @signal_listener("rotary_active")
     @signal_listener("rotary_flip_x")
     @signal_listener("rotary_flip_y")
+    @signal_listener("rotary_diameter_mm")
+    @signal_listener("rotary_length_mm")
+    @signal_listener("rotary_auto_wrap_scale")
+    @signal_listener("rotary_auto_length_scale")
+    @signal_listener("rotary_flat_y_steps")
+    @signal_listener("rotary_y_steps")
+    @signal_listener("rotary_steps_compensate")
+    @signal_listener("rotary_firmware_steps")
     def rotary_settings_changed(self, origin=None, *args):
-        """
-        Rotary settings were changed. We force the current device to realize
-
-        @param origin:
-        @param args:
-        @return:
-        """
         if origin is not None and origin != self.service.path:
             return
         device = self.service.device
         device.realize()
+        self.service.signal("refresh_scene", "Scene")
 
     @signal_listener("view;realized")
     def realize(self, origin=None, *args):
         """
-        Realization of current device requires that device to be additionally updated with rotary
-        @param origin:
-        @param args:
-        @return:
+        Do not warp device.view — that breaks scene rendering (text/paths).
+        Wrap and steps apply at job time in the GRBL driver only.
         """
-        if not self.service.rotary_active:
-            return
-        device = self.service.device
-        device.view.scale(self.service.rotary_scale_x, self.service.rotary_scale_y)
-        if self.service.rotary_flip_x:
-            device.view.flip_x()
-        if self.service.rotary_flip_y:
-            device.view.flip_y()
+        return
 
     def service_detach(self, *args, **kwargs):
         pass

--- a/meerk40t/rotary/rotary_cam.py
+++ b/meerk40t/rotary/rotary_cam.py
@@ -1,0 +1,86 @@
+"""
+Rotary CAM helpers — circumference, steps compensation, and layout math.
+
+Used when the Y motor drives a chuck-style rotary (Y-axis swap on GRBL).
+"""
+
+import math
+
+from meerk40t.core.units import Length
+
+
+def circumference_mm(diameter_mm: float) -> float:
+    if diameter_mm <= 0:
+        return 0.0
+    return math.pi * diameter_mm
+
+
+def y_steps_factor(flat_y_steps_per_mm: float, rotary_y_steps_per_mm: float) -> float:
+    """
+    Scale Y coordinates sent to GRBL when firmware $101 still matches the flat-bed
+    gantry motor but a different rotary motor is wired to the Y driver.
+
+    y_grbl = y_design * (flat_steps / rotary_steps)
+    """
+    if rotary_y_steps_per_mm <= 0:
+        return 1.0
+    if flat_y_steps_per_mm <= 0:
+        return 1.0
+    return flat_y_steps_per_mm / rotary_y_steps_per_mm
+
+
+def calibrate_rotary_steps(
+    current_steps_per_mm: float, commanded_mm: float, measured_mm: float
+) -> float:
+    """Adjust rotary steps/mm after a test line (commanded vs measured)."""
+    if measured_mm <= 0 or commanded_mm <= 0:
+        return current_steps_per_mm
+    return current_steps_per_mm * (commanded_mm / measured_mm)
+
+
+def suggest_rotary_steps_per_mm(
+    motor_steps_per_rev: int,
+    microsteps: int,
+    gear_ratio: float,
+    diameter_mm: float,
+) -> float:
+    """
+    Estimate GRBL $101 for a chuck rotary: steps per mm of surface travel
+  around the cylinder (one full turn = pi * diameter mm).
+    """
+    if diameter_mm <= 0 or gear_ratio <= 0:
+        return 0.0
+    steps_per_rev = motor_steps_per_rev * microsteps * gear_ratio
+    circ = circumference_mm(diameter_mm)
+    if circ <= 0:
+        return 0.0
+    return steps_per_rev / circ
+
+
+def wrap_scale_y(diameter_mm: float, bed_height_mm: float) -> float:
+    """Scene bed height -> one object circumference along Y."""
+    circ = circumference_mm(diameter_mm)
+    if bed_height_mm <= 0 or circ <= 0:
+        return 1.0
+    return circ / bed_height_mm
+
+
+def length_scale_x(object_length_mm: float, bed_width_mm: float) -> float:
+    """Scene bed width -> usable object length along X."""
+    if bed_width_mm <= 0 or object_length_mm <= 0:
+        return 1.0
+    return object_length_mm / bed_width_mm
+
+
+def bed_length_mm(service) -> float:
+    try:
+        return float(Length(service.bedwidth))
+    except (AttributeError, ValueError, TypeError):
+        return 0.0
+
+
+def bed_height_mm(service) -> float:
+    try:
+        return float(Length(service.bedheight))
+    except (AttributeError, ValueError, TypeError):
+        return 0.0

--- a/meerk40t/tools/kerftest.py
+++ b/meerk40t/tools/kerftest.py
@@ -855,8 +855,7 @@ class KerfPanel(wx.Panel):
                 create_operations()
 
         self.context.signal("rebuild_tree")
-        self.context.signal("invalidate_layer", "generic")
-        self.context.signal_refresh()
+        self.context.signal("refresh_scene", "Scene")
         # This is not really necessary if we have the sequence
         # of raster - engrave - cut. It might be still appropriate
         # in some other cases though

--- a/meerk40t/tools/livinghinges.py
+++ b/meerk40t/tools/livinghinges.py
@@ -186,7 +186,7 @@ class HingePanel(wx.Panel):
             +50,
             style=wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL,
         )
-        self.button_generate = wxButton(self, wx.ID_ANY, _("Generate"))
+        self.button_generate = wxButton(self, wx.ID_ANY, _("Apply to scene"))
         self.button_close = wxButton(self, wx.ID_ANY, _("Close"))
         self.context.setting(bool, "hinge_preview_pattern", True)
         self.context.setting(bool, "hinge_preview_shape", True)
@@ -455,11 +455,13 @@ class HingePanel(wx.Panel):
         # main_left.Add(self.check_debug_outline, 0, wx.EXPAND, 0)
 
         hsizer_buttons = wx.BoxSizer(wx.HORIZONTAL)
-        main_left.Add(hsizer_buttons, 0, wx.EXPAND, 0)
 
-        self.button_generate.SetToolTip(_("Generates the hinge"))
+        self.button_generate.SetToolTip(
+            _("Add hinge cut paths to the main scene (assign to Cut, then burn)")
+        )
         hsizer_buttons.Add(self.button_generate, 2, 0, 0)
 
+        self.button_close.SetToolTip(_("Close this window"))
         hsizer_buttons.Add(self.button_close, 1, 0, 0)
 
         main_right = StaticBoxSizer(self, wx.ID_ANY, _("Preview"), wx.VERTICAL)
@@ -473,6 +475,7 @@ class HingePanel(wx.Panel):
         hsizer_preview.Add(self.check_preview_show_shape, 1, wx.EXPAND, 0)
         self.panel_preview = wx.Panel(self, wx.ID_ANY)
         main_right.Add(self.panel_preview, 1, wx.EXPAND, 0)
+        main_right.Add(hsizer_buttons, 0, wx.EXPAND | wx.TOP, 4)
         main_left.Layout()
         main_right.Layout()
         main_sizer.Layout()
@@ -1328,7 +1331,7 @@ class LivingHingeTool(MWindow):
     """
 
     def __init__(self, *args, **kwds):
-        super().__init__(570, 420, submenu="Laser-Tools", *args, **kwds)
+        super().__init__(570, 480, submenu="Laser-Tools", *args, **kwds)
         self.panel_template = HingePanel(
             self,
             wx.ID_ANY,


### PR DESCRIPTION
GRBL TCP wake/auto-port, laser panel and simulation GUI fixes, material test/manager and tree UX improvements for Andre 400x285 mm setup.

## Summary by Sourcery

Improve GRBL TCP connectivity and homing behaviour, enhance laser job control and feedback in the GUI, and streamline material testing and preset workflows for GRBL/MKS DLC32 K40 devices.

New Features:
- Add GRBL TCP auto-port detection and LAN wake behaviour to connect reliably to MKS DLC32 and similar boards.
- Introduce a laser job progress display in the Laser panel, including percentage, ETA, and queue information.
- Add GUI controls for numeric power and speed overrides alongside refined 5% step sliders for live GRBL overrides.
- Expose a material preset combo box in the Operations tree for quickly loading Material Manager presets into the job.
- Allow cancelling long simulation cache calculations while keeping the job loaded.
- Add a button in the material test tool to queue the generated test pattern directly to the Job Spooler.
- Provide a predefined GRBL device profile for a K40 CO2 with MKS DLC32 (405×285 mm) including macros and TCP defaults.
- Introduce settings for longer, richer ribbon and context-menu hover help with configurable ribbon tooltip delay.

Bug Fixes:
- Fix GRBL jog confinement by clamping moves in UI bed coordinates instead of mixing native machine coordinates, avoiding inverted Y issues on negative-MPos machines.
- Ensure GRBL driver applies override commands in consistent 5% steps and within valid 10–200% ranges.
- Prevent scene rendering crashes by guarding against 0×0 and invalid bitmaps during startup and resize.
- Make scene background cache drawing robust when the background bitmap is not yet allocated.
- Treat numpad Delete the same as Delete in scene and tree, consistently triggering element deletion.
- Clamp material-test-generated power values to the valid 0–100% range when using percent-based power display.
- Handle GRBL TCP read timeouts and closed connections gracefully with status messages instead of hard errors.
- Persist the Tips-at-startup setting immediately so it is reliably saved on shutdown.
- Avoid incorrect deletion in Material Manager when categorising by laser type by using display labels for matching.

Enhancements:
- Refactor plan spooling from the Laser panel into a reusable helper that respects hold behaviour and auto-opens relevant windows.
- Improve GRBL TCP connection robustness with HTTP wake, retry loops, port probing, and better error logging.
- Align GRBL status handling with confined jogging by continuously declaring positions from MPos and warning when Flip Y is misconfigured.
- Add sequential homing support and configuration for GRBL devices, using $HY then $HX where appropriate for DLC32 top-left setups.
- Improve navigation confinement UX with a warning dialog before disabling bed limits and defaulting confinement to on.
- Update navigation home behaviour to prefer physical homing when endstops are present.
- Enhance Material Manager’s delete logic and category labelling for clearer laser/type/group handling.
- Improve operation property power display by capping shown percentages at 100% and explaining overrange values via tooltip.
- Unify tree and scene delete handling via shared helpers so keyboard deletes mirror ribbon behaviour.
- Enrich ribbon tooltips by combining short tips with extended help text and using a dedicated hover-delay mechanism.
- Extend context-menu help to show richer status-bar descriptions, optionally pulling from function docstrings when verbose help is enabled.
- Make material test parameters and generated operations better respect percent power display and mm/min speed settings.