### PR TITLE
fix optimization regression

### DIFF
--- a/meerk40t/core/cutplan.py
+++ b/meerk40t/core/cutplan.py
@@ -726,12 +726,13 @@ class CutPlan:
             # self.channel("Dumping scenarios:")
             # self.commands.append(self._dump_scenario)
 
-        # When effect_combine is True but effect_optimize is False, skip travel optimization
-        # and use basic sequencing to prevent skip-marked groups from being optimized
-        if context.opt_effect_combine and not context.opt_effect_optimize:
-            # Skip all travel optimization for effect-combined groups
-            self.commands.append(self.basic_cutcode_sequencing)
-        elif context.opt_inner_first:
+        # Inner-first / travel optimization still runs when effects are combined:
+        # combine_effects marks effect (hatch) groups with .skip, and
+        # short_travel_cutcode sequences those separately (honoring
+        # opt_effect_optimize via hatch_optimize) while optimizing the rest.
+        # A blanket basic_cutcode_sequencing here would disable optimization for
+        # every plan whenever "Keep effect lines together" is on (the default).
+        if context.opt_inner_first:
             # Inner-first optimization takes priority and includes travel optimization
             self.commands.append(self.optimize_cuts)
         elif context.opt_reduce_travel and (
@@ -965,8 +966,11 @@ class CutPlan:
                     c = self.plan[i]
                 self.plan[i] = short_travel_cutcode(
                     c,
+                    kernel=self.context.kernel,
                     channel=channel,
+                    complete_path=self.context.opt_complete_subpaths,
                     grouped_inner=grouped_inner,
+                    hatch_optimize=self.context.opt_effect_optimize,
                 )
 
     def optimize_travel(self):

--- a/test/test_cutplan_dispatch.py
+++ b/test/test_cutplan_dispatch.py
@@ -1,0 +1,77 @@
+"""
+CutPlan.preopt() chooses which optimizer to schedule from the optimization
+settings. These tests pin that choice for the key setting combinations.
+
+The subtle case is effect combining: "Keep effect lines together"
+(opt_effect_combine) groups hatch/effect lines so they burn together, but it
+must NOT disable optimization for ordinary geometry. combine_effects marks the
+effect groups with .skip and short_travel_cutcode sequences those separately,
+so inner-first / travel optimization still has to run for everything else even
+when effects are combined (which is the default).
+"""
+
+import unittest
+
+from test import bootstrap
+
+
+class TestCutplanDispatch(unittest.TestCase):
+    def _preopt_commands(self, **opts):
+        """Build a two-rect cut plan and return the names of the commands that
+        preopt scheduled for the optimize stage."""
+        kernel = bootstrap.bootstrap(profile="MeerK40t_TEST_optdispatch")
+        try:
+            kernel.console("service device start -i grbl 0\n")
+            planner = kernel.planner
+            for attr, value in opts.items():
+                setattr(planner, attr, value)
+            kernel.console("element* delete\noperation* delete\n")
+            kernel.console("rect 0cm 0cm 5cm 5cm\n")
+            kernel.console("rect 2cm 2cm 1cm 1cm\n")
+            kernel.console("element* cut -s 15\n")
+            kernel.console(
+                "plan clear copy preprocess validate blob preopt\n"
+            )
+            cutplan = planner.default_plan
+            return [
+                getattr(c, "__name__", repr(c)) for c in cutplan.commands
+            ]
+        finally:
+            kernel()
+
+    def test_inner_first_runs_with_combined_effects(self):
+        # Defaults: opt_effect_combine=True, opt_effect_optimize=False.
+        # Inner-first must still optimize ordinary geometry, not fall back to
+        # basic sequencing; combine_effects still runs to protect hatch lines.
+        commands = self._preopt_commands(opt_inner_first=True)
+        self.assertIn("optimize_cuts", commands)
+        self.assertNotIn("basic_cutcode_sequencing", commands)
+        self.assertIn("combine_effects", commands)
+
+    def test_travel_optimization_runs_with_combined_effects(self):
+        # Travel-only optimization (inner-first off) must also survive combined
+        # effects.
+        commands = self._preopt_commands(
+            opt_inner_first=False,
+            opt_reduce_travel=True,
+            opt_nearest_neighbor=True,
+        )
+        self.assertIn("optimize_travel", commands)
+        self.assertNotIn("basic_cutcode_sequencing", commands)
+
+    def test_no_optimization_uses_basic_sequencing(self):
+        # With no optimization requested, basic sequencing is the correct
+        # fallback (and no optimizer is scheduled).
+        commands = self._preopt_commands(
+            opt_inner_first=False,
+            opt_reduce_travel=False,
+            opt_nearest_neighbor=False,
+            opt_2opt=False,
+        )
+        self.assertIn("basic_cutcode_sequencing", commands)
+        self.assertNotIn("optimize_cuts", commands)
+        self.assertNotIn("optimize_travel", commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cutplan_travel_optimization.py
+++ b/test/test_cutplan_travel_optimization.py
@@ -73,6 +73,8 @@ class MockContext:
         self.opt_inners_grouped = opt_inners_grouped
         self.opt_inner_tolerance = 0
         self.opt_effect_combine = False
+        self.opt_effect_optimize = False
+        self.opt_complete_subpaths = False
         self.kernel = MockKernel()
         self.device = MockDevice()
 


### PR DESCRIPTION
The default settings turned off optimizing by accident: a change in commit b26d8a890 ("Hatch optimisation fixes") made the planner fall back to plain, unoptimized cutting whenever "Keep effect lines together" was on and "Optimize internally" was off (which is the default).  so "burn inner first" and travel reduction never actually ran. This fix keeps what that commit wanted (hatch lines still stay grouped and are left alone) but turns normal optimizing back on for everything else.

## Summary by Sourcery

Restore travel and inner-first optimization when effects are combined while preserving grouped hatch behavior.

Bug Fixes:
- Fix regression where enabling effect combining with default settings disabled all travel and inner-first optimization for regular geometry.

Enhancements:
- Pass additional context options into travel optimization to respect complete subpaths and effect optimization flags.
- Add targeted tests to pin CutPlan.preopt command dispatch for key optimization option combinations.

Tests:
- Extend existing travel optimization tests with new planner options and add a new test suite for preopt dispatch behavior under various optimization settings.