### PR TITLE
Fix flatpak build

### DIFF
--- a/.github/workflows/linux/meerk40t.appdata.xml
+++ b/.github/workflows/linux/meerk40t.appdata.xml
@@ -75,12 +75,6 @@
     </screenshot>
   </screenshots>
 
-  <!--
-    Placeholder release entry. The weekly-binaries flatpak job rewrites this
-    in-place via sed to set the actual build version (APPLICATION_VERSION +
-    run_number) and today's date. The committed values exist only so the file
-    passes `appstreamcli validate --strict` for local development.
-  -->
   <releases>
     <release version="0.9.9000" date="2026-05-27" type="development"/>
   </releases>


### PR DESCRIPTION
The recently added flatpak build has a comment with invalid xml character in it that is causing issues.. removing the comment allows the build to succeed.

## Summary by Sourcery

Build:
- Clean up the Flatpak appdata XML by removing a problematic comment so the Flatpak workflow can build successfully.