### PR TITLE
fix images shifting position when rasterized on galvo lasers

### DIFF
--- a/meerk40t/core/node/elem_image.py
+++ b/meerk40t/core/node/elem_image.py
@@ -951,13 +951,7 @@ class ImageNode(Node, LabelDisplay, Suppressable):
                 height = cbox[3] - cbox[1]
                 if width != image.width or height != image.height:
                     image = image.crop(cbox)
-                    # TODO:
-                    # We did not crop the image so far, but we already applied
-                    # the cropped transformation! That may be faulty, and needs to
-                    # be corrected at a later stage, but this logic, even if clumsy
-                    # is good enough: don't shift things twice!
-                    if orgbox[0] == 0 and orgbox[1] == 0:
-                        actualized_matrix.post_translate(cbox[0], cbox[1])
+                    actualized_matrix.post_translate(cbox[0], cbox[1])
 
         actualized_matrix.post_scale(step_x, step_y)
         actualized_matrix.post_translate(tx, ty)

--- a/test/test_image_bounds_position.py
+++ b/test/test_image_bounds_position.py
@@ -1,0 +1,73 @@
+import math
+import unittest
+
+from PIL import Image, ImageDraw
+
+from meerk40t.core.node.elem_image import ImageNode
+from meerk40t.svgelements import Matrix
+from test import bootstrap
+
+
+SOURCE_SIZE = 256
+CONTENT_INSET = 50
+CONTENT_SIZE = SOURCE_SIZE - 2 * CONTENT_INSET
+
+
+def _padded_source():
+    img = Image.new("RGBA", (SOURCE_SIZE, SOURCE_SIZE), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    inset = CONTENT_INSET
+    draw.rectangle(
+        (inset, inset, SOURCE_SIZE - inset - 1, SOURCE_SIZE - inset - 1),
+        fill=(0, 0, 0, 255),
+    )
+    return img
+
+
+def _unpadded_source():
+    return Image.new("RGBA", (SOURCE_SIZE, SOURCE_SIZE), (0, 0, 0, 255))
+
+
+class TestProcessImageCropTranslate(unittest.TestCase):
+    def setUp(self):
+        self.kernel = bootstrap.bootstrap()
+
+    def tearDown(self):
+        self.kernel()
+
+    def _process(self, source_image, matrix):
+        node = ImageNode(image=source_image, matrix=Matrix(matrix))
+        node.step_x = 1
+        node.step_y = 1
+        node.process_image(step_x=1, step_y=1, crop=True)
+        return node
+
+    def _assert_origin_matches_bbox(self, node):
+        bbox = node.bbox()
+        ax0, ay0 = node.active_matrix.point_in_matrix_space((0, 0))
+        self.assertAlmostEqual(ax0, bbox[0], delta=1.0)
+        self.assertAlmostEqual(ay0, bbox[1], delta=1.0)
+
+    def test_padded_rotated(self):
+        m = Matrix()
+        m.post_rotate(math.radians(9))
+        m.post_scale(10, 10)
+        m.post_translate(1000, 2000)
+        self._assert_origin_matches_bbox(self._process(_padded_source(), m))
+
+    def test_padded_unrotated(self):
+        m = Matrix.scale(10, 10)
+        m.post_translate(1000, 2000)
+        self._assert_origin_matches_bbox(self._process(_padded_source(), m))
+
+    def test_unpadded_rotated(self):
+        m = Matrix()
+        m.post_rotate(math.radians(9))
+        m.post_scale(10, 10)
+        m.post_translate(1000, 2000)
+        self._assert_origin_matches_bbox(self._process(_unpadded_source(), m))
+
+    def test_as_image_bounds_match_bbox(self):
+        node = self._process(_padded_source(), Matrix.scale(10, 10))
+        _img, asimage_bounds = node.as_image()
+        self.assertEqual(tuple(asimage_bounds), tuple(node.bbox()))


### PR DESCRIPTION
Images with transparent margins around the content were getting offset by a few mm in the burn versus where the design view showed them, visible mostly on galvo lasers because the device's rotational view matrix amplified the shift.

The cause was a guard in _process_image that skipped a translation correction whenever the source had transparent margins. PIL's affine transform crops twice — once based on the source content, then again after rotation/shear. The fix for the second crop was being gated on the first crop being at (0, 0), under a "don't shift twice" comment. Turns out the two crops are independent and skipping the second one just leaves the rendered image misplaced.

Test cases for padded+rotated, padded+unrotated, and unpadded+rotated to prevent regression.

This is an issue that came up in class and we were using the stable version so this issue has existed since then.  The below file was the file that presented the issue in class.  The sun image has padding around it... the design showed it one way but the simulation and burn showed it differently.  

<img width="567" height="567" alt="JSS-20260620" src="https://github.com/user-attachments/assets/6f2b71c5-cbc4-4572-bda4-c2967359048f" />

## Summary by Sourcery

Ensure rasterized images with transparent padding retain correct positioning after cropping and transformation, particularly on galvo lasers.

Bug Fixes:
- Fix misalignment of rotated images with transparent margins by always applying the second crop translation to the active matrix in image processing.

Tests:
- Add regression tests verifying active_matrix alignment with bbox for padded/rotated, padded/unrotated, and unpadded/rotated images, and consistency between as_image bounds and bbox.