### PR TITLE
use xwayland when available

### DIFF
--- a/.github/workflows/flatpak/io.github.meerk40t.meerk40t.yaml
+++ b/.github/workflows/flatpak/io.github.meerk40t.meerk40t.yaml
@@ -17,8 +17,9 @@ command: meerk40t
 finish-args:
   - --share=network
   - --share=ipc
+  # x11 (not fallback-x11) so XWayland is reachable for AUI pane drag/dock.
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=all
   - --filesystem=home
   # Suppress the in-app updater. The install path is read-only and updates

--- a/meerk40t/main.py
+++ b/meerk40t/main.py
@@ -11,6 +11,15 @@ import faulthandler
 import os.path
 import sys
 
+# Wayland can't reposition top-levels (breaks AUI pane drag/dock); use XWayland.
+if (
+    sys.platform.startswith("linux")
+    and os.environ.get("WAYLAND_DISPLAY")
+    and os.environ.get("DISPLAY")
+    and not os.environ.get("GDK_BACKEND")
+):
+    os.environ["GDK_BACKEND"] = "x11"
+
 # Print Python stack on native crashes (SIGSEGV etc).
 faulthandler.enable()
 


### PR DESCRIPTION
This is a fix for an issue that only shows up on Linux using Wayland.  On Wayland, wx is unable to get global mouse positions and this causes pane docking to fail when trying to drag panes around.  It is most apparent when a dock is floating as it's impossible to redock it without resetting all the panes.  

This fix basically just sets an environment variable that tells Wayland to use xwayland if it exists which uses x11 protocols and allows the docks/dragging to work correctly again.  Otherwise, if Wayland or xwayland doesn't exist then it does nothing and runs as it does today.

This also updates the flatpak build to ensure x11 protocols exist.  AppImage and other linux builds should work as they are now.

This fix will probably work for a very long time as xwayland won't go away anytime soon and eventually wx will update it's docking to work with the Wayland system.

## Summary by Sourcery

Ensure Linux Wayland sessions fall back to XWayland so AUI pane dragging and docking works correctly, and align the Flatpak configuration with this behavior.

Bug Fixes:
- Force use of X11 via XWayland on Linux Wayland sessions to restore functional pane dragging and docking in the wxWidgets UI.

Build:
- Update Flatpak permissions to use the x11 socket instead of fallback-x11 so XWayland is available when running under Wayland.