### PR TITLE
Toolbar icon and text consistency

### DIFF
--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -921,6 +921,9 @@ class RibbonBarPanel(wx.Control):
         self._paint_dirty = True
         self._layout_dirty = True
         self._ribbon_buffer = None
+        self._dock_cap = None
+        self._dock_snap_timer = None
+        self._snapping = False
 
         # self._overflow = list()
         # self._overflow_position = None
@@ -932,6 +935,7 @@ class RibbonBarPanel(wx.Control):
         self.Bind(wx.EVT_MOTION, self.on_mouse_move)
         self.Bind(wx.EVT_PAINT, self.on_paint)
         self.Bind(wx.EVT_SIZE, self.on_size)
+        self.Bind(wx.EVT_WINDOW_DESTROY, self.on_destroy)
 
         self.Bind(wx.EVT_LEFT_DOWN, self.on_click)
         self.Bind(wx.EVT_RIGHT_UP, self.on_click_right)
@@ -988,6 +992,16 @@ class RibbonBarPanel(wx.Control):
     def on_size(self, event: wx.SizeEvent):
         self._set_buffer()
         self.modified()
+        self._schedule_dock_snap()
+
+    def on_destroy(self, event):
+        if self._dock_snap_timer is not None:
+            try:
+                self._dock_snap_timer.Stop()
+            except RuntimeError:
+                pass
+            self._dock_snap_timer = None
+        event.Skip()
 
     def on_erase_background(self, event):
         pass
@@ -1089,6 +1103,7 @@ class RibbonBarPanel(wx.Control):
     def _paint_main_on_buffer(self):
         """Performs redrawing of the data in the UI thread."""
         # print (f"Redraw job started for RibbonBar with {self.visible_pages()} pages")
+        dock_extent = None
         if self._redraw_lock.acquire(timeout=0.2):
             try:
                 buf = self._set_buffer()
@@ -1098,6 +1113,7 @@ class RibbonBarPanel(wx.Control):
                     self.art.layout(dc, self)
                     self._layout_dirty = False
                 self.art.paint_main(dc, self)
+                dock_extent = self.art.dock_extent(self)
                 dc.SelectObject(wx.NullBitmap)
                 del dc
                 self._paint_dirty = False
@@ -1106,11 +1122,60 @@ class RibbonBarPanel(wx.Control):
                 # Shutdown error
             finally:
                 self._redraw_lock.release()
+        self._dock_cap = dock_extent
+        self._schedule_dock_snap()
         try:
             self.Refresh()  # Paint buffer on screen.
         except RuntimeError:
             # Shutdown error
             pass
+
+    def _schedule_dock_snap(self):
+        if self._snapping:
+            return
+        cap = self._dock_cap
+        if cap is None:
+            return
+        try:
+            if not self.prefer_horizontal():
+                return
+            if self.GetSize().GetHeight() <= cap + 2:
+                return
+        except RuntimeError:
+            return
+        if self._dock_snap_timer is not None:
+            self._dock_snap_timer.Stop()
+        self._dock_snap_timer = wx.CallLater(150, self._snap_dock)
+
+    def _snap_dock(self):
+        cap = self._dock_cap
+        if cap is None or self.pane is None:
+            return
+        try:
+            if self.context.kernel.is_shutdown:
+                return
+        except AttributeError:
+            return
+        self._snapping = True
+        try:
+            if not self.prefer_horizontal():
+                return
+            if self.GetSize().GetHeight() <= cap + 2:
+                return
+            mgr = self.pane.manager
+            pane = mgr.GetPane(self.pane.name)
+            if not pane.IsOk() or not pane.IsDocked():
+                return
+            # Resize a docked pane by briefly fixing it to the target size.
+            pane.Fixed()
+            pane.BestSize(wx.Size(-1, cap))
+            mgr.Update()
+            pane.Resizable(True)
+            mgr.Update()
+        except (AttributeError, RuntimeError):
+            pass
+        finally:
+            self._snapping = False
 
     def prefer_horizontal(self):
         result = None
@@ -1733,8 +1798,6 @@ class Art:
                         if ptsize < 6:  # too small
                             break
                     if not wouldfit:
-                        # A single button that cannot show its label turns
-                        # labels off for the whole bar (all-or-nothing).
                         self.all_labels_fit = False
 
     def _paint_tab(self, dc: wx.DC, page: RibbonPage):
@@ -2002,8 +2065,8 @@ class Art:
             button.toggle,  # Toggle state affects colors
             self.hover_button is button and self.hover_dropdown is None,  # Hover state
             self.show_labels,  # Whether labels are shown
-            self.all_labels_fit,  # Labels are all-or-nothing for the bar
-            self.label_reserve,  # Reserved label height affects icon size
+            self.all_labels_fit,
+            self.label_reserve,
             button.icon_size,  # Icon size affects rendering
         )
 
@@ -2020,8 +2083,7 @@ class Art:
         # No cached version - calculate text layout and render using helper
         start_y = y
         img_h = h
-        # Reserve space for labels only when they will actually be shown; when
-        # labels are suppressed for the bar the icon reclaims the full height.
+        # do we have text? if yes let's reduce the available space in y
         if self.show_labels and self.all_labels_fit:
             img_h -= self.bitmap_text_buffer
             img_h -= self.label_reserve
@@ -2033,22 +2095,16 @@ class Art:
             bitmap = button.bitmap_disabled
 
         bitmap_width, bitmap_height = bitmap.Size
-        # Reposition the drop-down caret for the icon at its just-rendered size.
         self._position_dropdown(button)
         ptsize = self.get_best_font_size(self.label_font_ceiling(w))
         # Use cached font instead of creating new one
         font = self.get_cached_font(ptsize)
 
         text_edge = self.bitmap_text_buffer
-        # Whether labels are shown is an all-or-nothing decision already made
-        # for the whole bar in look_at_button_font_sizes; never hide an
-        # individual button here. The uniform ptsize fits every button.
         show_text = bool(button.label) and self.show_labels and self.all_labels_fit
         if show_text:
             label_text = button.label.split(" ")
             dc.SetFont(font)
-            # Measure the wrapped label height so it can be centered below the
-            # icon (this mirrors the wrapping done in _render_button_content).
             total_text_height = 0
             i = 0
             while i < len(label_text):
@@ -2248,6 +2304,34 @@ class Art:
             # if self.parent.visible_pages() == 1:
             #     print(f"page: {page.position}")
             self.page_layout(dc, page)
+
+    def dock_extent(self, ribbon):
+        if not self.parent.prefer_horizontal():
+            return None
+        page = self.current_page
+        if page is None:
+            page = ribbon.first_page()
+        if page is None or page.position is None:
+            return None
+        bottom = 0
+        found = False
+        for panel in page.panels:
+            if panel is None or panel.visible_button_count == 0:
+                continue
+            for button in panel.visible_buttons():
+                if button.overflow or not button.visible or button.position is None:
+                    continue
+                found = True
+                x, y, x1, y1 = button.position
+                icon = min(button.max_size, int(round(x1 - x)))
+                content = y + icon + 2 * (icon // 25 + 1)
+                if self.show_labels and self.all_labels_fit:
+                    content += self.bitmap_text_buffer + self.label_reserve
+                bottom = max(bottom, content)
+        if not found:
+            return None
+        bottom += self.panel_button_buffer + self.page_panel_buffer
+        return int(bottom)
 
     def preferred_button_size_for_page(self, dc, page):
         x, y, max_x, max_y = page.position
@@ -2672,15 +2756,15 @@ class Art:
         self._position_dropdown(button)
 
     def _position_dropdown(self, button):
-        # Place the drop-down caret at the lower-right of the icon at its
-        # current size. Called on every paint so the caret tracks the icon as
-        # it is resized, rather than being frozen at its layout-time size.
         if button.dropdown is None or button.position is None:
             return
         if button.kind != "hybrid" or button.key == "toggle":
             return
         x, y, max_x, max_y = button.position
         bitmap_width, bitmap_height = button.bitmap.Size
+        # Calculate text height/width
+        # Calculate dropdown
+        # Same size regardless of bitmap-size
         sizx = 15
         sizy = 15
         if min(bitmap_width, bitmap_height) > 70:
@@ -2699,23 +2783,28 @@ class Art:
         if bitmap_height < 30:
             gap = 3
 
+        # print (f"{bitmap_width}x{bitmap_height} - siz={sizx}, gap={gap}")
         button.dropdown.position = (
             extx - sizx,
             exty - sizy - gap,
             extx,
             exty - gap,
         )
+        # button.dropdown.position = (
+        #     x + bitmap_width / 2,
+        #     y + bitmap_height / 2,
+        #     x + bitmap_width,
+        #     y + bitmap_height,
+        # )
+        # print (
+        #     f"Required for {button.label}: button: {x},{y} to {max_x},{max_y}," +
+        #     f"dropd: {extx-sizx},{exty-sizy} to {extx},{exty}"
+        # )
 
     def label_font_ceiling(self, w):
-        # Largest label size we attempt for a button of this width. Height is
-        # deliberately not a factor, so a shorter bar shrinks the icon (which
-        # takes the leftover height) before it shrinks the text. Floored at 6,
-        # the smallest readable size, below which labels are hidden instead.
         return max(6, min(18, int(round(w / 5.0, 2)) * 2))
 
     def _label_block_height(self, dc, label, w, ptsize):
-        # Wrapped height of `label` rendered at `ptsize` within width w.
-        # Returns 0 if any (combined) word is wider than w.
         words = label.split(" ")
         total_h = 0
         i = 0
@@ -2739,8 +2828,6 @@ class Art:
         return total_h
 
     def _label_width_fit(self, dc, label, w):
-        # Largest font size <= ceiling(w) at which every word in `label` fits
-        # width w. Height-independent. Returns 0 if it cannot fit even at 6.
         ptsize = self.label_font_ceiling(w)
         while ptsize >= 6:
             if self._label_block_height(dc, label, w, ptsize) > 0:
@@ -2749,12 +2836,6 @@ class Art:
         return 0
 
     def _compute_label_reserve(self, dc, page):
-        # Uniform vertical space for labels across the whole bar. First find the
-        # single largest font size at which every label still fits its width
-        # (height is irrelevant here, so it is stable while the bar resizes),
-        # then reserve the tallest label block at that one size. The icon takes
-        # the remaining height, so icons — not text — shrink first, and only by
-        # as much as the actual (uniform) text really needs.
         if not self.show_labels:
             return 0
         labels = []
@@ -2771,7 +2852,7 @@ class Art:
                 w = int(round(x1 - x))
                 labels.append((button.label, w))
                 fit = self._label_width_fit(dc, button.label, w)
-                if fit:  # ignore labels that cannot fit even at 6 (they hide)
+                if fit:
                     uniform = fit if uniform is None else min(uniform, fit)
         if uniform is None:
             return 0

--- a/meerk40t/gui/ribbon.py
+++ b/meerk40t/gui/ribbon.py
@@ -1439,6 +1439,8 @@ class Art:
         self.edge_page_buffer = 4
         self.rounded_radius = 3
         self.font_sizes = {}
+        self.all_labels_fit = True
+        self.label_reserve = 0
 
         # Font cache for performance optimization
         self._font_cache = {}
@@ -1646,11 +1648,15 @@ class Art:
 
     def look_at_button_font_sizes(self, dc, page):
         self.font_sizes = {}
+        self.all_labels_fit = True
+        self.label_reserve = self._compute_label_reserve(dc, page)
         for panel in page.panels:
             # We suppress empty panels
             if panel is None or panel.visible_button_count == 0:
                 continue
             for button in panel.visible_buttons():
+                if button.overflow or not button.visible or button.position is None:
+                    continue
                 x, y, x1, y1 = button.position
                 w = int(round(x1 - x))
                 h = int(round(y1 - y))
@@ -1658,8 +1664,7 @@ class Art:
                 # do we have text? if yes let's reduce the available space in y
                 if self.show_labels:  # Regardless whether we have a label or not...
                     img_h -= self.bitmap_text_buffer
-                    ptsize = min(18, int(round(min(w, img_h) / 5.0, 2)) * 2)
-                    img_h -= int(ptsize * 1.35)
+                    img_h -= self.label_reserve
 
                 button.get_bitmaps(min(w, img_h))
                 if button.enabled:
@@ -1668,8 +1673,7 @@ class Art:
                     bitmap = button.bitmap_disabled
 
                 bitmap_width, bitmap_height = bitmap.Size
-                bs = min(bitmap_width, bitmap_height)
-                ptsize = self.get_font_size(bs)
+                ptsize = self.label_font_ceiling(w)
                 y += bitmap_height
 
                 text_edge = self.bitmap_text_buffer
@@ -1728,6 +1732,10 @@ class Art:
                         ptsize -= 2
                         if ptsize < 6:  # too small
                             break
+                    if not wouldfit:
+                        # A single button that cannot show its label turns
+                        # labels off for the whole bar (all-or-nothing).
+                        self.all_labels_fit = False
 
     def _paint_tab(self, dc: wx.DC, page: RibbonPage):
         """
@@ -1994,6 +2002,8 @@ class Art:
             button.toggle,  # Toggle state affects colors
             self.hover_button is button and self.hover_dropdown is None,  # Hover state
             self.show_labels,  # Whether labels are shown
+            self.all_labels_fit,  # Labels are all-or-nothing for the bar
+            self.label_reserve,  # Reserved label height affects icon size
             button.icon_size,  # Icon size affects rendering
         )
 
@@ -2010,11 +2020,11 @@ class Art:
         # No cached version - calculate text layout and render using helper
         start_y = y
         img_h = h
-        # do we have text? if yes let's reduce the available space in y
-        if self.show_labels:  # Regardless whether we have a label or not...
+        # Reserve space for labels only when they will actually be shown; when
+        # labels are suppressed for the bar the icon reclaims the full height.
+        if self.show_labels and self.all_labels_fit:
             img_h -= self.bitmap_text_buffer
-            ptsize = min(18, int(round(min(w, img_h) / 5.0, 2)) * 2)
-            img_h -= int(ptsize * 1.35)
+            img_h -= self.label_reserve
 
         button.get_bitmaps(min(w, img_h))
         if button.enabled:
@@ -2023,76 +2033,45 @@ class Art:
             bitmap = button.bitmap_disabled
 
         bitmap_width, bitmap_height = bitmap.Size
-        bs = min(bitmap_width, bitmap_height)
-        ptsize = self.get_best_font_size(bs)
+        # Reposition the drop-down caret for the icon at its just-rendered size.
+        self._position_dropdown(button)
+        ptsize = self.get_best_font_size(self.label_font_ceiling(w))
         # Use cached font instead of creating new one
         font = self.get_cached_font(ptsize)
 
         text_edge = self.bitmap_text_buffer
-        if button.label and self.show_labels:
-            show_text = True
+        # Whether labels are shown is an all-or-nothing decision already made
+        # for the whole bar in look_at_button_font_sizes; never hide an
+        # individual button here. The uniform ptsize fits every button.
+        show_text = bool(button.label) and self.show_labels and self.all_labels_fit
+        if show_text:
             label_text = button.label.split(" ")
-            # We try to establish whether this would fit properly.
-            # We allow a small oversize of 25% to the button,
-            # before we try to reduce the fontsize
-            wouldfit = False
-            font = None  # Initialize font variable
-            while not wouldfit:
-                total_text_height = 0
-                # Use cached font instead of creating new one each time
-                font = self.get_cached_font(ptsize)
-                test_y = y + bitmap_height + text_edge
-                dc.SetFont(font)
-                wouldfit = True
-                i = 0
-                while i < len(label_text):
-                    # We know by definition that all single words
-                    # are okay for drawing, now we check whether
-                    # we can draw multiple in one line
-                    word = label_text[i]
-                    cont = True
-                    while cont:
-                        cont = False
-                        if i < len(label_text) - 1:
-                            nextword = label_text[i + 1]
-                            test = word + " " + nextword
-                            # Use cached text extent
-                            tw, th = self.get_cached_text_extent(dc, test, ptsize)
-                            if tw < w:  # Use full button width for text fitting
-                                word = test
-                                i += 1
-                                cont = True
-
-                    text_width, text_height = self.get_cached_text_extent(
-                        dc, word, ptsize
-                    )
-                    if text_width > w:
-                        wouldfit = False
-                        break
-                    test_y += text_height
-                    total_text_height += text_height
-                    if test_y > y + h:
-                        wouldfit = False
-                        text_edge = 0
-                        break
-                    i += 1
-
-                if wouldfit:
-                    # if it wasn't a full fit, the new textsize might still be okay to be drawn at the intended position
-                    text_edge = min(
-                        max(0, start_y + h - (y + bitmap_height) - total_text_height),
-                        self.bitmap_text_buffer,
-                    )
-                    break
-
-                ptsize -= 2
-                if ptsize < 6:  # too small
-                    break
-            if not wouldfit:
-                show_text = False
-                label_text = []
+            dc.SetFont(font)
+            # Measure the wrapped label height so it can be centered below the
+            # icon (this mirrors the wrapping done in _render_button_content).
+            total_text_height = 0
+            i = 0
+            while i < len(label_text):
+                word = label_text[i]
+                cont = True
+                while cont:
+                    cont = False
+                    if i < len(label_text) - 1:
+                        nextword = label_text[i + 1]
+                        test = word + " " + nextword
+                        tw, th = self.get_cached_text_extent(dc, test, ptsize)
+                        if tw < w:
+                            word = test
+                            i += 1
+                            cont = True
+                _, text_height = self.get_cached_text_extent(dc, word, ptsize)
+                total_text_height += text_height
+                i += 1
+            text_edge = min(
+                max(0, start_y + h - (y + bitmap_height) - total_text_height),
+                self.bitmap_text_buffer,
+            )
         else:
-            show_text = False
             label_text = []
 
         # Render button content using helper method
@@ -2690,48 +2669,116 @@ class Art:
         # print (f"layout for {button.label} ({button.bitmapsize}): {button.min_width}x{button.min_height}, icon={bitmap_width}x{bitmap_height}")
 
     def button_layout(self, dc: wx.DC, button):
+        self._position_dropdown(button)
+
+    def _position_dropdown(self, button):
+        # Place the drop-down caret at the lower-right of the icon at its
+        # current size. Called on every paint so the caret tracks the icon as
+        # it is resized, rather than being frozen at its layout-time size.
+        if button.dropdown is None or button.position is None:
+            return
+        if button.kind != "hybrid" or button.key == "toggle":
+            return
         x, y, max_x, max_y = button.position
-        bitmap = button.bitmap
-        bitmap_width, bitmap_height = bitmap.Size
-        if button.kind == "hybrid" and button.key != "toggle":
-            # Calculate text height/width
-            # Calculate dropdown
-            # Same size regardless of bitmap-size
-            sizx = 15
-            sizy = 15
-            if min(bitmap_width, bitmap_height) > 70:
-                sizx = 20
-                sizy = 20
-            elif min(bitmap_width, bitmap_height) > 100:
-                sizx = 25
-                sizy = 25
+        bitmap_width, bitmap_height = button.bitmap.Size
+        sizx = 15
+        sizy = 15
+        if min(bitmap_width, bitmap_height) > 70:
+            sizx = 20
+            sizy = 20
+        elif min(bitmap_width, bitmap_height) > 100:
+            sizx = 25
+            sizy = 25
 
-            # Let's see whether we have enough room
-            extx = (x + max_x) / 2 + bitmap_width / 2 + sizx - 1
-            exty = y + bitmap_height + sizy - 1
-            extx = max(x - sizx, min(extx, max_x - 1))
-            exty = max(y + sizy, min(exty, max_y - 1))
-            gap = 15
-            if bitmap_height < 30:
-                gap = 3
+        # Let's see whether we have enough room
+        extx = (x + max_x) / 2 + bitmap_width / 2 + sizx - 1
+        exty = y + bitmap_height + sizy - 1
+        extx = max(x - sizx, min(extx, max_x - 1))
+        exty = max(y + sizy, min(exty, max_y - 1))
+        gap = 15
+        if bitmap_height < 30:
+            gap = 3
 
-            # print (f"{bitmap_width}x{bitmap_height} - siz={sizx}, gap={gap}")
-            button.dropdown.position = (
-                extx - sizx,
-                exty - sizy - gap,
-                extx,
-                exty - gap,
-            )
-            # button.dropdown.position = (
-            #     x + bitmap_width / 2,
-            #     y + bitmap_height / 2,
-            #     x + bitmap_width,
-            #     y + bitmap_height,
-            # )
-            # print (
-            #     f"Required for {button.label}: button: {x},{y} to {max_x},{max_y}," +
-            #     f"dropd: {extx-sizx},{exty-sizy} to {extx},{exty}"
-            # )
+        button.dropdown.position = (
+            extx - sizx,
+            exty - sizy - gap,
+            extx,
+            exty - gap,
+        )
+
+    def label_font_ceiling(self, w):
+        # Largest label size we attempt for a button of this width. Height is
+        # deliberately not a factor, so a shorter bar shrinks the icon (which
+        # takes the leftover height) before it shrinks the text. Floored at 6,
+        # the smallest readable size, below which labels are hidden instead.
+        return max(6, min(18, int(round(w / 5.0, 2)) * 2))
+
+    def _label_block_height(self, dc, label, w, ptsize):
+        # Wrapped height of `label` rendered at `ptsize` within width w.
+        # Returns 0 if any (combined) word is wider than w.
+        words = label.split(" ")
+        total_h = 0
+        i = 0
+        while i < len(words):
+            word = words[i]
+            cont = True
+            while cont:
+                cont = False
+                if i < len(words) - 1:
+                    test = word + " " + words[i + 1]
+                    tw, _th = self.get_cached_text_extent(dc, test, ptsize)
+                    if tw < w:
+                        word = test
+                        i += 1
+                        cont = True
+            tw, th = self.get_cached_text_extent(dc, word, ptsize)
+            if tw > w:
+                return 0
+            total_h += th
+            i += 1
+        return total_h
+
+    def _label_width_fit(self, dc, label, w):
+        # Largest font size <= ceiling(w) at which every word in `label` fits
+        # width w. Height-independent. Returns 0 if it cannot fit even at 6.
+        ptsize = self.label_font_ceiling(w)
+        while ptsize >= 6:
+            if self._label_block_height(dc, label, w, ptsize) > 0:
+                return ptsize
+            ptsize -= 2
+        return 0
+
+    def _compute_label_reserve(self, dc, page):
+        # Uniform vertical space for labels across the whole bar. First find the
+        # single largest font size at which every label still fits its width
+        # (height is irrelevant here, so it is stable while the bar resizes),
+        # then reserve the tallest label block at that one size. The icon takes
+        # the remaining height, so icons — not text — shrink first, and only by
+        # as much as the actual (uniform) text really needs.
+        if not self.show_labels:
+            return 0
+        labels = []
+        uniform = None
+        for panel in page.panels:
+            if panel is None or panel.visible_button_count == 0:
+                continue
+            for button in panel.visible_buttons():
+                if button.overflow or not button.visible or button.position is None:
+                    continue
+                if not button.label:
+                    continue
+                x, y, x1, y1 = button.position
+                w = int(round(x1 - x))
+                labels.append((button.label, w))
+                fit = self._label_width_fit(dc, button.label, w)
+                if fit:  # ignore labels that cannot fit even at 6 (they hide)
+                    uniform = fit if uniform is None else min(uniform, fit)
+        if uniform is None:
+            return 0
+        reserve = 0
+        for label, w in labels:
+            reserve = max(reserve, self._label_block_height(dc, label, w, uniform))
+        return reserve
 
     def get_font_size(self, imgsize):
         if imgsize <= 20:
@@ -2748,14 +2795,9 @@ class Art:
             ptsize = 16
         return ptsize
 
-    def get_best_font_size(self, imgsize):
-        sizes = [(pt, amount) for pt, amount in self.font_sizes.items()]
-        sizes.sort(key=lambda e: e[1], reverse=True)
-        best = 32768
-        if len(sizes):
-            # Take the one where we have most...
-            best = sizes[0][0]
-        ptsize = self.get_font_size(imgsize)
-        if ptsize > best:
-            ptsize = best
-        return ptsize
+    def get_best_font_size(self, fallback):
+        if not self.font_sizes:
+            return fallback
+        # The smallest size that fits any button is the largest size that
+        # fits them all, giving every button a single uniform text size.
+        return min(self.font_sizes)


### PR DESCRIPTION
This is a purely visual/aesthetic change to the top ribbon.

* Uniform icon sizes and spacing across all buttons
* Uniform text sizes across all buttons
* Decision to hide the labels are all or nothing instead of individually
* Better sizing of icons when no labels
* Buttons won't resize beyond the height needed for the icon and label
* The dock snaps back to match the size of the buttons if dragged too big.

In the below images, the current ribbon is on top and after this pr on bottom.
<img width="957" height="202" alt="ribbon_no_labels" src="https://github.com/user-attachments/assets/46e1a3ab-cbc7-400f-8195-486517643428" />
<img width="969" height="202" alt="ribbon_missing_labels" src="https://github.com/user-attachments/assets/c02b9025-e4f2-4472-a5a2-aa764453e975" />
<img width="1278" height="419" alt="ribbon_size_and_text" src="https://github.com/user-attachments/assets/df8a8b25-0786-4a25-b210-c7bcb872035e" />

## Summary by Sourcery

Unify toolbar ribbon button layout so icons and labels render with consistent sizing and the dock auto-snaps to fit the computed button height.

Enhancements:
- Ensure all visible ribbon buttons on a page share a uniform label font size based on available width and precomputed label height reservation.
- Prevent labels from rendering on individual buttons if any label would not fit, keeping icon-only layout consistent when space is constrained.
- Standardize dropdown arrow positioning for hybrid buttons independently of icon size to improve visual consistency.
- Calculate the ribbon dock’s ideal vertical extent from button geometry and automatically snap the dock height back to that value when resized larger.