### PR TITLE
Fix unit tests failing on NumPy 2.x

### DIFF
--- a/meerk40t/core/geomstr.py
+++ b/meerk40t/core/geomstr.py
@@ -223,6 +223,19 @@ def distance_squared(p1_x, p1_y, p2_x, p2_y):
     return dx * dx + dy * dy
 
 
+def _cross_2d(a, b):
+    """
+    2D scalar cross product (z-component), broadcasting over the last axis.
+
+    NumPy 2.3 removed support for 2-dimensional inputs to ``np.cross``; this
+    helper replaces those calls. Accepts single vectors or arrays of vectors
+    shaped ``(..., 2)`` and returns ``a_x * b_y - a_y * b_x``.
+    """
+    a = np.asarray(a)
+    b = np.asarray(b)
+    return a[..., 0] * b[..., 1] - a[..., 1] * b[..., 0]
+
+
 # Centralized utilities for NumPy and point conversion
 def _convert_points_to_arrays(points):
     """
@@ -7175,7 +7188,7 @@ class Geomstr:
         """
 
         def process(S, P, a, b):
-            signed_dist = np.cross(S[P] - S[a], S[b] - S[a])
+            signed_dist = _cross_2d(S[P] - S[a], S[b] - S[a])
             K = [i for s, i in zip(signed_dist, P) if s > 0 and i != a and i != b]
 
             if len(K) == 0:
@@ -8282,7 +8295,7 @@ class Geomstr:
             if line_length == 0:
                 return np.linalg.norm(points - start, axis=-1)
             if line.size == 2:
-                return abs(np.cross(line, start - points)) / line_length  # 2D case
+                return abs(_cross_2d(line, start - points)) / line_length  # 2D case
             return (
                 abs(np.linalg.norm(np.cross(line, start - points), axis=-1))
                 / line_length
@@ -8410,7 +8423,7 @@ class Geomstr:
                 side2 = sides[i + 2]
 
                 # Check if parallel (cross product should be near zero)
-                cross = abs(np.cross(side1, side2))
+                cross = abs(_cross_2d(side1, side2))
                 side1_len = np.linalg.norm(side1)
                 side2_len = np.linalg.norm(side2)
 
@@ -8493,7 +8506,7 @@ class Geomstr:
             for i in range(n):
                 v1 = points[i] - center
                 v2 = points[(i + 1) % n] - center
-                angle = np.arctan2(np.cross(v1, v2), np.dot(v1, v2))
+                angle = np.arctan2(_cross_2d(v1, v2), np.dot(v1, v2))
                 angles.append(angle)
 
             expected_angle = 2 * np.pi / n


### PR DESCRIPTION
Fix unit tests failing on NumPy 2.x — np.cross dropped support for 2D vectors, which broke geomstr's simplify and convex-hull code.

Swapped those calls for a small _cross_2d helper that does the same math the old way.

## Summary by Sourcery

Restore 2D geometric operations compatibility with newer NumPy versions by replacing deprecated np.cross usage with an internal helper.

Bug Fixes:
- Fix failures in convex hull and distance-related geometry computations when running tests against NumPy 2.x.

Enhancements:
- Introduce a dedicated _cross_2d helper to provide a stable 2D scalar cross product implementation for geometry utilities.