### PR TITLE
Fix console-server GUI handover binding; typed settings and feedback in console set

### DIFF
--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -3771,6 +3771,11 @@ class Kernel(Settings):
                             setattr(relevant_context, attr, float(value))
                         elif isinstance(v, str):
                             setattr(relevant_context, attr, str(value))
+                        else:
+                            # Typed settings (e.g. Length, Angle): reconstruct
+                            # from the string value so `set` can address any
+                            # registered choice attribute.
+                            setattr(relevant_context, attr, type(v)(value))
                 except RuntimeError:
                     channel(_("Attempt failed. Produced a runtime error."))
                 except ValueError:

--- a/meerk40t/kernel/kernel.py
+++ b/meerk40t/kernel/kernel.py
@@ -3773,15 +3773,25 @@ class Kernel(Settings):
                             setattr(relevant_context, attr, str(value))
                         else:
                             # Typed settings (e.g. Length, Angle): reconstruct
-                            # from the string value so `set` can address any
-                            # registered choice attribute.
+                            # the typed value from the string form and keep it
+                            # typed on the live context; persistence serializes
+                            # via str() at the storage boundary.
                             setattr(relevant_context, attr, type(v)(value))
+                        channel(
+                            f'"{attr}" := {str(getattr(relevant_context, attr))}'
+                        )
+                    else:
+                        channel(
+                            _("No such attribute: {attr}").format(attr=attr)
+                        )
                 except RuntimeError:
                     channel(_("Attempt failed. Produced a runtime error."))
                 except ValueError:
                     channel(_("Attempt failed. Produced a value error."))
                 except AttributeError:
                     channel(_("Attempt failed. Produced an attribute error."))
+                except TypeError:
+                    channel(_("Attempt failed. Produced a type error."))
             return
 
         @self.console_command("flush", help=_("flush current settings to disk"))

--- a/meerk40t/kernel/settings.py
+++ b/meerk40t/kernel/settings.py
@@ -421,6 +421,11 @@ class Settings:
                 continue
             if isinstance(value, (str, int, float, bool, list, tuple)):
                 self.write_persistent(section, key, value)
+            elif type(value).__module__ == "meerk40t.core.units":
+                # Typed settings (e.g. Length, Angle): persist the canonical
+                # string form; consumers reconstruct through the registered
+                # choice type.
+                self.write_persistent(section, key, str(value))
 
     def write_persistent_attributes(self, section: str, obj: Any) -> None:
         """

--- a/meerk40t/network/console_server.py
+++ b/meerk40t/network/console_server.py
@@ -89,17 +89,18 @@ def plugin(kernel, lifecycle=None):
                     pos = root.__console_buffer.find("\n")
                     command = root.__console_buffer[0:pos].strip("\r")
                     root.__console_buffer = root.__console_buffer[pos + 1 :]
+                    handover = find_handover()
                     if handover is None:
                         root.console(command + "\n")
                     else:
                         handover(command)
 
-            handover = None
-            for result in root.find("gui/handover"):
-                # Do we have a thread handover routine?
-                if result is not None:
-                    handover, _path, suffix_path = result
-                    break
+            def find_handover():
+                # Resolve at execution time: the gui (and its thread handover
+                # routine) may not exist yet when the server is started, e.g.
+                # from a batch file at boot. lookup() is an exact-key access
+                # and safe against concurrent registration, unlike find().
+                return root.lookup("gui/handover")
             recv.watch(exec_command)
 
             channel(

--- a/meerk40t/network/web_server.py
+++ b/meerk40t/network/web_server.py
@@ -440,6 +440,12 @@ class WebServer(Module):
             self.debug_channel(f"[WEB CMD] {command}")
 
             if self.handover is None:
+                # Resolve at execution time: the gui (and its thread handover
+                # routine) may not exist yet when the server is started.
+                # lookup() is an exact-key access and safe against concurrent
+                # registration, unlike find().
+                self.handover = self.context.root.lookup("gui/handover")
+            if self.handover is None:
                 self.context(f"{command}\n")
             else:
                 self.handover(command)

--- a/test/test_console_set_typed.py
+++ b/test/test_console_set_typed.py
@@ -1,0 +1,57 @@
+import unittest
+
+from test import bootstrap
+
+from meerk40t.core.units import Length
+
+
+class TestConsoleSetTyped(unittest.TestCase):
+    def test_set_keeps_typed_value_live(self):
+        """
+        `set` on a Length-typed registered setting must keep the live
+        attribute typed (consumers call e.g. `.mm`), not replace it with str.
+        """
+        kernel = bootstrap.bootstrap()
+        try:
+            root = kernel.root
+            root.setting(Length, "typed_test_length", Length("235mm"))
+            kernel.console("set typed_test_length 410mm\n")
+            value = root.typed_test_length
+            self.assertIsInstance(value, Length)
+            self.assertAlmostEqual(value.mm, 410.0)
+        finally:
+            kernel()
+
+    def test_set_unknown_attribute_reports(self):
+        """
+        `set` on a missing attribute must not create it.
+        """
+        kernel = bootstrap.bootstrap()
+        try:
+            kernel.console("set no_such_attribute_xyz 5\n")
+            self.assertFalse(hasattr(kernel.root, "no_such_attribute_xyz"))
+        finally:
+            kernel()
+
+    def test_typed_setting_round_trip_persistence(self):
+        """
+        Length-typed settings must survive write_persistent_dict and read
+        back through the registered type.
+        """
+        kernel = bootstrap.bootstrap()
+        try:
+            settings = kernel  # Kernel subclasses Settings
+            settings.write_persistent_dict(
+                "typed_test", {"width": Length("410mm"), "plain": 5}
+            )
+            stored = settings.read_persistent(str, "typed_test", "width")
+            self.assertEqual(str(Length(stored)), str(Length("410mm")))
+            self.assertEqual(
+                settings.read_persistent(int, "typed_test", "plain"), 5
+            )
+        finally:
+            kernel()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three small fixes to remote/console control, found while driving MeerK40t headlessly and via `consoleserver` from an agent CLI (live-verified against a Sculpfun S9 GRBL machine on macOS, GUI 0.9.9000 source install).

## 1. Console/web server: resolve GUI handover at execution time

When `consoleserver` (or the web server) starts before the GUI window exists - e.g. from a batch file at boot (`meerk40t -b bootfile` with `consoleserver` in the batch) - the server binds `gui/handover` once at startup, finds nothing, and permanently routes remote commands onto the network thread. Element-mutating commands then crash the GUI in `wxGenericTreeCtrl::SetItemText` (tree updated off the main thread, segfault).

Fix: look up `gui/handover` lazily at command-execution time. Uses `lookup()` (exact key) rather than `find()` so a concurrent GUI-startup registration cannot invalidate the iteration. Headless behaviour (no GUI, no handover) is unchanged.

## 2. Console `set`: support typed settings (Length, Angle)

`set -p grbl bedwidth 410mm` previously did nothing, silently: the command only handled `bool/int/float/str` attributes. Typed settings are now reconstructed through their current type and kept typed on the live context (consumers like `redlight_angle.radians` keep working); persistence serializes the canonical string form at the storage boundary (`write_persistent_dict`), narrowly scoped to `meerk40t.core.units` types.

## 3. Console `set`: report the result

A successful `set` now echoes the resulting value, and setting an unknown attribute reports "No such attribute" instead of silent inaction - previously misconfiguration (e.g. a typo, or the typed-setting silence above) was undetectable over a remote console.

## Tests

- New: `test/test_console_set_typed.py` - typed value stays live-typed, unknown attribute is not created, Length round-trips through persistence.
- `unittest discover test -p 'test_kernel*.py'`: 12/12 OK.
- Full suite: 631 tests, 10 errors - identical errors on unpatched main (628 tests, same 10): all are `test_geomstr` failures from NumPy 2.x removing 2-D support in `np.cross`, unrelated to this change (happy to file that as a separate issue).

## Summary by Sourcery

Improve remote console and web server interaction with the GUI and enhance console settings handling and persistence.

New Features:
- Echo the resulting value of successful console `set` commands to the caller.
- Report an explicit error when attempting to `set` an unknown attribute over the console.

Bug Fixes:
- Resolve GUI handover bindings for console and web servers at command execution time so servers started before the GUI safely hand off commands once the GUI is available.
- Prevent GUI crashes caused by executing element-mutating commands on the wrong thread when `consoleserver` starts before the GUI.

Enhancements:
- Support typed settings (such as Length and Angle) in console `set` so values remain properly typed in the live context.
- Persist typed unit settings by storing their canonical string form and relying on registered types to reconstruct them on read.

Tests:
- Add tests verifying typed console `set` preserves type, does not create unknown attributes, and that typed settings round-trip correctly through persistence.