### PR TITLE
Fix numpy 2.x removal of 2D np.cross in geomstr (Outline button crash)

### DIFF
--- a/meerk40t/core/geomstr.py
+++ b/meerk40t/core/geomstr.py
@@ -72,6 +72,15 @@ from copy import copy
 
 import numpy as np
 
+
+def _cross2d(a, b):
+    """z-component of the 2D cross product (np.cross for 2D vectors was
+    removed in numpy 2.0)."""
+    a = np.asarray(a)
+    b = np.asarray(b)
+    return a[..., 0] * b[..., 1] - a[..., 1] * b[..., 0]
+
+
 # Import numba for JIT compilation optimization
 try:
     from numba import njit
@@ -7175,7 +7184,7 @@ class Geomstr:
         """
 
         def process(S, P, a, b):
-            signed_dist = np.cross(S[P] - S[a], S[b] - S[a])
+            signed_dist = _cross2d(S[P] - S[a], S[b] - S[a])
             K = [i for s, i in zip(signed_dist, P) if s > 0 and i != a and i != b]
 
             if len(K) == 0:
@@ -8282,7 +8291,7 @@ class Geomstr:
             if line_length == 0:
                 return np.linalg.norm(points - start, axis=-1)
             if line.size == 2:
-                return abs(np.cross(line, start - points)) / line_length  # 2D case
+                return abs(_cross2d(line, start - points)) / line_length  # 2D case
             return (
                 abs(np.linalg.norm(np.cross(line, start - points), axis=-1))
                 / line_length
@@ -8410,7 +8419,7 @@ class Geomstr:
                 side2 = sides[i + 2]
 
                 # Check if parallel (cross product should be near zero)
-                cross = abs(np.cross(side1, side2))
+                cross = abs(_cross2d(side1, side2))
                 side1_len = np.linalg.norm(side1)
                 side2_len = np.linalg.norm(side2)
 
@@ -8493,7 +8502,7 @@ class Geomstr:
             for i in range(n):
                 v1 = points[i] - center
                 v2 = points[(i + 1) % n] - center
-                angle = np.arctan2(np.cross(v1, v2), np.dot(v1, v2))
+                angle = np.arctan2(_cross2d(v1, v2), np.dot(v1, v2))
                 angles.append(angle)
 
             expected_angle = 2 * np.pi / n


### PR DESCRIPTION
## What

`np.cross` for 2D vectors was removed in numpy 2.0 ([numpy/numpy#26443](https://github.com/numpy/numpy/releases/tag/v2.0.0) deprecation completed). `geomstr.py` has four 2D call sites that now raise `ValueError: Both input arrays must be (arrays of) 3-dimensional vectors`:

- quickhull signed distance (`convex_hull`) — crashes the GUI **Outline** button for any device without a native `outline()` (e.g. GRBL), via `element* trace hull`
- point-line distance 2D branch (`_douglas_peucker`)
- parallel-side check
- polygon angle check

All four compute the scalar z-component, so they are replaced with an explicit `_cross2d` helper (`a[...,0]*b[...,1] - a[...,1]*b[...,0]`), which is also what numpy's own release notes recommend.

## Why

With numpy 2.x installed (the default for any fresh `pip install meerk40t` environment today), pressing **Outline** in the Laser panel with a GRBL device crashes. Found live-driving a Sculpfun S9 on macOS / Python 3.12 / numpy 2.x.

## Testing

`python -m unittest test.test_geomstr` on current main with numpy 2.x: **10 errors** (all `np.cross` 2D).
With this patch: **61 tests, OK** — zero errors, no other behaviour change.

Also verified the exact crash reproduction (convex hull over three rects from the GUI trace path) returns a correct 5-point hull.

## Summary by Sourcery

Replace deprecated 2D np.cross usage in geometric computations with a dedicated helper to restore compatibility with NumPy 2.x and prevent GUI outline crashes.

Bug Fixes:
- Fix convex hull signed-distance calculation to avoid runtime errors with NumPy 2.x when computing outlines.
- Fix 2D point-to-line distance calculation to work correctly without np.cross for 2D vectors.
- Fix parallel-side detection and regular polygon angle checks that relied on 2D np.cross, eliminating NumPy 2.x ValueErrors.

Enhancements:
- Introduce a reusable _cross2d helper for computing the 2D cross-product z-component in geometric routines.