### PR TITLE
live light job: stop tracing deleted elements

### DIFF
--- a/meerk40t/balormk/livelightjob.py
+++ b/meerk40t/balormk/livelightjob.py
@@ -274,6 +274,8 @@ class LiveLightJob:
         """
         if not self.listen:
             return
+        # Deletion fires element_removed/tree_changed. Without them a
+        # deleted shape keeps being traced by the live light job.
         for method in (
             "emphasized",
             "modified_by_tool",
@@ -281,6 +283,8 @@ class LiveLightJob:
             "view;realized",
             "update_group_labels",
             "element_property_reload",
+            "element_removed",
+            "tree_changed",
         ):
             if start:
                 self.service.listen(method, self.on_emphasis_changed)


### PR DESCRIPTION
While testing the V1 board profile I noticed the live light job keeps tracing a shape after you delete it. Deletion fires `element_removed` and `tree_changed`, and neither is in the listener list, so the deleted geometry stays in the simulated outline until the selection changes.

This adds both signals to the list. Tested with a balormk (JCZ) device: delete an element while live outline is running and the trace stops immediately.

(The same fix ships bundled in the usblm-v1-meerk40t profile, applied on import - it gets dropped once this lands.)

## Summary by Sourcery

Bug Fixes:
- Ensure live light job stops tracing shapes as soon as they are deleted from the board profile.