### PR TITLE
Fix newly driver bed dimension type

### DIFF
--- a/meerk40t/newly/device.py
+++ b/meerk40t/newly/device.py
@@ -138,7 +138,7 @@ class NewlyDevice(Service, Status):
                 "attr": "bedwidth",
                 "object": self,
                 "default": "310mm",
-                "type": str,
+                "type": Length,
                 "label": _("Width"),
                 "tip": _("Width of the laser bed."),
                 # Hint for translation _("General")
@@ -152,7 +152,7 @@ class NewlyDevice(Service, Status):
                 "attr": "bedheight",
                 "object": self,
                 "default": "210mm",
-                "type": str,
+                "type": Length,
                 "label": _("Height"),
                 "tip": _("Height of the laser bed."),
                 # Hint for translation _("General")


### PR DESCRIPTION
Fixes #3259

newly/device.py declared bedwidth and bedheight as "type": str.
Every other driver uses "type": Length. View assigns width and
height without coercion, so on newly the raw string reached the
confined-jog clamp in driver.py move_rel and blew up on
str - float.

Changed the two declarations to Length to match grbl, ruida, moshi
and lihuiyu. No driver.py change needed, and it fixes any other
consumer of view.width/view.height in this driver rather than just
the one call site.

Root cause was confirmed by reading the source at 0.9.9100. The
fix itself is not yet hardware-tested. I have the affected machine
(Artsign JSM-40U over USB) and will confirm shortly that jogging
into the far edge clamps instead of crashing, and that an existing
config storing the value as a bare string still loads. I will
follow up on this PR with the result.

## Summary by Sourcery

Align newly driver bed dimension types with other drivers and bump application version.

Bug Fixes:
- Prevent crashes in the newly driver by declaring bedwidth and bedheight as Length instead of raw strings.

Build:
- Update application and package version metadata from 0.9.9000 to 0.9.9100, including Windows file version.