### PR TITLE
wx: Fix linux reparent errors with AddPage calls

### DIFF
--- a/meerk40t/balormk/gui/balorconfig.py
+++ b/meerk40t/balormk/gui/balorconfig.py
@@ -118,6 +118,7 @@ class BalorConfiguration(MWindow):
                     injector=injection,
                 )
                 self.panels.append(newpanel)
+                newpanel.Reparent(self.notebook_main)
                 self.notebook_main.AddPage(newpanel, pagetitle)
 
         # newpanel = EffectsPanel(self, id=wx.ID_ANY, context=self.context)
@@ -126,14 +127,17 @@ class BalorConfiguration(MWindow):
 
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Warning"))
 
         newpanel = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Default Actions"))
 
         newpanel = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Display Options"))
 
         self.Layout()

--- a/meerk40t/grbl/gui/grblconfiguration.py
+++ b/meerk40t/grbl/gui/grblconfiguration.py
@@ -272,6 +272,9 @@ class GRBLConfiguration(MWindow):
         self.panels.append(panel_actions)
         self.panels.append(panel_formatter)
 
+        for panel in self.panels:
+            panel.Reparent(self.notebook_main)
+
         self.notebook_main.AddPage(panel_dim, _("Device"))
         self.notebook_main.AddPage(panel_interface, _("Interface"))
         self.notebook_main.AddPage(panel_protocol, _("Protocol"))

--- a/meerk40t/gui/about.py
+++ b/meerk40t/gui/about.py
@@ -2120,6 +2120,13 @@ class About(MWindow):
         self.panel_david = DavidPanel(self, wx.ID_ANY, context=self.context)
         self.panel_info = InformationPanel(self, wx.ID_ANY, context=self.context)
         self.panel_component = ComponentPanel(self, wx.ID_ANY, context=self.context)
+        for panel in (
+            self.panel_about,
+            self.panel_david,
+            self.panel_info,
+            self.panel_component,
+        ):
+            panel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_about, _("About"))
         self.notebook_main.AddPage(self.panel_david, _("In Memory of David Olsen"))
         self.notebook_main.AddPage(self.panel_info, _("System-Information"))

--- a/meerk40t/gui/alignment.py
+++ b/meerk40t/gui/alignment.py
@@ -1598,14 +1598,17 @@ class Alignment(MWindow):
         self.panel_align = AlignmentPanel(
             self, wx.ID_ANY, context=self.context, scene=self.scene
         )
+        self.panel_align.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_align, _("Align"))
         self.panel_distribution = DistributionPanel(
             self, wx.ID_ANY, context=self.context, scene=self.scene
         )
+        self.panel_distribution.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_distribution, _("Distribute"))
         self.panel_arrange = ArrangementPanel(
             self, wx.ID_ANY, context=self.context, scene=self.scene
         )
+        self.panel_arrange.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_arrange, _("Arrange"))
         self.sizer.Add(self.notebook_main, 1, wx.EXPAND, 0)
         self.Layout()

--- a/meerk40t/gui/imagesplitter.py
+++ b/meerk40t/gui/imagesplitter.py
@@ -509,6 +509,11 @@ class RenderSplit(MWindow):
         self.panel_keyhole = KeyholePanel(
             self, wx.ID_ANY, context=self.context, scene=self.scene
         )
+        for panel in (
+            self.panel_split,
+            self.panel_keyhole
+        ):
+            panel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_split, _("Render + Split"))
         self.notebook_main.AddPage(self.panel_keyhole, _("Keyhole operation"))
 

--- a/meerk40t/gui/laserpanel.py
+++ b/meerk40t/gui/laserpanel.py
@@ -181,6 +181,14 @@ def register_panel_laser(window, context):
     pane.helptext = _("Laser job control panel")
     pane.control = notebook
     pane.dock_proportion = 270
+    for panel in (
+        laser_panel,
+        jog_drag,
+        plan_panel,
+        optimize_panel,
+        move_panel
+    ):
+        panel.Reparent(notebook)
     notebook.AddPage(laser_panel, _("Laser"))
     notebook.AddPage(jog_drag, _("Jog"))
     notebook.AddPage(plan_panel, _("Plan"))

--- a/meerk40t/gui/lasertoolpanel.py
+++ b/meerk40t/gui/lasertoolpanel.py
@@ -54,6 +54,7 @@ class LaserToolPanel(wx.Panel):
         # ------------------------ Circle with 3 points
 
         self.nb_circle = wx.Panel(self.nbook_lasertools, wx.ID_ANY)
+        self.nb_circle.Reparent(self.nbook_lasertools)
         self.nbook_lasertools.AddPage(self.nb_circle, _("Find center"))
 
         self.sizer_circle = wx.BoxSizer(wx.VERTICAL)
@@ -146,6 +147,7 @@ class LaserToolPanel(wx.Panel):
         # ------------------------ Rectangle with 2 points
 
         self.nb_rectangle = wx.Panel(self.nbook_lasertools, wx.ID_ANY)
+        self.nb_rectangle.Reparent(self.nbook_lasertools)
         self.nbook_lasertools.AddPage(self.nb_rectangle, _("Place frame"))
 
         self.sizer_rectangle = wx.BoxSizer(wx.VERTICAL)
@@ -215,6 +217,7 @@ class LaserToolPanel(wx.Panel):
         # ------------------------ Square with 3 points
 
         self.nb_square = wx.Panel(self.nbook_lasertools, wx.ID_ANY)
+        self.nb_square.Reparent(self.nbook_lasertools)
         self.nbook_lasertools.AddPage(self.nb_square, _("Place square"))
 
         self.sizer_square = wx.BoxSizer(wx.VERTICAL)

--- a/meerk40t/gui/magnetoptions.py
+++ b/meerk40t/gui/magnetoptions.py
@@ -551,6 +551,8 @@ class MagnetPanel(wx.Panel):
             self.notebook, wx.ID_ANY, context=self.context
         )
         self.panels = (panel_action, panel_options)
+        for panel in self.panels:
+            panel.Reparent(self.notebook)
         self.notebook.AddPage(panel_action, _("Actions"))
         self.notebook.AddPage(panel_options, _("Options"))
         self.SetSizer(sizer_main)

--- a/meerk40t/gui/materialmanager.py
+++ b/meerk40t/gui/materialmanager.py
@@ -3481,6 +3481,12 @@ class MaterialManager(MWindow):
         self.notebook_main.GetArtProvider().SetActiveColour(bg_active)
 
         self.sizer.Add(self.notebook_main, 1, wx.EXPAND, 0)
+        for panel in (
+            self.panel_library,
+            # self.panel_import,
+            self.panel_about,
+        ):
+            panel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_library, _("Library"))
         # self.notebook_main.AddPage(self.panel_import, _("Import"))
         self.notebook_main.AddPage(self.panel_about, _("How to use"))

--- a/meerk40t/gui/materialtest.py
+++ b/meerk40t/gui/materialtest.py
@@ -2099,11 +2099,13 @@ class TemplateTool(MWindow):
         self.notebook_main.GetArtProvider().SetColour(bg_std)
         self.notebook_main.GetArtProvider().SetActiveColour(bg_active)
         self.sizer.Add(self.notebook_main, 1, wx.EXPAND, 0)
+        self.panel_template.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_template, _("Generator"))
 
         self.panel_template.set_callback(self.set_node)
         self.add_module_delegate(self.panel_template)
 
+        self.panel_saveload.Reparent(self.notebook_main)
         self.notebook_main.AddPage(self.panel_saveload, _("Templates"))
         self.panel_saveload.set_callback(self.callback_templates)
         self.add_module_delegate(self.panel_saveload)

--- a/meerk40t/gui/preferences.py
+++ b/meerk40t/gui/preferences.py
@@ -799,15 +799,6 @@ class Preferences(MWindow):
 
         self.panel_ribbon = RibbonEditor(self, wx.ID_ANY, context=self.context)
 
-        self.notebook_main.AddPage(self.panel_main, _("General"))
-        self.notebook_main.AddPage(self.panel_input_output, _("Input/Output"))
-        self.notebook_main.AddPage(self.panel_classification, _("Classification"))
-        self.notebook_main.AddPage(self.panel_ops, _("Operations"))
-        self.notebook_main.AddPage(self.panel_gui, _("GUI"))
-        self.notebook_main.AddPage(self.panel_scene, _("Scene"))
-        self.notebook_main.AddPage(self.panel_color, _("Colors"))
-        self.notebook_main.AddPage(self.panel_ribbon, _("Ribbon"))
-
         self.panels = [
             self.panel_main,
             self.panel_input_output,
@@ -818,6 +809,18 @@ class Preferences(MWindow):
             self.panel_color,
             self.panel_ribbon,
         ]
+        for panel in self.panels:
+            panel.Reparent(self.notebook_main)
+
+        self.notebook_main.AddPage(self.panel_main, _("General"))
+        self.notebook_main.AddPage(self.panel_input_output, _("Input/Output"))
+        self.notebook_main.AddPage(self.panel_classification, _("Classification"))
+        self.notebook_main.AddPage(self.panel_ops, _("Operations"))
+        self.notebook_main.AddPage(self.panel_gui, _("GUI"))
+        self.notebook_main.AddPage(self.panel_scene, _("Scene"))
+        self.notebook_main.AddPage(self.panel_color, _("Colors"))
+        self.notebook_main.AddPage(self.panel_ribbon, _("Ribbon"))
+
         self.panel_ids = [
             "main",
             "classification",
@@ -832,6 +835,7 @@ class Preferences(MWindow):
             panel_space = ChoicePropertyPanel(
                 self, wx.ID_ANY, context=self.context, choices="space"
             )
+            panel_space.Reparent(self.notebook_main)
             self.notebook_main.AddPage(panel_space, _("Coordinate Space"))
             self.panels.append(panel_space)
             self.panel_ids.append("space")

--- a/meerk40t/gui/propertypanels/propertywindow.py
+++ b/meerk40t/gui/propertypanels/propertywindow.py
@@ -90,6 +90,7 @@ class PropertyWindow(MWindow):
             except AttributeError:
                 name = instance.__class__.__name__
 
+            page_panel.Reparent(self.notebook_main)
             self.notebook_main.AddPage(page_panel, _(name))
             if hasattr(page_panel, "set_widgets"):
                 page_panel.set_widgets(instance)

--- a/meerk40t/gui/propertypanels/textproperty.py
+++ b/meerk40t/gui/propertypanels/textproperty.py
@@ -507,7 +507,13 @@ class TextPropertyPanel(ScrolledPanel):
             page_fonthistory.Layout()
 
         page_fonthistory.Bind(wx.EVT_SIZE, on_size_fh)
-
+        for panel in (
+            page_main,
+            page_variables,
+            page_fonthistory,
+            page_extended,
+        ):
+            panel.Reparent(self.notebook)
         self.notebook.AddPage(page_main, _("Colors"))
         self.notebook.AddPage(page_variables, _("Text-Variables"))
         self.notebook.AddPage(page_fonthistory, _("Font-History"))

--- a/meerk40t/gui/simpleui.py
+++ b/meerk40t/gui/simpleui.py
@@ -305,6 +305,7 @@ class SimpleUI(MWindow):
             except AttributeError:
                 name = page_panel.__class__.__name__
 
+            page_panel.Reparent(self.notebook_main)
             self.notebook_main.AddPage(page_panel, _(name))
             self.add_module_delegate(page_panel)
             self.panel_instances.append(page_panel)

--- a/meerk40t/gui/wordlisteditor.py
+++ b/meerk40t/gui/wordlisteditor.py
@@ -1841,6 +1841,14 @@ class WordlistEditor(MWindow):
         self.notebook_main.GetArtProvider().SetActiveColour(bg_active)
 
         self.sizer.Add(self.notebook_main, 1, wx.EXPAND, 0)
+
+        for panel in (
+            self.panel_editor,
+            self.panel_import,
+            self.panel_about
+        ):
+            panel.Reparent(self.notebook_main)
+
         self.notebook_main.AddPage(self.panel_editor, _("Editing"))
         self.notebook_main.AddPage(self.panel_import, _("Import/Export"))
         self.notebook_main.AddPage(self.panel_about, _("How to use"))

--- a/meerk40t/gui/wxmtree.py
+++ b/meerk40t/gui/wxmtree.py
@@ -114,6 +114,11 @@ def register_panel_tree(window, context):
         .TopDockable(False)
     )
     pane.helptext = _("Tree containing all objects")
+    for panel in (
+        basic_op,
+        wxtree,
+    ):
+        panel.Reparent(notetab)
     notetab.AddPage(basic_op, _("Burn-Operation"))
     notetab.AddPage(wxtree, _("Details"))
     notetab.SetSelection(lastpage)

--- a/meerk40t/lihuiyu/gui/lhydrivergui.py
+++ b/meerk40t/lihuiyu/gui/lhydrivergui.py
@@ -442,6 +442,9 @@ class LihuiyuDriverGui(MWindow):
         self.panels.append(panel_actions)
         self.panels.append(panel_format)
 
+        for panel in self.panels:
+            panel.Reparent(self.notebook_main)
+
         self.notebook_main.AddPage(panel_config, _("Configuration"))
         self.notebook_main.AddPage(panel_interface, _("Interface"))
         self.notebook_main.AddPage(panel_setup, _("Setup"))

--- a/meerk40t/moshi/gui/moshidrivergui.py
+++ b/meerk40t/moshi/gui/moshidrivergui.py
@@ -70,6 +70,9 @@ class MoshiDriverGui(MWindow):
         self.panels.append(panel_actions)
         self.panels.append(newpanel)
 
+        for panel in self.panels:
+            panel.Reparent(self.notebook_main)
+
         self.notebook_main.AddPage(panel_config, _("Configuration"))
         self.notebook_main.AddPage(panel_effects, _("Effects"))
         self.notebook_main.AddPage(panel_defaults, _("Operation Defaults"))

--- a/meerk40t/newly/gui/newlyconfig.py
+++ b/meerk40t/newly/gui/newlyconfig.py
@@ -61,35 +61,42 @@ class NewlyConfiguration(MWindow):
                     self, wx.ID_ANY, context=self.context, choices=section
                 )
                 self.panels.append(newpanel)
+                newpanel.Reparent(self.notebook_main)
                 self.notebook_main.AddPage(newpanel, pagetitle)
         newpanel = ChoicePropertyPanel(
             self, id=wx.ID_ANY, context=self.context, choices="newly-speedchart"
         )
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Raster Chart"))
 
         newpanel = ChoicePropertyPanel(
             self, id=wx.ID_ANY, context=self.context, choices="newly-effects"
         )
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Effects"))
 
         newpanel = ChoicePropertyPanel(
             self, id=wx.ID_ANY, context=self.context, choices="newly-defaults"
         )
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Operation Defaults"))
 
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Warning"))
 
         newpanel = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Default Actions"))
 
         newpanel = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Display Options"))
 
         self.Layout()

--- a/meerk40t/ruida/gui/ruidaconfig.py
+++ b/meerk40t/ruida/gui/ruidaconfig.py
@@ -231,12 +231,14 @@ class RuidaConfiguration(MWindow):
                     self, wx.ID_ANY, context=self.context, choices=section
                 )
                 self.panels.append(newpanel)
+                newpanel.Reparent(self.notebook_main)
                 self.notebook_main.AddPage(newpanel, pagetitle)
 
         panel_interface = ConfigurationInterfacePanel(
             self.notebook_main, wx.ID_ANY, context=self.context
         )
         self.panels.append(panel_interface)
+        panel_interface.Reparent(self.notebook_main)
         self.notebook_main.AddPage(panel_interface, _("Interface"))
 
         panel_config = ChoicePropertyPanel(
@@ -246,12 +248,14 @@ class RuidaConfiguration(MWindow):
             choices=("ruida-global", "ruida-magic"),
         )
         self.panels.append(panel_config)
+        panel_config.Reparent(self.notebook_main)
         self.notebook_main.AddPage(panel_config, _("Configuration"))
 
         panel_effects = ChoicePropertyPanel(
             self.notebook_main, wx.ID_ANY, context=self.context, choices="ruida-effects"
         )
         self.panels.append(panel_effects)
+        panel_effects.Reparent(self.notebook_main)
         self.notebook_main.AddPage(panel_effects, _("Effects"))
 
         panel_defaults = ChoicePropertyPanel(
@@ -261,18 +265,22 @@ class RuidaConfiguration(MWindow):
             choices="ruida-defaults",
         )
         self.panels.append(panel_defaults)
+        panel_defaults.Reparent(self.notebook_main)
         self.notebook_main.AddPage(panel_defaults, _("Operation Defaults"))
 
         newpanel = WarningPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Warning"))
 
         newpanel = DefaultActionPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Default Actions"))
 
         newpanel = FormatterPanel(self, id=wx.ID_ANY, context=self.context)
         self.panels.append(newpanel)
+        newpanel.Reparent(self.notebook_main)
         self.notebook_main.AddPage(newpanel, _("Display Options"))
 
         self.Layout()


### PR DESCRIPTION
This fixes the various errors seen in #3268 by calling `panel.Reparent(notebook)` for every usage of `AuiNotebook.AddPage`. 

I'm not sure if this is linux only or something with a more recent wx (I currently have 3.3.3). This makes the main UI and all the dialogs work for me.

## Summary by Sourcery

Fix AUI notebook initialization by reparenting all page panels before adding them.

Bug Fixes:
- Fix Linux and wxPython compatibility errors when adding panels to AUI notebooks.

Enhancements:
- Ensure notebook page panels are explicitly parented to their target notebooks throughout the application.